### PR TITLE
Fix: if calls Close or Dispose many times it'll throws a NullReferenceException

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.ReaderWriter.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.ReaderWriter.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis
 
         partial void OnCloseReaderWriter()
         {
-            if (ownsSocketManager) socketManager.Dispose();
+            if (ownsSocketManager && socketManager != null) socketManager.Dispose();
             socketManager = null;
         }
 


### PR DESCRIPTION
This simple code:

static void Main(string[] args)
{
    var redis = ConnectionMultiplexer.Connect("localhost");
    redis.Close();
    redis.Close();
}

on second Close throws a NullReferenceException in StackExchange.Redis.ConnectionMultiplexer.OnCloseReaderWriter()
