### PR TITLE
Fix: Null RedisValue from boolean value

### DIFF
--- a/StackExchange.Redis.Tests/Bits.cs
+++ b/StackExchange.Redis.Tests/Bits.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace StackExchange.Redis.Tests
+{
+    [TestFixture]
+    public class Bits : TestBase
+    {
+        [Test]
+        public void BasicOps()
+        {
+            using (var conn = Create())
+            {
+                var db = conn.GetDatabase();
+                RedisKey key = Me();
+
+                db.KeyDelete(key, CommandFlags.FireAndForget);
+                db.StringSetBit(key, 10, true);
+                Assert.True(db.StringGetBit(key, 10));
+                Assert.False(db.StringGetBit(key, 11));
+            }
+        }
+    }
+}

--- a/StackExchange.Redis.Tests/KeysAndValues.cs
+++ b/StackExchange.Redis.Tests/KeysAndValues.cs
@@ -42,6 +42,13 @@ namespace StackExchange.Redis.Tests
             RedisValue i8 = 1L;
             CheckNotNull(i8);
 
+            RedisValue bool1 = true;
+            CheckNotNull(bool1);
+            RedisValue bool2 = false;
+            CheckNotNull(bool2);
+            RedisValue bool3 = true;
+            CheckNotNull(bool3);
+
             CheckSame(a0, a0);
             CheckSame(a1, a1);
             CheckSame(a0, a1);
@@ -53,6 +60,9 @@ namespace StackExchange.Redis.Tests
             CheckSame(i4, i4);
             CheckSame(i8, i8);
             CheckSame(i4, i8);
+
+            CheckSame(bool1, bool3);
+            CheckNotSame(bool1, bool2);
         }
 
         private void CheckSame(RedisValue x, RedisValue y)

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicOps.cs" />
+    <Compile Include="Bits.cs" />
     <Compile Include="Cluster.cs" />
     <Compile Include="Commands.cs" />
     <Compile Include="ConnectionShutdown.cs" />

--- a/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
@@ -274,7 +274,7 @@ namespace StackExchange.Redis
         /// </summary>
         public static implicit operator RedisValue(bool value)
         {
-            return value ? new RedisValue(1, null) : new RedisValue(0, null);
+            return value ? new RedisValue(1, IntegerSentinel) : new RedisValue(0, IntegerSentinel);
         }
         /// <summary>
         /// Creates a new RedisValue from a Boolean


### PR DESCRIPTION
When implicit cast a boolen value into RedisValue the valueBlob was
setted to null.
