### PR TITLE
Support for .NET 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ obj
 *.suo
 *.user
 *.nupkg
-packages/NuGet.CommandLine.*
+packages/*
 *.sln.docstates
 _ReSharper.*
 Mono/

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StackExchange.Redis</RootNamespace>
     <AssemblyName>StackExchange.Redis</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,6 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Debug\StackExchange.Redis.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Release\StackExchange.Redis.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Verbose|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Log Output|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -55,12 +59,31 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.166\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.166\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.166\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.7\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.7\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.7\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="StackExchange\Redis\Aggregate.cs" />
@@ -148,13 +171,23 @@
     <Compile Include="StackExchange\Redis\When.cs" />
     <Compile Include="StackExchange\Redis\ShutdownMode.cs" />
     <Compile Include="StackExchange\Redis\SaveType.cs" />
+    <Compile Include="StackExchange\Redis\ZipArchive.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="StackExchange\Redis\SocketManager.Poll.cs">
       <DependentUpon>SocketManager.cs</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -7,9 +7,11 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
+using Microsoft.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 namespace StackExchange.Redis
 {
     internal static partial class TaskExtensions

--- a/StackExchange.Redis/StackExchange/Redis/ZipArchive.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ZipArchive.cs
@@ -1,0 +1,49 @@
+﻿//#if NET40
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace StackExchange.Redis
+{
+    internal enum CompressionLevel
+    {
+        Optimal = 0,
+        Fastest = 1
+    }
+
+    internal enum ZipArchiveMode
+    {
+        Create = 1
+    }
+
+    internal class ZipArchive : IDisposable
+    {
+        private readonly Stream stream;
+
+        public ZipArchive(Stream stream, ZipArchiveMode mode, bool leaveOpen)
+        {
+
+        }
+
+        public ZipArchiveEntry CreateEntry(string entryName, CompressionLevel compressionLevel)
+        {
+            return null;
+        }
+
+        public void Dispose()
+        {
+            
+        }
+    }
+
+    internal class ZipArchiveEntry
+    {
+        public Stream Open()
+        {
+            return null;
+        }
+    }
+}
+//#endif

--- a/StackExchange.Redis/app.config
+++ b/StackExchange.Redis/app.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.7.0" newVersion="2.6.7.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.7.0" newVersion="2.6.7.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/StackExchange.Redis/packages.config
+++ b/StackExchange.Redis/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.7" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.166" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -2,4 +2,5 @@
 <repositories>
   <repository path="..\MigratedBookSleeveTestSuite\packages.config" />
   <repository path="..\StackExchange.Redis.Tests\packages.config" />
+  <repository path="..\StackExchange.Redis\packages.config" />
 </repositories>


### PR DESCRIPTION
Hey Marc,

I'm interested in adding support for .NET 4. I maintain [a few libraries using Redis](https://github.com/search?q=%40TheCloudlessSky+redis) that I'm switching over from ServiceStack.Redis. However, I'd like to maintain .NET 4 support for those that require it. All of my apps use .NET 4.5, so it isn't a problem. I dropped the framework version to 4.0 and started digging. Here's what's needed:
- [x] Support async on .NET 4. From what I've read, this means taking a dependency on [Microsoft.Bcl.Async](http://blogs.msdn.com/b/bclteam/archive/2013/04/17/microsoft-bcl-async-is-now-stable.aspx).
- [ ] Make an implementation of `ZipArchive` (perhaps using `System.IO.Packaging`).
- [x] Conditionally support `Environment.CurrentManagedThreadId`:
  
  ```
  #if NET40
      int currentThread = Thread.CurrentThread.ManagedThreadId;
  #else
      int currentThread = Environment.CurrentManagedThreadId;
  #endif
  ```
- [x] Implementation for `Dns.GetHostAddressesAsync()`
- [x] Implementation for `Task.Delay()`, `Task.WhenAll()` and `Task.WhenAny()`.
- [x] Update the build process to support building packages for `lib\net40` and `lib\net45`.

Would this be something you're willing to pull in?
