### PR TITLE
Fix RedisServer.Save(SaveType.BackgroundSave)

### DIFF
--- a/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
+++ b/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace StackExchange.Redis.Tests.Issues
+{
+    [TestFixture]
+    public class BgSaveResponse : TestBase
+    {
+        [Test]
+        public void ShouldntThrowException()
+        {
+            using (var conn = Create(null, null, true))
+            {
+                var Server = GetServer(conn);
+                Server.Save(SaveType.BackgroundSave);
+            }
+        }
+    }
+}

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Expiry.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="FloatingPoint.cs" />
+    <Compile Include="Issues\BGSAVEResponse.cs" />
     <Compile Include="Issues\Issue6.cs" />
     <Compile Include="Issues\SO22786599.cs" />
     <Compile Include="Keys.cs" />

--- a/StackExchange.Redis/StackExchange/Redis/RedisLiterals.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisLiterals.cs
@@ -65,6 +65,7 @@ namespace StackExchange.Redis
 
         public static readonly byte[] BytesOK = Encoding.UTF8.GetBytes("OK");
         public static readonly byte[] BytesPONG = Encoding.UTF8.GetBytes("PONG");
+        public static readonly byte[] BytesBackgroundSavingStarted = Encoding.UTF8.GetBytes("Background saving started");
         public static readonly byte[] ByteWildcard = { (byte)'*' };
         internal static RedisValue Get(Bitwise operation)
         {

--- a/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
@@ -251,13 +251,13 @@ namespace StackExchange.Redis
         public void Save(SaveType type, CommandFlags flags = CommandFlags.None)
         {
             var msg = GetSaveMessage(type, flags);
-            ExecuteSync(msg, ResultProcessor.DemandOK);
+            ExecuteSync(msg, GetSaveResultProcessor(type));
         }
 
         public Task SaveAsync(SaveType type, CommandFlags flags = CommandFlags.None)
         {
             var msg = GetSaveMessage(type, flags);
-            return ExecuteAsync(msg, ResultProcessor.DemandOK);
+            return ExecuteAsync(msg, GetSaveResultProcessor(type));
         }
 
         public bool ScriptExists(string script, CommandFlags flags = CommandFlags.None)
@@ -541,6 +541,17 @@ namespace StackExchange.Redis
                 default:  throw new ArgumentOutOfRangeException("type");
             }
         }
+
+        ResultProcessor<bool> GetSaveResultProcessor(SaveType type)
+        {
+            switch (type)
+            {
+                case SaveType.BackgroundRewriteAppendOnlyFile: return ResultProcessor.DemandOK;
+                case SaveType.BackgroundSave: return ResultProcessor.BackgroundSaveStarted;
+                default: throw new ArgumentOutOfRangeException("type");
+            }
+        }
+
         struct KeysScanResult
         {
             public static readonly ResultProcessor<KeysScanResult> Processor = new KeysResultProcessor();

--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -13,12 +13,13 @@ namespace StackExchange.Redis
         public static readonly ResultProcessor<bool>
             Boolean = new BooleanProcessor(),
             DemandOK = new ExpectBasicStringProcessor(RedisLiterals.BytesOK),
-            DemandPONG = new ExpectBasicStringProcessor("PONG"),
+            DemandPONG = new ExpectBasicStringProcessor(RedisLiterals.BytesPONG),
             DemandZeroOrOne = new DemandZeroOrOneProcessor(),
             AutoConfigure = new AutoConfigureProcessor(),
             TrackSubscriptions = new TrackSubscriptionsProcessor(),
             Tracer = new TracerProcessor(false),
-            EstablishConnection = new TracerProcessor(true);
+            EstablishConnection = new TracerProcessor(true),
+            BackgroundSaveStarted = new ExpectBasicStringProcessor(RedisLiterals.BytesBackgroundSavingStarted);
 
         public static readonly ResultProcessor<byte[]>
             ByteArray = new ByteArrayProcessor(),


### PR DESCRIPTION
Hi Marc,

First, thanks for the good work !

I stumbled upon what seems to be a small protocol bug when calling BGSAVE.
The library expects the usual "OK" response from the server, just like BGREWRITEAOF, but in the case of this call, Redis will return "Background saving started" as success.

Occurred on version 1.0.247.0 (fresh from NuGet), Redis 2.6.12.
The reproduction code is simple enough :

``` c#
using System;
using System.Collections.Generic;
using System.Linq;
using System.Text;
using System.Threading.Tasks;
using StackExchange.Redis;

namespace RedisBGSAVE
{
    class Program
    {
        static void Main(string[] args)
        {
            var Options = new ConfigurationOptions();
            Options.EndPoints.Add("localhost", 6379);
            Options.AllowAdmin = true;
            var Multiplexer = ConnectionMultiplexer.Connect(Options);
            var Server = Multiplexer.GetServer(Multiplexer.GetEndPoints().First());
            Server.Save(SaveType.BackgroundSave);
        }
    }
}
```

This will throw a

```
[StackExchange.Redis.RedisConnectionException]:
    {"Unexpected response to BGSAVE: SimpleString: Background saving started"}
```
