### PR TITLE
Default connection timeout to 5 seconds

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -184,7 +184,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Specifies the time in milliseconds that should be allowed for connection
         /// </summary>
-        public int ConnectTimeout { get { return connectTimeout ?? SyncTimeout; } set { connectTimeout = value; } }
+        public int ConnectTimeout { get { return connectTimeout.GetValueOrDefault(5000); } set { connectTimeout = value; } }
 
         /// <summary>
         /// The server version to assume


### PR DESCRIPTION
Sometimes while creating a connection it takes more that 1 [edited] second to connect to the redis server if it's not running on the same machine. Proposing to change the default connection timeout to 5 [edited] seconds to help in this scenario.
