### PR TITLE
for 'NOAUTH Authentication required.' recordconnection failure

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -1084,6 +1084,7 @@ namespace StackExchange.Redis
         private class TracerProcessor : ResultProcessor<bool>
         {
             static readonly byte[]
+                authRequired = Encoding.UTF8.GetBytes("NOAUTH Authentication required."),
                 authFail = Encoding.UTF8.GetBytes("ERR operation not permitted"),
                 loading = Encoding.UTF8.GetBytes("LOADING ");
 
@@ -1098,7 +1099,7 @@ namespace StackExchange.Redis
                 var final = base.SetResult(connection, message, result);
                 if (result.IsError)
                 {
-                    if (result.IsEqual(authFail))
+                    if (result.IsEqual(authFail) || result.IsEqual(authRequired))
                     {
                         connection.RecordConnectionFailed(ConnectionFailureType.AuthenticationFailure);
                     }


### PR DESCRIPTION
When connectionmultiplexer is used with a log textwriter, with this change it would show something like this

Requesting tie-break from test.redis.cache.windows.net:6380 > __Bookslee
ve_TieBreak...
Allowing endpoints 24.20:31:23.6470000 to respond...
test.redis.cache.windows.net:6380 faulted: AuthenticationFailure on PING
