### PR TITLE
Minor change to WrapperBase

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
@@ -706,7 +706,7 @@ namespace StackExchange.Redis.StackExchange.Redis.KeyspaceIsolation
 
         protected RedisValue ToInner(RedisValue outer)
         {
-            return this.Prefix + outer;
+            return RedisKey.Concatenate(this.Prefix, outer);
         }
 
         protected RedisValue SortByToInner(RedisValue outer)


### PR DESCRIPTION
Avoiding a string conversion by using the new `Concatenate` method.
