### PR TITLE
Azure stale connection detection

### DIFF
--- a/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -8,7 +8,7 @@ namespace StackExchange.Redis.Tests
     public class ConnectingFailDetection : TestBase
     {
 #if DEBUG
-        [TestCase]
+        [Test]
         public void FastNoticesFailOnConnectingSync()
         {
             try
@@ -34,16 +34,15 @@ namespace StackExchange.Redis.Tests
 
                     Assert.IsTrue(muxer.IsConnected);
                 }
-
-                ClearAmbientFailures();
             }
             finally 
             {
                 SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
             }
         }
 
-        [TestCase]
+        [Test]
         public void ConnectsWhenBeginConnectCompletesSynchronously()
         {
             try
@@ -57,16 +56,15 @@ namespace StackExchange.Redis.Tests
 
                     Assert.IsTrue(muxer.IsConnected);
                 }
-
-                ClearAmbientFailures();
             }
             finally
             {
                 SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
             }
         }
 
-        [TestCase]
+        [Test]
         public void FastNoticesFailOnConnectingAsync()
         {
             try
@@ -92,13 +90,12 @@ namespace StackExchange.Redis.Tests
                     Thread.Sleep(2000);
 
                     Assert.IsTrue(muxer.IsConnected);
-                    ClearAmbientFailures();
-
                 }
             }
             finally
             {
                 SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
             }
         }
 #endif

--- a/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -98,6 +98,35 @@ namespace StackExchange.Redis.Tests
                 ClearAmbientFailures();
             }
         }
+
+        [Test]
+        public void ReconnectsOnStaleConnection()
+        {
+            try
+            {
+                using (var muxer = Create(keepAlive: 1, connectTimeout: 3000))
+                {
+                    var conn = muxer.GetDatabase();
+                    conn.Ping();
+
+                    Assert.IsTrue(muxer.IsConnected);
+
+                    PhysicalConnection.EmulateStaleConnection = true;
+                    Thread.Sleep(500);
+                    Assert.IsFalse(muxer.IsConnected);
+
+                    PhysicalConnection.EmulateStaleConnection = false;
+                    Thread.Sleep(1000);
+                    Assert.IsTrue(muxer.IsConnected);
+                }
+            }
+            finally
+            {
+                PhysicalConnection.EmulateStaleConnection = false;
+                ClearAmbientFailures();
+            }
+        }
+
 #endif
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -273,11 +273,11 @@ namespace StackExchange.Redis
             }
         }
 
-        partial void DebugEmulateStaleConnection(ref int lastRead)
+        partial void DebugEmulateStaleConnection(ref int firstUnansweredWrite)
         {
             if (emulateStaleConnection)
             {
-                lastRead -= 100500;
+                firstUnansweredWrite = Environment.TickCount - 100000;
             }
         }
     }

--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -260,6 +260,26 @@ namespace StackExchange.Redis
         {
             get { return multiplexer.IgnoreConnect; }
         }
+
+        private volatile static bool emulateStaleConnection;
+        public static bool EmulateStaleConnection 
+        { get
+            {
+                return emulateStaleConnection;
+            }
+            set
+            {
+                emulateStaleConnection = value;
+            }
+        }
+
+        partial void DebugEmulateStaleConnection(ref int lastRead)
+        {
+            if (emulateStaleConnection)
+            {
+                lastRead -= 100500;
+            }
+        }
     }
 #endif
 

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
@@ -679,23 +679,6 @@ namespace StackExchange.Redis
             return result;
         }
 
-        private void Flush()
-        {
-            var tmp = physical;
-            if (tmp != null)
-            {
-                try
-                {
-                    Trace(connectionType + " flushed");
-                    tmp.Flush();
-                }
-                catch (Exception ex)
-                {
-                    OnInternalError(ex);
-                }
-            }
-        }
-
         private PhysicalConnection GetConnection()
         {
             if (state == (int)State.Disconnected)

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -164,8 +164,6 @@ namespace StackExchange.Redis
 
             if (isCurrent && Interlocked.CompareExchange(ref failureReported, 1, 0) == 0)
             {
-                //try
-                //{
                 int now = Environment.TickCount, lastRead = Thread.VolatileRead(ref lastReadTickCount), lastWrite = Thread.VolatileRead(ref lastWriteTickCount),
                     lastBeat = Thread.VolatileRead(ref lastBeatTickCount);
 
@@ -181,13 +179,6 @@ namespace StackExchange.Redis
                     : new RedisConnectionException(failureType, message, innerException);
 
                 bridge.OnConnectionFailed(this, failureType, ex);
-                //    throw ex;
-                //}
-                //catch (Exception caught)
-                //{
-                //    bridge.OnConnectionFailed(this, failureType, caught);
-                //}
-
             }
 
             // cleanup

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
@@ -39,6 +39,9 @@ namespace StackExchange.Redis
         /// Indicates that we cannot know whether data is available, and that the consume should commence reading asynchronously
         /// </summary>
         void StartReading();
+
+        // check for write-read timeout
+        void CheckForStaleConnection();
     }
 
     internal struct SocketToken


### PR DESCRIPTION
Fixed #124 - added check to detect azure-specific disconnection type. 
I used a SyncTimeout as a read-write threshold. Maybe this check needs a separate timeout settings?