### PR TITLE
StackExchange.Redis to consider separately Response Array as either NULL  or an Empty Array

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -877,9 +877,16 @@ namespace StackExchange.Redis
                 long i64;
                 if (!itemCount.TryGetInt64(out i64)) throw ExceptionFactory.ConnectionFailure(multiplexer.IncludeDetailInExceptions, ConnectionFailureType.ProtocolFailure, "Invalid array length", bridge.ServerEndPoint);
                 int itemCountActual = checked((int)i64);
-
-                if (itemCountActual <= 0) return RawResult.EmptyArray;
-
+                if (itemCountActual < 0)
+                {
+                    //for null response by command like EXEC, RESP array: *-1\r\n
+                    return new RawResult(ResultType.SimpleString, null, 0, 0); 
+                }
+                else if (itemCountActual == 0)
+                {
+                    //for zero array response by command like SCAN, Resp array: *0\r\n 
+                    return RawResult.EmptyArray; 
+                }
                 var arr = new RawResult[itemCountActual];
                 for (int i = 0; i < itemCountActual; i++)
                 {


### PR DESCRIPTION
When multiple clients are trying to modify the same key in a transaction, Redis server returns null response *-1\r\n causing it to throw an “Unexpected response to EXEC: MultiBulk: 0” exception during transaction.ExecuteAsync()."
The fix is to consider *-1\r\n as a null array instead of empty array.