### PR TITLE
add TryParse() methods to Redis.Value for common conversion; exposing publicly functions already available internally

### DIFF
--- a/StackExchange.Redis.Tests/KeysAndValues.cs
+++ b/StackExchange.Redis.Tests/KeysAndValues.cs
@@ -161,5 +161,52 @@ namespace StackExchange.Redis.Tests
             Assert.AreEqual((byte)'b', blob[1]);
             Assert.AreEqual((byte)'c', blob[2]);
         }
+
+        [Test]
+        public void TryParse()
+        {
+            {
+                RedisValue val = "1";
+                int i;
+                Assert.IsTrue(val.TryParse(out i));
+                Assert.AreEqual(1, i);
+                long l;
+                Assert.IsTrue(val.TryParse(out l));
+                Assert.AreEqual(1L, l);
+                double d;
+                Assert.IsTrue(val.TryParse(out d));
+                Assert.AreEqual(1.0, l);
+            }
+
+            {
+                RedisValue val = "8675309";
+                int i;
+                Assert.IsTrue(val.TryParse(out i));
+                Assert.AreEqual(8675309, i);
+                long l;
+                Assert.IsTrue(val.TryParse(out l));
+                Assert.AreEqual(8675309L, l);
+                double d;
+                Assert.IsTrue(val.TryParse(out d));
+                Assert.AreEqual(8675309.0, l);
+            }
+
+            {
+                RedisValue val = "3.14159";
+                double d;
+                Assert.IsTrue(val.TryParse(out d));
+                Assert.AreEqual(3.14159, d);
+            }
+
+            {
+                RedisValue val = "not a real number";
+                int i;
+                Assert.IsFalse(val.TryParse(out i));
+                long l;
+                Assert.IsFalse(val.TryParse(out l));
+                double d;
+                Assert.IsFalse(val.TryParse(out d));
+            }
+        }
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
@@ -638,5 +638,70 @@ namespace StackExchange.Redis
         {
             return (ulong)this;
         }
+
+        /// <summary>
+        /// Convert to a long if possible, returning true.
+        /// 
+        /// Returns false otherwise.
+        /// </summary>
+        public bool TryParse(out long val)
+        {
+            var blob = valueBlob;
+            if (blob == IntegerSentinel)
+            {
+                val = valueInt64;
+                return true;
+            }
+
+            if (blob == null)
+            {
+                // in redis-land 0 approx. equal null; so roll with it
+                val = 0;
+                return true;
+            }
+
+            return TryParseInt64(blob, 0, blob.Length, out val);
+        }
+
+        /// <summary>
+        /// Convert to a int if possible, returning true.
+        /// 
+        /// Returns false otherwise.
+        /// </summary>
+        public bool TryParse(out int val)
+        {
+            long l;
+            if (!TryParse(out l) || l > int.MaxValue || l < int.MinValue)
+            {
+                val = 0;
+                return false;
+            }
+
+            val = (int)l;
+            return true;
+        }
+
+        /// <summary>
+        /// Convert to a double if possible, returning true.
+        /// 
+        /// Returns false otherwise.
+        /// </summary>
+        public bool TryParse(out double val)
+        {
+            var blob = valueBlob;
+            if (blob == IntegerSentinel)
+            {
+                val = valueInt64;
+                return true;
+            }
+            if (blob == null)
+            {
+                // in redis-land 0 approx. equal null; so roll with it
+                val = 0;
+                return true;
+            }
+
+            return TryParseDouble(blob, out val);
+        }
     }
 }


### PR DESCRIPTION
We've got a bit of an pattern in some code (let's just say it involves an all seeing eye) where hashes are key'd by number *except* for one key that has a proper string-y name.

Right now we either have to treat everything as a `string` (implying extra allocations), pass `RedisValue` around everywhere (making comparisons less efficient than they could be, but avoiding allocations), try/catch conversions (inefficient to say the least), or check the first `byte[]` to see if the the value looks like a number and proceed accordingly.  The last one works, but is kind of ugly.

This PR exposes the already existing [`TryParseInt64`](https://github.com/StackExchange/StackExchange.Redis/blob/d994b7ad57a76586487cd2d460d55cb850498448/StackExchange.Redis/StackExchange/Redis/RedisValue.cs#L216) and [`TryParseDouble`](https://github.com/StackExchange/StackExchange.Redis/blob/d994b7ad57a76586487cd2d460d55cb850498448/StackExchange.Redis/StackExchange/Redis/RedisValue.cs#L456) methods wrapped up in a slightly nicer interface.