### PR TITLE
expose Prepend and Append methods on RedisKey, so we can avoid some string concats in common cases

### DIFF
--- a/StackExchange.Redis.Tests/Keys.cs
+++ b/StackExchange.Redis.Tests/Keys.cs
@@ -66,5 +66,40 @@ namespace StackExchange.Redis.Tests
 
             }
         }
+
+        [Test]
+        public void PrependAppend()
+        {
+            {
+                // simple
+                RedisKey key = "world";
+                var ret = key.Prepend("hello");
+                Assert.AreEqual("helloworld", (string)ret);
+            }
+
+            {
+                RedisKey key1 = "world";
+                RedisKey key2 = Encoding.UTF8.GetBytes("hello");
+                var key3 = key1.Prepend(key2);
+                Assert.IsTrue(object.ReferenceEquals(key1.KeyValue, key3.KeyValue));
+                Assert.IsTrue(object.ReferenceEquals(key2.KeyValue, key3.KeyPrefix));
+                Assert.AreEqual("helloworld", (string)key3);
+            }
+
+            {
+                RedisKey key = "hello";
+                var ret = key.Append("world");
+                Assert.AreEqual("helloworld", (string)ret);
+            }
+
+            {
+                RedisKey key1 = Encoding.UTF8.GetBytes("hello");
+                RedisKey key2 = "world";
+                var key3 = key1.Append(key2);
+                Assert.IsTrue(object.ReferenceEquals(key2.KeyValue, key3.KeyValue));
+                Assert.IsTrue(object.ReferenceEquals(key1.KeyValue, key3.KeyPrefix));
+                Assert.AreEqual("helloworld", (string)key3);
+            }
+        }
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/RedisKey.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisKey.cs
@@ -295,5 +295,27 @@ namespace StackExchange.Redis
             if (cLen != 0) Buffer.BlockCopy(c, 0, result, aLen + bLen, cLen);
             return result;
         }
+
+        /// <summary>
+        /// Prepends p to this RedisKey, returning a new RedisKey.
+        /// 
+        /// Avoids some allocations if possible, repeated Prepend/Appends make
+        /// it less possible.
+        /// </summary>
+        public RedisKey Prepend(RedisKey p)
+        {
+            return WithPrefix(p, this);
+        }
+
+        /// <summary>
+        /// Appends p to this RedisKey, returning a new RedisKey.
+        /// 
+        /// Avoids some allocations if possible, repeated Prepend/Appends make
+        /// it less possible.
+        /// </summary>
+        public RedisKey Append(RedisKey p)
+        {
+            return WithPrefix(this, p);
+        }
     }
 }


### PR DESCRIPTION
We've got some code that routinely concats an arbitrary string to a fixed prefix.  It'd be nice to not have to allocate a whole new `string` (or `byte[]`, or whatever) when we're just gonna turn this into a `RedisKey` and be done with it.

This commit exposes the already existing [`WithPrefix`](https://github.com/StackExchange/StackExchange.Redis/blob/d994b7ad57a76586487cd2d460d55cb850498448/StackExchange.Redis/StackExchange/Redis/RedisKey.cs#L253) method on `RedisKey` in separate `Prepend` and `Append` wrapper methods.