### PR TITLE
Prevent EVAL to SCRIPT conversion if it is not supported 

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -2220,7 +2220,7 @@ namespace StackExchange.Redis
 
             public IEnumerable<Message> GetMessages(PhysicalConnection connection)
             {
-                if (script != null) // a script was provided (rather than a hash); check it is known
+               if (script != null && connection.Multiplexer.CommandMap.IsAvailable(RedisCommand.SCRIPT)) // a script was provided (rather than a hash); check it is known and supported
                 {
                     asciiHash = connection.Bridge.ServerEndPoint.GetScriptHash(script, command);
 


### PR DESCRIPTION
StackExchange.Redis "optimizes" all Lua scripts by preloading them and executing by hash. This fix allows to execute Lua scripts as is through the EVAL when SCRIPT command is not supported. Without this fix you can't run any Lua script with twemproxy. 