### PR TITLE
fix keyExpiry's DateTime convert to Utc

### DIFF
--- a/StackExchange.Redis.Tests/Expiry.cs
+++ b/StackExchange.Redis.Tests/Expiry.cs
@@ -61,7 +61,7 @@ namespace StackExchange.Redis.Tests
                 var conn = muxer.GetDatabase();
                 conn.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var now = utc ? DateTime.UtcNow : DateTime.Now;
+                var now = utc ? DateTime.UtcNow : new DateTime(DateTime.UtcNow.Ticks + TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time").BaseUtcOffset.Ticks, DateTimeKind.Local);
                 conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
                 var a = conn.KeyTimeToLiveAsync(key);
                 conn.KeyExpire(key, now.AddHours(1), CommandFlags.FireAndForget);

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -1602,7 +1602,7 @@ namespace StackExchange.Redis
                 default:
                     throw new ArgumentException("Expiry time must be either Utc or Local", "expiry");
             }
-            long milliseconds = (when - RedisBase.UnixEpoch).Ticks / TimeSpan.TicksPerMillisecond;
+            long milliseconds = (when.ToUniversalTime() - RedisBase.UnixEpoch).Ticks / TimeSpan.TicksPerMillisecond;
 
             if ((milliseconds % 1000) != 0)
             {


### PR DESCRIPTION
Fixed Issue #157 KeyExpire's DateTime expiry is affected by LocalTime and test case failed
This pullRequest changed KeyExpiry's DateTime to `when.ToUniversalTime()` and if UnitTest in utc = false create Tokyo(UTC+9:00) local time.