### PR TITLE
Added a way to specify the default database in the connection string

### DIFF
--- a/StackExchange.Redis.Tests/Issues/DefaultDatabase.cs
+++ b/StackExchange.Redis.Tests/Issues/DefaultDatabase.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StackExchange.Redis;
+
+namespace StackExchange.Redis.Tests.Issues
+{
+	[TestFixture]
+	public class DefaultDatabase : TestBase
+	{
+		[Test]
+		public void UnspecifiedDbId_ReturnsNull()
+		{
+			var config = ConfigurationOptions.Parse("localhost");
+			Assert.IsNull(config.DefaultDatabase);
+		}
+
+		[Test]
+		public void SpecifiedDbId_ReturnsExpected()
+		{
+			var config = ConfigurationOptions.Parse("localhost,defaultDatabase=3");
+			Assert.AreEqual(3, config.DefaultDatabase);
+		}
+
+        [Test]
+        public void ConfigurationOptions_UnspecifiedDefaultDb()
+        {
+            var log = new StringWriter();
+            try
+            {
+                using (var conn = ConnectionMultiplexer.Connect(string.Format("{0}:{1}", PrimaryServer, PrimaryPort), log)) {
+                    var db = conn.GetDatabase();
+                    Assert.AreEqual(0, db.Database);
+                }
+            }
+            finally
+            {
+                Console.WriteLine(log);
+            }
+        }
+
+        [Test]
+        public void ConfigurationOptions_SpecifiedDefaultDb()
+        {
+            var log = new StringWriter();
+            try
+            {
+                using (var conn = ConnectionMultiplexer.Connect(string.Format("{0}:{1},defaultDatabase=3", PrimaryServer, PrimaryPort), log)) {
+                    var db = conn.GetDatabase();
+                    Assert.AreEqual(3, db.Database);
+                }
+            }
+            finally
+            {
+                Console.WriteLine(log);
+            }
+        }
+	}
+}

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ConnectingFailDetection.cs" />
     <Compile Include="ConnectToUnexistingHost.cs" />
     <Compile Include="HyperLogLog.cs" />
+    <Compile Include="Issues\DefaultDatabase.cs" />
     <Compile Include="Issues\Issue182.cs" />
     <Compile Include="WrapperBaseTests.cs" />
     <Compile Include="TransactionWrapperTests.cs" />

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -73,7 +73,7 @@ namespace StackExchange.Redis
                         TieBreaker = "tiebreaker", WriteBuffer = "writeBuffer", Ssl = "ssl", SslHost = "sslHost",
                         ConfigChannel = "configChannel", AbortOnConnectFail = "abortConnect", ResolveDns = "resolveDns",
                         ChannelPrefix = "channelPrefix", Proxy = "proxy", ConnectRetry = "connectRetry",
-                        ConfigCheckSeconds = "configCheckSeconds", ResponseTimeout = "responseTimeout";
+                        ConfigCheckSeconds = "configCheckSeconds", ResponseTimeout = "responseTimeout", DefaultDatabase = "defaultDatabase";
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
                 AllowAdmin, SyncTimeout,
@@ -82,7 +82,7 @@ namespace StackExchange.Redis
                 TieBreaker, WriteBuffer, Ssl, SslHost,
                 ConfigChannel, AbortOnConnectFail, ResolveDns,
                 ChannelPrefix, Proxy, ConnectRetry,
-                ConfigCheckSeconds
+                ConfigCheckSeconds, DefaultDatabase,
             }.ToDictionary(x => x, StringComparer.InvariantCultureIgnoreCase);
 
             public static string TryNormalize(string value)
@@ -107,7 +107,7 @@ namespace StackExchange.Redis
 
         private Version defaultVersion;
 
-        private int? keepAlive, syncTimeout, connectTimeout, responseTimeout, writeBuffer, connectRetry, configCheckSeconds;
+        private int? keepAlive, syncTimeout, connectTimeout, responseTimeout, writeBuffer, connectRetry, configCheckSeconds, defaultDatabase;
 
         private Proxy? proxy;
 
@@ -264,6 +264,11 @@ namespace StackExchange.Redis
         /// </summary>
         public int WriteBuffer { get { return writeBuffer.GetValueOrDefault(4096); } set { writeBuffer = value; } }
 
+        /// <summary>
+        /// Specifies the default database to be used when calling ConnectionMultiplexer.GetDatabase() without any parameters
+        /// </summary>
+        public int? DefaultDatabase { get { return defaultDatabase; } set { defaultDatabase = value; } }
+
         internal LocalCertificateSelectionCallback CertificateSelectionCallback { get { return CertificateSelection; } private set { CertificateSelection = value; } }
 
         // these just rip out the underlying handlers, bypassing the event accessors - needed when creating the SSL stream
@@ -327,7 +332,8 @@ namespace StackExchange.Redis
                 SocketManager = SocketManager,
                 connectRetry = connectRetry,
                 configCheckSeconds = configCheckSeconds,
-                responseTimeout = responseTimeout
+                responseTimeout = responseTimeout,
+				defaultDatabase = defaultDatabase,
             };
             foreach (var item in endpoints)
                 options.endpoints.Add(item);
@@ -373,6 +379,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.Proxy, proxy);
             Append(sb, OptionKeys.ConfigCheckSeconds, configCheckSeconds);
             Append(sb, OptionKeys.ResponseTimeout, responseTimeout);
+            Append(sb, OptionKeys.DefaultDatabase, defaultDatabase);
             if (commandMap != null) commandMap.AppendDeltas(sb);
             return sb.ToString();
         }
@@ -462,7 +469,7 @@ namespace StackExchange.Redis
         void Clear()
         {
             clientName = serviceName = password = tieBreaker = sslHost = configChannel = null;
-            keepAlive = syncTimeout = connectTimeout = writeBuffer = connectRetry = configCheckSeconds = null;
+            keepAlive = syncTimeout = connectTimeout = writeBuffer = connectRetry = configCheckSeconds = defaultDatabase = null;
             allowAdmin = abortOnConnectFail = resolveDns = ssl = null;
             defaultVersion = null;
             endpoints.Clear();
@@ -567,6 +574,9 @@ namespace StackExchange.Redis
                             break;
                         case OptionKeys.ResponseTimeout:
                             ResponseTimeout = OptionKeys.ParseInt32(key, value, minValue: 1);
+                            break;
+                        case OptionKeys.DefaultDatabase:
+                            defaultDatabase = OptionKeys.ParseInt32(key, value);
                             break;
                         default:
                             if (!string.IsNullOrEmpty(key) && key[0] == '$')

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -897,11 +897,12 @@ namespace StackExchange.Redis
         /// <summary>
         /// Obtain an interactive connection to a database inside redis
         /// </summary>
-        public IDatabase GetDatabase(int db = 0, object asyncState = null)
+        public IDatabase GetDatabase(int? db = null, object asyncState = null)
         {
-            if (db < 0) throw new ArgumentOutOfRangeException("db");
-            if (db != 0 && RawConfig.Proxy == Proxy.Twemproxy) throw new NotSupportedException("Twemproxy only supports database 0");
-            return new RedisDatabase(this, db, asyncState);
+            int dbId = db ?? configuration.DefaultDatabase ?? 0;
+            if (dbId < 0) throw new ArgumentOutOfRangeException("db");
+            if (dbId != 0 && RawConfig.Proxy == Proxy.Twemproxy) throw new NotSupportedException("Twemproxy only supports database 0");
+            return new RedisDatabase(this, dbId, asyncState);
         }
 
 

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -897,12 +897,14 @@ namespace StackExchange.Redis
         /// <summary>
         /// Obtain an interactive connection to a database inside redis
         /// </summary>
-        public IDatabase GetDatabase(int? db = null, object asyncState = null)
+        public IDatabase GetDatabase(int db = -1, object asyncState = null)
         {
-            int dbId = db ?? configuration.DefaultDatabase ?? 0;
-            if (dbId < 0) throw new ArgumentOutOfRangeException("db");
-            if (dbId != 0 && RawConfig.Proxy == Proxy.Twemproxy) throw new NotSupportedException("Twemproxy only supports database 0");
-            return new RedisDatabase(this, dbId, asyncState);
+            if (db == -1)
+                db = configuration.DefaultDatabase ?? 0;
+
+            if (db < 0) throw new ArgumentOutOfRangeException("db");
+            if (db != 0 && RawConfig.Proxy == Proxy.Twemproxy) throw new NotSupportedException("Twemproxy only supports database 0");
+            return new RedisDatabase(this, db, asyncState);
         }
 
 


### PR DESCRIPTION
I believe there is value in being able to specify the default database ID within the connection string. It falls back to zero if left unspecified.