### PR TITLE
Default SslHost in clustering mode

### DIFF
--- a/StackExchange.Redis.Tests/SSL.cs
+++ b/StackExchange.Redis.Tests/SSL.cs
@@ -271,5 +271,24 @@ namespace StackExchange.Redis.Tests
 
         }
 
+        [Test]
+        public void SSLHostInferredFromEndpoints() {
+            var options = new ConfigurationOptions() {
+                EndPoints = { 
+                              { "mycache.rediscache.windows.net", 15000},
+                              { "mycache.rediscache.windows.net", 15001 },
+                              { "mycache.rediscache.windows.net", 15002 },
+                            }
+                };
+            options.Ssl = true;
+            Assert.True(options.SslHost == "mycache.rediscache.windows.net");
+            options = new ConfigurationOptions() {
+                EndPoints = { 
+                              { "121.23.23.45", 15000},
+                            }
+            };
+            Assert.True(options.SslHost == null);
+        }
+
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -243,7 +243,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The target-host to use when validating SSL certificate; setting a value here enables SSL mode
         /// </summary>
-        public string SslHost { get { return sslHost; } set { sslHost = value; } }
+        public string SslHost { get { return sslHost ?? InferSslHostFromEndpoints(); } set { sslHost = value; } }
 
         /// <summary>
         /// Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 1 second)
@@ -607,6 +607,16 @@ namespace StackExchange.Redis
             {
                 this.CommandMap = CommandMap.Create(map);
             }
+        }
+
+        private string InferSslHostFromEndpoints() {
+            var dnsEndpoints = endpoints.Select(endpoint => endpoint as DnsEndPoint);
+            string dnsHost = dnsEndpoints.First() != null ? dnsEndpoints.First().Host : null;
+            if (dnsEndpoints.All(dnsEndpoint => (dnsEndpoint != null && dnsEndpoint.Host == dnsHost))) {
+                return dnsHost;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
In clustering mode currently, ClusterConfiguration for every server endpoint is built using the output of "CLUSTER NODES" command which consists of IP addresses of the nodes inside the cluster (SetClusterConfiguration and UpdateClusterRange methods)

However, when we try to authenticate the client to the ssl endpoint, inside SocketMode ISocketCallback.Connected, using the ssl.AuthenticateAsClient method it throws an exception
"The remote certificate is invalid according to the validation procedure” since we are trying to authenticate using the IP address as opposed to the Dns Host name.
An existing workaround this problem is to configure "SslHost" explictly inside the connection string or specify it inside ConfigurationOptions.
However if the users of the client do not configure this explicitly, it is a reasonable fallback behavior to infer this information from the specified server endpoints. The fallback behavior will be as follows:
If all the endpoints inside the configuration are dns endpoints and have identical hostnames, the SslHost is the dns host name for one for one of these endpoints.