### PR TITLE
#248 Exchanging operands in the ternary operators of server selection in TryResend in ServerSelectionStrategy

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ServerSelectionStrategy.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerSelectionStrategy.cs
@@ -133,13 +133,13 @@ namespace StackExchange.Redis
                         switch (Message.GetMasterSlaveFlags(message.Flags))
                         {
                             case CommandFlags.DemandMaster:
-                                resendVia = server.IsSelectable(command) ? null : server;
+                                resendVia = server.IsSelectable(command) ? server : null;
                                 break;
                             case CommandFlags.PreferMaster:
-                                resendVia = server.IsSelectable(command) ? FindSlave(server, command) : server;
+                                resendVia = server.IsSelectable(command) ? server : FindSlave(server, command);
                                 break;
                             case CommandFlags.PreferSlave:
-                                resendVia = FindSlave(server, command) ?? (server.IsSelectable(command) ? null : server);
+                                resendVia = FindSlave(server, command) ?? (server.IsSelectable(command) ? server : null);
                                 break;
                             case CommandFlags.DemandSlave:
                                 resendVia = FindSlave(server, command);


### PR DESCRIPTION
The client was selecting in a wrong way the server endpoint to resend the command, therefore it was failing and propagating the MOVED exception. 
I have noticed that although it was rearranging well the map of servers and hashSlots, if the flag was CommandFlags.DemandMaster and server.IsSelectable(command) returned true then it was selecting null instead selecting the server endpoint itself which was fulfilling the condition needed. Something similar was happening with the other flags.
By exchanging those operands the client is able to select correctly the server to which it will resend the command issued and there is no more MOVED exceptions.