### PR TITLE
Change property type IRedisAsync.Multiplexer to IConnectionMultiplexer

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/IRedisAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IRedisAsync.cs
@@ -11,7 +11,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets the multiplexer that created this instance
         /// </summary>
-        ConnectionMultiplexer Multiplexer { get; }
+        IConnectionMultiplexer Multiplexer { get; }
 
         /// <summary>
         /// This command is often used to test if a connection is still alive, or to measure latency.

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
             _keyPrefix = keyPrefix;
         }
 
-        public ConnectionMultiplexer Multiplexer
+        public IConnectionMultiplexer Multiplexer
         {
             get { return this.Inner.Multiplexer; }
         }

--- a/StackExchange.Redis/StackExchange/Redis/RedisBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisBase.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Redis
             this.asyncState = asyncState;
         }
 
-        ConnectionMultiplexer IRedisAsync.Multiplexer { get { return multiplexer; } }
+        IConnectionMultiplexer IRedisAsync.Multiplexer { get { return multiplexer; } }
         public virtual TimeSpan Ping(CommandFlags flags = CommandFlags.None)
         {
             var msg = GetTimerMessage(flags);


### PR DESCRIPTION
A few weeks ago IConnectionMultiplexer was added to facilitate unit testing.
The return type of IRedisAsync.Multiplexer is not this interface but ConnectionMultiplexer.

For example it's impossible to test the connection status (mydb.Multiplexer.IsConnected) from the IDatabase/IDatabaseAsync point of view.