### PR TITLE
Ensure Message.resultBox is nulled after successful async TryComplete

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/Message.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Message.cs
@@ -501,6 +501,12 @@ namespace StackExchange.Redis
             if (resultBox != null)
             {
                 var ret = resultBox.TryComplete(isAsync);
+
+                if (ret && isAsync)
+                {
+                    resultBox = null; // in async mode TryComplete will have unwrapped and recycled resultBox; ensure we no longer reference it via this message
+                }
+
                 if (performance != null)
                 {
                     performance.SetCompleted();


### PR DESCRIPTION
Attempting to address #237, #275, #205.  I believe @bencican called out the root cause in #237, which is the multiple completions of same the PING message in `PhysicalBridge.OnDisconnected`.  The `PhysicalBridge` code is a bit too unfamiliar to me and it felt safer/more future proof to guard against this within `Message.TryComplete`.  

#275 has a sample unit test that I was using to check this fix, results looked good.  Not sure if we should lock the `resultBox` in case of concurrent calls to `Message.TryComplete`.