### PR TITLE
Handle "inf" as well as "+inf"

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/Format.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Format.cs
@@ -144,7 +144,7 @@ namespace StackExchange.Redis
                 return true;
             }
             // need to handle these
-            if(string.Equals("+inf", s, StringComparison.OrdinalIgnoreCase))
+            if(string.Equals("+inf", s, StringComparison.OrdinalIgnoreCase) || string.Equals("inf", s, StringComparison.OrdinalIgnoreCase))
             {
                 value = double.PositiveInfinity;
                 return true;


### PR DESCRIPTION
Redis (v2.8 and v3) returns "inf" for positive infinity values, but here a "+inf" is expected. So changed the code to work with both: "+inf" as well as "inf".
See Issue #287: https://github.com/StackExchange/StackExchange.Redis/issues/287