### PR TITLE
Set AbortConnectOnFailure to false for Azure

### DIFF
--- a/MigratedBookSleeveTestSuite/Config.cs
+++ b/MigratedBookSleeveTestSuite/Config.cs
@@ -176,6 +176,49 @@ namespace Tests
             }
         }
 
+        [Test]
+        public void AbortConnectFalseForAzure()
+        {
+            var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net");
+            Assert.IsFalse(options.AbortOnConnectFail);
+        }
+
+        [Test]
+        public void AbortConnectTrueForAzureWhenSpecified()
+        {
+            var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net,abortConnect=true");
+            Assert.IsTrue(options.AbortOnConnectFail);
+        }
+
+        [Test]
+        public void AbortConnectFalseForAzureChina()
+        {
+            // added a few upper case chars to validate comparison
+            var options = ConfigurationOptions.Parse("contoso.REDIS.CACHE.chinacloudapi.cn");
+            Assert.IsFalse(options.AbortOnConnectFail);
+        }
+
+        [Test]
+        public void AbortConnectFalseForAzureUSGov()
+        {
+            var options = ConfigurationOptions.Parse("contoso.redis.cache.usgovcloudapi.net");
+            Assert.IsFalse(options.AbortOnConnectFail);
+        }
+
+        [Test]
+        public void AbortConnectTrueForNonAzure()
+        {
+            var options = ConfigurationOptions.Parse("redis.contoso.com");
+            Assert.IsTrue(options.AbortOnConnectFail);
+        }
+
+        [Test]
+        public void AbortConnectDefaultWhenNoEndpointsSpecifiedYet()
+        {
+            var options = new ConfigurationOptions();
+            Assert.IsTrue(options.AbortOnConnectFail);
+        }
+
         internal static void AssertNearlyEqual(double x, double y)
         {
             if (Math.Abs(x - y) > 0.00001) Assert.AreEqual(x, y);

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -129,7 +129,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException
         /// </summary>
-        public bool AbortOnConnectFail { get { return abortOnConnectFail ?? true; } set { abortOnConnectFail = value; } }
+        public bool AbortOnConnectFail { get { return abortOnConnectFail ?? GetDefaultAbortOnConnectFailSetting(); } set { abortOnConnectFail = value; } }
 
         /// <summary>
         /// Indicates whether admin operations should be allowed
@@ -607,6 +607,38 @@ namespace StackExchange.Redis
             {
                 this.CommandMap = CommandMap.Create(map);
             }
+        }
+
+        private bool GetDefaultAbortOnConnectFailSetting()
+        {
+            // Microsoft Azure team wants abortConnect=false by default
+            if (IsAzureEndpoint())
+                return false;
+
+            return true;
+        }
+
+        private bool IsAzureEndpoint()
+        {
+            var result = false; 
+            var dnsEndpoints = endpoints.Select(endpoint => endpoint as DnsEndPoint).Where(ep => ep != null);
+            foreach(var ep in dnsEndpoints)
+            {
+                int firstDot = ep.Host.IndexOf('.');
+                if (firstDot >= 0)
+                {
+                    var domain = ep.Host.Substring(firstDot).ToLowerInvariant();
+                    switch(domain)
+                    {
+                        case ".redis.cache.windows.net":
+                        case ".redis.cache.chinacloudapi.cn":
+                        case ".redis.cache.usgovcloudapi.net":
+                            return true;
+                    }
+                }
+            }
+
+            return result; 
         }
 
         private string InferSslHostFromEndpoints() {


### PR DESCRIPTION
The Microsoft Azure team is requesting that AbortConnectOnFailure be false by default at least for Azure endpoints.