### PR TITLE
GetTypeCode() extension method bug fix

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisValue.cs
@@ -753,7 +753,7 @@ namespace StackExchange.Redis
 #else
         internal static TypeCode GetTypeCode(this Type type)
         {
-            return type.GetTypeCode();
+            return Type.GetTypeCode(type);
         }
 #endif
     }


### PR DESCRIPTION
This fixes the non-CoreClr version of the GetTypeCode() extension method.