### PR TITLE
proposing to change back SE.REdis synctimeout to be 1 second 

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -262,7 +262,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 1 second)
         /// </summary>
-        public int SyncTimeout { get { return syncTimeout.GetValueOrDefault(20000); } set { syncTimeout = value; } }
+        public int SyncTimeout { get { return syncTimeout.GetValueOrDefault(1000); } set { syncTimeout = value; } }
 
         /// <summary>
         /// Specifies the time in milliseconds that the system should allow for responses before concluding that the socket is unhealthy

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -14,7 +14,6 @@ using System.Collections.Concurrent;
 using Microsoft.Runtime.CompilerServices;
 #else
 using System.Runtime.CompilerServices;
-using System.Runtime;
 #endif
 
 namespace StackExchange.Redis
@@ -1975,7 +1974,6 @@ namespace StackExchange.Redis
                             add("Active-Readers", "ar", ar.ToString());
 
                             add("Client-Name", "clientName", ClientName);
-                            add("Server-GC", "serverGC", GCSettings.IsServerGC.ToString());
 #if !CORE_CLR
                             string iocp, worker;
                             int busyWorkerCount = GetThreadPoolStats(out iocp, out worker);

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -14,6 +14,7 @@ using System.Collections.Concurrent;
 using Microsoft.Runtime.CompilerServices;
 #else
 using System.Runtime.CompilerServices;
+using System.Runtime;
 #endif
 
 namespace StackExchange.Redis
@@ -1974,6 +1975,7 @@ namespace StackExchange.Redis
                             add("Active-Readers", "ar", ar.ToString());
 
                             add("Client-Name", "clientName", ClientName);
+                            add("Server-GC", "serverGC", GCSettings.IsServerGC.ToString());
 #if !CORE_CLR
                             string iocp, worker;
                             int busyWorkerCount = GetThreadPoolStats(out iocp, out worker);

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -10,11 +10,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
+using System.Runtime;
 #if NET40
 using Microsoft.Runtime.CompilerServices;
 #else
 using System.Runtime.CompilerServices;
-using System.Runtime;
 #endif
 
 namespace StackExchange.Redis

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -10,11 +10,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
-using System.Runtime;
 #if NET40
 using Microsoft.Runtime.CompilerServices;
 #else
 using System.Runtime.CompilerServices;
+using System.Runtime;
 #endif
 
 namespace StackExchange.Redis


### PR DESCRIPTION
ResponseTimeout is set as default to synctimeout. A higher responseTime would have adverse side effect on quickly reconnecting a mux in case of a network blip.

