### PR TITLE
Remove indirection to mitigate a presumed deadlock. Fixes StackExchange/StackExchange.Redis#42.

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -813,8 +813,7 @@ namespace StackExchange.Redis
                 var muxer = multiplexerFactory();
                 killMe = muxer;
                 // note that task has timeouts internally, so it might take *just over* the regular timeout
-                // wrap into task to force async execution
-                var task = Factory.StartNew(() => muxer.ReconfigureAsync(true, false, log, null, "connect").Result);
+                var task = muxer.ReconfigureAsync(true, false, log, null, "connect");
 
                 if (!task.Wait(muxer.SyncConnectTimeout(true)))
                 {


### PR DESCRIPTION
So I ran into this issue as well. After reading through some of the comments and taking a look at the code, I noticed an unnecessary indirection in `ConnectionMultiPlexer.ConnectImpl` which appears to be causing a deadlock:

```
// note that task has timeouts internally, so it might take *just over* the regular timeout
// wrap into task to force async execution
var task = Factory.StartNew(() => muxer.ReconfigureAsync(true, false, log, null, "connect").Result);
```

What's happening here is the code is spawning an async task which waits _synchronously_ on an async task result. This is bad juju. What it appears is happening next is the code blocks the context thread waiting for the wrapper task created with `Factory.StartNew` to return:

```
if (!task.Wait(muxer.SyncConnectTimeout(true)))
```

When the continuation from `ReconfigureAsync` returns, it waits for the context thread to become available. Since the context thread is blocked waiting for the continuation, it results in deadlock. Stephen Cleary has an [excellent description](http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html) of the pattern on his blog.

The fix, I believe, is simple: spawn the `ReconfigureAsync` method directly:

```
// note that task has timeouts internally, so it might take *just over* the regular timeout
var task = muxer.ReconfigureAsync(true, false, log, null, "connect");

if (!task.Wait(muxer.SyncConnectTimeout(true)))
```

If I had to guess, I'd say `ReconfigureAsync` was once a synchronous method that was converted to async without updating the `ConnectImpl` implementation to remove the async wrapping. 

The above is conjecture at this point, however in my limited testing it appears to solve the problem.