### PR TITLE
Capture client system CPU percentage in timeout error messages

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -1962,6 +1962,8 @@ namespace StackExchange.Redis
                             add("ThreadPool-IO-Completion", "IOCP", iocp);
                             add("ThreadPool-Workers", "WORKER", worker);
                             data.Add(Tuple.Create("Busy-Workers", busyWorkerCount.ToString()));
+
+                            add("Local-CPU", "Local-CPU", GetSystemCpuPercent());
 #endif
                             errMessage = sb.ToString();
                             if (stormLogThreshold >= 0 && queue >= stormLogThreshold && Interlocked.CompareExchange(ref haveStormLog, 1, 0) == 0)
@@ -1994,6 +1996,16 @@ namespace StackExchange.Redis
         }
 
 #if !CORE_CLR
+        private static string GetSystemCpuPercent()
+        {
+            float systemCPU;
+            if (PerfCounterHelper.TryGetSystemCPU(out systemCPU))
+            {
+                return Math.Round(systemCPU, 2) + "%";
+            }
+            return "unavailable";
+        }
+
         private static int GetThreadPoolStats(out string iocp, out string worker)
         {
             //BusyThreads =  TP.GetMaxThreads() –TP.GetAVailable();

--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -297,6 +298,53 @@ namespace StackExchange.Redis
         Async = 2
     }
 #if !CORE_CLR
+
+    internal static class PerfCounterHelper
+    {
+        static object staticLock = new object();
+        static volatile PerformanceCounter _cpu;
+        static volatile bool _disabled;
+
+        public static bool TryGetSystemCPU(out float value)
+        {
+            value = -1;
+
+            try
+            {   
+                if (!_disabled && _cpu == null)
+                {
+                    lock (staticLock)
+                    {
+                        if (_cpu == null)
+                        {
+                            _cpu = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+
+                            // First call always returns 0, so get that out of the way.
+                            _cpu.NextValue();
+                        }
+                    }
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Some environments don't allow access to Performance Counters, so stop trying.
+                _disabled = true;
+            }
+            catch (Exception)
+            {
+                // this shouldn't happen, but just being safe...
+            }
+
+            if (_cpu != null)
+            {
+                value = _cpu.NextValue();
+                return true;
+            }
+
+            return false;
+        }
+    }
+    
     internal class CompletionTypeHelper
     {
 


### PR DESCRIPTION
Capture client system CPU percentage in timeout error messages when possible to help debug timeouts.