### PR TITLE
SE.Redis to surface error from serverendpoint as an innerexception 

### DIFF
--- a/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
+++ b/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using NUnit.Framework;
+using System.Threading;
+
+namespace StackExchange.Redis.Tests
+{
+    [TestFixture]
+    public class ConnectionFailedErrors : TestBase
+    {
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SSLCertificateValidationError(bool isCertValidationSucceeded)
+        {
+            string name, password;
+            GetAzureCredentials(out name, out password);
+            var options = new ConfigurationOptions();
+            options.EndPoints.Add(name + ".redis.cache.windows.net");
+            options.Ssl = true;
+            options.Password = password;
+            options.CertificateValidation += (sender, cert, chain, errors) => { return isCertValidationSucceeded; };
+            options.AbortOnConnectFail = false;
+
+            using (var connection = ConnectionMultiplexer.Connect(options))
+            {
+                connection.ConnectionFailed += (object sender, ConnectionFailedEventArgs e) =>
+                {
+                    Assert.That(e.FailureType.ToString(), Is.EqualTo(ConnectionFailureType.AuthenticationFailure.ToString()));
+                };
+                if (!isCertValidationSucceeded)
+                {
+                    //validate that in this case it throws an certificatevalidation exception
+                    var ex = Assert.Throws<RedisConnectionException>(() => connection.GetDatabase().Ping());
+                  
+                    ((AggregateException)ex.InnerException).Handle(e =>
+                    {
+                       var rde = (RedisConnectionException)e;
+                       Assert.That(rde.FailureType.ToString(), Is.EqualTo(ConnectionFailureType.AuthenticationFailure.ToString()));
+                       Assert.That(rde.InnerException.Message, Is.EqualTo("The remote certificate is invalid according to the validation procedure."));
+                       return e is RedisConnectionException;
+                    });
+                    
+                }
+                else
+                {
+                    Assert.DoesNotThrow(() => connection.GetDatabase().Ping());
+                }
+
+                //wait for a second for connectionfailed event to fire
+                Thread.Sleep(1000);
+            }
+
+
+        }
+
+        [Test]
+        public void AuthenticationFailureError()
+        {
+            string name, password;
+            GetAzureCredentials(out name, out password);
+            var options = new ConfigurationOptions();
+            options.EndPoints.Add(name + ".redis.cache.windows.net");
+            options.Ssl = true;
+            options.Password = "";
+            options.AbortOnConnectFail = false;
+            using (var muxer = ConnectionMultiplexer.Connect(options))
+            {
+                muxer.ConnectionFailed += (object sender, ConnectionFailedEventArgs e) =>
+                {
+                    Assert.That(e.FailureType.ToString(), Is.EqualTo(ConnectionFailureType.AuthenticationFailure.ToString()));
+                };
+
+                var ex = Assert.Throws<RedisConnectionException>(() => muxer.GetDatabase().Ping());
+
+                ((AggregateException)ex.InnerException).Handle(e =>
+                {
+                    var rde = (RedisConnectionException)e;
+                    Assert.That(rde.FailureType.ToString(), Is.EqualTo(ConnectionFailureType.AuthenticationFailure.ToString()));
+                    return e is RedisConnectionException;
+                });
+                //wait for a second  for connectionfailed event to fire
+                Thread.Sleep(1000);
+            }
+        }
+
+        [Test]
+        public void SocketFailureError()
+        {
+            var options = new ConfigurationOptions();
+            options.EndPoints.Add(".redis.cache.windows.net");
+            options.Ssl = true;
+            options.Password = "";
+            options.AbortOnConnectFail = false;
+            using (var muxer = ConnectionMultiplexer.Connect(options))
+            {
+                var ex = Assert.Throws<RedisConnectionException>(() => muxer.GetDatabase().Ping());
+                 ((AggregateException)ex.InnerException).Handle(e =>
+                {
+                    var rde = (RedisConnectionException)e;
+                    Assert.That(rde.FailureType.ToString(), Is.EqualTo(ConnectionFailureType.SocketFailure.ToString()));
+                    return e is RedisConnectionException;
+                });
+            }
+        }
+
+        [Test]
+        public void CheckFailureRecovered()
+        {
+            try
+            {
+                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
+                {
+                    var conn = muxer.GetDatabase();
+                    var server = muxer.GetServer(muxer.GetEndPoints()[0]);
+
+                    muxer.AllowConnect = false;
+                    SocketManager.ConnectCompletionType = CompletionType.Async;
+
+                    server.SimulateConnectionFailure();
+
+                    Assert.AreEqual(ConnectionFailureType.SocketFailure, ((RedisConnectionException)muxer.GetServerSnapShot()[0].LastException).FailureType);
+
+                    // should reconnect within 1 keepalive interval
+                    muxer.AllowConnect = true;
+                    Thread.Sleep(2000);
+
+                    Assert.Null(muxer.GetServerSnapShot()[0].LastException);
+                }
+            }
+            finally
+            {
+                SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
+            }
+        }
+    }
+}

--- a/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace StackExchange.Redis.Tests
+{
+    [TestFixture]
+    public class ExceptionFactoryTests : TestBase
+    {
+        [Test]
+        public void NullLastException()
+        {
+            using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
+            {
+                var conn = muxer.GetDatabase();
+                Assert.Null(muxer.GetServerSnapshot()[0].LastException);
+                var ex = ExceptionFactory.NoConnectionAvailable(true, new RedisCommand(), null, null, muxer.GetServerSnapshot());
+                Assert.Null(ex.InnerException);
+            }
+
+        }
+
+        [Test]
+        public void NullSnapshot()
+        {
+            var ex = ExceptionFactory.NoConnectionAvailable(true, new RedisCommand(), null, null, null);
+            Assert.Null(ex.InnerException);
+        }
+
+        [Test]
+        public void MultipleEndpointsThrowAggregateException()
+        {
+            try
+            {
+                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
+                {
+                    var conn = muxer.GetDatabase();
+                    muxer.AllowConnect = false;
+                    SocketManager.ConnectCompletionType = CompletionType.Async;
+
+                    foreach (var endpoint in muxer.GetEndPoints())
+                    {
+                        muxer.GetServer(endpoint).SimulateConnectionFailure();
+                    }
+
+                    var ex = ExceptionFactory.NoConnectionAvailable(true, new RedisCommand(), null, null, muxer.GetServerSnapshot());
+                    Assert.IsInstanceOf<RedisConnectionException>(ex);
+                    Assert.IsInstanceOf<AggregateException>(ex.InnerException);
+                    var aggException = (AggregateException)ex.InnerException;
+                    Assert.That(aggException.InnerExceptions.Count, Is.EqualTo(2));
+                    for (int i = 0; i < aggException.InnerExceptions.Count; i++)
+                    {
+                        Assert.That(((RedisConnectionException)aggException.InnerExceptions[i]).FailureType, Is.EqualTo(ConnectionFailureType.SocketFailure));
+                    }
+                }
+            }
+            finally
+            {
+                SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
+            }
+        }
+
+        [Test]
+        public void NullInnerExceptionForMultipleEndpointsWithNoLastException()
+        {
+            try
+            {
+                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
+                {
+                    var conn = muxer.GetDatabase();
+                    muxer.AllowConnect = false;
+                    SocketManager.ConnectCompletionType = CompletionType.Async;
+                    var ex = ExceptionFactory.NoConnectionAvailable(true, new RedisCommand(), null, null, muxer.GetServerSnapshot());
+                    Assert.IsInstanceOf<RedisConnectionException>(ex);
+                    Assert.Null(ex.InnerException);
+                 }
+            }
+            finally
+            {
+                SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
+            }
+        }
+
+        [Test]
+        public void ServerTakesPrecendenceOverSnapshot()
+        {
+             try
+            {
+                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
+                {
+                    var conn = muxer.GetDatabase();
+                    muxer.AllowConnect = false;
+                    SocketManager.ConnectCompletionType = CompletionType.Async;
+
+                    muxer.GetServer(muxer.GetEndPoints()[0]).SimulateConnectionFailure();
+
+                    var ex = ExceptionFactory.NoConnectionAvailable(true, new RedisCommand(), null,muxer.GetServerSnapshot()[0], muxer.GetServerSnapshot());
+                    Assert.IsInstanceOf<RedisConnectionException>(ex);
+                    Assert.IsInstanceOf<Exception>(ex.InnerException);
+                    Assert.That(muxer.GetServerSnapshot()[0].LastException, Is.EqualTo(ex.InnerException));
+                }
+            }
+            finally
+            {
+                SocketManager.ConnectCompletionType = CompletionType.Any;
+                ClearAmbientFailures();
+            }
+
+        }
+
+    }
+}

--- a/StackExchange.Redis.Tests/TestBase.cs
+++ b/StackExchange.Redis.Tests/TestBase.cs
@@ -310,5 +310,15 @@ namespace StackExchange.Redis.Tests
             return watch.Elapsed;
         }
 
+        
+        protected virtual void GetAzureCredentials(out string name, out string password)
+        {
+            var lines = File.ReadAllLines(@"d:\dev\azure.txt");
+            if (lines == null || lines.Length != 2)
+                Assert.Inconclusive("azure credentials missing");
+            name = lines[0];
+            password = lines[1];
+        }
+
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionFailureType.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionFailureType.cs
@@ -18,7 +18,7 @@
         /// </summary>
         SocketFailure,
         /// <summary>
-        /// The connection did not authenticate correctly
+        /// Either SSL Stream or Redis authentication failed
         /// </summary>
         AuthenticationFailure,
         /// <summary>

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -295,7 +295,7 @@ namespace StackExchange.Redis
 
             if (server == null) throw new ArgumentNullException(nameof(server));
             var srv = new RedisServer(this, server, null);
-            if (!srv.IsConnected) throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, RedisCommand.SLAVEOF, null, server, GetServerSnapShot());
+            if (!srv.IsConnected) throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, RedisCommand.SLAVEOF, null, server, GetServerSnapshot());
 
             if (log == null) log = TextWriter.Null;
             CommandMap.AssertAvailable(RedisCommand.SLAVEOF);
@@ -1657,7 +1657,7 @@ namespace StackExchange.Redis
 
         private readonly ServerSelectionStrategy serverSelectionStrategy;
 
-        internal ServerEndPoint[] GetServerSnapShot()
+        internal ServerEndPoint[] GetServerSnapshot()
         {
             var tmp = serverSnapshot;
             return tmp;
@@ -1872,7 +1872,7 @@ namespace StackExchange.Redis
                 var source = ResultBox<T>.Get(tcs);
                 if (!TryPushMessageToBridge(message, processor, source, ref server))
                 {
-                    ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server, GetServerSnapShot()));
+                    ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server, GetServerSnapshot()));
                 }
                 return tcs.Task;
             }
@@ -1913,7 +1913,7 @@ namespace StackExchange.Redis
                 {
                     if (!TryPushMessageToBridge(message, processor, source, ref server))
                     {
-                        throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server, GetServerSnapShot());
+                        throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server, GetServerSnapshot());
                     }
 
                     if (Monitor.Wait(source, timeoutMilliseconds))

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -295,7 +295,7 @@ namespace StackExchange.Redis
 
             if (server == null) throw new ArgumentNullException(nameof(server));
             var srv = new RedisServer(this, server, null);
-            if (!srv.IsConnected) throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, RedisCommand.SLAVEOF, null, server);
+            if (!srv.IsConnected) throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, RedisCommand.SLAVEOF, null, server, GetServerSnapShot());
 
             if (log == null) log = TextWriter.Null;
             CommandMap.AssertAvailable(RedisCommand.SLAVEOF);
@@ -1657,6 +1657,12 @@ namespace StackExchange.Redis
 
         private readonly ServerSelectionStrategy serverSelectionStrategy;
 
+        internal ServerEndPoint[] GetServerSnapShot()
+        {
+            var tmp = serverSnapshot;
+            return tmp;
+        }
+
         internal ServerEndPoint SelectServer(Message message)
         {
             if (message == null) return null;
@@ -1866,7 +1872,7 @@ namespace StackExchange.Redis
                 var source = ResultBox<T>.Get(tcs);
                 if (!TryPushMessageToBridge(message, processor, source, ref server))
                 {
-                    ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server));
+                    ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server, GetServerSnapShot()));
                 }
                 return tcs.Task;
             }
@@ -1907,7 +1913,7 @@ namespace StackExchange.Redis
                 {
                     if (!TryPushMessageToBridge(message, processor, source, ref server))
                     {
-                        throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server);
+                        throw ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, message.Command, message, server, GetServerSnapShot());
                     }
 
                     if (Monitor.Wait(source, timeoutMilliseconds))

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
@@ -70,7 +70,6 @@ namespace StackExchange.Redis
         public ConnectionType ConnectionType { get; }
 
         public bool IsConnected => state == (int)State.ConnectedEstablished;
-        
 
         public ConnectionMultiplexer Multiplexer { get; }
 
@@ -267,7 +266,7 @@ namespace StackExchange.Redis
                 Multiplexer.Trace("Enqueue: " + msg);
                 if (!TryEnqueue(msg, ServerEndPoint.IsSlave))
                 {
-                    OnInternalError(ExceptionFactory.NoConnectionAvailable(Multiplexer.IncludeDetailInExceptions, msg.Command, msg, ServerEndPoint, Multiplexer.GetServerSnapShot()));
+                    OnInternalError(ExceptionFactory.NoConnectionAvailable(Multiplexer.IncludeDetailInExceptions, msg.Command, msg, ServerEndPoint, Multiplexer.GetServerSnapshot()));
                 }
             }
         }

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
@@ -385,6 +385,7 @@ namespace StackExchange.Redis
                         int connectTimeMilliseconds = unchecked(Environment.TickCount - VolatileWrapper.Read(ref connectStartTicks));
                         if (connectTimeMilliseconds >= Multiplexer.RawConfig.ConnectTimeout)
                         {
+                            LastException = ExceptionFactory.UnableToConnect("ConnectTimeout");
                             Trace("Aborting connect");
                             // abort and reconnect
                             var snapshot = physical;

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -781,9 +781,9 @@ namespace StackExchange.Redis
                     {
                         ssl.AuthenticateAsClient(host);
                     }
-                    catch (AuthenticationException)
+                    catch (AuthenticationException authexception)
                     {
-                        RecordConnectionFailed(ConnectionFailureType.AuthenticationFailure);
+                        RecordConnectionFailed(ConnectionFailureType.AuthenticationFailure, authexception);
                         Multiplexer.Trace("Encryption failure");
                         return SocketMode.Abort;
                     }

--- a/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
@@ -30,13 +30,13 @@ namespace StackExchange.Redis
                 if (server == null)
                 {
                     FailNoServer(snapshot);
-                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server);
+                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server,multiplexer.GetServerSnapShot());
                 }
                 var bridge = server.GetBridge(message.Command);
                 if (bridge == null)
                 {
                     FailNoServer(snapshot);
-                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server);
+                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapShot());
                 }
 
                 // identity a list

--- a/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
@@ -30,13 +30,13 @@ namespace StackExchange.Redis
                 if (server == null)
                 {
                     FailNoServer(snapshot);
-                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server,multiplexer.GetServerSnapShot());
+                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server,multiplexer.GetServerSnapshot());
                 }
                 var bridge = server.GetBridge(message.Command);
                 if (bridge == null)
                 {
                     FailNoServer(snapshot);
-                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapShot());
+                    throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapshot());
                 }
 
                 // identity a list

--- a/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
@@ -542,7 +542,7 @@ namespace StackExchange.Redis
 
                 // no need to deny exec-sync here; will be complete before they see if
                 var tcs = TaskSource.Create<T>(asyncState);
-                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server));
+                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapShot()));
                 return tcs.Task;
             }
             return base.ExecuteAsync<T>(message, processor, server);
@@ -555,7 +555,7 @@ namespace StackExchange.Redis
             if (!server.IsConnected)
             {
                 if (message == null || message.IsFireAndForget) return default(T);
-                throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server);
+                throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapShot());
             }
             return base.ExecuteSync<T>(message, processor, server);
         }

--- a/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
@@ -542,7 +542,7 @@ namespace StackExchange.Redis
 
                 // no need to deny exec-sync here; will be complete before they see if
                 var tcs = TaskSource.Create<T>(asyncState);
-                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapShot()));
+                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapshot()));
                 return tcs.Task;
             }
             return base.ExecuteAsync<T>(message, processor, server);
@@ -555,7 +555,7 @@ namespace StackExchange.Redis
             if (!server.IsConnected)
             {
                 if (message == null || message.IsFireAndForget) return default(T);
-                throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapShot());
+                throw ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, server, multiplexer.GetServerSnapshot());
             }
             return base.ExecuteSync<T>(message, processor, server);
         }

--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -1165,7 +1165,7 @@ namespace StackExchange.Redis
                 {
                     if (result.IsEqual(authFail) || result.IsEqual(authRequired))
                     {
-                        connection.RecordConnectionFailed(ConnectionFailureType.AuthenticationFailure);
+                        connection.RecordConnectionFailed(ConnectionFailureType.AuthenticationFailure, new Exception(result.ToString() + " Verify if the Redis password provided is correct."));
                     }
                     else if (result.AssertStarts(loading))
                     {

--- a/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
@@ -119,9 +119,6 @@ namespace StackExchange.Redis
             }
         }
 
-
-
-
         public bool IsSlave { get { return isSlave; } set { SetConfig(ref isSlave, value); } }
 
         public long OperationCount
@@ -555,7 +552,7 @@ namespace StackExchange.Redis
             if (bridge == null) bridge = GetBridge(message.Command);
             if (!bridge.TryEnqueue(message, isSlave))
             {
-                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, this, multiplexer.GetServerSnapShot()));
+                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, this, multiplexer.GetServerSnapshot()));
             }
             return tcs.Task;
         }

--- a/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
@@ -91,6 +91,37 @@ namespace StackExchange.Redis
             }
         }
 
+        internal Exception LastException
+        {
+            get
+            {
+                var tmp1 = interactive;
+                var tmp2 = subscription;
+
+                //check if subscription endpoint has a better lastexception
+                if (tmp2 != null && tmp2.LastException != null)
+                {
+                    if (!tmp2.LastException.Data["Redis-FailureType"].ToString().Equals(ConnectionFailureType.UnableToConnect.ToString()))
+                    {
+                        return tmp2.LastException;
+                    }
+                }
+                return tmp1?.LastException;
+            }
+        }
+
+        internal PhysicalBridge.State ConnectionState
+        {
+            get
+            {
+                var tmp = interactive;
+                return tmp.ConnectionState;
+            }
+        }
+
+
+
+
         public bool IsSlave { get { return isSlave; } set { SetConfig(ref isSlave, value); } }
 
         public long OperationCount
@@ -524,7 +555,7 @@ namespace StackExchange.Redis
             if (bridge == null) bridge = GetBridge(message.Command);
             if (!bridge.TryEnqueue(message, isSlave))
             {
-                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, this));
+                ConnectionMultiplexer.ThrowFailed(tcs, ExceptionFactory.NoConnectionAvailable(multiplexer.IncludeDetailInExceptions, message.Command, message, this, multiplexer.GetServerSnapShot()));
             }
             return tcs.Task;
         }


### PR DESCRIPTION
Currently there is not an easy way to understand from the RedisConnectionException thrown for the root cause of an error.
for example, for certification validation failure, it doesn't give any details about the error.

This pull request is help surface the exception from Serverendpoints as an innerexception of 
RedisConnectionException which would further help a user in investigating the root cause of an error.

Following are examples of how the exception would look like after this change:
1. Redis cert validation failure
StackExchange.Redis.RedisConnectionException: No connection is available to service this operation: GET test 
---> StackExchange.Redis.RedisConnectionException: AuthenticationFailure on *.redis.cache.windows.net:6380/Subscription, origin: Connected, input-buffer: 0, outstanding: 0, last-read: 0s ago, last-write: 0s ago, unanswered-write: 1750210s ago, keep-alive: 60s, pending: 0, state: Connecting, last-heartbeat: never, last-mbeat: -1s ago, global: 0s ago, mgr: Inactive, err: never 
---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure.
   at System.Net.Security.SslState.StartSendAuthResetSignal(ProtocolToken message, AsyncProtocolRequest asyncRequest, Exception exception)
   at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartSendBlob(Byte[] incoming, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReadFrame(Byte[] buffer, Int32 readBytes, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartSendBlob(Byte[] incoming, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReadFrame(Byte[] buffer, Int32 readBytes, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartSendBlob(Byte[] incoming, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReadFrame(Byte[] buffer, Int32 readBytes, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken message, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartSendBlob(Byte[] incoming, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ForceAuthentication(Boolean receiveFirst, Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessAuthentication(LazyAsyncResult lazyResult)
   at System.Net.Security.SslStream.AuthenticateAsClient(String targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, Boolean checkCertificateRevocation)
   at System.Net.Security.SslStream.AuthenticateAsClient(String targetHost)
   at StackExchange.Redis.PhysicalConnection.StackExchange.Redis.ISocketCallback.Connected(Stream stream, TextWriter log) in    --- End of inner exception stack trace ---
2. AUTH failure
StackExchange.Redis.RedisConnectionException: No connection is available to service this operation: GET test ---> StackExchange.Redis.RedisConnectionException: AuthenticationFailure on *.redis.cache.windows.net:6380/Subscription, origin: SetResult, input-buffer: 125, outstanding: 1, last-read: 0s ago, last-write: 0s ago, unanswered-write: 1750445s ago, keep-alive: 60s, pending: 0, state: ConnectedEstablishing, last-heartbeat: never, last-mbeat: -1s ago, global: 0s ago, mgr: Inactive, err: never ---> System.Exception: Error: NOAUTH Authentication required. Verify if the Redis password provided is correct.
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---

Here's the code snippet:
            var server = args[0];
            var password = args[1];
            var config = new ConfigurationOptions();
            config.EndPoints.Add(server);
            config.Ssl = true;
            //config.Password = "errorpwd";
            config.AbortOnConnectFail = false;
            config.CertificateValidation += Config_CertificateValidation;
                  try
                    {
                       db.StringGet("test");
                    }
                    catch (Exception e)
                    {
                            Console.WriteLine(e.ToString());
                    }
  private static bool Config_CertificateValidation(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors)
        {

            return false;
        }