### PR TITLE
Set default version to 3.0 for Azure

### DIFF
--- a/MigratedBookSleeveTestSuite/Config.cs
+++ b/MigratedBookSleeveTestSuite/Config.cs
@@ -188,45 +188,59 @@ namespace Tests
         }
 
         [Test]
-        public void AbortConnectFalseForAzure()
+        public void ConfigurationOptionsDefaultForAzure()
         {
             var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net");
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(3, 0, 0)));
             Assert.IsFalse(options.AbortOnConnectFail);
         }
 
         [Test]
-        public void AbortConnectTrueForAzureWhenSpecified()
+        public void ConfigurationOptionsForAzureWhenSpecified()
         {
-            var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net,abortConnect=true");
+            var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net,abortConnect=true, version=2.1.1");
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(2, 1, 1)));
             Assert.IsTrue(options.AbortOnConnectFail);
         }
 
         [Test]
-        public void AbortConnectFalseForAzureChina()
+        public void ConfigurationOptionsDefaultForAzureChina()
         {
             // added a few upper case chars to validate comparison
             var options = ConfigurationOptions.Parse("contoso.REDIS.CACHE.chinacloudapi.cn");
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(3, 0, 0)));
             Assert.IsFalse(options.AbortOnConnectFail);
         }
 
         [Test]
-        public void AbortConnectFalseForAzureUSGov()
+        public void ConfigurationOptionsDefaultForAzureGermany()
+        {
+            var options = ConfigurationOptions.Parse("contoso.redis.cache.cloudapi.de");
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(3, 0, 0)));
+            Assert.IsFalse(options.AbortOnConnectFail);
+        }
+
+        [Test]
+        public void ConfigurationOptionsDefaultForAzureUSGov()
         {
             var options = ConfigurationOptions.Parse("contoso.redis.cache.usgovcloudapi.net");
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(3, 0, 0)));
             Assert.IsFalse(options.AbortOnConnectFail);
         }
 
         [Test]
-        public void AbortConnectTrueForNonAzure()
+        public void ConfigurationOptionsDefaultForNonAzure()
         {
             var options = ConfigurationOptions.Parse("redis.contoso.com");
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(2, 0, 0)));
             Assert.IsTrue(options.AbortOnConnectFail);
         }
 
         [Test]
-        public void AbortConnectDefaultWhenNoEndpointsSpecifiedYet()
+        public void ConfigurationOptionsDefaultWhenNoEndpointsSpecifiedYet()
         {
             var options = new ConfigurationOptions();
+            Assert.IsTrue(options.DefaultVersion.Equals(new Version(2, 0, 0)));
             Assert.IsTrue(options.AbortOnConnectFail);
         }
 

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -210,7 +210,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The server version to assume
         /// </summary>
-        public Version DefaultVersion { get { return defaultVersion ?? RedisFeatures.v2_0_0; } set { defaultVersion = value; } }
+        public Version DefaultVersion { get { return defaultVersion ?? (IsAzureEndpoint() ? RedisFeatures.v3_0_0 : RedisFeatures.v2_0_0); } set { defaultVersion = value; } }
 
         /// <summary>
         /// The endpoints defined for this configuration
@@ -656,6 +656,7 @@ namespace StackExchange.Redis
                         case ".redis.cache.windows.net":
                         case ".redis.cache.chinacloudapi.cn":
                         case ".redis.cache.usgovcloudapi.net":
+                        case ".redis.cache.cloudapi.de":
                             return true;
                     }
                 }

--- a/StackExchange.Redis/StackExchange/Redis/RedisFeatures.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisFeatures.cs
@@ -26,7 +26,8 @@ namespace StackExchange.Redis
                                          v2_8_0 = new Version(2, 8, 0),
                                          v2_8_12 = new Version(2, 8, 12),
                                          v2_8_18 = new Version(2, 8, 18),
-                                         v2_9_5 = new Version(2, 9, 5);
+                                         v2_9_5 = new Version(2, 9, 5),
+                                         v3_0_0 = new Version(3, 0, 0);
 
         private readonly Version version;
         /// <summary>


### PR DESCRIPTION
With default version of 2.0, for a large number of connection to a Redis endpoint features.InfoSections returns false and  causes full info command to be executed during initiation of a multiplexer. 
info command from high number of connections trying to connect,  can be expensive for redis server.

Making default version to 3.0 so that 'info replication' and 'info server' commands are leveraged and improves performance.