### PR TITLE
Prevent ResultBox from being recycled twice

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/MessageQueue.cs
+++ b/StackExchange.Redis/StackExchange/Redis/MessageQueue.cs
@@ -35,11 +35,13 @@ namespace StackExchange.Redis
                 queueLength = high.Count + regular.Count;
                 if (high.Count != 0 && (peeked = high.Peek()).Command == RedisCommand.PING)
                 {
-                    return peeked;
+                    //In a disconnect scenario, we don't want to complete the Ping message twice,
+                    //dequeue it now so it wont get dequeued in AbortUnsent (if we're going down that code path)
+                    return high.Dequeue();
                 }
                 if (regular.Count != 0 && (peeked = regular.Peek()).Command == RedisCommand.PING)
                 {
-                    return peeked;
+                    return regular.Dequeue();
                 }
             }
             return null;

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
@@ -315,7 +315,6 @@ namespace StackExchange.Redis
             Trace("OnDisconnected");
 
             // if the next thing in the pipe is a PING, we can tell it that we failed (this really helps spot doomed connects)
-            // note that for simplicity we haven't removed it from the queue; that's OK
             int count;
             var ping = queue.PeekPing(out count);
             if (ping != null)


### PR DESCRIPTION
Stop PING from being completed twice in disconnect scenario by making PeekPing actually dequeue. Prevent any Message from having its resultBox recycled twice by getting/nulling resultBox in a thread safe way