### PR TITLE
Default ClientName to Roleinstance ID for a web/worker role 

### DIFF
--- a/StackExchange.Redis.Tests/Config.cs
+++ b/StackExchange.Redis.Tests/Config.cs
@@ -125,6 +125,28 @@ namespace StackExchange.Redis.Tests
         }
 
         [Test]
+        public void DefaultClientName()
+        {
+            using (var muxer = Create(allowAdmin: true))
+            {
+                Assert.AreEqual(Environment.MachineName, muxer.ClientName);
+                var conn = muxer.GetDatabase();
+                conn.Ping();
+#if DEBUG
+                var name = GetServer(muxer).ClientGetName();
+                Assert.AreEqual(Environment.MachineName, name);
+#endif
+            }
+        }
+
+        [Test]
+        public void TryGetAzureRoleInstanceIdNoThrow()
+        {
+            ConfigurationOptions config = new ConfigurationOptions();
+            Assert.IsNull(config.TryGetAzureRoleInstanceIdNoThrow());
+        }
+
+        [Test]
         public void ReadConfigWithConfigDisabled()
         {
             using (var muxer = Create(allowAdmin: true, disabledCommands: new[] { "config", "info" }))

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -162,7 +161,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The client name to use for all connections
         /// </summary>
-        public string ClientName { get { return clientName ?? (clientName = (AzureRoleInstanceId != null ? AzureRoleInstanceId : Environment.GetEnvironmentVariable("ComputerName"))); } set { clientName = value; } }
+        public string ClientName { get { return clientName; } set { clientName = value; } }
 
         /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly
@@ -664,46 +663,6 @@ namespace StackExchange.Redis
             }
 
             return result; 
-        }
-
-        internal static string AzureRoleInstanceId = TryGetAzureRoleInstanceIdNoThrow();
-
-        /// <summary>
-        /// Tries to get the Roleinstance Id if Microsoft.WindowsAzure.ServiceRuntime is loaded.
-        /// In case of any failure, swallows the exception and returns null
-        /// </summary>
-        private static string TryGetAzureRoleInstanceIdNoThrow()
-        {
-            string roleInstanceId = null;
-            try
-            {
-                Assembly asm = null;
-                foreach (var asmb in AppDomain.CurrentDomain.GetAssemblies())
-                {
-                    if (asmb.GetName().Name.Equals("Microsoft.WindowsAzure.ServiceRuntime"))
-                    {
-                        asm = asmb;
-                        break;
-                    }
-                }
-                if (asm == null)
-                    return null;
-
-                var currentRoleInstanceProp = asm.GetType("Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironment").GetProperty("CurrentRoleInstance");
-                var currentRoleInstanceId = currentRoleInstanceProp.GetValue(null, null);
-                roleInstanceId = currentRoleInstanceId.GetType().GetProperty("Id").GetValue(currentRoleInstanceId, null).ToString();
-
-                if (String.IsNullOrEmpty(roleInstanceId))
-                {
-                    roleInstanceId = null;
-                }
-            }
-            catch (Exception)
-            {
-                //silently ignores the exception
-                roleInstanceId = null;
-            }
-            return roleInstanceId;
         }
 
         private string InferSslHostFromEndpoints() {

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -162,7 +162,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The client name to use for all connections
         /// </summary>
-        public string ClientName { get { return clientName ?? (clientName = AzureRoleInstanceId); } set { clientName = value; } }
+        public string ClientName { get { return clientName ?? (clientName = (AzureRoleInstanceId != null ? AzureRoleInstanceId : Environment.GetEnvironmentVariable("ComputerName"))); } set { clientName = value; } }
 
         /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -161,7 +162,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The client name to use for all connections
         /// </summary>
-        public string ClientName { get { return clientName; } set { clientName = value; } }
+        public string ClientName { get { return clientName ?? (clientName = AzureRoleInstanceId); } set { clientName = value; } }
 
         /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly
@@ -663,6 +664,46 @@ namespace StackExchange.Redis
             }
 
             return result; 
+        }
+
+        internal static string AzureRoleInstanceId = TryGetAzureRoleInstanceIdNoThrow();
+
+        /// <summary>
+        /// Tries to get the Roleinstance Id if Microsoft.WindowsAzure.ServiceRuntime is loaded.
+        /// In case of any failure, swallows the exception and returns null
+        /// </summary>
+        private static string TryGetAzureRoleInstanceIdNoThrow()
+        {
+            string roleInstanceId = null;
+            try
+            {
+                Assembly asm = null;
+                foreach (var asmb in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (asmb.GetName().Name.Equals("Microsoft.WindowsAzure.ServiceRuntime"))
+                    {
+                        asm = asmb;
+                        break;
+                    }
+                }
+                if (asm == null)
+                    return null;
+
+                var currentRoleInstanceProp = asm.GetType("Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironment").GetProperty("CurrentRoleInstance");
+                var currentRoleInstanceId = currentRoleInstanceProp.GetValue(null, null);
+                roleInstanceId = currentRoleInstanceId.GetType().GetProperty("Id").GetValue(currentRoleInstanceId, null).ToString();
+
+                if (String.IsNullOrEmpty(roleInstanceId))
+                {
+                    roleInstanceId = null;
+                }
+            }
+            catch (Exception)
+            {
+                //silently ignores the exception
+                roleInstanceId = null;
+            }
+            return roleInstanceId;
         }
 
         private string InferSslHostFromEndpoints() {

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -91,7 +91,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets the client-name that will be used on all new connections
         /// </summary>
-        public string ClientName => configuration.ClientName ?? Environment.GetEnvironmentVariable("ComputerName");
+        public string ClientName => configuration.ClientName;
 
         /// <summary>
         /// Gets the configuration of the connection


### PR DESCRIPTION
helps to identify where a client connection is coming from, further helps to identify any connection related problems.