### PR TITLE
Sentinel GET-MASTER-ADDR-BY-NAME throws exception when service name i…

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -1237,6 +1237,11 @@ namespace StackExchange.Redis
                             return true;
                         }
                         break;
+                    case ResultType.SimpleString:
+                        //We don't want to blow up if the master is not found
+                        if (result.IsNull)
+                            return true;
+                        break;
                 }
                 return false;
             }


### PR DESCRIPTION
…s not being watched by sentinel.