### PR TITLE
Fixed build error caused by TryGetAzureRoleInstanceIdNoThrow test

### DIFF
--- a/StackExchange.Redis.Tests/Config.cs
+++ b/StackExchange.Redis.Tests/Config.cs
@@ -138,14 +138,7 @@ namespace StackExchange.Redis.Tests
 #endif
             }
         }
-
-        [Test]
-        public void TryGetAzureRoleInstanceIdNoThrow()
-        {
-            ConfigurationOptions config = new ConfigurationOptions();
-            Assert.IsNull(config.TryGetAzureRoleInstanceIdNoThrow());
-        }
-
+        
         [Test]
         public void ReadConfigWithConfigDisabled()
         {

--- a/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
+++ b/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
@@ -117,5 +117,11 @@ namespace StackExchange.Redis.Tests
                 ClearAmbientFailures();
             }
         }
+
+        [Test]
+        public void TryGetAzureRoleInstanceIdNoThrow()
+        {
+            Assert.IsNull(ConnectionMultiplexer.TryGetAzureRoleInstanceIdNoThrow());
+        }
     }
 }


### PR DESCRIPTION
Looks like this was missed in PR #379 when moving the _TryGetAzureRoleInstanceIdNoThrow_ method from the _ConfigurationOptions_ class to the _ConnectionMultiplexer_ class.