### PR TITLE
net 40 project packages.config already has dependency on 1.1.10 updat…

### DIFF
--- a/StackExchange.Redis.nuspec
+++ b/StackExchange.Redis.nuspec
@@ -15,7 +15,7 @@
 
     <dependencies>
       <group targetFramework="net40">
-        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+        <dependency id="Microsoft.Bcl" version="1.1.10"/>
         <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
       </group>
       <group targetFramework="net45">


### PR DESCRIPTION
…ing nuspec as well.

 with 1.1.9 customers run into following error:
 Method System.Runtime.CompilerServices.AsyncTaskMethodBuilder 1[System.Boolean].AwaitUnsafeOnCompleted: type argument 'Microsoft.Runtime.CompilerServices.ConfiguredTaskAwaitable 1+ConfiguredTaskAwaiter[StackExchange.Redis.ServerEndPoint]' violates the constraint of type parameter 'TAwaiter'.
 Description: An unhandled exception occurred during the execution of the current web request. Please review the stack trace for more information about the error and where it originated in the code.

Exception Details: System.Security.VerificationException: Method System.Runtime.CompilerServices.AsyncTaskMethodBuilder 1[System.Boolean].AwaitUnsafeOnCompleted: type argument 'Microsoft.Runtime.CompilerServices.ConfiguredTaskAwaitable 1+ConfiguredTaskAwaiter[StackExchange.Redis.ServerEndPoint]' violates the constraint of type parameter 'TAwaiter'.