### PR TITLE
Add support for the ZCOUNT command

### DIFF
--- a/StackExchange.Redis.Tests/SortedSets.cs
+++ b/StackExchange.Redis.Tests/SortedSets.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+
+namespace StackExchange.Redis.Tests
+{
+    [TestFixture]
+    public class SortedSets : TestBase
+    {
+        [Test]
+        public void ZCount()
+        {
+            using (var conn = Create())
+            {
+                var server = GetServer(conn);
+
+                RedisKey key = "testzcount";
+                var db = conn.GetDatabase();
+                db.KeyDelete(key);
+
+                db.SortedSetAdd(key, "one", 1);
+                db.SortedSetAdd(key, "two", 2);
+                db.SortedSetAdd(key, "three", 3);
+                db.SortedSetAdd(key, "four", 4);
+                db.SortedSetAdd(key, "five", 5);
+                db.SortedSetAdd(key, "seven", 7);
+                db.SortedSetAdd(key, "eight", 8);
+                db.SortedSetAdd(key, "nine", 9);
+
+                long count = db.SortedSetCount("testzcount", 1, 9);
+
+                Assert.AreEqual(count, 8);
+
+            }
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
@@ -698,7 +698,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <returns> the number of elements in the sorted set at key with a score between min and max.</returns>
         /// <remarks>http://redis.io/commands/zcount</remarks>
-        long SortedSetCount(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
+        long SortedSetCount(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.

--- a/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
@@ -694,6 +694,13 @@ namespace StackExchange.Redis
         long SortedSetLengthByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Returns the number of elements in the sorted set at key with a score between min and max.
+        /// </summary>
+        /// <returns> the number of elements in the sorted set at key with a score between min and max.</returns>
+        /// <remarks>http://redis.io/commands/zcount</remarks>
+        long SortedSetCount(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
         /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>

--- a/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
@@ -652,6 +652,13 @@ namespace StackExchange.Redis
         Task<long> SortedSetLengthByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Returns the number of elements in the sorted set at key with a score between min and max.
+        /// </summary>
+        /// <returns> the number of elements in the sorted set at key with a score between min and max.</returns>
+        /// <remarks>http://redis.io/commands/zcount</remarks>
+        Task<long> SortedSetCountAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
         /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>

--- a/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
@@ -656,7 +656,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <returns> the number of elements in the sorted set at key with a score between min and max.</returns>
         /// <remarks>http://redis.io/commands/zcount</remarks>
-        Task<long> SortedSetCountAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
+        Task<long> SortedSetCountAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -649,9 +649,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SortedSetScan(ToInner(key), pattern, pageSize, cursor, pageOffset, flags);
         }
 
-        public long SortedSetCount(RedisKey key, double min, double max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public long SortedSetCount(RedisKey key, double min, double max, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.SortedSetCount(key, min, max, exclude, flags);
+            return Inner.SortedSetCount(key, min, max, flags);
         }
 
 #if DEBUG

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -649,6 +649,10 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SortedSetScan(ToInner(key), pattern, pageSize, cursor, pageOffset, flags);
         }
 
+        public long SortedSetCount(RedisKey key, double min, double max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.SortedSetCount(key, min, max, exclude, flags);
+        }
 
 #if DEBUG
         public string ClientGetName(CommandFlags flags = CommandFlags.None)

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
@@ -516,6 +516,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SortedSetScoreAsync(ToInner(key), member, flags);
         }
 
+        public Task<long> SortedSetCountAsync(RedisKey key, double min, double max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.SortedSetCountAsync(key, min, max, exclude, flags);
+        }
+
         public Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
         {
             return Inner.StringAppendAsync(ToInner(key), value, flags);
@@ -767,5 +772,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
             // create as a delegate when first required, then re-use
             return mapFunction ?? (mapFunction = new Func<RedisKey, RedisKey>(ToInner)); 
         }
+
+      
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
@@ -516,9 +516,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SortedSetScoreAsync(ToInner(key), member, flags);
         }
 
-        public Task<long> SortedSetCountAsync(RedisKey key, double min, double max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public Task<long> SortedSetCountAsync(RedisKey key, double min, double max, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.SortedSetCountAsync(key, min, max, exclude, flags);
+            return Inner.SortedSetCountAsync(key, min, max, flags);
         }
 
         public Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -2108,6 +2108,12 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
 
+        public long SortedSetCount(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = GetLexMessage(RedisCommand.ZCOUNT, key, min, max, exclude, 0, -1, flags);
+            return ExecuteSync(msg, ResultProcessor.Int64);
+        }
+
         public Task<long> SortedSetLengthByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
         {
             var msg = GetLexMessage(RedisCommand.ZLEXCOUNT, key, min, max, exclude, 0, -1, flags);
@@ -2126,6 +2132,11 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
+        public Task<long> SortedSetCountAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = GetLexMessage(RedisCommand.ZCOUNT, key, min, max, exclude, 0, -1, flags);
+            return ExecuteAsync(msg, ResultProcessor.Int64);
+        }
 
         internal class ScanIterator<T> : CursorEnumerable<T>
         {

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -2108,9 +2108,9 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
 
-        public long SortedSetCount(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public long SortedSetCount(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, CommandFlags flags = CommandFlags.None)
         {
-            var msg = GetLexMessage(RedisCommand.ZCOUNT, key, min, max, exclude, 0, -1, flags);
+            var msg = Message.Create(Database, flags, RedisCommand.ZCOUNT, key, min, max);
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
 
@@ -2132,9 +2132,9 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
-        public Task<long> SortedSetCountAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public Task<long> SortedSetCountAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, CommandFlags flags = CommandFlags.None)
         {
-            var msg = GetLexMessage(RedisCommand.ZCOUNT, key, min, max, exclude, 0, -1, flags);
+            var msg = Message.Create(Database, flags, RedisCommand.ZCOUNT, key, min, max);
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 


### PR DESCRIPTION
Hello!

This is my first pull request ever, so I'm sorry if I'm doing something wrong. We are creating a wrapper around StackExchange.Redis and we missed the ZCOUNT method. Although we don't really use it, I figured I could add the method myself, am I doing this correctly? 

I added the SortedSetCount and SortedSetCountAsync to the related interfaces and implementations, but I was wondering if I really need to add the method, or if there is a reason for not having the ZCOUNT method (and other methods as well). It seems that there are more missing methods. Anyway, here is the pull request :smile: 