### PR TITLE
Fixing Documentation for ConfigurationOptions.Proxy

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -233,7 +233,7 @@ namespace StackExchange.Redis
         public string Password { get { return password; } set { password = value; } }
 
         /// <summary>
-        /// Indicates whether admin operations should be allowed
+        /// Type of proxy to use (if any); for example Proxy.Twemproxy
         /// </summary>
         public Proxy Proxy { get { return proxy.GetValueOrDefault(); } set { proxy = value; } }
 


### PR DESCRIPTION
Spotted this whilst using the library, thought I'd contribute a fix!

The Intellisense documentation for the Proxy Property was the same as AllowAdmin

Probably error through Copy and Paste.
