### PR TITLE
Give specific cause of timeouts for known ThreadPool and CPU cases.

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -2094,11 +2094,9 @@ namespace StackExchange.Redis
                 return; // don't add IOCP and CPU details to the error message because connection management trumps all other causes of timeouts.
             }
 
-            bool detailsAdded = false;
             bool timeoutHelpLinkAdded = false;
             if (iocp.Busy > iocp.Min || worker.Busy > worker.Min)
             {
-                detailsAdded = true;
                 timeoutHelpLinkAdded = true;
                 sb.Append($" The number of busy IOCP or WORKER threads in the ThreadPool is greater than the 'Min' setting, which could easily be the cause of this timeout.  See https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Timeouts.md#are-you-seeing-high-number-of-busyio-or-busyworker-threads-in-the-timeout-exception for details on how ThreadPool Growth Throttling can affect performance.");
             }
@@ -2108,14 +2106,7 @@ namespace StackExchange.Redis
                 localCpuPercent = Math.Round(systemCPU, 2) + "%";
                 if (systemCPU > 85)
                 {
-                    if (detailsAdded)
-                    {
-                        sb.Append($" Additionally, this timeout may be a result of the local CPU usage being high ({localCpuPercent}).");
-                    }
-                    else
-                    {
-                        sb.Append($" This timeout may be a result of the local CPU usage being high ({localCpuPercent}).");
-                    }
+                    sb.Append($" This timeout may be a result of the local CPU usage being high ({localCpuPercent}).");
                 }
             }
 

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -2079,7 +2079,7 @@ namespace StackExchange.Redis
             if (iocp.Busy > iocp.Min || worker.Busy > worker.Min)
             {
                 detailsAdded = true;
-                sb.Append($" The number of busy IOCP or WORKER threads in the ThreadPool is greater than the Min setting, which could easily be the cause of this timeout.  See https://aka.ms/redis/threadpool for details on how ThreadPool Growth Throttling can affect performance.");
+                sb.Append($" The number of busy IOCP or WORKER threads in the ThreadPool is greater than the 'Min' setting, which could easily be the cause of this timeout.  See https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Timeouts.md#are-you-seeing-high-number-of-busyio-or-busyworker-threads-in-the-timeout-exception for details on how ThreadPool Growth Throttling can affect performance.");
             }
 
             float systemCPU;

--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -299,12 +299,12 @@ namespace StackExchange.Redis
     }
 #if !CORE_CLR
 
-    internal class ThreadPoolStats
+    internal struct ThreadPoolStats
     {
-        public int Busy { get; set; }
-        public int Free { get; set; }
-        public int Min { get; set; }
-        public int Max { get; set; }
+        public int Busy { get; private set; }
+        public int Free { get; private set; }
+        public int Min { get; private set; }
+        public int Max { get; private set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
This changes the timeout error message to give better guidance around what may have caused the timeout.  Example timeout error message after this change:

> System.TimeoutException: Timeout performing GET q. The number of busy IOCP or WORKER threads in the ThreadPool is greater than the Min setting, which could easily be the cause of this timeout.  See https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Timeouts.md#are-you-seeing-high-number-of-busyio-or-busyworker-threads-in-the-timeout-exception for details on how ThreadPool Growth Throttling can affect performance. Diagnostics Info: inst: 2, mgr: Inactive, err: never, queue: 6, qu: 0, qs: 6, qc: 0, wr: 0, wq: 0, in: 51750, ar: 0, clientName: myComputer, IOCP: (Busy=1,Free=999,Min=1,Max=1000), WORKER: (Busy=4,Free=32763,Min=1,Max=32767), Local-CPU: 0% 
