### PR TITLE
Fixing comparison of node endpoints when configuring cluster

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
@@ -214,7 +214,7 @@ namespace StackExchange.Redis
                 multiplexer.Trace("Updating cluster ranges...");
                 multiplexer.UpdateClusterRange(configuration);
                 multiplexer.Trace("Resolving genealogy...");
-                var thisNode = configuration.Nodes.FirstOrDefault(x => x.EndPoint == this.EndPoint);
+                var thisNode = configuration.Nodes.FirstOrDefault(x => x.EndPoint.Equals(this.EndPoint));
                 if (thisNode != null)
                 {
                     List<ServerEndPoint> slaves = null;


### PR DESCRIPTION
In `ClusterNodesProcessor.Parse`, the server endpoint that `SetClusterConfiguration` is called with won't be the same endpoint object in any of the `ClusterConfiguration.Nodes`, so the reference equality check on line 217 will always return false.

This is because when a new ClusterNode is created, it creates a new endpoint by parsing the raw configuration string

`EndPoint = Format.TryParseEndPoint(parts[1]);`

This causes issues in the cluster when using `CommandFlags.PreferSlave` or `CommandFlags.DemandSlave`, since node.Slaves is always an empty array.
