### PR TITLE
check the endpoints are actually equal to populate the cluster master…

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
@@ -214,7 +214,7 @@ namespace StackExchange.Redis
                 multiplexer.Trace("Updating cluster ranges...");
                 multiplexer.UpdateClusterRange(configuration);
                 multiplexer.Trace("Resolving genealogy...");
-                var thisNode = configuration.Nodes.FirstOrDefault(x => x.EndPoint == this.EndPoint);
+                var thisNode = configuration.Nodes.FirstOrDefault(x => x.EndPoint.Equals(this.EndPoint));
                 if (thisNode != null)
                 {
                     List<ServerEndPoint> slaves = null;


### PR DESCRIPTION
… and slave nodes correctly
repro:

``` C#
cm.GetDatabase().StringSet("test", "test");
for (int i = 0; i < 10; i++)
{
    try
    {
        Console.WriteLine(cm.GetDatabase().StringGet("test", CommandFlags.DemandSlave));
    }
    catch(Exception e)
    {
        Console.WriteLine("?");
    }
}
```

the get call would fail to get the slave node and end up selecting anynode, which results in moved exception.
