### PR TITLE
Use the supplied flags when selecting a server to subscribe to

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/RedisSubscriber.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisSubscriber.cs
@@ -185,7 +185,7 @@ namespace StackExchange.Redis
             public Task SubscribeToServer(ConnectionMultiplexer multiplexer, RedisChannel channel, CommandFlags flags, object asyncState, bool internalCall)
             {
                 var cmd = channel.IsPatternBased ? RedisCommand.PSUBSCRIBE : RedisCommand.SUBSCRIBE;
-                var selected = multiplexer.SelectServer(-1, cmd, CommandFlags.DemandMaster, default(RedisKey));
+                var selected = multiplexer.SelectServer(-1, cmd, flags, default(RedisKey));
 
                 if (selected == null || Interlocked.CompareExchange(ref owner, selected, null) != null) return null;
 


### PR DESCRIPTION
SUBSCRIBE and PSUBSCRIBE are not write ops and can be
performed on slaved instances, so there's no reason to
explicitly pass DemandMaster when selecting the server.

Instead, use the CommandFlags passed as the parameter to Subscribe()