### PR TITLE
Work around build issue for existing csproj's

### DIFF
--- a/BasicTest/BasicTest.project.json
+++ b/BasicTest/BasicTest.project.json
@@ -1,0 +1,9 @@
+{
+  "runtimes": { "win": {} },
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+      }
+    }
+  }
+}

--- a/MigratedBookSleeveTestSuite/MigratedBookSleeveTestSuite.project.json
+++ b/MigratedBookSleeveTestSuite/MigratedBookSleeveTestSuite.project.json
@@ -1,0 +1,10 @@
+﻿{
+  "runtimes": { "win": {} },
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "NUnit": "3.0.0"
+      }
+    }
+  }
+}

--- a/MigratedBookSleeveTestSuite/packages.config
+++ b/MigratedBookSleeveTestSuite/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.0.0" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Visual Studio tooling will use `project.json` to restore nuget dependencies
when it finds one beside .csproj. This change uses more specific
`<project name>.project.json` to specify dependencies.

Connect to #446.