### PR TITLE
Remove password from logging of configuration string.

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -366,9 +366,20 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Returns the effective configuration string for this configuration
+        /// Returns the effective configuration string for this configuration, including Redis credentials.
         /// </summary>
         public override string ToString()
+        {
+            // include password to allow generation of configuration strings 
+            // used for connecting multiplexer
+            return ToString(includePassword: true);
+        }
+
+        /// <summary>
+        /// Returns the effective configuration string for this configuration
+        /// with the option to include or exclude the password from the string.
+        /// </summary>
+        public string ToString(bool includePassword)
         {
             var sb = new StringBuilder();
             foreach (var endpoint in endpoints)
@@ -382,7 +393,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.AllowAdmin, allowAdmin);
             Append(sb, OptionKeys.Version, defaultVersion);
             Append(sb, OptionKeys.ConnectTimeout, connectTimeout);
-            Append(sb, OptionKeys.Password, password);
+            Append(sb, OptionKeys.Password, includePassword ? password : "*****");
             Append(sb, OptionKeys.TieBreaker, tieBreaker);
             Append(sb, OptionKeys.WriteBuffer, writeBuffer);
             Append(sb, OptionKeys.Ssl, ssl);

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -1197,7 +1197,7 @@ namespace StackExchange.Redis
                 Trace("Starting reconfiguration...");
                 Trace(blame != null, "Blaming: " + Format.ToString(blame));
 
-                LogLocked(log, Configuration);
+                LogLocked(log, configuration.ToString(includePassword: false));
                 LogLocked(log, "");
 
 


### PR DESCRIPTION
ReconfigureAsync in ConnectionMultiplexer.cs logs the configuration string, including the password.
This change addresses the security concern of logging passwords without changing other behavior. 