### PR TITLE
Add support for Redis WAIT command

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
@@ -963,5 +963,11 @@ namespace StackExchange.Redis
         /// <returns>the length of the string after it was modified by the command.</returns>
         /// <remarks>http://redis.io/commands/setrange</remarks>
         RedisValue StringSetRange(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Issues Redis WAIT command to wait for writes to a given number of slaves to have completed before returning or before timing out. Setting timeout to 0 means that the operation will never timeout.
+        /// </summary>
+        /// <returns>Always returns the number of slaves that have acknowledged the most recent writes, regardless of whether the specified number of slaves was reached or if a timeout occurred.</returns>
+        long SyncWait(int numOfSlaves = 1, int timeoutMilliseconds = 0, CommandFlags flags = CommandFlags.None);
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -616,6 +616,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.StringSetRange(ToInner(key), offset, value, flags);
         }
 
+        public long SyncWait(int numOfSlaves = 1, int timeoutMilliseconds = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.SyncWait(numOfSlaves, timeoutMilliseconds, flags);
+        }
+
         public TimeSpan Ping(CommandFlags flags = CommandFlags.None)
         {
             return Inner.Ping(flags);

--- a/StackExchange.Redis/StackExchange/Redis/RedisCommand.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisCommand.cs
@@ -154,6 +154,7 @@
         UNSUBSCRIBE,
         UNWATCH,
 
+        WAIT,
         WATCH,
 
         ZADD,

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -1603,6 +1603,12 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.RedisValue);
         }
 
+        public long SyncWait(int numOfSlaves = 1, int timeoutMilliseconds = 0, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.WAIT, numOfSlaves, timeoutMilliseconds);
+            return ExecuteSync(msg, ResultProcessor.Int64);
+        }
+
         public Task<RedisValue> StringSetRangeAsync(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(Database, flags, RedisCommand.SETRANGE, key, offset, value);


### PR DESCRIPTION
StackExchange.Redis seems to be missing support for the Redis WAIT command that was introduced in Redis 3.0.

I decided to name the corresponding method SyncWait, to distinguish it from the existing Wait methods available.