### PR TITLE
SE.Redis Reconnect retry policy

### DIFF
--- a/StackExchange.Redis.Tests/ConnectionReconnectRetryPolicyTests.cs
+++ b/StackExchange.Redis.Tests/ConnectionReconnectRetryPolicyTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace StackExchange.Redis.Tests
+{
+    [TestFixture]
+    public class TransientErrorTests : TestBase
+    {
+
+        [TestCase]
+        public void TestExponentialRetry()
+        {
+            IReconnectRetryPolicy exponentialRetry = new ExponentialRetry(5000);
+            Assert.False(exponentialRetry.ShouldRetry(0, 0));
+            Assert.True(exponentialRetry.ShouldRetry(1, 5600));
+            Assert.True(exponentialRetry.ShouldRetry(2, 6050));
+            Assert.False(exponentialRetry.ShouldRetry(2, 4050));
+        }
+
+        [TestCase]
+        public void TestExponentialMaxRetry()
+        {
+            IReconnectRetryPolicy exponentialRetry = new ExponentialRetry(5000);
+            Assert.True(exponentialRetry.ShouldRetry(long.MaxValue, (int)TimeSpan.FromSeconds(30).TotalMilliseconds));
+        }
+
+        [TestCase]
+        public void TestLinearRetry()
+        {
+            IReconnectRetryPolicy linearRetry = new LinearRetry(5000);
+            Assert.False(linearRetry.ShouldRetry(0, 0));
+            Assert.False(linearRetry.ShouldRetry(2, 4999));
+            Assert.True(linearRetry.ShouldRetry(1, 5000));
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -115,6 +115,8 @@ namespace StackExchange.Redis
 
         private Proxy? proxy;
 
+        private IReconnectRetryPolicy reconnectRetryPolicy; 
+
         /// <summary>
         /// A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication; note
         /// that this cannot be specified in the configuration-string.
@@ -206,6 +208,12 @@ namespace StackExchange.Redis
             }
             set { connectTimeout = value; }
         }
+
+        /// <summary>
+        /// The retry policy to be used for connection reconnects
+        /// </summary>
+        public IReconnectRetryPolicy ReconnectRetryPolicy { get { return reconnectRetryPolicy ?? new LinearRetry(ConnectTimeout); } set { reconnectRetryPolicy = value; } }
+
 
         /// <summary>
         /// The server version to assume
@@ -350,6 +358,7 @@ namespace StackExchange.Redis
                 configCheckSeconds = configCheckSeconds,
                 responseTimeout = responseTimeout,
 				defaultDatabase = defaultDatabase,
+                ReconnectRetryPolicy = ReconnectRetryPolicy,
             };
             foreach (var item in endpoints)
                 options.endpoints.Add(item);

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -212,7 +212,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The retry policy to be used for connection reconnects
         /// </summary>
-        public IReconnectRetryPolicy ReconnectRetryPolicy { get { return reconnectRetryPolicy ?? new LinearRetry(ConnectTimeout); } set { reconnectRetryPolicy = value; } }
+        public IReconnectRetryPolicy ReconnectRetryPolicy { get { return reconnectRetryPolicy ?? (reconnectRetryPolicy = new LinearRetry(ConnectTimeout)); } set { reconnectRetryPolicy = value; } }
 
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace StackExchange.Redis
                 configCheckSeconds = configCheckSeconds,
                 responseTimeout = responseTimeout,
 				defaultDatabase = defaultDatabase,
-                ReconnectRetryPolicy = ReconnectRetryPolicy,
+                ReconnectRetryPolicy = reconnectRetryPolicy,
             };
             foreach (var item in endpoints)
                 options.endpoints.Add(item);

--- a/StackExchange.Redis/StackExchange/Redis/ExponentialRetry.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ExponentialRetry.cs
@@ -2,24 +2,40 @@ using System;
 
 namespace StackExchange.Redis
 {
-
+    /// <summary>
+    /// Represents a retry policy that performs retries, using a randomized exponential back off scheme to determine the interval between retries. 
+    /// </summary>
     public class ExponentialRetry : IReconnectRetryPolicy
     {
         private int deltaBackOffMilliseconds;
         private int maxDeltaBackOffMilliseconds = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
         [ThreadStatic]
-        static private Random r;
+        private static Random r;
 
+        /// <summary>
+        /// Initializes a new instance using the specified back off interval with default maxDeltaBackOffMilliseconds of 10 seconds
+        /// </summary>
+        /// <param name="deltaBackOffMilliseconds">time in milliseconds for the back-off interval between retries</param>
         public ExponentialRetry(int deltaBackOffMilliseconds) : this(deltaBackOffMilliseconds, (int)TimeSpan.FromSeconds(10).TotalMilliseconds)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance using the specified back off interval.
+        /// </summary>
+        /// <param name="deltaBackOffMilliseconds">time in milliseconds for the back-off interval between retries</param>
+        /// <param name="maxDeltaBackOffMilliseconds">time in milliseconds for the maximum value that the back-off interval can exponentailly grow upto</param>
         public ExponentialRetry(int deltaBackOffMilliseconds, int maxDeltaBackOffMilliseconds)
         {
             this.deltaBackOffMilliseconds = deltaBackOffMilliseconds;
             this.maxDeltaBackOffMilliseconds = maxDeltaBackOffMilliseconds;
         }
 
+        /// <summary>
+        /// This method is called by the ConnectionMultiplexer to determine if a reconnect operation can be retried now.
+        /// </summary>
+        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the ConnectionMultiplexer while it was in the connecting state</param>
+        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total elapsed time in milliseconds since the last reconnect retry was made</param>
         public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry)
         {
             var exponential = (int)Math.Min(maxDeltaBackOffMilliseconds, deltaBackOffMilliseconds * Math.Pow(1.1, currentRetryCount));

--- a/StackExchange.Redis/StackExchange/Redis/ExponentialRetry.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ExponentialRetry.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace StackExchange.Redis
+{
+
+    public class ExponentialRetry : IReconnectRetryPolicy
+    {
+        private int deltaBackOffMilliseconds;
+        private int maxDeltaBackOffMilliseconds = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+        [ThreadStatic]
+        static private Random r;
+
+        public ExponentialRetry(int deltaBackOffMilliseconds) : this(deltaBackOffMilliseconds, (int)TimeSpan.FromSeconds(10).TotalMilliseconds)
+        {
+        }
+
+        public ExponentialRetry(int deltaBackOffMilliseconds, int maxDeltaBackOffMilliseconds)
+        {
+            this.deltaBackOffMilliseconds = deltaBackOffMilliseconds;
+            this.maxDeltaBackOffMilliseconds = maxDeltaBackOffMilliseconds;
+        }
+
+        public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry)
+        {
+            var exponential = (int)Math.Min(maxDeltaBackOffMilliseconds, deltaBackOffMilliseconds * Math.Pow(1.1, currentRetryCount));
+            int random;
+            r = r ?? new Random();
+            random = r.Next((int)deltaBackOffMilliseconds, exponential);
+            return timeElapsedMillisecondsSinceLastRetry >= random;
+            //exponential backoff with deltaBackOff of 5000ms
+            //deltabackoff  exponential 
+            //5000	        5500	   
+            //5000	        6050	   
+            //5000	        6655	   
+            //5000	        8053	   
+            //5000	        10718	   
+            //5000	        17261	   
+            //5000	        37001	   
+            //5000	        127738	   
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/IReconnectRetryPolicy.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IReconnectRetryPolicy.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace StackExchange.Redis
+{
+    /// <summary>
+    /// Describes retry policy functionality that can be provided to the multiplexer to be used for connection reconnects
+    /// </summary>
+    public interface IReconnectRetryPolicy
+    {
+        /// <summary>
+        /// This method is called by the multiplexer to determine if a reconnect operation can be retried now.
+        /// </summary>
+        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the multiplexer while it was in connecting state</param>
+        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total time elapsed in milliseconds since the last reconnect retry was made</param>
+        bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry);
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/LinearRetry.cs
+++ b/StackExchange.Redis/StackExchange/Redis/LinearRetry.cs
@@ -2,18 +2,30 @@ using System;
 
 namespace StackExchange.Redis
 {
+    /// <summary>
+    /// Represents a retry policy that performs retries at a fixed interval. The retries are performed upto a maximum allowed time.
+    /// </summary>
     public class LinearRetry : IReconnectRetryPolicy
     {
-        private int deltaBackOffMilliseconds;
+        private int maxRetryElapsedTimeAllowedMilliseconds;
 
-        public LinearRetry(int deltaBackOffMilliseconds)
+        /// <summary>
+        /// Initializes a new instance using the specified maximum retry elapsed time allowed.
+        /// </summary>
+        /// <param name="maxRetryElapsedTimeAllowedMilliseconds">maximum elapsed time in milliseconds to be allowed for it to perform retries</param>
+        public LinearRetry(int maxRetryElapsedTimeAllowedMilliseconds)
         {
-            this.deltaBackOffMilliseconds = deltaBackOffMilliseconds;
+            this.maxRetryElapsedTimeAllowedMilliseconds = maxRetryElapsedTimeAllowedMilliseconds;
         }
 
+        /// <summary>
+        /// This method is called by the ConnectionMultiplexer to determine if a reconnect operation can be retried now.
+        /// </summary>
+        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the ConnectionMultiplexer while it was in the connecting state</param>
+        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total elapsed time in milliseconds since the last reconnect retry was made</param>
         public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry)
         {
-            return timeElapsedMillisecondsSinceLastRetry >= deltaBackOffMilliseconds;
+            return timeElapsedMillisecondsSinceLastRetry >= maxRetryElapsedTimeAllowedMilliseconds;
         }
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/LinearRetry.cs
+++ b/StackExchange.Redis/StackExchange/Redis/LinearRetry.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace StackExchange.Redis
+{
+    public class LinearRetry : IReconnectRetryPolicy
+    {
+        private int deltaBackOffMilliseconds;
+
+        public LinearRetry(int deltaBackOffMilliseconds)
+        {
+            this.deltaBackOffMilliseconds = deltaBackOffMilliseconds;
+        }
+
+        public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry)
+        {
+            return timeElapsedMillisecondsSinceLastRetry >= deltaBackOffMilliseconds;
+        }
+    }
+}


### PR DESCRIPTION
Implemented reconnect retry policies to back off connectimeout wait time linearly (default) or exponentially
config.ReconnectRetryPolicy = new ExponentialRetry(config.ConnectTimeout);

Looking for code review and any other feedback on the pull request.

thx.
