### PR TITLE
supporting status for being able to retry, if command was never sent over the wire.

### DIFF
--- a/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
+++ b/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
@@ -64,6 +64,7 @@ namespace StackExchange.Redis.Tests
                 };
                 var ex = Assert.Throws<RedisConnectionException>(() => muxer.GetDatabase().Ping());
                 var rde = (RedisConnectionException)ex.InnerException;
+                Assert.That(ex.CommandStatus, Is.EqualTo(CommandStatus.WaitingToBeSent));
                 Assert.That(rde.FailureType, Is.EqualTo(ConnectionFailureType.AuthenticationFailure));
                 Assert.That(rde.InnerException.Message, Is.EqualTo("Error: NOAUTH Authentication required. Verify if the Redis password provided is correct."));
                 //wait for a second  for connectionfailed event to fire

--- a/StackExchange.Redis/StackExchange/Redis/CommandStatus.cs
+++ b/StackExchange.Redis/StackExchange/Redis/CommandStatus.cs
@@ -1,0 +1,21 @@
+﻿namespace StackExchange.Redis
+{
+    /// <summary>
+    /// track status of a command while communicating with Redis
+    /// </summary>
+    public enum CommandStatus
+    {
+        /// <summary>
+        /// command status unknown
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// ConnectionMultiplexer has not yet started writing this command to redis 
+        /// </summary>
+        WaitingToBeSent,
+        /// <summary>
+        /// command has been sent to Redis
+        /// </summary>
+        Sent,
+    }
+}


### PR DESCRIPTION
I would like to get feedback on this proposal, where client application can read status of a command and to be able to retry if it was never sent over the wire. 

```c#
var policy = Policy.Handle<RedisTimeoutException>(p=> p.Commandstatus == CommandStatus.WaitingToBeSentToRedis)
.Or<RedisConnectionException>(p=> p.CommandStatus == CommandStatus.WaitingToBeSentToRedis)
.Retry(3,(exception, retrycount) =>
{
    //log("Try {0} failed with {1}", retrycount, exception);
});

try
{
    policy.Execute(() => conn.GetDatabase().StringGet("test"));
}
catch (Exception e)
{ 
    //log
}
```