### PR TITLE
If an UnauthorizedAccessException occurs and _disabled is set to true…

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
+++ b/StackExchange.Redis/StackExchange/Redis/DebuggingAids.cs
@@ -335,7 +335,7 @@ namespace StackExchange.Redis
                 // this shouldn't happen, but just being safe...
             }
 
-            if (_cpu != null)
+            if (!_disabled && _cpu != null)
             {
                 value = _cpu.NextValue();
                 return true;


### PR DESCRIPTION
…, ensure subsequent calls to this method will not cause another UnauthorizedAccessException.

This is to solve exceptions in the form:

```
System.UnauthorizedAccessException: Access to the registry key '238' is denied.
   at Microsoft.Win32.RegistryKey.Win32Error(Int32 errorCode, String str)
   at Microsoft.Win32.RegistryKey.InternalGetValue(String name, Object defaultValue, Boolean doNotExpand, Boolean checkSecurity)
   at Microsoft.Win32.RegistryKey.GetValue(String name)
   at System.Diagnostics.PerformanceMonitor.GetData(String item)
   at System.Diagnostics.PerformanceCounterLib.GetPerformanceData(String item)
   at System.Diagnostics.PerformanceCounterLib.GetCategorySample(String category)
   at System.Diagnostics.PerformanceCounterLib.GetCategorySample(String machine, String category)
   at System.Diagnostics.PerformanceCounter.NextSample()
   at System.Diagnostics.PerformanceCounter.NextValue()
   at StackExchange.Redis.PerfCounterHelper.TryGetSystemCPU(Single& value)
   at StackExchange.Redis.ConnectionMultiplexer.GetSystemCpuPercent()
   at StackExchange.Redis.ConnectionMultiplexer.ExecuteSyncImpl[T](Message message, ResultProcessor`1 processor, ServerEndPoint server)
   at StackExchange.Redis.RedisBase.ExecuteSync[T](Message message, ResultProcessor`1 processor, ServerEndPoint server)
   at StackExchange.Redis.RedisDatabase.StringGet(RedisKey key, CommandFlags flags)
```