### PR TITLE
Support ZREVRANGEBYLEX operation

### DIFF
--- a/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -725,8 +725,15 @@ namespace StackExchange.Redis.Tests
         [Test]
         public void SortedSetRangeByValue()
         {
-            wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority);
-            mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority));
+            wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Ascending);
+            mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Ascending));
+        }
+
+        [Test]
+        public void SortedSetRangeByValueDescending()
+        {
+            wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Descending);
+            mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Descending));
         }
 
         [Test]

--- a/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -688,8 +688,15 @@ namespace StackExchange.Redis.Tests
         [Test]
         public void SortedSetRangeByValueAsync()
         {
-            wrapper.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority);
-            mock.Verify(_ => _.SortedSetRangeByValueAsync("prefix:key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority));
+            wrapper.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Ascending);
+            mock.Verify(_ => _.SortedSetRangeByValueAsync("prefix:key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Ascending));
+        }
+
+        [Test]
+        public void SortedSetRangeByValueDescendingAsync()
+        {
+            wrapper.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Descending);
+            mock.Verify(_ => _.SortedSetRangeByValueAsync("prefix:key", "min", "max", Exclude.Start, 123, 456, CommandFlags.HighPriority, Order.Descending));
         }
 
         [Test]

--- a/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabase.cs
@@ -838,7 +838,7 @@ namespace StackExchange.Redis
         /// <returns>list of elements in the specified score range.</returns>
         RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue),
             Exclude exclude = Exclude.None, long skip = 0, long take = -1,
-            CommandFlags flags = CommandFlags.None);
+            CommandFlags flags = CommandFlags.None, Order order = Order.Ascending);
 
         /// <summary>
         /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high. The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.

--- a/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IDatabaseAsync.cs
@@ -795,7 +795,7 @@ namespace StackExchange.Redis
         /// <returns>list of elements in the specified score range.</returns>
         Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue),
             Exclude exclude = Exclude.None, long skip = 0, long take = -1,
-            CommandFlags flags = CommandFlags.None);
+            CommandFlags flags = CommandFlags.None, Order order = Order.Ascending);
 
         /// <summary>
         /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high. The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -536,9 +536,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SortedSetRangeByScoreWithScores(ToInner(key), start, stop, exclude, order, skip, take, flags);
         }
 
-        public RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None, Order order = Order.Ascending)
         {
-            return Inner.SortedSetRangeByValue(ToInner(key), min, max, exclude, skip, take, flags);
+            return Inner.SortedSetRangeByValue(ToInner(key), min, max, exclude, skip, take, flags, order);
         }
 
         public long? SortedSetRank(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
@@ -519,9 +519,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SortedSetRangeByScoreWithScoresAsync(ToInner(key), start, stop, exclude, order, skip, take, flags);
         }
 
-        public Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None, Order order = Order.Ascending)
         {
-            return Inner.SortedSetRangeByValueAsync(ToInner(key), min, max, exclude, skip, take, flags);
+            return Inner.SortedSetRangeByValueAsync(ToInner(key), min, max, exclude, skip, take, flags, order);
         }
 
         public Task<long?> SortedSetRankAsync(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)

--- a/StackExchange.Redis/StackExchange/Redis/RedisCommand.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisCommand.cs
@@ -171,6 +171,7 @@
         ZLEXCOUNT,
         ZRANGE,
         ZRANGEBYLEX,
+        ZREVRANGEBYLEX,
         ZRANGEBYSCORE,
         ZRANK,
         ZREM,

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -2304,9 +2304,9 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
 
-        public RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None, Order order = Order.Ascending)
         {
-            var msg = GetLexMessage(RedisCommand.ZRANGEBYLEX, key, min, max, exclude, skip, take, flags);
+            var msg = GetLexMessage(order == Order.Ascending ? RedisCommand.ZRANGEBYLEX : RedisCommand.ZREVRANGEBYLEX, key, min, max, exclude, skip, take, flags);
             return ExecuteSync(msg, ResultProcessor.RedisValueArray);
         }
 
@@ -2322,9 +2322,9 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
-        public Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default(RedisValue), RedisValue max = default(RedisValue), Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None, Order order = Order.Ascending)
         {
-            var msg = GetLexMessage(RedisCommand.ZRANGEBYLEX, key, min, max, exclude, skip, take, flags);
+            var msg = GetLexMessage(order == Order.Ascending ? RedisCommand.ZRANGEBYLEX : RedisCommand.ZREVRANGEBYLEX, key, min, max, exclude, skip, take, flags);
             return ExecuteAsync(msg, ResultProcessor.RedisValueArray);
         }
 


### PR DESCRIPTION
Added support for Redis [ZREVRANGEBYLEX](ZREVRANGEBYLEX) operation which should address #316 
Methods `SortedSetRangeByValue` & `SortedSetRangeByValueAsync` were extended with optional column `Order` which decides whether to use `ZRANGEBYLEX` or `ZREVRANGEBYLEX`