### PR TITLE
Add SslProtocols property to ConfigurationOptions

### DIFF
--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -79,11 +79,11 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | serviceName={string}   | `ServiceName`          | `null`                       | Not currently implemented (intended for use with sentinel)                                                |
 | ssl={bool}             | `Ssl`                  | `false`                      | Specifies that SSL encryption should be used                                                              |
 | sslHost={string}       | `SslHost`              | `null`                       | Enforces a particular SSL host identity on the server's certificate                                       |
+| sslProtocols={enum}    | `SslProtocols`         | `null`			             | Ssl/Tls versions supported when using an encrypted connection.  Use '\|' to provide multiple values.      |
 | syncTimeout={int}      | `SyncTimeout`          | `1000`                       | Time (ms) to allow for synchronous operations                                                             |
 | tiebreaker={string}    | `TieBreaker`           | `__Booksleeve_TieBreak`      | Key to use for selecting a server in an ambiguous master scenario                                         |
 | version={string}       | `DefaultVersion`       | (`3.0` in Azure, else `2.0`) | Redis version level (useful when the server does not make this available)                                 |
 | writeBuffer={int}      | `WriteBuffer`          | `4096`                       | Size of the output buffer                                                                                 |
-| sslProtocols={enum}    | `SslProtocols`         | `null`			             | Ssl/Tls versions supported when using an encrypted connection.  Use '\|' to provide multiple values.      |
 
 Additional code-only options:
 - ReconnectRetryPolicy (`IReconnectRetryPolicy`) - Default: `ReconnectRetryPolicy = LinearRetry(ConnectTimeout);`

--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -62,27 +62,28 @@ Configuration Options
 
 The `ConfigurationOptions` object has a wide range of properties, all of which are fully documented in intellisense. Some of the more common options to use include:
 
-| Configuration string   | `ConfigurationOptions` | Default                      | Meaning                                                                          |
-| ---------------------- | ---------------------- | ---------------------------- | -------------------------------------------------------------------------------- |
-| abortConnect={bool}    | `AbortOnConnectFail`   | `true` (`false` on Azure)    | If true, `Connect` will not create a connection while no servers are available   |
-| allowAdmin={bool}      | `AllowAdmin`           | `false`                      | Enables a range of commands that are considered risky                            |
-| channelPrefix={string} | `ChannelPrefix`        | `null`                       | Optional channel prefix for all pub/sub operations                               |
-| connectRetry={int}     | `ConnectRetry`         | `3`                          | The number of times to repeat connect attempts during initial `Connect`          |
-| connectTimeout={int}   | `ConnectTimeout`       | `5000`                       | Timeout (ms) for connect operations                                              |
-| configChannel={string} | `ConfigurationChannel` | `__Booksleeve_MasterChanged` | Broadcast channel name for communicating configuration changes                   |
-| defaultDatabase={int}  | `DefaultDatabase`      | `null`                       | Default database index, from `0` to `databases - 1`                              |
-| keepAlive={int}        | `KeepAlive`            | `-1`                         | Time (seconds) at which to send a message to help keep sockets alive             |
-| name={string}          | `ClientName`           | `null`                       | Identification for the connection within redis                                   |
-| password={string}      | `Password`             | `null`                       | Password for the redis server                                                    |
-| proxy={proxy type}     | `Proxy`                | `Proxy.None`                 | Type of proxy in use (if any); for example "twemproxy"                           |
-| resolveDns={bool}      | `ResolveDns`           | `false`                      | Specifies that DNS resolution should be explicit and eager, rather than implicit |
-| serviceName={string}   | `ServiceName`          | `null`                       | Not currently implemented (intended for use with sentinel)                       |
-| ssl={bool}             | `Ssl`                  | `false`                      | Specifies that SSL encryption should be used                                     |
-| sslHost={string}       | `SslHost`              | `null`                       | Enforces a particular SSL host identity on the server's certificate              |
-| syncTimeout={int}      | `SyncTimeout`          | `1000`                       | Time (ms) to allow for synchronous operations                                    |
-| tiebreaker={string}    | `TieBreaker`           | `__Booksleeve_TieBreak`      | Key to use for selecting a server in an ambiguous master scenario                |
-| version={string}       | `DefaultVersion`       | (`3.0` in Azure, else `2.0`) | Redis version level (useful when the server does not make this available)        |
-| writeBuffer={int}      | `WriteBuffer`          | `4096`                       | Size of the output buffer                                                        |
+| Configuration string   | `ConfigurationOptions` | Default                      | Meaning                                                                                                   |
+| ---------------------- | ---------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------- |
+| abortConnect={bool}    | `AbortOnConnectFail`   | `true` (`false` on Azure)    | If true, `Connect` will not create a connection while no servers are available                            |
+| allowAdmin={bool}      | `AllowAdmin`           | `false`                      | Enables a range of commands that are considered risky                                                     |
+| channelPrefix={string} | `ChannelPrefix`        | `null`                       | Optional channel prefix for all pub/sub operations                                                        |
+| connectRetry={int}     | `ConnectRetry`         | `3`                          | The number of times to repeat connect attempts during initial `Connect`                                   |
+| connectTimeout={int}   | `ConnectTimeout`       | `5000`                       | Timeout (ms) for connect operations                                                                       |
+| configChannel={string} | `ConfigurationChannel` | `__Booksleeve_MasterChanged` | Broadcast channel name for communicating configuration changes                                            |
+| defaultDatabase={int}  | `DefaultDatabase`      | `null`                       | Default database index, from `0` to `databases - 1`                                                       |
+| keepAlive={int}        | `KeepAlive`            | `-1`                         | Time (seconds) at which to send a message to help keep sockets alive                                      |
+| name={string}          | `ClientName`           | `null`                       | Identification for the connection within redis                                                            |
+| password={string}      | `Password`             | `null`                       | Password for the redis server                                                                             |
+| proxy={proxy type}     | `Proxy`                | `Proxy.None`                 | Type of proxy in use (if any); for example "twemproxy"                                                    |
+| resolveDns={bool}      | `ResolveDns`           | `false`                      | Specifies that DNS resolution should be explicit and eager, rather than implicit                          |
+| serviceName={string}   | `ServiceName`          | `null`                       | Not currently implemented (intended for use with sentinel)                                                |
+| ssl={bool}             | `Ssl`                  | `false`                      | Specifies that SSL encryption should be used                                                              |
+| sslHost={string}       | `SslHost`              | `null`                       | Enforces a particular SSL host identity on the server's certificate                                       |
+| syncTimeout={int}      | `SyncTimeout`          | `1000`                       | Time (ms) to allow for synchronous operations                                                             |
+| tiebreaker={string}    | `TieBreaker`           | `__Booksleeve_TieBreak`      | Key to use for selecting a server in an ambiguous master scenario                                         |
+| version={string}       | `DefaultVersion`       | (`3.0` in Azure, else `2.0`) | Redis version level (useful when the server does not make this available)                                 |
+| writeBuffer={int}      | `WriteBuffer`          | `4096`                       | Size of the output buffer                                                                                 |
+| sslProtocols={enum}    | `SslProtocols`         | `null`			             | Ssl/Tls versions supported when using an encrypted connection.  Use '\|' to provide multiple values.      |
 
 Additional code-only options:
 - ReconnectRetryPolicy (`IReconnectRetryPolicy`) - Default: `ReconnectRetryPolicy = LinearRetry(ConnectTimeout);`

--- a/MigratedBookSleeveTestSuite/Config.cs
+++ b/MigratedBookSleeveTestSuite/Config.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Authentication;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using StackExchange.Redis;
@@ -185,6 +186,42 @@ namespace Tests
             {
                 Console.WriteLine(log);
             }
+        }
+
+        [Test]
+        public void SslProtocols_SingleValue()
+        {
+            var log = new StringWriter();
+            var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11");
+            Assert.AreEqual(SslProtocols.Tls11, options.SslProtocols.Value);
+        }
+
+        [Test]
+        public void SslProtocols_MultipleValues()
+        {
+            var log = new StringWriter();
+            var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11|Tls12");
+            Assert.AreEqual(SslProtocols.Tls11|SslProtocols.Tls12, options.SslProtocols.Value);
+        }
+
+        [Test]
+        public void SslProtocols_UsingIntegerValue()
+        {
+            var log = new StringWriter();
+
+            // The below scenario is for cases where the *targeted*
+            // .NET framework version (e.g. .NET 4.0) doesn't define an enum value (e.g. Tls11)
+            // but the OS has been patched with support
+            int integerValue = (int)(SslProtocols.Tls11 | SslProtocols.Tls12);
+            var options = ConfigurationOptions.Parse("myhost,sslProtocols=" + integerValue);
+            Assert.AreEqual(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.Value);
+        }
+
+        [Test]
+        public void SslProtocols_InvalidValue()
+        {
+            var log = new StringWriter();
+            Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse("myhost,sslProtocols=InvalidSslProtocol"));            
         }
 
         [Test]

--- a/MigratedBookSleeveTestSuite/Config.cs
+++ b/MigratedBookSleeveTestSuite/Config.cs
@@ -187,7 +187,7 @@ namespace Tests
                 Console.WriteLine(log);
             }
         }
-#if !CORE_CLR
+
         [Test]
         public void SslProtocols_SingleValue()
         {
@@ -223,7 +223,6 @@ namespace Tests
             var log = new StringWriter();
             Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse("myhost,sslProtocols=InvalidSslProtocol"));            
         }
-#endif //#if !CORE_CLR
 
         [Test]
         public void ConfigurationOptionsDefaultForAzure()

--- a/MigratedBookSleeveTestSuite/Config.cs
+++ b/MigratedBookSleeveTestSuite/Config.cs
@@ -187,7 +187,7 @@ namespace Tests
                 Console.WriteLine(log);
             }
         }
-
+#if !CORE_CLR
         [Test]
         public void SslProtocols_SingleValue()
         {
@@ -223,6 +223,7 @@ namespace Tests
             var log = new StringWriter();
             Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse("myhost,sslProtocols=InvalidSslProtocol"));            
         }
+#endif //#if !CORE_CLR
 
         [Test]
         public void ConfigurationOptionsDefaultForAzure()

--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -66,7 +66,7 @@ namespace StackExchange.Redis
                 if (!Enum.TryParse(value, true, out tmp)) throw new ArgumentOutOfRangeException("Keyword '" + key + "' requires a proxy value");
                 return tmp;
             }
-#if !CORE_CLR
+
             internal static SslProtocols ParseSslProtocols(string key, string value)
             {
                 SslProtocols tmp;
@@ -77,7 +77,7 @@ namespace StackExchange.Redis
 
                 return tmp;                
             }
-#endif
+
             internal static void Unknown(string key)
             {
                 throw new ArgumentException("Keyword '" + key + "' is not supported");
@@ -90,10 +90,8 @@ namespace StackExchange.Redis
                         ConfigChannel = "configChannel", AbortOnConnectFail = "abortConnect", ResolveDns = "resolveDns",
                         ChannelPrefix = "channelPrefix", Proxy = "proxy", ConnectRetry = "connectRetry",
                         ConfigCheckSeconds = "configCheckSeconds", ResponseTimeout = "responseTimeout", DefaultDatabase = "defaultDatabase";
-#if !CORE_CLR
             internal const string SslProtocols = "sslProtocols";
-#endif
-                
+
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
                 AllowAdmin, SyncTimeout,
@@ -103,9 +101,7 @@ namespace StackExchange.Redis
                 ConfigChannel, AbortOnConnectFail, ResolveDns,
                 ChannelPrefix, Proxy, ConnectRetry,
                 ConfigCheckSeconds, DefaultDatabase,
-#if !CORE_CLR
                 SslProtocols,
-#endif
             }.ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
             public static string TryNormalize(string value)
@@ -175,13 +171,11 @@ namespace StackExchange.Redis
         /// </summary>
         public bool Ssl { get { return ssl.GetValueOrDefault(); } set { ssl = value; } }
 
-
-#if !CORE_CLR
         /// <summary>
         /// Configures which Ssl/TLS protocols should be allowed.  If not set, defaults are chosen by the .NET framework.
         /// </summary>
         public SslProtocols? SslProtocols { get; set; }
-#endif
+
         /// <summary>
         /// Automatically encodes and decodes channels
         /// </summary>

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -786,7 +786,18 @@ namespace StackExchange.Redis
 #if CORE_CLR
                         ssl.AuthenticateAsClientAsync(host).GetAwaiter().GetResult();
 #else
-                        ssl.AuthenticateAsClient(host);
+                        if (config.SslProtocols.HasValue)
+                        {
+                            var allowedProtocols = config.SslProtocols.Value;
+                            ssl.AuthenticateAsClient(host, new X509CertificateCollection(), allowedProtocols, checkCertificateRevocation: true);
+                        }
+                        else
+                        {
+                            // default to defaults for the .NET framework
+                            ssl.AuthenticateAsClient(host);
+                        }
+
+                        Multiplexer.LogLocked(log, $"SSL connection established successfully using protocol: {ssl.SslProtocol}");
 #endif
                     }
                     catch (AuthenticationException authexception)

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -783,22 +783,9 @@ namespace StackExchange.Redis
                         );
                     try
                     {
-#if CORE_CLR
-                        ssl.AuthenticateAsClientAsync(host).GetAwaiter().GetResult();
-#else
-                        if (config.SslProtocols.HasValue)
-                        {
-                            var allowedProtocols = config.SslProtocols.Value;
-                            ssl.AuthenticateAsClient(host, new X509CertificateCollection(), allowedProtocols, checkCertificateRevocation: true);
-                        }
-                        else
-                        {
-                            // default to defaults for the .NET framework
-                            ssl.AuthenticateAsClient(host);
-                        }
+                        ssl.AuthenticateAsClient(host, config.SslProtocols);
 
                         Multiplexer.LogLocked(log, $"SSL connection established successfully using protocol: {ssl.SslProtocol}");
-#endif
                     }
                     catch (AuthenticationException authexception)
                     {


### PR DESCRIPTION
This property allows you to configure the list of acceptable SSL/TLS Protocols for encrypted communication.  Without this setting, users are required to make changes to machine wide settings, which can break other applications that are not compatible.  