### PR TITLE
Support for netstandard1.4 and netappcore1.0.

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -22,7 +22,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
 
-    <LibraryTargetFrameworks>net45;net46;netstandard1.5</LibraryTargetFrameworks><!--net40;-->
+    <LibraryTargetFrameworks>net45;net46;netstandard1.5;netstandard1.4</LibraryTargetFrameworks><!--net40;-->
     <CoreFxVersion>4.3.0</CoreFxVersion>
   </PropertyGroup>
   

--- a/MigratedBookSleeveTestSuite/redis-sharp.cs
+++ b/MigratedBookSleeveTestSuite/redis-sharp.cs
@@ -242,7 +242,11 @@ public class Redis : IDisposable
             socket = null;
             return;
         }
+#if !CORE_CLR_14
         bstream = new BufferedStream(new NetworkStream(socket), 16 * 1024);
+#else
+        bstream = new NetworkStream(socket);
+#endif
 
         if (Password != null)
             SendExpectSuccess("AUTH {0}\r\n", Password);

--- a/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
+++ b/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
@@ -68,4 +68,34 @@
     <PackageReference Include="System.Threading.Timer" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <PackageReference Include="System.Collections" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Collections.Concurrent" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Diagnostics.Tools" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.IO.Compression" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Linq" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Net.NameResolution" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Net.Security" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Net.Sockets" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.Emit" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.Extensions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.Timer" Version="$(CoreFxVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -71,4 +71,34 @@
     <PackageReference Include="System.Threading.Timer" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <DefineConstants>$(DefineConstants);CORE_CLR;CORE_CLR_14</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <PackageReference Include="System.Collections" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Collections.Concurrent" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Diagnostics.Tools" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.IO.Compression" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Linq" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Net.NameResolution" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Net.Security" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Net.Sockets" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.Emit" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.Extensions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.Timer" Version="$(CoreFxVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -815,7 +815,12 @@ namespace StackExchange.Redis
 
                 int bufferSize = config.WriteBuffer;
                 this.netStream = stream;
+#if !CORE_CLR_14
                 this.outStream = bufferSize <= 0 ? stream : new BufferedStream(stream, bufferSize);
+#else
+                this.outStream = stream;
+#endif
+            
                 Multiplexer.LogLocked(log, "Connected {0}", Bridge);
 
                 Bridge.OnConnected(this, log);


### PR DESCRIPTION
AWS Lambda only supports netcoreapp1.0, and will never support 1.1. 

This means that to run StackExchange.Redis in AWS Lambda, it must run on netstandard1.4 or lower.

This PR adjusts the targeted version to 1.4, and excludes BufferedStream, which is only supported in 1.5.

I welcome feedback on how to handle this shortfall.