### PR TITLE
Give defaultClientName a value when it is null

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -24,6 +24,6 @@
 
     <LibraryTargetFrameworks>net45;net46;netstandard1.5</LibraryTargetFrameworks>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <xUnitVersion>2.4.0-beta1-build3908</xUnitVersion>
+    <xUnitVersion>2.4.0-beta.1.build3958</xUnitVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -24,6 +24,6 @@
 
     <LibraryTargetFrameworks>net45;net46;netstandard1.5</LibraryTargetFrameworks>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <xUnitVersion>2.3.1</xUnitVersion>
+    <xUnitVersion>2.4.0-beta1-build3908</xUnitVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -24,6 +24,6 @@
 
     <LibraryTargetFrameworks>net45;net46;netstandard1.5</LibraryTargetFrameworks>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <xUnitVersion>2.3.0-beta5-build3750</xUnitVersion>
+    <xUnitVersion>2.3.1</xUnitVersion>
   </PropertyGroup>
 </Project>

--- a/StackExchange.Redis.Tests/Helpers/Attributes.cs
+++ b/StackExchange.Redis.Tests/Helpers/Attributes.cs
@@ -49,7 +49,7 @@ namespace StackExchange.Redis.Tests
         public FactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
 
         protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
-            => new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            => new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod);
     }
 
     public class TheoryDiscoverer : Xunit.Sdk.TheoryDiscoverer
@@ -57,16 +57,16 @@ namespace StackExchange.Redis.Tests
         public TheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
-            => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow) };
+            => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod, dataRow) };
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, string skipReason)
-            => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+            => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod) };
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
-            => new[] { new SkippableTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+            => new[] { new SkippableTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod) };
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkippedDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow, string skipReason)
-            => new[] { new NamedSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, skipReason, dataRow) };
+            => new[] { new NamedSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod, skipReason, dataRow) };
     }
 
     public class SkippableTestCase : XunitTestCase
@@ -77,8 +77,8 @@ namespace StackExchange.Redis.Tests
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public SkippableTestCase() { }
 
-        public SkippableTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        public SkippableTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
         }
 
@@ -103,8 +103,8 @@ namespace StackExchange.Redis.Tests
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public SkippableTheoryTestCase() { }
 
-        public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod) { }
+        public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
 
         public override async Task<RunSummary> RunAsync(
             IMessageSink diagnosticMessageSink,
@@ -127,8 +127,8 @@ namespace StackExchange.Redis.Tests
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public NamedSkippedDataRowTestCase() { }
 
-        public NamedSkippedDataRowTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, string skipReason, object[] testMethodArguments = null)
-        : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, skipReason, testMethodArguments) { }
+        public NamedSkippedDataRowTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, string skipReason, object[] testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, skipReason, testMethodArguments) { }
     }
 
     public class SkippableMessageBus : IMessageBus

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -25,8 +25,6 @@
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
-    <!-- Temp workaround for analyzer issue -->
-    <PackageReference Include="xunit.analyzers" Version="0.6.1" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -95,7 +95,10 @@ namespace StackExchange.Redis
         {
             if (defaultClientName == null)
             {
-                defaultClientName =  TryGetAzureRoleInstanceIdNoThrow() ?? Environment.GetEnvironmentVariable("ComputerName");
+                defaultClientName = TryGetAzureRoleInstanceIdNoThrow()
+                    ?? Environment.MachineName
+                    ?? Environment.GetEnvironmentVariable("ComputerName")
+                    ?? "StackExchange.Redis";
             }
             return defaultClientName;
         }


### PR DESCRIPTION
This prevents calling TryGetAzureRoleInstanceIdNoThrow() repeatedly in the null
case.