### PR TITLE
Removed invalid call to SetRequestSent for IMultiMessage

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -24,6 +24,6 @@
 
     <LibraryTargetFrameworks>net45;net46;netstandard1.5</LibraryTargetFrameworks>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <xUnitVersion>2.3.0-beta5-build3750</xUnitVersion>
+    <xUnitVersion>2.3.1</xUnitVersion>
   </PropertyGroup>
 </Project>

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <!-- Temp workaround for analyzer issue -->
-    <PackageReference Include="xunit.analyzers" Version="0.6.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(xUnitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(xUnitVersion)" />

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
@@ -547,7 +547,7 @@ namespace StackExchange.Redis
                     }
                     //The parent message (next) may be returned from GetMessages
                     //and should not be marked as sent again below
-                    messageIsSent = subCommand == next;
+                    messageIsSent = messageIsSent || subCommand == next;
                 }
                 if (!messageIsSent)
                 {

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalBridge.cs
@@ -530,6 +530,7 @@ namespace StackExchange.Redis
         internal bool WriteMessageDirect(PhysicalConnection tmp, Message next)
         {
             Trace("Writing: " + next);
+            var messageIsSent = false;
             if (next is IMultiMessage)
             {
                 SelectDatabase(tmp, next); // need to switch database *before* the transaction
@@ -544,9 +545,14 @@ namespace StackExchange.Redis
                         CompleteSyncOrAsync(next);
                         return false;
                     }
+                    //The parent message (next) may be returned from GetMessages
+                    //and should not be marked as sent again below
+                    messageIsSent = subCommand == next;
                 }
-
-                next.SetRequestSent();
+                if (!messageIsSent)
+                {
+                    next.SetRequestSent();
+                }
 
                 return true;
             }

--- a/StackExchange.Redis/StackExchange/Redis/ProfileStorage.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ProfileStorage.cs
@@ -70,7 +70,7 @@ namespace StackExchange.Redis
         public void SetMessage(Message msg)
         {
             // This method should never be called twice
-            if (Message != null) throw new InvalidOperationException();
+            if (Message != null) throw new InvalidOperationException($"{nameof(SetMessage)} called more than once");
 
             Message = msg;
             MessageCreatedDateTime = msg.createdDateTime;
@@ -80,7 +80,7 @@ namespace StackExchange.Redis
         public void SetEnqueued()
         {
             // This method should never be called twice
-            if (EnqueuedTimeStamp > 0) throw new InvalidOperationException();
+            if (EnqueuedTimeStamp > 0) throw new InvalidOperationException($"{nameof(SetEnqueued)} called more than once");
 
             EnqueuedTimeStamp = Stopwatch.GetTimestamp();
         }
@@ -88,14 +88,14 @@ namespace StackExchange.Redis
         public void SetRequestSent()
         {
             // This method should never be called twice
-            if (RequestSentTimeStamp > 0) throw new InvalidOperationException();
+            if (RequestSentTimeStamp > 0) throw new InvalidOperationException($"{nameof(SetRequestSent)} called more than once");
 
             RequestSentTimeStamp = Stopwatch.GetTimestamp();
         }
 
         public void SetResponseReceived()
         {
-            if (ResponseReceivedTimeStamp > 0) throw new InvalidOperationException();
+            if (ResponseReceivedTimeStamp > 0) throw new InvalidOperationException($"{nameof(SetResponseReceived)} called more than once");
 
             ResponseReceivedTimeStamp = Stopwatch.GetTimestamp();
         }


### PR DESCRIPTION
Hopefully solves #280. 

For `IMultiMessage`:s, such as a `ScriptEvalMessage`, `SetRequestSent` was called twice, which triggered an exception in `ProfileStorage`. The exception is weirdly rethrown as `UnableToResolvePhysicalConnection`.

Possible solutions:

1. Don't throw the exception in `ProfileStorage`
2. Detect in `Message.SetRequestSent` if the message was already sent, and don't forward the call to  `ProfileStorage` if it was.
3. Detect in `PhysicalBridge` whether the `IMultiMessage` instance was returned from `GetMessages` and ignore the extra call to `SetRequestSent` if it was.

I chose solution 3, since it scoped the change to `IMultiMessage`:s, but the other solutions should work equally fine. If it's really regarded as an error to call `SetRequestSent` twice, I think the exception should be thrown in `Message` instead.
