### PR TITLE
Support PreserveAsyncOrder in connection string

### DIFF
--- a/StackExchange.Redis.Tests/Issues/Issue791.cs
+++ b/StackExchange.Redis.Tests/Issues/Issue791.cs
@@ -1,0 +1,39 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests.Issues
+{
+    public class Issue791 : TestBase
+    {
+        public Issue791(ITestOutputHelper output) : base(output) { }
+
+        
+        [Fact]
+        public void PreserveAsyncOrderImplicitValue_ParsedFromConnectionString()
+        {
+            var options = ConfigurationOptions.Parse("preserveAsyncOrder=true");
+            Assert.True(options.PreserveAsyncOrder);
+            Assert.Equal("preserveAsyncOrder=True", options.ToString());
+
+            options = ConfigurationOptions.Parse("preserveAsyncOrder=false");
+            Assert.False(options.PreserveAsyncOrder);
+            Assert.Equal("preserveAsyncOrder=False", options.ToString());
+        }
+
+
+        [Fact]
+        public void DefaultValue_IsTrue()
+        {
+            var options = ConfigurationOptions.Parse("ssl=true");
+            Assert.True(options.PreserveAsyncOrder);            
+        }
+
+        
+        [Fact]
+        public void PreserveAsyncOrder_SetConnectionMultiplexerProperty()
+        {
+            var multiplexer = ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,preserveAsyncOrder=false");
+            Assert.False(multiplexer.PreserveAsyncOrder);
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -936,7 +936,7 @@ namespace StackExchange.Redis
                 map.AssertAvailable(RedisCommand.EXISTS);
             }
 
-            PreserveAsyncOrder = true; // safest default
+            PreserveAsyncOrder = configuration.PreserveAsyncOrder;
             timeoutMilliseconds = configuration.SyncTimeout;
 
             OnCreateReaderWriter(configuration);


### PR DESCRIPTION
Currently **ConnectionMultiplexer.PreserveAsyncOrder** can be changed by the property only.

Add **PreserveAsyncOrder** property  to **ConfigurationOptions** and make **ConfigurationOptions .Parse** method to parse it from connection string. It could look like this:

```
"contoso.redis.cache.windows.net,abortConnect=true, preserveAsyncOrder=true"
```

#791 