### PR TITLE
Remove TaskSource.CreateDenyExecSync

### DIFF
--- a/NRediSearch.Test/ExampleUsage.cs
+++ b/NRediSearch.Test/ExampleUsage.cs
@@ -36,7 +36,23 @@ namespace NRediSearch.Test
                 .AddTextField("body", 1.0)
                 .AddNumericField("price");
 
-            Assert.True(client.CreateIndex(sc, Client.IndexOptions.Default));
+            bool result = false;
+            try
+            {
+                result = client.CreateIndex(sc, Client.IndexOptions.Default);
+            }
+            catch (RedisServerException ex)
+            {
+                // TODO: Convert to Skip
+                if (ex.Message == "ERR unknown command 'FT.CREATE'")
+                {
+                    Console.WriteLine(ex.Message);
+                    Console.WriteLine("Module not installed, aborting");
+                    return; // the module isn't installed
+                }
+            }
+
+            Assert.True(result);
 
             // note: using java API equivalent here; it would be nice to
             // use meta-programming / reflection instead in .NET

--- a/StackExchange.Redis.Tests/Cluster.cs
+++ b/StackExchange.Redis.Tests/Cluster.cs
@@ -162,15 +162,8 @@ namespace StackExchange.Redis.Tests
                     string b = conn.GetServer(node.EndPoint).StringGet(db.Database, key);
                     Assert.Equal(value, b); // wrong master, allow redirect
 
-                    try
-                    {
-                        string c = conn.GetServer(node.EndPoint).StringGet(db.Database, key, CommandFlags.NoRedirect);
-                        Assert.True(false, "wrong master, no redirect");
-                    }
-                    catch (RedisServerException ex)
-                    {
-                        Assert.True("MOVED " + slot + " " + rightMasterNode.EndPoint == ex.Message, "wrong master, no redirect");
-                    }
+                    var ex = Assert.Throws<RedisServerException>(() => conn.GetServer(node.EndPoint).StringGet(db.Database, key, CommandFlags.NoRedirect));
+                    Assert.StartsWith($"Key has MOVED from Endpoint {rightMasterNode.EndPoint} and hashslot {slot}", ex.Message);
                 }
 
                 node = config.Nodes.FirstOrDefault(x => x.IsSlave && x.ParentNodeId == rightMasterNode.NodeId);
@@ -187,16 +180,9 @@ namespace StackExchange.Redis.Tests
                 {
                     string e = conn.GetServer(node.EndPoint).StringGet(db.Database, key);
                     Assert.Equal(value, e); // wrong slave, allow redirect
-
-                    try
-                    {
-                        string f = conn.GetServer(node.EndPoint).StringGet(db.Database, key, CommandFlags.NoRedirect);
-                        Assert.True(false, "wrong slave, no redirect");
-                    }
-                    catch (RedisServerException ex)
-                    {
-                        Assert.True("MOVED " + slot + " " + rightMasterNode.EndPoint == ex.Message, "wrong slave, no redirect");
-                    }
+                    
+                    var ex = Assert.Throws<RedisServerException>(() => conn.GetServer(node.EndPoint).StringGet(db.Database, key, CommandFlags.NoRedirect));
+                    Assert.StartsWith($"Key has MOVED from Endpoint {rightMasterNode.EndPoint} and hashslot {slot}", ex.Message);
                 }
 #endif
 

--- a/StackExchange.Redis.Tests/ConnectFailTimeout.cs
+++ b/StackExchange.Redis.Tests/ConnectFailTimeout.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,28 +11,26 @@ namespace StackExchange.Redis.Tests
 
 #if DEBUG
         [Fact]
-        public void NoticesConnectFail()
+        public async Task NoticesConnectFail()
         {
             SetExpectedAmbientFailureCount(-1);
             using (var conn = Create(allowAdmin: true))
             {
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
-                conn.IgnoreConnect = true;
                 conn.ConnectionFailed += (s, a) =>
                     Output.WriteLine("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
                 conn.ConnectionRestored += (s, a) =>
                     Output.WriteLine("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
-                server.SimulateConnectionFailure();
-                Thread.Sleep(2000);
-                try
-                {
-                    server.Ping();
-                    Assert.True(false, "Did not expect PING to succeed");
-                }
-                catch (RedisConnectionException) { /* expected */ }
 
+                // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
+                conn.IgnoreConnect = true;
+                server.SimulateConnectionFailure();
                 conn.IgnoreConnect = false;
-                Thread.Sleep(2000);
+                Assert.Throws<RedisConnectionException>(() => server.Ping());
+
+                // Heartbeat should reconnect by now
+                await Task.Delay(5000);
+
                 var time = server.Ping();
                 Output.WriteLine(time.ToString());
             }

--- a/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
+++ b/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
@@ -28,7 +28,7 @@ namespace StackExchange.Redis.Tests
 
                 SocketManager.ConnectCompletionType = completionType;
 
-                using (var muxer = ConnectionMultiplexer.Connect(config))
+                using (var muxer = ConnectionMultiplexer.Connect(config, Writer))
                 {
                     Thread.Sleep(10000);
                 }
@@ -40,7 +40,7 @@ namespace StackExchange.Redis.Tests
                 var elapsed = sw.ElapsedMilliseconds;
                 Output.WriteLine("Elapsed time: " + elapsed);
                 Output.WriteLine("Timeout: " + timeout);
-                Assert.True(elapsed < 9000, "Connect should fail within ConnectTimeout");
+                Assert.True(elapsed < 9000, "Connect should fail within ConnectTimeout, ElapsedMs: " + elapsed);
             }
             finally
             {

--- a/StackExchange.Redis.Tests/Expiry.cs
+++ b/StackExchange.Redis.Tests/Expiry.cs
@@ -64,7 +64,7 @@ namespace StackExchange.Redis.Tests
                 var conn = muxer.GetDatabase();
                 conn.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var offset = utc ? TimeSpan.Zero : TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time").BaseUtcOffset;
+                var offset = utc ? TimeSpan.Zero : TimeZoneInfo.Local.BaseUtcOffset;
                 var now = utc ? DateTime.UtcNow : new DateTime(DateTime.UtcNow.Ticks + offset.Ticks, DateTimeKind.Local);
                 var resultOffset = utc ? TimeSpan.Zero : now - DateTime.Now;
                 Output.WriteLine("Now: {0}", now);

--- a/StackExchange.Redis.Tests/Issues/Issue791.cs
+++ b/StackExchange.Redis.Tests/Issues/Issue791.cs
@@ -32,7 +32,7 @@ namespace StackExchange.Redis.Tests.Issues
         [Fact]
         public void PreserveAsyncOrder_SetConnectionMultiplexerProperty()
         {
-            var multiplexer = ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,preserveAsyncOrder=false");
+            var multiplexer = ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":" + TestConfig.Current.MasterPort + ",preserveAsyncOrder=false");
             Assert.False(multiplexer.PreserveAsyncOrder);
         }
     }

--- a/StackExchange.Redis.Tests/Secure.cs
+++ b/StackExchange.Redis.Tests/Secure.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests
 {
+    [Collection(NonParallelCollection.Name)]
     public class Secure : TestBase
     {
         protected override string GetConfiguration() =>
@@ -42,7 +43,7 @@ namespace StackExchange.Redis.Tests
 #if DEBUG
                 long newAlloc = ConnectionMultiplexer.GetResultBoxAllocationCount();
                 Output.WriteLine("ResultBox allocations: {0}", newAlloc - oldAlloc);
-                Assert.True(newAlloc - oldAlloc <= 2);
+                Assert.True(newAlloc - oldAlloc <= 2, $"NewAllocs: {newAlloc}, OldAllocs: {oldAlloc}");
 #endif
             }
         }

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -1967,7 +1967,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.CreateDenyExecSync<T>(state);
+                var tcs = TaskSource.Create<T>(state);
                 var source = ResultBox<T>.Get(tcs);
                 if (!TryPushMessageToBridge(message, processor, source, ref server))
                 {

--- a/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
@@ -78,7 +78,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.CreateDenyExecSync<T>(asyncState);
+                var tcs = TaskSource.Create<T>(asyncState);
                 var source = ResultBox<T>.Get(tcs);
                 message.SetSource(source, processor);
                 task = tcs.Task;

--- a/StackExchange.Redis/StackExchange/Redis/RedisTransaction.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisTransaction.cs
@@ -72,7 +72,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.CreateDenyExecSync<T>(asyncState);
+                var tcs = TaskSource.Create<T>(asyncState);
                 var source = ResultBox<T>.Get(tcs);
                 message.SetSource(source, processor);
                 task = tcs.Task;

--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -175,7 +175,14 @@ namespace StackExchange.Redis
                             }
                             else
                             {
-                                err = string.Format("Endpoint {0} serving hashslot {1} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect.  ", endpoint, hashSlot);
+                                if (isMoved && (message.Flags & CommandFlags.NoRedirect) != 0)
+                                {
+                                    err = $"Key has MOVED from Endpoint {endpoint} and hashslot {hashSlot} but CommandFlags.NoRedirect was specified - redirect not followed. ";
+                                }
+                                else
+                                {
+                                    err = $"Endpoint {endpoint} serving hashslot {hashSlot} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect.  ";
+                                }
 #if FEATURE_PERFCOUNTER
                                 err += ConnectionMultiplexer.GetThreadPoolAndCPUSummary(bridge.Multiplexer.IncludePerformanceCountersInExceptions);
 #endif

--- a/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
@@ -562,7 +562,7 @@ namespace StackExchange.Redis
 
         internal Task<T> QueueDirectAsync<T>(Message message, ResultProcessor<T> processor, object asyncState = null, PhysicalBridge bridge = null)
         {
-            var tcs = TaskSource.CreateDenyExecSync<T>(asyncState);
+            var tcs = TaskSource.Create<T>(asyncState);
             var source = ResultBox<T>.Get(tcs);
             message.SetSource(processor, source);
             if (bridge == null) bridge = GetBridge(message.Command);

--- a/StackExchange.Redis/StackExchange/Redis/TaskSource.cs
+++ b/StackExchange.Redis/StackExchange/Redis/TaskSource.cs
@@ -13,10 +13,7 @@ namespace StackExchange.Redis
     /// see https://stackoverflow.com/a/22588431/23354 for more information; a huge
     /// thanks to Eli Arbel for spotting this (even though it is pure evil; it is *my kind of evil*)
     /// </summary>
-#if DEBUG
-    public // for the unit tests in TaskTests.cs
-#endif
-    static class TaskSource
+    internal static class TaskSource
     {
 #if !PLAT_SAFE_CONTINUATIONS
         // on .NET < 4.6, it was possible to have threads hijacked; this is no longer a problem in 4.6 and core-clr 5,
@@ -92,16 +89,6 @@ namespace StackExchange.Redis
 #else
             return new TaskCompletionSource<T>(asyncState, TaskCreationOptions.None);
 #endif
-        }        
-
-        /// <summary>
-        /// Create a new TaskCompletionSource that will not allow result-setting threads to be hijacked
-        /// </summary>
-        public static TaskCompletionSource<T> CreateDenyExecSync<T>(object asyncState)
-        {
-            var source = new TaskCompletionSource<T>(asyncState);
-            //DenyExecSync(source.Task);
-            return source;
         }
     }
 }


### PR DESCRIPTION
After 50547eba453ff42b7b1b965f3f710dfcb177ca98, TaskSource.Create and TaskSource.CreateDenyExecSync methods are the same. There was some crud left everywhere that appeared like differences but it's really determined once in the static initializer for TaskSource based on the platform anyway.

I've fixed the tests as well - they were a bit backwards on logic/assumptions so hard to read, and have been failing for some time. Now we'd expect ContinueWithExecSync to *not* be hijacked, and everything else to be...that's how the tests are as well.

Note: the #if DEBUG change is because internals are already visible to tests...just simpler.

cc @mgravell for eyes - I've tested and running cross-platform. This is part of an overall effort to get tests green and cleanup in prep for network rewrite.