### PR TITLE
Remove TaskSource.CreateDenyExecSync

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -1967,7 +1967,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.CreateDenyExecSync<T>(state);
+                var tcs = TaskSource.Create<T>(state);
                 var source = ResultBox<T>.Get(tcs);
                 if (!TryPushMessageToBridge(message, processor, source, ref server))
                 {

--- a/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisBatch.cs
@@ -78,7 +78,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.CreateDenyExecSync<T>(asyncState);
+                var tcs = TaskSource.Create<T>(asyncState);
                 var source = ResultBox<T>.Get(tcs);
                 message.SetSource(source, processor);
                 task = tcs.Task;

--- a/StackExchange.Redis/StackExchange/Redis/RedisTransaction.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisTransaction.cs
@@ -72,7 +72,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.CreateDenyExecSync<T>(asyncState);
+                var tcs = TaskSource.Create<T>(asyncState);
                 var source = ResultBox<T>.Get(tcs);
                 message.SetSource(source, processor);
                 task = tcs.Task;

--- a/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ServerEndPoint.cs
@@ -562,7 +562,7 @@ namespace StackExchange.Redis
 
         internal Task<T> QueueDirectAsync<T>(Message message, ResultProcessor<T> processor, object asyncState = null, PhysicalBridge bridge = null)
         {
-            var tcs = TaskSource.CreateDenyExecSync<T>(asyncState);
+            var tcs = TaskSource.Create<T>(asyncState);
             var source = ResultBox<T>.Get(tcs);
             message.SetSource(processor, source);
             if (bridge == null) bridge = GetBridge(message.Command);

--- a/StackExchange.Redis/StackExchange/Redis/TaskSource.cs
+++ b/StackExchange.Redis/StackExchange/Redis/TaskSource.cs
@@ -13,10 +13,7 @@ namespace StackExchange.Redis
     /// see https://stackoverflow.com/a/22588431/23354 for more information; a huge
     /// thanks to Eli Arbel for spotting this (even though it is pure evil; it is *my kind of evil*)
     /// </summary>
-#if DEBUG
-    public // for the unit tests in TaskTests.cs
-#endif
-    static class TaskSource
+    internal static class TaskSource
     {
 #if !PLAT_SAFE_CONTINUATIONS
         // on .NET < 4.6, it was possible to have threads hijacked; this is no longer a problem in 4.6 and core-clr 5,
@@ -92,16 +89,6 @@ namespace StackExchange.Redis
 #else
             return new TaskCompletionSource<T>(asyncState, TaskCreationOptions.None);
 #endif
-        }        
-
-        /// <summary>
-        /// Create a new TaskCompletionSource that will not allow result-setting threads to be hijacked
-        /// </summary>
-        public static TaskCompletionSource<T> CreateDenyExecSync<T>(object asyncState)
-        {
-            var source = new TaskCompletionSource<T>(asyncState);
-            //DenyExecSync(source.Task);
-            return source;
         }
     }
 }


### PR DESCRIPTION
After 50547eba453ff42b7b1b965f3f710dfcb177ca98, TaskSource.Create and TaskSource.CreateDenyExecSync methods are the same. There was some crud left everywhere that appeared like differences but it's really determined once in the static initializer for TaskSource based on the platform anyway.

I've fixed the tests as well - they were a bit backwards on logic/assumptions so hard to read, and have been failing for some time. Now we'd expect ContinueWithExecSync to *not* be hijacked, and everything else to be...that's how the tests are as well.

Note: the #if DEBUG change is because internals are already visible to tests...just simpler.

cc @mgravell for eyes - I've tested and running cross-platform. This is part of an overall effort to get tests green and cleanup in prep for network rewrite.