### PR TITLE
AsyncSockets configuration option

### DIFF
--- a/StackExchange.Redis.Tests/Config.cs
+++ b/StackExchange.Redis.Tests/Config.cs
@@ -335,5 +335,32 @@ namespace StackExchange.Redis.Tests
                 }
             }
         }
+        
+        [Fact]
+        public void AsyncSocketMode()
+        {
+            var options = ConfigurationOptions.Parse($"socketMode={SocketMode.Async}");
+            Assert.True(options.SocketMode.Equals(SocketMode.Async));
+        }
+
+        [Fact]
+        public void PollSocketMode()
+        {
+            var options = ConfigurationOptions.Parse($"socketMode={SocketMode.Poll}");
+            Assert.True(options.SocketMode.Equals(SocketMode.Poll));
+        }
+
+        [Fact]
+        public void InvalidSocketMode()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse($"socketMode={SocketMode.Abort}"));
+        }
+
+        [Fact]
+        public void DefaultSocketMode()
+        {
+            var options = new ConfigurationOptions();
+            Assert.True(options.SocketMode.Equals(SocketManager.DefaultSocketMode));
+        }
     }
 }

--- a/StackExchange.Redis.Tests/SocketModeTests.cs
+++ b/StackExchange.Redis.Tests/SocketModeTests.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests.Booksleeve
+{
+    public class SocketModeTests : BookSleeveTestBase
+    {
+        public SocketModeTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void Equality()
+        {
+            Assert.True(SocketMode.Poll == SocketMode.Poll);
+            Assert.True(SocketMode.Poll.Equals(SocketMode.Poll));
+            Assert.True(SocketMode.Poll.Equals(SocketMode.Poll as object));
+        }
+
+        [Fact]
+        public void Inequality()
+        {
+            Assert.True(SocketMode.Poll != SocketMode.Async);
+            Assert.True(!SocketMode.Poll.Equals(SocketMode.Async));
+            Assert.True(!SocketMode.Poll.Equals(SocketMode.Async as object));
+            Assert.True(!SocketMode.Poll.Equals(""));
+            Assert.True(!SocketMode.Poll.Equals(null));
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -787,14 +787,14 @@ namespace StackExchange.Redis
         {
             try
             {
-                var socketMode = SocketManager.DefaultSocketMode;
-
                 // disallow connection in some cases
                 OnDebugAbort();
 
                 // the order is important here:
                 // [network]<==[ssl]<==[logging]<==[buffered]
                 var config = Multiplexer.RawConfig;
+
+                var socketMode = config.SocketMode ?? SocketManager.DefaultSocketMode;
 
                 if (config.Ssl)
                 {

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.NoPoll.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.NoPoll.cs
@@ -3,7 +3,7 @@ namespace StackExchange.Redis
 {
     public partial class SocketManager
     {
-        internal const SocketMode DefaultSocketMode = SocketMode.Async;
+        internal static readonly SocketMode DefaultSocketMode = SocketMode.Async;
 
         private void OnAddRead(System.Net.Sockets.Socket socket, ISocketCallback callback)
         {

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.Poll.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.Poll.cs
@@ -10,7 +10,7 @@ namespace StackExchange.Redis
 {
     public partial class SocketManager
     {
-        internal const SocketMode DefaultSocketMode = SocketMode.Poll;
+        internal static readonly SocketMode DefaultSocketMode = SocketMode.Poll;
         private static readonly IntPtr[] EmptyPointers = new IntPtr[0];
         private static readonly WaitCallback HelpProcessItems = state =>
         {

--- a/StackExchange.Redis/StackExchange/Redis/SocketMode.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketMode.cs
@@ -1,0 +1,93 @@
+﻿using System;
+
+namespace StackExchange.Redis
+{
+    /// <summary>
+    /// Specifies socket mode for the physical connection
+    /// </summary>
+    public struct SocketMode : IEquatable<SocketMode>
+    {
+        private enum _SocketMode
+        {
+            Abort,
+            Poll,
+            Async
+        }
+
+        private readonly _SocketMode socketMode;
+
+        internal static SocketMode Abort => new SocketMode(_SocketMode.Abort);
+
+        /// <summary>
+        /// Using polling threads
+        /// </summary>
+        public static SocketMode Poll => new SocketMode(_SocketMode.Poll);
+
+        /// <summary>
+        /// Using async socket API
+        /// </summary>
+        public static SocketMode Async => new SocketMode(_SocketMode.Async);
+
+        private SocketMode(_SocketMode socketMode)
+        {
+            this.socketMode = socketMode;
+        }
+
+        #region Equality
+        /// <summary>
+        /// See Object.Equals
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            if (obj is SocketMode other)
+            {
+                return Equals(other);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// See Object.GetHashCode
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return this.socketMode.GetHashCode();
+        }
+
+        /// <summary>
+        /// Indicate whether two socket modes are equal
+        /// </summary>
+        public bool Equals(SocketMode other)
+        {
+            return this.socketMode == other.socketMode;
+        }
+
+        /// <summary>
+        /// Indicate whether two socket modes are equal
+        /// </summary>
+        public static bool operator ==(SocketMode x, SocketMode y)
+        {
+            return x.Equals(y);
+        }
+
+        /// <summary>
+        /// Indicate whether two socket modes are not equal
+        /// </summary>
+        public static bool operator !=(SocketMode x, SocketMode y)
+        {
+            return !(x == y);
+        }
+        #endregion
+
+        /// <summary>
+        /// Obtain string representation of the socket mode
+        /// </summary>
+        public override string ToString()
+        {
+            return this.socketMode.ToString();
+        }
+    }
+}


### PR DESCRIPTION
We use single-box test environment with multiple services deployed. Each of those may create one or more ```ConnectionMultiplexer``` objects (for connection pooling) resulting overall in dozens of ```ConnectionMultiplexer``` objects across all processes talking to the local ```Redis``` instance. Each of ```ConnectionMultiplexer``` objects create two polling socket threads and consume CPU even if services are idle and slowly but surely draining the battery.

With 100 ```ConnectionMultiplexer``` objects I observe ~30% CPU consumption on my laptop. Settings ```HighPrioritySocketThreads``` to false does not really help. The proposal is to allow using asynchronous sockets for non-SSL connections which are enabled by default (and actually required) for SSL connections.

I am introducing new ```AsyncSockets``` configuration option which when set to true configures socket mode to ```SocketMode.Async``` even for non-SSL connections.