### PR TITLE
Clarify the documentation for IDatabase(Async).HashSet(Async)

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabase.cs
@@ -329,7 +329,7 @@ namespace StackExchange.Redis
         IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any specified fields that already exist in the hash, leaving other unspecified fields untouched. If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The entries to set in the hash.</param>

--- a/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabaseAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabaseAsync.cs
@@ -292,7 +292,7 @@ namespace StackExchange.Redis
         Task<long> HashLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any existing fields in the hash. If key does not exist, a new key holding a hash is created.
+        /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any specified fields that already exist in the hash, leaving other unspecified fields untouched. If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The entries to set in the hash.</param>


### PR DESCRIPTION
The documentation for the overload of IDatabaseAsync.HashSetAsync that takes multiple fields/values was somewhat ambiguous. It could have been read to mean that fields not set as a part of the HashSetAsync are deleted rather than preserved. The documentation for HMSET was clearer, so this borrows some of the verbiage from the Redis documentation into the documentation for HashSetAsync.