### PR TITLE
Cluster Keyspace Notification Support

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/RedisChannel.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisChannel.cs
@@ -12,6 +12,7 @@ namespace StackExchange.Redis
 
         internal readonly byte[] Value;
         internal readonly bool IsPatternBased;
+        internal readonly bool IsKeyspaceChannel;
 
         /// <summary>
         /// Indicates whether the channel-name is either null or a zero-length value
@@ -38,6 +39,7 @@ namespace StackExchange.Redis
         {
             Value = value;
             IsPatternBased = isPatternBased;
+            IsKeyspaceChannel = value != null && Encoding.UTF8.GetString(value).ToLower().StartsWith("__key");
         }
 
         private static bool DeterminePatternBased(byte[] value, PatternMode mode)


### PR DESCRIPTION
Attempt at adding support for cluster keyspace notifications to subscriber by allowing subscription to multiple nodes.

The basic goal with this was to alter the internal logic of the `Subscription` class to accommodate connection to multiple endpoints for a single channel when a pattern-based keyspace/keyevent subscription is detected (rather than having `Subscription` simply represent a 1:1 relationship between channel/endpoint). The hope was that a subscriber could handle subscriptions uniformly, regardless of the special cases.

However, this approach has been problematic for me so far. This could be my setup, but it seems that there's a significant delay for the subscription to connect, which is causing the initial `PSUBSCRIBE` command messages to fail. Other times, the application will intermittently work, receiving notifications from the various masters in the cluster, and then will just start throwing repeated "No connection found to handle X operation" exceptions, occasionally correcting itself. So, it seems like something somewhere doesn't like me forcing these connections. I'm not sure if there's a flaw with my understanding of how the Subscriber fits into the application, or just the implementation (or both). 

I appreciate any feedback/insights. I'm happy to put in the time to make this work, with any guidance. Also, wasn't sure how to proceed with the tests as (last I checked) there were a few failing already. Happy to implement those too.

implements: #789 