### PR TITLE
Makes Exception constructors public

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/Exceptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Exceptions.cs
@@ -76,8 +76,8 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisCommandException : Exception
     {
-        internal RedisCommandException(string message) : base(message) { }
-        internal RedisCommandException(string message, Exception innerException) : base(message, innerException) { }
+        public RedisCommandException(string message) : base(message) { }
+        public RedisCommandException(string message, Exception innerException) : base(message, innerException) { }
     }
 
     /// <summary>
@@ -85,7 +85,7 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisTimeoutException : TimeoutException
     {
-        internal RedisTimeoutException(string message, CommandStatus commandStatus) : base(message)
+        pulic RedisTimeoutException(string message, CommandStatus commandStatus) : base(message)
         {
             Commandstatus = commandStatus;
         }
@@ -101,11 +101,11 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisConnectionException : RedisException
     {
-        internal RedisConnectionException(ConnectionFailureType failureType, string message) : this(failureType, message, null, CommandStatus.Unknown) {}
+        public RedisConnectionException(ConnectionFailureType failureType, string message) : this(failureType, message, null, CommandStatus.Unknown) {}
 
-        internal RedisConnectionException(ConnectionFailureType failureType, string message, Exception innerException) : this(failureType, message, innerException, CommandStatus.Unknown) {}
+        public RedisConnectionException(ConnectionFailureType failureType, string message, Exception innerException) : this(failureType, message, innerException, CommandStatus.Unknown) {}
 
-        internal RedisConnectionException(ConnectionFailureType failureType, string message, Exception innerException, CommandStatus commandStatus) : base(message, innerException)
+        public RedisConnectionException(ConnectionFailureType failureType, string message, Exception innerException, CommandStatus commandStatus) : base(message, innerException)
         {
             FailureType = failureType;
             CommandStatus = commandStatus;
@@ -127,8 +127,8 @@ namespace StackExchange.Redis
     /// </summary>
     public partial class RedisException : Exception
     {
-        internal RedisException(string message) : base(message) { }
-        internal RedisException(string message, Exception innerException) : base(message, innerException) { }
+        public RedisException(string message) : base(message) { }
+        public RedisException(string message, Exception innerException) : base(message, innerException) { }
     }
 
     /// <summary>
@@ -136,6 +136,6 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisServerException : RedisException
     {
-        internal RedisServerException(string message) : base(message) { }
+        public RedisServerException(string message) : base(message) { }
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/Exceptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Exceptions.cs
@@ -76,7 +76,17 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisCommandException : Exception
     {
+        /// <summary>
+        /// Creates a new <see cref="RedisCommandException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
         public RedisCommandException(string message) : base(message) { }
+
+        /// <summary>
+        /// Creates a new <see cref="RedisCommandException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
+        /// <param name="innerException">The inner exception.</param>
         public RedisCommandException(string message, Exception innerException) : base(message, innerException) { }
     }
 
@@ -85,7 +95,12 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisTimeoutException : TimeoutException
     {
-        pulic RedisTimeoutException(string message, CommandStatus commandStatus) : base(message)
+        /// <summary>
+        /// Creates a new <see cref="RedisTimeoutException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
+        /// <param name="commandStatus">The command status, as of when the timeout happened.</param>
+        public RedisTimeoutException(string message, CommandStatus commandStatus) : base(message)
         {
             Commandstatus = commandStatus;
         }
@@ -101,10 +116,28 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisConnectionException : RedisException
     {
+        /// <summary>
+        /// Creates a new <see cref="RedisConnectionException"/>.
+        /// </summary>
+        /// <param name="failureType">The type of connection failure.</param>
+        /// <param name="message">The message for the exception.</param>
         public RedisConnectionException(ConnectionFailureType failureType, string message) : this(failureType, message, null, CommandStatus.Unknown) {}
 
+        /// <summary>
+        /// Creates a new <see cref="RedisConnectionException"/>.
+        /// </summary>
+        /// <param name="failureType">The type of connection failure.</param>
+        /// <param name="message">The message for the exception.</param>
+        /// <param name="innerException">The inner exception.</param>
         public RedisConnectionException(ConnectionFailureType failureType, string message, Exception innerException) : this(failureType, message, innerException, CommandStatus.Unknown) {}
 
+        /// <summary>
+        /// Creates a new <see cref="RedisConnectionException"/>.
+        /// </summary>
+        /// <param name="failureType">The type of connection failure.</param>
+        /// <param name="message">The message for the exception.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="commandStatus">The status of the command.</param>
         public RedisConnectionException(ConnectionFailureType failureType, string message, Exception innerException, CommandStatus commandStatus) : base(message, innerException)
         {
             FailureType = failureType;
@@ -127,7 +160,17 @@ namespace StackExchange.Redis
     /// </summary>
     public partial class RedisException : Exception
     {
+        /// <summary>
+        /// Crerates a new <see cref="RedisException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
         public RedisException(string message) : base(message) { }
+
+        /// <summary>
+        /// Crerates a new <see cref="RedisException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
+        /// <param name="innerException">The inner exception.</param>
         public RedisException(string message, Exception innerException) : base(message, innerException) { }
     }
 
@@ -136,6 +179,10 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed partial class RedisServerException : RedisException
     {
+        /// <summary>
+        /// Creates a new <see cref="RedisServerException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
         public RedisServerException(string message) : base(message) { }
     }
 }


### PR DESCRIPTION
In unit tests mocking out an IDatabase with implementations that throw
an error was not possible. Constructing the Exception instances wasn't
accessible in user code. It is now.

This fixes #825.