### PR TITLE
Simplify SocketManager.BeginConnect() with not-used-outside-of-tests code removal.

### DIFF
--- a/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
+++ b/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
@@ -10,11 +10,8 @@ namespace StackExchange.Redis.Tests
         public ConnectToUnexistingHost(ITestOutputHelper output) : base (output) { }
 
 #if DEBUG
-        [Theory]
-        [InlineData(CompletionType.Any)]
-        [InlineData(CompletionType.Sync)]
-        [InlineData(CompletionType.Async)]
-        public void FailsWithinTimeout(CompletionType completionType)
+        [Fact]
+        public void FailsWithinTimeout()
         {
             const int timeout = 1000;
             var sw = Stopwatch.StartNew();
@@ -25,9 +22,7 @@ namespace StackExchange.Redis.Tests
                     EndPoints = { { "invalid", 1234 } },
                     ConnectTimeout = timeout
                 };
-
-                SocketManager.ConnectCompletionType = completionType;
-
+                
                 using (var muxer = ConnectionMultiplexer.Connect(config, Writer))
                 {
                     Thread.Sleep(10000);
@@ -41,10 +36,6 @@ namespace StackExchange.Redis.Tests
                 Output.WriteLine("Elapsed time: " + elapsed);
                 Output.WriteLine("Timeout: " + timeout);
                 Assert.True(elapsed < 9000, "Connect should fail within ConnectTimeout, ElapsedMs: " + elapsed);
-            }
-            finally
-            {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
             }
         }
 #endif

--- a/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -23,7 +23,6 @@ namespace StackExchange.Redis.Tests
                     var server2 = muxer.GetServer(muxer.GetEndPoints()[1]);
 
                     muxer.AllowConnect = false;
-                    SocketManager.ConnectCompletionType = CompletionType.Sync;
 
                     // muxer.IsConnected is true of *any* are connected, simulate failure for all cases.
                     server.SimulateConnectionFailure();
@@ -46,7 +45,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }
@@ -56,8 +54,6 @@ namespace StackExchange.Redis.Tests
         {
             try
             {
-                SocketManager.ConnectCompletionType = CompletionType.Sync;
-
                 using (var muxer = Create(keepAlive: 1, connectTimeout: 3000))
                 {
                     var conn = muxer.GetDatabase();
@@ -68,7 +64,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }
@@ -87,7 +82,6 @@ namespace StackExchange.Redis.Tests
                     var server2 = muxer.GetServer(muxer.GetEndPoints()[1]);
 
                     muxer.AllowConnect = false;
-                    SocketManager.ConnectCompletionType = CompletionType.Async;
 
                     // muxer.IsConnected is true of *any* are connected, simulate failure for all cases.
                     server.SimulateConnectionFailure();
@@ -110,7 +104,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }

--- a/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
+++ b/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
@@ -114,7 +114,6 @@ namespace StackExchange.Redis.Tests
                     var server = muxer.GetServer(muxer.GetEndPoints()[0]);
 
                     muxer.AllowConnect = false;
-                    SocketManager.ConnectCompletionType = CompletionType.Async;
 
                     server.SimulateConnectionFailure();
 
@@ -129,7 +128,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }

--- a/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -36,7 +36,6 @@ namespace StackExchange.Redis.Tests
                 {
                     var conn = muxer.GetDatabase();
                     muxer.AllowConnect = false;
-                    SocketManager.ConnectCompletionType = CompletionType.Async;
 
                     foreach (var endpoint in muxer.GetEndPoints())
                     {
@@ -56,7 +55,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }
@@ -70,7 +68,6 @@ namespace StackExchange.Redis.Tests
                 {
                     var conn = muxer.GetDatabase();
                     muxer.AllowConnect = false;
-                    SocketManager.ConnectCompletionType = CompletionType.Async;
                     var ex = ExceptionFactory.NoConnectionAvailable(true, true, new RedisCommand(), null, null, muxer.GetServerSnapshot());
                     Assert.IsType<RedisConnectionException>(ex);
                     Assert.Null(ex.InnerException);
@@ -78,7 +75,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }
@@ -92,7 +88,6 @@ namespace StackExchange.Redis.Tests
                 {
                     var conn = muxer.GetDatabase();
                     muxer.AllowConnect = false;
-                    SocketManager.ConnectCompletionType = CompletionType.Async;
 
                     muxer.GetServer(muxer.GetEndPoints()[0]).SimulateConnectionFailure();
 
@@ -104,7 +99,6 @@ namespace StackExchange.Redis.Tests
             }
             finally
             {
-                SocketManager.ConnectCompletionType = CompletionType.Any;
                 ClearAmbientFailures();
             }
         }


### PR DESCRIPTION
This was an expedition, but here's the history:
- There are 2 forks in the connection logic
  - One for Mono (the `DnsEndpoint` split, see #20 and #155)
  - One for `.BeginConnect()` and one for `.ConnectAsync()` (because `netstandard1.x` was "async all the things!")
- There's a behind-the-scenes fork on completion type, but for actual library consumers (and not tests), it was always `.Any`, which was effectively `.Sync`.

There was also a critical bug fix in #113 that unfortuantely added a lot of complexity here. The maintenance problem is this complexity wasn't even used, as far as I can tell. It was only ever exposed to even be possibly used in the test project. So we had complicated connection logic, only for the sake of testing it. Unless I'm an idiot, which is entirely possible.

This commit removes that logic and simplifies things, as a first step that's a unit in itself. It does not fix Mono. There are other issues there, but thanks to WSL I can readily run the test suite under Mono on Linux now. Mono has a littany of other issues which I'll comment on in #314.

The most important thing here is that we don't regress what was fixed in #113, as this doesn't readily show in tests. After that I'd like to discuss when we should ditch `netstandard1.5` (I'll open an issue), because it has various bits of weight I think we want to remove for the Pipelines overhaul anyway.