### PR TITLE
Mono Support!

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -194,13 +194,7 @@ namespace StackExchange.Redis
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         private static void Write<T>(ZipArchive zip, string name, Task task, Action<T, StreamWriter> callback)
         {
-            var entry = zip.CreateEntry(name,
-#if __MonoCS__
-                CompressionLevel.Fastest
-#else
-                CompressionLevel.Optimal
-#endif
-                );
+            var entry = zip.CreateEntry(name, PlatformHelper.GetCompressionLevel(nameof(CompressionLevel.Optimal)));
             using (var stream = entry.Open())
             using (var writer = new StreamWriter(stream))
             {

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -194,7 +194,7 @@ namespace StackExchange.Redis
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         private static void Write<T>(ZipArchive zip, string name, Task task, Action<T, StreamWriter> callback)
         {
-            var entry = zip.CreateEntry(name, PlatformHelper.GetCompressionLevel(nameof(CompressionLevel.Optimal)));
+            var entry = zip.CreateEntry(name, CompressionLevel.Optimal);
             using (var stream = entry.Open())
             using (var writer = new StreamWriter(stream))
             {

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -741,9 +741,6 @@ namespace StackExchange.Redis
 
                     var ssl = new SslStream(stream, false, config.CertificateValidationCallback,
                         config.CertificateSelectionCallback ?? GetAmbientCertificateCallback()
-#if !__MonoCS__
-                        , EncryptionPolicy.RequireEncryption
-#endif
                         );
                     try
                     {

--- a/StackExchange.Redis/StackExchange/Redis/PlatformHelper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PlatformHelper.cs
@@ -1,15 +1,14 @@
 ﻿using System;
-using System.IO.Compression;
 
 namespace StackExchange.Redis
 {
     internal class PlatformHelper
     {
-        public static SocketMode DefaultSocketMode => IsMono && IsUnix ? SocketMode.Async : SocketMode.Poll;
+        public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+        public static bool IsUnix { get; } = (int)Environment.OSVersion.Platform == 4
+                                          || (int)Environment.OSVersion.Platform == 6
+                                          || (int)Environment.OSVersion.Platform == 128;
 
-        public static bool IsMono => Type.GetType("Mono.Runtime") != null;
-        public static bool IsUnix => (int)Environment.OSVersion.Platform == 4
-                                  || (int)Environment.OSVersion.Platform == 6
-                                  || (int)Environment.OSVersion.Platform == 128;
+        public static SocketMode DefaultSocketMode = IsMono && IsUnix ? SocketMode.Async : SocketMode.Poll;
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/PlatformHelper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PlatformHelper.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Security;
+
+namespace StackExchange.Redis
+{
+    internal class PlatformHelper
+    {
+        public static SocketMode DefaultSocketMode = IsMono && IsUnix ? SocketMode.Async : SocketMode.Poll;
+
+        public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+        public static bool IsUnix { get; } = (int)Environment.OSVersion.Platform == 4
+                                          || (int)Environment.OSVersion.Platform == 6
+                                          || (int)Environment.OSVersion.Platform == 128;
+
+        /// <summary>
+        /// Gets the compression level from a string, avoiding a naming bug inside ancient mono versions.
+        /// </summary>
+        /// <remarks>
+        /// See: https://github.com/mono/mono/commit/714efcf7d1f9c9017b370af16bb3117179dd60e5
+        /// </remarks>
+        /// <param name="level">The level.</param>
+        /// <returns></returns>
+        public static CompressionLevel GetCompressionLevel(string level)
+        {
+            try
+            {
+                return (CompressionLevel)Enum.Parse(typeof(CompressionLevel), level);
+            }
+            catch (ArgumentException)
+            {
+                // Oops, ancient mono here.. let's tray again.
+                return (CompressionLevel)Enum.Parse(typeof(CompressionLevel), level.Replace(nameof(CompressionLevel.Optimal), "Optional"));
+            }
+        }
+    }
+}

--- a/StackExchange.Redis/StackExchange/Redis/PlatformHelper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PlatformHelper.cs
@@ -1,38 +1,15 @@
 ﻿using System;
-using System.IO;
 using System.IO.Compression;
-using System.Net.Security;
 
 namespace StackExchange.Redis
 {
     internal class PlatformHelper
     {
-        public static SocketMode DefaultSocketMode = IsMono && IsUnix ? SocketMode.Async : SocketMode.Poll;
+        public static SocketMode DefaultSocketMode => IsMono && IsUnix ? SocketMode.Async : SocketMode.Poll;
 
-        public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-        public static bool IsUnix { get; } = (int)Environment.OSVersion.Platform == 4
-                                          || (int)Environment.OSVersion.Platform == 6
-                                          || (int)Environment.OSVersion.Platform == 128;
-
-        /// <summary>
-        /// Gets the compression level from a string, avoiding a naming bug inside ancient mono versions.
-        /// </summary>
-        /// <remarks>
-        /// See: https://github.com/mono/mono/commit/714efcf7d1f9c9017b370af16bb3117179dd60e5
-        /// </remarks>
-        /// <param name="level">The level.</param>
-        /// <returns></returns>
-        public static CompressionLevel GetCompressionLevel(string level)
-        {
-            try
-            {
-                return (CompressionLevel)Enum.Parse(typeof(CompressionLevel), level);
-            }
-            catch (ArgumentException)
-            {
-                // Oops, ancient mono here.. let's tray again.
-                return (CompressionLevel)Enum.Parse(typeof(CompressionLevel), level.Replace(nameof(CompressionLevel.Optimal), "Optional"));
-            }
-        }
+        public static bool IsMono => Type.GetType("Mono.Runtime") != null;
+        public static bool IsUnix => (int)Environment.OSVersion.Platform == 4
+                                  || (int)Environment.OSVersion.Platform == 6
+                                  || (int)Environment.OSVersion.Platform == 128;
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.Poll.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.Poll.cs
@@ -10,7 +10,7 @@ namespace StackExchange.Redis
 {
     public partial class SocketManager
     {
-        internal const SocketMode DefaultSocketMode = SocketMode.Poll;
+        internal static SocketMode DefaultSocketMode = PlatformHelper.DefaultSocketMode;
         private static readonly IntPtr[] EmptyPointers = new IntPtr[0];
         private static readonly WaitCallback HelpProcessItems = state =>
         {


### PR DESCRIPTION
This is an attempt at the fixes for Mono in #314, but it doesn't actually ever connect to redis. It's possible something is wrong with:
- My fix porting from #314
- Unrelated changes since #314 was created that don't work in our networking stack
- How we're using sockets and Mono 5.12 I'm testing on
- Mono 5.12 specifically on Windows Subsystem for Linux
- All of the above

Posting this branch up so that people can a) check for idiot mistakes, and b) grab the branch to poke it.

Note: I've been testing using the `net46` lib, but `netstandard2.0` may be a viable candidate here. But...I don't really know how you'd test it directly. Would need to make an executable that references the `netstandard2.0` build in a wrapper, which doesn't exist today.

Note 2: This PR is against the `netstandard1.5` drop branch to demonstrate the equivalent diff to #314, but the branch state (no `netstandard1.5`) would be how we'd support Mono, if we can get it to work...

Here's an example test run:
```
16:11:33.836: 127.0.0.1:6379,127.0.0.1:6380,password=*****
16:11:33.843:
16:11:33.847: Connecting 127.0.0.1:6379/Interactive...
16:11:33.966: BeginConnect: 127.0.0.1:6379
16:11:33.973: Connecting 127.0.0.1:6380/Interactive...
16:11:33.974: BeginConnect: 127.0.0.1:6380
16:11:33.977: 2 unique nodes specified
16:11:33.980: EndConnect: 127.0.0.1:6380
16:11:33.981: EndConnect: 127.0.0.1:6379
16:11:33.986: Connected Interactive/127.0.0.1:6379
16:11:33.986: Connected Interactive/127.0.0.1:6380
16:11:33.987: Server handshake
16:11:33.987: Server handshake
16:11:33.994: Setting client name: Cravertop
16:11:33.994: Setting client name: Cravertop
16:11:34.002: Auto-configure...
16:11:34.002: Auto-configure...
16:11:34.004: Sending critical tracer: Interactive/127.0.0.1:6379
16:11:34.005: Sending critical tracer: Interactive/127.0.0.1:6380
16:11:34.005: Writing to Interactive/127.0.0.1:6379: ECHO
16:11:34.005: Flushing outbound buffer
16:11:34.005: Writing to Interactive/127.0.0.1:6380: ECHO
16:11:34.005: Flushing outbound buffer
16:11:34.006: Requesting tie-break from 127.0.0.1:6379 > __Booksleeve_TieBreak...
16:11:34.007: Starting poll
16:11:34.008: Starting poll
16:11:34.009: Requesting tie-break from 127.0.0.1:6380 > __Booksleeve_TieBreak...
16:11:34.010: Connect complete: 127.0.0.1:6380
16:11:34.011: Allowing endpoints 00:00:05 to respond...
16:11:34.011: Connect complete: 127.0.0.1:6379
16:11:34.013: Awaiting task completion, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
16:11:39.020: Not all tasks completed cleanly, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
16:11:39.020: 127.0.0.1:6379 did not respond
16:11:39.020: 127.0.0.1:6380 did not respond
16:11:39.023: Awaiting task completion, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
16:11:39.073: Not all tasks completed cleanly, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
16:11:39.074: 127.0.0.1:6379 failed to nominate (WaitingForActivation)
16:11:39.074: 127.0.0.1:6380 failed to nominate (WaitingForActivation)
16:11:39.074: No masters detected
16:11:39.076: 127.0.0.1:6379: Standalone v2.0.0, master; keep-alive: 00:01:00; int: ConnectedEstablishing; sub: ConnectedEstablishing; not in use: DidNotRespond
16:11:39.077: 127.0.0.1:6379: int ops=7, qu=2, qs=7, qc=0, wr=0, socks=1; sub ops=3, qu=0, qs=3, qc=0, wr=0, socks=1
16:11:39.082: Circular op-count snapshot; int: 0+7=7 (0.70 ops/s; spans 10s); sub: 0+3=3 (0.30 ops/s; spans 10s)
16:11:39.082: 127.0.0.1:6380: Standalone v2.0.0, master; keep-alive: 00:01:00; int: ConnectedEstablishing; sub: ConnectedEstablishing; not in use: DidNotRespond
16:11:39.082: 127.0.0.1:6380: int ops=7, qu=2, qs=7, qc=0, wr=0, socks=1; sub ops=3, qu=0, qs=3, qc=0, wr=0, socks=1
16:11:39.083: Circular op-count snapshot; int: 0+7=7 (0.70 ops/s; spans 10s); sub: 0+3=3 (0.30 ops/s; spans 10s)
16:11:39.083: Sync timeouts: 0; fire and forget: 0; last heartbeat: -1s ago
16:11:39.083: resetting failing connections to retry...
16:11:39.096: retrying; attempts left: 2...
16:11:39.096: 2 unique nodes specified
16:11:39.097: Requesting tie-break from 127.0.0.1:6379 > __Booksleeve_TieBreak...
16:11:39.097: Requesting tie-break from 127.0.0.1:6380 > __Booksleeve_TieBreak...
16:11:39.097: Allowing endpoints 00:00:05 to respond...
16:11:39.097: Awaiting task completion, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
```
Relevant portion:
```
16:11:34.013: Awaiting task completion, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
16:11:39.020: Not all tasks completed cleanly, IOCP: (Busy=0,Free=800,Min=8,Max=800), WORKER: (Busy=12,Free=788,Min=8,Max=800)
```