### PR TITLE
Added support for UnixDomainSocketEndPoint introduced in .NET Core 2.1

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
@@ -190,9 +190,13 @@ namespace StackExchange.Redis
             }
 
             var addressFamily = endpoint.AddressFamily == AddressFamily.Unspecified ? AddressFamily.InterNetwork : endpoint.AddressFamily;
-            var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
+            var protocolType = addressFamily == AddressFamily.Unix ? ProtocolType.Unspecified : ProtocolType.Tcp;
+            var socket = new Socket(addressFamily, SocketType.Stream, protocolType);
             SetFastLoopbackOption(socket);
-            socket.NoDelay = true;
+            if (addressFamily != AddressFamily.Unix)
+            {
+                socket.NoDelay = true;
+            }
             try
             {
                 var formattedEndpoint = Format.ToString(endpoint);


### PR DESCRIPTION
.NET Core 2.1 introduced `UnixDomainSocketEndPoint` and it doesn't work with redis client because of 2 things:  

1. `ProtocolType` should be `Unspecified` instead of `Tcp` otherwise Socket constructor throws that it is not supported. [See these tests in corefx repo](https://github.com/dotnet/corefx/blob/b21589f01d699617fb2fba6589af4e43c02d4f31/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs) - they use `ProtocolType.Unspecified`  
2.  `Socket.NoDelay` is not supported by Unix domain sockets - it throws when trying to set it