### PR TITLE
Redisvalue

### DIFF
--- a/StackExchange.Redis.Tests/KeysAndValues.cs
+++ b/StackExchange.Redis.Tests/KeysAndValues.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
@@ -64,6 +65,13 @@ namespace StackExchange.Redis.Tests
         private void CheckSame(RedisValue x, RedisValue y)
         {
             Assert.True(Equals(x, y));
+            Assert.True(Equals(y, x));
+            Assert.True(EqualityComparer<RedisValue>.Default.Equals(x, y));
+            Assert.True(EqualityComparer<RedisValue>.Default.Equals(y, x));
+            Assert.True(x == y);
+            Assert.True(y == x);
+            Assert.False(x != y);
+            Assert.False(y != x);
             Assert.True(x.Equals(y));
             Assert.True(y.Equals(x));
             Assert.True(x.GetHashCode() == y.GetHashCode());
@@ -72,6 +80,13 @@ namespace StackExchange.Redis.Tests
         private void CheckNotSame(RedisValue x, RedisValue y)
         {
             Assert.False(Equals(x, y));
+            Assert.False(Equals(y, x));
+            Assert.False(EqualityComparer<RedisValue>.Default.Equals(x, y));
+            Assert.False(EqualityComparer<RedisValue>.Default.Equals(y, x));
+            Assert.False(x == y);
+            Assert.False(y == x);
+            Assert.True(x != y);
+            Assert.True(y != x);
             Assert.False(x.Equals(y));
             Assert.False(y.Equals(x));
             Assert.False(x.GetHashCode() == y.GetHashCode()); // well, very unlikely
@@ -107,9 +122,9 @@ namespace StackExchange.Redis.Tests
             Assert.Equal(0L, (long)value);
 
             CheckSame(value, value);
-            CheckSame(value, default(RedisValue));
-            CheckSame(value, (string)null);
-            CheckSame(value, (byte[])null);
+            //CheckSame(value, default(RedisValue));
+            //CheckSame(value, (string)null);
+            //CheckSame(value, (byte[])null);
         }
 
         [Fact]

--- a/StackExchange.Redis.Tests/RawResultTests.cs
+++ b/StackExchange.Redis.Tests/RawResultTests.cs
@@ -6,6 +6,12 @@ namespace StackExchange.Redis.Tests
     public class RawResultTests
     {
         [Fact]
+        public void TypeLoads()
+        {
+            var type = typeof(RawResult);
+            Assert.Equal(nameof(RawResult), type.Name);
+        }
+        [Fact]
         public void NullWorks()
         {
             var result = new RawResult(ResultType.BulkString, ReadOnlySequence<byte>.Empty, true);

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.IO.Pipelines" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(CoreFxVersion)" />

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.IO.Pipelines" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(CoreFxVersion)" />

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -11,6 +11,8 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <LangVersion>latest</LangVersion>
+
+    <!--<DefineConstants>$(DefineConstants);LOGOUTPUT</DefineConstants>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/StackExchange.Redis/StackExchange/Redis/LoggingPipe.cs
+++ b/StackExchange.Redis/StackExchange/Redis/LoggingPipe.cs
@@ -40,8 +40,15 @@ namespace StackExchange.Redis
 
         private async void CloneAsync(string path, PipeReader from, PipeWriter to)
         {
-            to.OnReaderCompleted((ex, o) => ((PipeReader)o).Complete(ex), from);
-            from.OnWriterCompleted((ex, o) => ((PipeWriter)o).Complete(ex), to);
+            to.OnReaderCompleted((ex, o) => {
+                if (ex != null) Console.Error.WriteLine(ex);
+                ((PipeReader)o).Complete(ex);                
+            }, from);
+            from.OnWriterCompleted((ex, o) =>
+            {
+                if (ex != null) Console.Error.WriteLine(ex);
+                ((PipeWriter)o).Complete(ex);
+            }, to);
             while(true)
             {
                 var result = await from.ReadAsync();

--- a/StackExchange.Redis/StackExchange/Redis/LoggingTextStream.cs
+++ b/StackExchange.Redis/StackExchange/Redis/LoggingTextStream.cs
@@ -1,141 +1,80 @@
-﻿namespace StackExchange.Redis
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Runtime.InteropServices;
+
+namespace StackExchange.Redis
 {
 #if LOGOUTPUT
-    sealed class LoggingTextStream : Stream
+    sealed class LoggingPipe : IDuplexPipe
     {
-        [Conditional("VERBOSE")]
-        void Trace(string value, [CallerMemberName] string caller = null)
+        private IDuplexPipe _inner;
+
+        public LoggingPipe(IDuplexPipe inner, string inPath, string outPath)
         {
-            Debug.WriteLine(value, this.category + ":" + caller);
-        }
-        [Conditional("VERBOSE")]
-        void Trace(char value, [CallerMemberName] string caller = null)
-        {
-            Debug.WriteLine(value, this.category + ":" + caller);
+            _inner = inner;
+            if (string.IsNullOrWhiteSpace(inPath))
+            {
+                Input = inner.Input;
+            }
+            else
+            {
+                var pipe = new Pipe();
+                Input = pipe.Reader;
+                CloneAsync(inPath, inner.Input, pipe.Writer);
+            }
+
+            if (string.IsNullOrWhiteSpace(outPath))
+            {
+                Output = inner.Output;
+            }
+            else
+            {
+                var pipe = new Pipe();
+                Output = pipe.Writer;
+                CloneAsync(outPath, pipe.Reader, inner.Output);
+            }
+
         }
 
-        private readonly Stream stream, echo;
-        private readonly string category;
-        public LoggingTextStream(Stream stream, string category, Stream echo)
+        private async void CloneAsync(string path, PipeReader from, PipeWriter to)
         {
-            if (stream == null) throw new ArgumentNullException("stream");
-            if (string.IsNullOrWhiteSpace(category)) category = GetType().Name;
-            this.stream = stream;
-            this.category = category;
-            this.echo = echo;
-        }
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            asyncBuffer = buffer;
-            asyncOffset = offset;
-            asyncCount = count;
-            return stream.BeginRead(buffer, offset, count, callback, state);
-        }
-        private volatile byte[] asyncBuffer;
-        private volatile int asyncOffset, asyncCount;
-        public override int EndRead(IAsyncResult asyncResult)
-        {
-            int bytes = stream.EndRead(asyncResult);
-            if (bytes <= 0)
+            to.OnReaderCompleted((ex, o) => ((PipeReader)o).Complete(ex), from);
+            from.OnWriterCompleted((ex, o) => ((PipeWriter)o).Complete(ex), to);
+            while(true)
             {
-                Trace("<EOF>");
+                var result = await from.ReadAsync();
+                var buffer = result.Buffer;
+                if (result.IsCompleted && buffer.IsEmpty) break;
+
+                using (var file = new FileStream(path, FileMode.Append, FileAccess.Write))
+                {
+                    foreach (var segment in buffer)
+                    {
+                        // append it to the file
+                        bool leased = false;
+                        if (!MemoryMarshal.TryGetArray(segment, out var arr))
+                        {
+                            var tmp = ArrayPool<byte>.Shared.Rent(segment.Length);
+                            segment.CopyTo(tmp);
+                            arr = new ArraySegment<byte>(tmp, 0, segment.Length);
+                            leased = true;
+                        }
+                        await file.WriteAsync(arr.Array, arr.Offset, arr.Count);
+                        await file.FlushAsync();
+                        if (leased) ArrayPool<byte>.Shared.Return(arr.Array);
+
+                        // and flush it upstream
+                        await to.WriteAsync(segment);
+                    }
+                }
+                from.AdvanceTo(buffer.End);
             }
-            else
-            {
-                Trace(Encoding.UTF8.GetString(asyncBuffer, asyncOffset, asyncCount));
-            }
-            return bytes;
         }
-        public override bool CanRead { get {  return stream.CanRead; } }
-        public override bool CanSeek { get {  return stream.CanSeek; } }
-        public override bool CanWrite { get { return stream.CanWrite; } }
-        public override bool CanTimeout { get { return stream.CanTimeout; } }
-        public override long Length { get { return stream.Length; } }
-        public override long Position
-        {
-            get { return stream.Position; }
-            set { stream.Position = value; }
-        }
-        public override int ReadTimeout
-        {
-            get { return stream.ReadTimeout; }
-            set { stream.ReadTimeout = value; }
-        }
-        public override int WriteTimeout
-        {
-            get { return stream.WriteTimeout; }
-            set { stream.WriteTimeout = value; }
-        }
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                stream.Dispose();
-                if (echo != null) echo.Flush();
-            }
-            base.Dispose(disposing);
-        }
-        public override void Close()
-        {
-            Trace("Close");
-            stream.Close();
-            if (echo != null) echo.Close();
-            base.Close();
-        }
-        public override void Flush()
-        {
-            Trace("Flush");
-            stream.Flush();
-            if (echo != null) echo.Flush();
-        }
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            return stream.Seek(offset, origin);
-        }
-        public override void SetLength(long value)
-        {
-            stream.SetLength(value);
-        }
-        public override void WriteByte(byte value)
-        {
-            Trace((char)value);
-            stream.WriteByte(value);
-            if (echo != null) echo.WriteByte(value);
-        }
-        public override int ReadByte()
-        {
-            int value = stream.ReadByte();
-            if(value < 0)
-            {
-                Trace("<EOF>");
-            } else
-            {
-                Trace((char)value);
-            }
-            return value;
-        }
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            int bytes = stream.Read(buffer, offset, count);
-            if(bytes <= 0)
-            {
-                Trace("<EOF>");
-            }
-            else
-            {
-                Trace(Encoding.UTF8.GetString(buffer, offset, bytes));
-            }
-            return bytes;
-        }
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            if (count != 0)
-            {
-                Trace(Encoding.UTF8.GetString(buffer, offset, count));
-            }
-            stream.Write(buffer, offset, count);
-            if (echo != null) echo.Write(buffer, offset, count);
-        }
+        public PipeReader Input { get; }
+
+        public PipeWriter Output { get; }
     }
 #endif
 }

--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -697,7 +697,7 @@ namespace StackExchange.Redis
             {
                 // ${total-len}\r\n         3 + MaxInt32TextLen
                 // {prefix}{value}\r\n
-                int encodedLength = Encoding.UTF8.GetByteCount(value),
+                int encodedLength = Format.GetEncodedLength(value),
                     prefixLength = prefix == null ? 0 : prefix.Length,
                     totalLength = prefixLength + encodedLength;
 
@@ -719,7 +719,7 @@ namespace StackExchange.Redis
                 }
             }
         }
-
+        
         private unsafe void WriteRaw(PipeWriter writer, string value, int encodedLength)
         {
             const int MaxQuickEncodeSize = 512;

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -2484,7 +2484,9 @@ namespace StackExchange.Redis
                     }
                     else
                     {   // recognises well-known types
-                        physical.Write(RedisValue.Parse(arg));
+                        var val = RedisValue.TryParse(arg);
+                        if (val.IsNull && arg != null) throw new InvalidCastException($"Unable to parse value: '{arg}'");
+                        physical.Write(val);
                     }
                 }
             }

--- a/StackExchange.Redis/StackExchange/Redis/RedisKey.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisKey.cs
@@ -255,7 +255,7 @@ namespace StackExchange.Redis
 
             int aLen = a?.Length ?? 0,
                 bLen = b == null ? 0 : (b is string
-                ? Encoding.UTF8.GetByteCount((string)b)
+                ? Format.GetEncodedLength((string)b)
                 : ((byte[])b).Length),
                 cLen = c?.Length ?? 0;
 

--- a/StackExchange.Redis/StackExchange/Redis/RedisKey.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisKey.cs
@@ -255,7 +255,7 @@ namespace StackExchange.Redis
 
             int aLen = a?.Length ?? 0,
                 bLen = b == null ? 0 : (b is string
-                ? Format.GetEncodedLength((string)b)
+                ? Encoding.UTF8.GetByteCount((string)b)
                 : ((byte[])b).Length),
                 cLen = c?.Length ?? 0;
 

--- a/StackExchange.Redis/StackExchange/Redis/RedisResult.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisResult.cs
@@ -29,7 +29,7 @@ namespace StackExchange.Redis
                         return new SingleRedisResult(result.AsRedisValue());
                     case ResultType.MultiBulk:
                         var items = result.GetItems();
-                        var arr = new RedisResult[items.Length];
+                        var arr = result.IsNull ? null : new RedisResult[items.Length];
                         for (int i = 0; i < arr.Length; i++)
                         {
                             var next = TryCreate(connection, items[i]);

--- a/StackExchange.Redis/StackExchange/Redis/RedisTransaction.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisTransaction.cs
@@ -423,7 +423,7 @@ namespace StackExchange.Redis
                             if (!tran.IsAborted)
                             {
                                 var arr = result.GetItems();
-                                if (arr == null)
+                                if (result.IsNull)
                                 {
                                     connection.Multiplexer.Trace("Server aborted due to failed WATCH");
                                     foreach (var op in wrapped)

--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -487,7 +487,7 @@ namespace StackExchange.Redis
                 {
                     case ResultType.MultiBulk:
                         var arr = result.GetItems();
-                        if (arr == null)
+                        if (result.IsNull)
                         {
                             pairs = null;
                         }
@@ -962,7 +962,7 @@ namespace StackExchange.Redis
                 if (result.Type == ResultType.MultiBulk)
                 {
                     var arr = result.GetItems();
-                    if (arr?.Length == 2 && arr[1].TryGetInt64(out long val))
+                    if (arr.Length == 2 && arr[1].TryGetInt64(out long val))
                     {
                         SetResult(message, val);
                         return true;
@@ -1201,10 +1201,10 @@ namespace StackExchange.Redis
                 switch (result.Type)
                 {
                     case ResultType.MultiBulk:
-                        var arr = result.GetItemsAsRawResults();
+                        var arr = result.GetItems();
 
                         GeoRadiusResult[] typed;
-                        if (arr == null)
+                        if (result.IsNull)
                         {
                             typed = null;
                         }

--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -36,7 +36,8 @@ class Program
         finally
         {
             Console.WriteLine();
-            //Console.WriteLine(s);
+            // Console.WriteLine(s);
+            Console.ReadKey();
         }
     }
 

--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -9,9 +9,6 @@ class Program
 {
     static int Main()
     {
-        var options = PipeOptions.Default;
-        Console.WriteLine(options.PauseWriterThreshold);
-        Console.WriteLine(options.ResumeWriterThreshold);
         var s = new StringWriter();
         try
         {
@@ -38,8 +35,8 @@ class Program
         }
         finally
         {
-            // Console.WriteLine();
-            // Console.WriteLine(s);
+            Console.WriteLine();
+            //Console.WriteLine(s);
         }
     }
 

--- a/TestConsole/TestConsole.csproj
+++ b/TestConsole/TestConsole.csproj
@@ -6,13 +6,17 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Computername)'=='OCHO' or '$(Computername)'=='SKINK'">
+    <LocalReference>true</LocalReference>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\StackExchange.Redis\StackExchange.Redis.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Computername)'=='OCHO'">
+  <ItemGroup Condition="'$(LocalReference)'=='true'">
     <ProjectReference Include="..\..\Pipelines.Sockets.Unofficial\src\Pipelines.Sockets.Unofficial\Pipelines.Sockets.Unofficial.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Computername)'!='OCHO'">
+  <ItemGroup Condition="'$(LocalReference)'!='true'">
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="0.2.1-alpha.48" />
   </ItemGroup>
 


### PR DESCRIPTION
- refactor internals of `RedisValue` to avoid allocations - don't pre-encode strings, for example
- tweak read/write code of `RedisValue` accordingly
- use `ArrayPool<T>.Shared` for the internals of `RawResult` to avoid allocations
- ensure `RawResult` is recycled on success or failure