### PR TITLE
API: Add SetPop/SetPopAsync count overloads

### DIFF
--- a/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -567,6 +567,9 @@ namespace StackExchange.Redis.Tests
         {
             wrapper.SetPop("key", CommandFlags.HighPriority);
             mock.Verify(_ => _.SetPop("prefix:key", CommandFlags.HighPriority));
+
+            wrapper.SetPop("key", 5, CommandFlags.HighPriority);
+            mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.HighPriority));
         }
 
         [Fact]

--- a/StackExchange.Redis.Tests/Sets.cs
+++ b/StackExchange.Redis.Tests/Sets.cs
@@ -55,5 +55,57 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(0, await db.SetRemoveAsync(key, values, CommandFlags.HighPriority).ForAwait());
             }
         }
+
+        [Fact]
+        public void SetPop()
+        {
+            using (var conn = Create())
+            {
+                var db = conn.GetDatabase();
+                var key = Me();
+
+                for (int i = 1; i < 11; i++)
+                {
+                    db.SetAdd(key, i);
+                }
+
+                var random = db.SetPop(key);
+                Assert.False(random.IsNull);
+                Assert.True((int)random > 0);
+                Assert.True((int)random < 10);
+                Assert.Equal(9, db.SetLength(key));
+
+                var moreRandoms = db.SetPop(key, 2);
+                Assert.Equal(2, moreRandoms.Length);
+                Assert.False(moreRandoms[0].IsNull);
+                Assert.Equal(7, db.SetLength(key));
+            }
+        }
+
+        [Fact]
+        public async Task SetPopAsync()
+        {
+            using (var conn = Create())
+            {
+                var db = conn.GetDatabase();
+                var key = Me();
+
+                for (int i = 1; i < 11; i++)
+                {
+                    db.SetAdd(key, i);
+                }
+
+                var random = await db.SetPopAsync(key).ForAwait();
+                Assert.False(random.IsNull);
+                Assert.True((int)random > 0);
+                Assert.True((int)random < 10);
+                Assert.Equal(9, db.SetLength(key));
+
+                var moreRandoms = await db.SetPopAsync(key, 2).ForAwait();
+                Assert.Equal(2, moreRandoms.Length);
+                Assert.False(moreRandoms[0].IsNull);
+                Assert.Equal(7, db.SetLength(key));
+            }
+        }
     }
 }

--- a/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -539,6 +539,9 @@ namespace StackExchange.Redis.Tests
         {
             wrapper.SetPopAsync("key", CommandFlags.HighPriority);
             mock.Verify(_ => _.SetPopAsync("prefix:key", CommandFlags.HighPriority));
+
+            wrapper.SetPopAsync("key", 5, CommandFlags.HighPriority);
+            mock.Verify(_ => _.SetPopAsync("prefix:key", 5, CommandFlags.HighPriority));
         }
 
         [Fact]

--- a/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
 
@@ -961,6 +961,16 @@ namespace StackExchange.Redis
         /// <returns>The removed element, or nil when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/spop</remarks>
         RedisValue SetPop(RedisKey key, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Removes and returns the specified number of random elements from the set value stored at key.
+        /// </summary>
+        /// <param name="key">The key of the set.</param>
+        /// <param name="count">The number of elements to return.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>The removed elements, or nil when key does not exist.</returns>
+        /// <remarks>https://redis.io/commands/spop</remarks>
+        RedisValue[] SetPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return a random element from the set value stored at key.

--- a/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabaseAsync.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Interfaces/IDatabaseAsync.cs
@@ -926,6 +926,16 @@ namespace StackExchange.Redis
         Task<RedisValue> SetPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Removes and returns the specified number of random elements from the set value stored at key.
+        /// </summary>
+        /// <param name="key">The key of the set.</param>
+        /// <param name="count">The number of elements to return.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>The removed elements, or nil when key does not exist.</returns>
+        /// <remarks>https://redis.io/commands/spop</remarks>
+        Task<RedisValue[]> SetPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Return a random element from the set value stored at key.
         /// </summary>
         /// <param name="key">The key of the set.</param>

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -447,6 +447,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SetPop(ToInner(key), flags);
         }
 
+        public RedisValue[] SetPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.SetPop(ToInner(key), count, flags);
+        }
+
         public RedisValue SetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return Inner.SetRandomMember(ToInner(key), flags);

--- a/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/KeyspaceIsolation/WrapperBase.cs
@@ -426,6 +426,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.SetPopAsync(ToInner(key), flags);
         }
 
+        public Task<RedisValue[]> SetPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.SetPopAsync(ToInner(key), count, flags);
+        }
+
         public Task<RedisValue> SetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return Inner.SetRandomMemberAsync(ToInner(key), flags);

--- a/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisDatabase.cs
@@ -1251,6 +1251,18 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.RedisValue);
         }
 
+        public RedisValue[] SetPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.SPOP, key, count);
+            return ExecuteSync(msg, ResultProcessor.RedisValueArray);
+        }
+
+        public Task<RedisValue[]> SetPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.SPOP, key, count);
+            return ExecuteAsync(msg, ResultProcessor.RedisValueArray);
+        }
+
         public RedisValue SetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(Database, flags, RedisCommand.SRANDMEMBER, key);


### PR DESCRIPTION
This API was missing the newer overload added in Redis 3.2 - resolves #203 for v2.