### PR TITLE
Initial IPv6 connection support

### DIFF
--- a/StackExchange.Redis.Tests/FormatTests.cs
+++ b/StackExchange.Redis.Tests/FormatTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests
+{
+    public class FormatTests : TestBase
+    {
+        public FormatTests(ITestOutputHelper output) : base(output) { }
+
+        public static IEnumerable<object[]> EndpointData()
+        {
+            // DNS
+            yield return new object[] { "localhost", new DnsEndPoint("localhost", 0) };
+            yield return new object[] { "localhost:6390", new DnsEndPoint("localhost", 6390) };
+            yield return new object[] { "bob.the.builder.com", new DnsEndPoint("bob.the.builder.com", 0) };
+            yield return new object[] { "bob.the.builder.com:6390", new DnsEndPoint("bob.the.builder.com", 6390) };
+            // IPv4
+            yield return new object[] { "0.0.0.0", new IPEndPoint(IPAddress.Parse("0.0.0.0"), 0) };
+            yield return new object[] { "127.0.0.1", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 0) };
+            yield return new object[] { "127.1", new IPEndPoint(IPAddress.Parse("127.1"), 0) };
+            yield return new object[] { "127.1:6389", new IPEndPoint(IPAddress.Parse("127.1"), 6389) };
+            yield return new object[] { "127.0.0.1:6389", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 6389) };
+            yield return new object[] { "127.0.0.1:1", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1) };
+            yield return new object[] { "127.0.0.1:2", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 2) };
+            yield return new object[] { "10.10.9.18:2", new IPEndPoint(IPAddress.Parse("10.10.9.18"), 2) };
+            // IPv6
+            yield return new object[] { "::1", new IPEndPoint(IPAddress.Parse("::1"), 0) };
+            yield return new object[] { "::1:6379", new IPEndPoint(IPAddress.Parse("::0.1.99.121"), 0) }; // remember your brackets!
+            yield return new object[] { "[::1]:6379", new IPEndPoint(IPAddress.Parse("::1"), 6379) };
+            yield return new object[] { "[::1]", new IPEndPoint(IPAddress.Parse("::1"), 0) };
+            yield return new object[] { "[::1]:1000", new IPEndPoint(IPAddress.Parse("::1"), 1000) };
+            yield return new object[] { "[2001:db7:85a3:8d2:1319:8a2e:370:7348]", new IPEndPoint(IPAddress.Parse("2001:db7:85a3:8d2:1319:8a2e:370:7348"), 0) };
+            yield return new object[] { "[2001:db7:85a3:8d2:1319:8a2e:370:7348]:1000", new IPEndPoint(IPAddress.Parse("2001:db7:85a3:8d2:1319:8a2e:370:7348"), 1000) };
+        }
+
+        [Theory]
+        [MemberData(nameof(EndpointData))]
+        public void ParseEndPoint(string data, EndPoint expected)
+        {
+            var result = Format.TryParseEndPoint(data);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/StackExchange.Redis.Tests/Performance.cs
+++ b/StackExchange.Redis.Tests/Performance.cs
@@ -6,6 +6,7 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests
 {
+    [Collection(NonParallelCollection.Name)]
     public class Performance : TestBase
     {
         public Performance(ITestOutputHelper output) : base(output) { }

--- a/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
+++ b/StackExchange.Redis/StackExchange/Redis/SocketManager.cs
@@ -124,9 +124,8 @@ namespace StackExchange.Redis
 
         internal static Socket CreateSocket(EndPoint endpoint)
         {
-            var addressFamily = endpoint.AddressFamily == AddressFamily.Unspecified ? AddressFamily.InterNetwork : endpoint.AddressFamily;
-            var protocolType = addressFamily == AddressFamily.Unix ? ProtocolType.Unspecified : ProtocolType.Tcp;
-            var socket = new Socket(addressFamily, SocketType.Stream, protocolType);
+            var protocolType = endpoint.AddressFamily == AddressFamily.Unix ? ProtocolType.Unspecified : ProtocolType.Tcp;
+            var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, protocolType);
             SocketConnection.SetRecommendedClientOptions(socket);
             return socket;
         }


### PR DESCRIPTION
TL;DR: We previously did IP:Port parsing based on splitting at the semicolon...that's pretty hostile for IPv6 and breaks everything. This adopts better parsing from Microsoft.AspNetCore since it doesn't exist in the BCL. The BCL/API conversation is started here: https://github.com/dotnet/corefx/issues/23463

A quick way to test this across all tests is via TestConfig, for example:
```json
{
  "MasterServer": "[::1]",
  "SlaveServer": "[::1]",
  "SecureServer": "[::1]"
}
```

Note: there's still an `Unspecified` == `AddressFamily.InterNetwork` in `SocketManager` which may be affecting DNS endpoints that are v6...need to look at that next. This change allows actually connecting to an IPv6 endpoint via IP though, that's step 1.

cc @mgravell as a heads up this is in-progress