### PR TITLE
add a command sentinels 

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/Interfaces/IServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/Interfaces/IServer.cs
@@ -646,6 +646,25 @@ namespace StackExchange.Redis
         /// <remarks>https://redis.io/topics/sentinel</remarks>
         Task SentinelFailoverAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
+        /// <summary>  
+        /// show a list of sentinels info about a redis master  
+        /// </summary>  
+        /// <param name="serviceName">The sentinel service name.</param>  
+        /// <param name="flags">The command flags to use.</param>  
+        /// <returns>an array of sentinel info KeyValuePair arrays</returns>  
+        /// <remarks>https://redis.io/topics/sentinel</remarks>  
+        KeyValuePair<string, string>[][] SentinelSentinels(string serviceName, CommandFlags flags = CommandFlags.None);  
+   
+        /// <summary>  
+        /// show a list of sentinels info about a redis master  
+        /// </summary>  
+        /// <param name="serviceName">The sentinel service name.</param>  
+        /// <param name="flags">The command flags to use.</param>  
+        /// <returns>an array of sentinel info KeyValuePair arrays</returns>  
+        /// <remarks>https://redis.io/topics/sentinel</remarks>  
+        Task<KeyValuePair<string, string>[][]> SentinelSentinelsAsync(string serviceName, CommandFlags flags = CommandFlags.None);
+
+
         #endregion
     }
 }

--- a/StackExchange.Redis/StackExchange/Redis/RedisLiterals.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisLiterals.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 
 namespace StackExchange.Redis
@@ -66,6 +66,7 @@ namespace StackExchange.Redis
             GETMASTERADDRBYNAME = "GET-MASTER-ADDR-BY-NAME",
 //            RESET = "RESET",
             FAILOVER = "FAILOVER",
+            Sentinels = "Sentinels",
 
             // Sentinel Literals as of 2.8.4
             MONITOR = "MONITOR",

--- a/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
@@ -812,6 +812,18 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.SentinelArrayOfArrays);
         }
 
+        public KeyValuePair<string, string>[][] SentinelSentinels(string serviceName, CommandFlags flags = CommandFlags.None)
+        {  
+            var msg = Message.Create(-1, flags, RedisCommand.SENTINEL, RedisLiterals.Sentinels, (RedisValue)serviceName);  
+            return ExecuteSync(msg, ResultProcessor.SentinelArrayOfArrays);  
+        }  
+            
+        public Task<KeyValuePair<string, string>[][]> SentinelSentinelsAsync(string serviceName, CommandFlags flags = CommandFlags.None)
+        {  
+            var msg = Message.Create(-1, flags, RedisCommand.SENTINEL, RedisLiterals.Sentinels, (RedisValue)serviceName);  
+            return ExecuteAsync(msg, ResultProcessor.SentinelArrayOfArrays);  
+        }  
+
         #endregion
     }
 }


### PR DESCRIPTION
1.Node about sentinels 
Sometimes wo need get a redisMaster‘s seninels info,so i add a command sentinels
2.Node about scan
SCAN is a cursor based iterator.Sometime because some reasons we don't need all keys,we just need 
one pageSize keys,and the value of the cursor argument in the next call. So I add a method .
RedisKey[] Keys(ref long refCursor, int database = 0, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
refCursor is the cursor argument in the next call. 