### PR TITLE
fix `PhysicalConnection.BeginReading()` exception handling

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
+++ b/StackExchange.Redis/StackExchange/Redis/PhysicalConnection.cs
@@ -685,6 +685,7 @@ namespace StackExchange.Redis
             catch (IOException ex)
             {
                 Multiplexer.Trace("Could not connect: " + ex.Message, physicalName);
+                throw;
             }
         }
 


### PR DESCRIPTION
FIX. All Operation will timeout on SSL connection.
When NetworkStream.BeginRead () throws an IOException, the ConnectionMultiplexer.IsConnected will keep true.

The PhysicalConnection.BeginReading () method is called by the PhysicalConnection.endRead delegate and the SocketManager.EndConnectImpl () method (via the PhysicalConnection.StartReading()).

PhysicalConnection.RecordConnectionFailed() is being handled by catching an exception in these functions.

If the IOException is not thrown again, the caller's disconnection detection is hindered.
And endRead is never called again.