### PR TITLE
Build: add Ubuntu

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Copyright>2017 Stack Exchange, Inc.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyOriginatorKeyFile>../StackExchange.Redis.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StackExchange.Redis.snk</AssemblyOriginatorKeyFile>
     <PackageId>$(AssemblyName)</PackageId>
     <Features>strict</Features>
     <Authors>Stack Exchange, Inc.; marc.gravell</Authors>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -24,7 +24,6 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
 
-    <LibraryTargetFrameworks>netstandard2.0</LibraryTargetFrameworks>
     <xUnitVersion>2.4.0-beta.2.build3981</xUnitVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/NRediSearch/NRediSearch.csproj
+++ b/NRediSearch/NRediSearch.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>Redis;Search;Modules;RediSearch</PackageTags>
     <SignAssembly>true</SignAssembly>

--- a/RedisConfigs/start-all.sh
+++ b/RedisConfigs/start-all.sh
@@ -1,22 +1,23 @@
-echo Starting Redis servers for testing...
+INDENT='   '
+echo "Starting Redis servers for testing..."
 
 #Basic Servers
-echo Starting Basic: 6379-6382
+echo "Starting Basic: 6379-6382"
 pushd Basic > /dev/null
-echo   Master: 6379
+echo "${INDENT}Master: 6379"
 redis-server master-6379.conf &>/dev/null &
-echo   Slave: 6380
+echo "${INDENT}Slave: 6380"
 redis-server slave-6380.conf &>/dev/null &
-echo   Secure: 6381
+echo "${INDENT}Secure: 6381"
 redis-server secure-6381.conf &>/dev/null &
 popd > /dev/null
 
 #Failover Servers
 echo Starting Failover: 6382-6383
 pushd Failover > /dev/null
-echo   Master: 6382
+echo "${INDENT}Master: 6382"
 redis-server master-6382.conf &>/dev/null &
-echo   Slave: 6383
+echo "${INDENT}Slave: 6383"
 redis-server slave-6383.conf &>/dev/null &
 popd > /dev/null
 
@@ -34,10 +35,10 @@ popd > /dev/null
 #Sentinel Servers
 echo Starting Sentinel: 7010-7011,26379-26380
 pushd Sentinel > /dev/null
-echo   Targets: 7010-7011
+echo "${INDENT}Targets: 7010-7011"
 redis-server redis-7010.conf &>/dev/null &
 redis-server redis-7011.conf &>/dev/null &
-echo   Monitors: 26379-26380
+echo "${INDENT}Monitors: 26379-26380"
 redis-server sentinel-26379.conf --sentinel &>/dev/null &
 redis-server sentinel-26380.conf --sentinel &>/dev/null &
 popd > /dev/null

--- a/StackExchange.Redis.Modules/StackExchange.Redis.Modules.csproj
+++ b/StackExchange.Redis.Modules/StackExchange.Redis.Modules.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.1</VersionPrefix>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>Redis;Search;Modules;RediSearch</PackageTags>

--- a/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
+++ b/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Basic redis server based on StackExchange.Redis</Description>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
+++ b/StackExchange.Redis.StrongName/StackExchange.Redis.StrongName.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyTitle>StackExchange.Redis.StrongName</AssemblyTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,7 +13,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  
+
   <ItemGroup>
     <ProjectReference Include="..\StackExchange.Redis\StackExchange.Redis.csproj" />
   </ItemGroup>

--- a/StackExchange.Redis.Tests/GeoTests.cs
+++ b/StackExchange.Redis.Tests/GeoTests.cs
@@ -189,9 +189,9 @@ namespace StackExchange.Redis.Tests
                 // Invalid overload
                 // Since this would throw ERR could not decode requested zset member, we catch and return something more useful to the user earlier.
                 var ex = Assert.Throws<ArgumentException>(() => db.GeoRadius(key, -1.759925, 52.19493, GeoUnit.Miles, 500, Order.Ascending, GeoRadiusOptions.WithDistance));
-                Assert.Equal("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload.\r\nParameter name: member", ex.Message);
+                Assert.Equal("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload." + Environment.NewLine + "Parameter name: member", ex.Message);
                 ex = await Assert.ThrowsAsync<ArgumentException>(() => db.GeoRadiusAsync(key, -1.759925, 52.19493, GeoUnit.Miles, 500, Order.Ascending, GeoRadiusOptions.WithDistance)).ForAwait();
-                Assert.Equal("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload.\r\nParameter name: member", ex.Message);
+                Assert.Equal("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload." + Environment.NewLine + "Parameter name: member", ex.Message);
 
                 // The good stuff
                 GeoRadiusResult[] result = db.GeoRadius(key, -1.759925, 52.19493, 500, unit: GeoUnit.Miles, order: Order.Ascending, options: GeoRadiusOptions.WithDistance);

--- a/StackExchange.Redis.Tests/RedisFeaturesTests.cs
+++ b/StackExchange.Redis.Tests/RedisFeaturesTests.cs
@@ -11,20 +11,20 @@ namespace StackExchange.Redis.Tests
             var features = new RedisFeatures(new Version(2, 9));
             var s = features.ToString();
             Assert.True(features.ExecAbort);
-            Assert.StartsWith("Features in 2.9\r\n", s);
-            Assert.Contains("ExecAbort: True\r\n", s);
+            Assert.StartsWith("Features in 2.9" + Environment.NewLine, s);
+            Assert.Contains("ExecAbort: True" + Environment.NewLine, s);
 
             features = new RedisFeatures(new Version(2, 9, 5));
             s = features.ToString();
             Assert.False(features.ExecAbort);
-            Assert.StartsWith("Features in 2.9.5\r\n", s);
-            Assert.Contains("ExecAbort: False\r\n", s);
+            Assert.StartsWith("Features in 2.9.5" + Environment.NewLine, s);
+            Assert.Contains("ExecAbort: False" + Environment.NewLine, s);
 
             features = new RedisFeatures(new Version(3, 0));
             s = features.ToString();
             Assert.True(features.ExecAbort);
-            Assert.StartsWith("Features in 3.0\r\n", s);
-            Assert.Contains("ExecAbort: True\r\n", s);
+            Assert.StartsWith("Features in 3.0" + Environment.NewLine, s);
+            Assert.Contains("ExecAbort: True" + Environment.NewLine, s);
         }
     }
 }

--- a/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>StackExchange.Redis.Tests</Description>
-    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/StackExchange.Redis/ExceptionFactory.cs
+++ b/StackExchange.Redis/ExceptionFactory.cs
@@ -110,7 +110,7 @@ namespace StackExchange.Redis
 
             if (includeDetail)
             {
-                exceptionmessage.Append("; ").Append(ConnectionMultiplexer.GetThreadPoolAndCPUSummary(includePerformanceCounters));
+                exceptionmessage.Append("; ").Append(PerfCounterHelper.GetThreadPoolAndCPUSummary(includePerformanceCounters));
             }
 
             var ex = new RedisConnectionException(ConnectionFailureType.UnableToResolvePhysicalConnection, exceptionmessage.ToString(), innerException, message?.Status ?? CommandStatus.Unknown);

--- a/StackExchange.Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/ResultProcessor.cs
@@ -213,7 +213,7 @@ namespace StackExchange.Redis
                                     unableToConnectError = true;
                                     err = $"Endpoint {endpoint} serving hashslot {hashSlot} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect. ";
                                 }
-                                err += ConnectionMultiplexer.GetThreadPoolAndCPUSummary(bridge.Multiplexer.IncludePerformanceCountersInExceptions);
+                                err += PerfCounterHelper.GetThreadPoolAndCPUSummary(bridge.Multiplexer.IncludePerformanceCountersInExceptions);
                             }
                         }
                     }

--- a/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/StackExchange.Redis/StackExchange.Redis.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>
@@ -17,7 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' and '$(Computername)'=='OCHO'">
     <!--<DefineConstants>$(DefineConstants);LOGOUTPUT</DefineConstants>-->
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="0.2.1-alpha.77" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,12 @@ install:
     redis-server.exe --service-install --service-name "redis-26380" "..\Sentinel\sentinel-26380.conf" --sentinel
 
     cd ..\..
-- sh: ./RedisConfigs/start-all.sh
+- sh: >-
+    cd RedisConfigs
+
+    ./start-all.sh
+
+    cd ..
 - ps: Start-Service redis-*
 
 skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-#- Visual Studio 2017
+- Visual Studio 2017
 - Ubuntu
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-- Visual Studio 2017
+#- Visual Studio 2017
 - Ubuntu
 
 init:
@@ -43,10 +43,12 @@ install:
 - sh: >-
     cd RedisConfigs
 
+    chmod +x start-all.sh
+
     ./start-all.sh
 
     cd ..
-- ps: Start-Service redis-*
+- ps: >- if (Get-Command "Start-Service" -errorAction SilentlyContinue) { Start-Service redis-* }
 
 skip_branch_with_pr: true
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
-image: Visual Studio 2017
+image:
+- Visual Studio 2017
+- Ubuntu
 
 init:
   - git config --global core.autocrlf input
@@ -38,6 +40,7 @@ install:
     redis-server.exe --service-install --service-name "redis-26380" "..\Sentinel\sentinel-26380.conf" --sentinel
 
     cd ..\..
+- sh: ./RedisConfigs/start-all.sh
 - ps: Start-Service redis-*
 
 skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,10 @@ install:
     ./start-all.sh
 
     cd ..
-- ps: >- if (Get-Command "Start-Service" -errorAction SilentlyContinue) { Start-Service redis-* }
+- ps: >-
+    if (Get-Command "Start-Service" -errorAction SilentlyContinue) {
+      Start-Service redis-*
+    }
 
 skip_branch_with_pr: true
 skip_tags: true


### PR DESCRIPTION
This won't pass yet (some tests are failing on Ubuntu) and it ~1.5x double build times. I'll inquire about paying for concurrent builds Monday to resolve the latter.

But! Those tests are going against the pre-installed Redis 4.0.8 official build instead of redis-64. \o/

What's interesting is right out of the gate it reproduced #913 (protocol error): https://ci.appveyor.com/project/StackExchange/stackexchange-redis/build/2.0.0-alpha.357+g67ded86dd3/tests