### PR TITLE
Clear ResultBox state prior to caching

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ResultBox.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultBox.cs
@@ -80,6 +80,7 @@ namespace StackExchange.Redis
                 box.exception = null;
                 if (recycle)
                 {
+                    box.stateOrCompletionSource = null;
                     for (int i = 0; i < store.Length; i++)
                     {
                         if (Interlocked.CompareExchange(ref store[i], box, null) == null) return;


### PR DESCRIPTION
Else it keeps a bunch of stuff around (e.g. the AsyncLocal+Execution context for TaskCompletionSources, which can end up being a big tree fanning out from HttpContext)

As seen in https://github.com/aspnet/KestrelHttpServer/issues/2840#issuecomment-416017410 (comment now deleted)

