### PR TITLE
remove indirect vector usage (on < net472, at least); it breaks the world

### DIFF
--- a/src/StackExchange.Redis/BufferReader.cs
+++ b/src/StackExchange.Redis/BufferReader.cs
@@ -155,7 +155,7 @@ namespace StackExchange.Redis
                 if (reader.RemainingThisSpan == 0) continue;
 
                 var span = reader.SlicedSpan;
-                int found = span.IndexOf(value);
+                int found = span.VectorSafeIndexOf(value);
                 if (found >= 0) return totalSkipped + found;
 
                 totalSkipped += span.Length;
@@ -168,7 +168,6 @@ namespace StackExchange.Redis
 
             int totalSkipped = 0;
             bool haveTrailingCR = false;
-            ReadOnlySpan<byte> CRLF = stackalloc byte[2] { (byte)'\r', (byte)'\n' };
             do
             {
                 if (reader.RemainingThisSpan == 0) continue;
@@ -180,7 +179,7 @@ namespace StackExchange.Redis
                     haveTrailingCR = false;
                 }
 
-                int found = span.IndexOf(CRLF);
+                int found = span.VectorSafeIndexOfCRLF();
                 if (found >= 0) return totalSkipped + found;
 
                 haveTrailingCR = span[span.Length - 1] == '\r';

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -966,38 +966,8 @@ namespace StackExchange.Redis
 
         internal readonly CommandMap CommandMap;
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void CheckNumericsVectors()
-        {
-            try
-            {
-                CheckNumericsVectorsImpl();
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    "It looks like there's a problem resolving System.Numerics.Vectors.dll; "
-                    + "this is a well-known pain point between .NET Framework and .NET Core - "
-                    + "try adding an explicit package reference to System.Numerics.Vectors; "
-                    + "and if you're wondering 'why do you need that?' - we actually don't: "
-                    + "it is a down-stream dependency that we don't need directly, but which "
-                    + "keeps causing pain.", ex);
-            }
-        }
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void CheckNumericsVectorsImpl()
-        {
-            DoNothingWith(System.Numerics.Vector.IsHardwareAccelerated, System.Numerics.Vector<byte>.Count);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-#pragma warning disable RCS1163 // Unused parameter.
-        private static void DoNothingWith(bool b, int i) { }
-#pragma warning restore RCS1163 // Unused parameter.
         private ConnectionMultiplexer(ConfigurationOptions configuration)
         {
-            CheckNumericsVectors();
-
             IncludeDetailInExceptions = true;
             IncludePerformanceCountersInExceptions = false;
 

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -12,10 +12,23 @@
 
     <!-- we should preferably not include this in release builds, but isn't dramatic -->
     <DefineConstants>$(DefineConstants);TEST</DefineConstants>
+    <VectorSafe>true</VectorSafe>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+    <VectorSafe>false</VectorSafe>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <!--<PackageReference Include="System.IO.Compression" Version="4.3.0" />-->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' and '$(Computername)'=='OCHO'">
     <!--<DefineConstants>$(DefineConstants);LOGOUTPUT</DefineConstants>-->
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(VectorSafe)' == 'true'">
+    <DefineConstants>$(DefineConstants);VECTOR_SAFE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +36,5 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/toys/TestConsole/TestConsole.csproj
+++ b/toys/TestConsole/TestConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net462;net47</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\tests\BasicTest\BasicTest.csproj" />
+    <!--<ProjectReference Include="..\..\tests\BasicTest\BasicTest.csproj" />
     <ProjectReference Include="..\StackExchange.Redis.Server\StackExchange.Redis.Server.csproj" />
-    <ProjectReference Include="..\..\tests\StackExchange.Redis.Tests\StackExchange.Redis.Tests.csproj" />
+    <ProjectReference Include="..\..\tests\StackExchange.Redis.Tests\StackExchange.Redis.Tests.csproj" />-->
     <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
giving up on making "vectors" happy; instead, just give up and use black-box knowledge of which code paths touch vectors, and just manually remove those path dependencies via manual fallbacks