### PR TITLE
Fix project link under build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For all documentation, [see here](https://stackexchange.github.io/StackExchange.
 
 #### Build Status
 
-[![Build status](https://ci.appveyor.com/api/projects/status/2o3frasprum8mbaj/branch/master?svg=true)](https://ci.appveyor.com/project/StackExchange/dotnet/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/2o3frasprum8mbaj/branch/master?svg=true)](https://ci.appveyor.com/project/StackExchange/stackexchange-redis/branch/master)
 
 #### Package Status
 


### PR DESCRIPTION
Current link is to the miniprofiler project.