### PR TITLE
make transaction inner tasks use RunContinuationsAsynchronously

### DIFF
--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -73,7 +73,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var tcs = TaskSource.Create<T>(asyncState);
+                var tcs = TaskSource.Create<T>(asyncState, TaskCreationOptions.RunContinuationsAsynchronously);
                 var source = ResultBox<T>.Get(tcs);
                 message.SetSource(source, processor);
                 task = tcs.Task;

--- a/src/StackExchange.Redis/TaskSource.cs
+++ b/src/StackExchange.Redis/TaskSource.cs
@@ -9,7 +9,8 @@ namespace StackExchange.Redis
         /// </summary>
         /// <typeparam name="T">The type for the created <see cref="TaskCompletionSource{TResult}"/>.</typeparam>
         /// <param name="asyncState">The state for the created <see cref="TaskCompletionSource{TResult}"/>.</param>
-        public static TaskCompletionSource<T> Create<T>(object asyncState)
-            => new TaskCompletionSource<T>(asyncState, TaskCreationOptions.None);
+        /// <param name="options">The options to apply to the task</param>
+        public static TaskCompletionSource<T> Create<T>(object asyncState, TaskCreationOptions options = TaskCreationOptions.None)
+            => new TaskCompletionSource<T>(asyncState, options);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Transactions.cs
+++ b/tests/StackExchange.Redis.Tests/Transactions.cs
@@ -981,6 +981,8 @@ namespace StackExchange.Redis.Tests
             }
 
             Writer.WriteLine($"hash hit: {hashHit}, miss: {hashMiss}; expire hit: {expireHit}, miss: {expireMiss}");
+            Assert.Equal(0, hashMiss);
+            Assert.Equal(0, expireMiss);
         }
     }
 }

--- a/toys/StackExchange.Redis.Server/RespServer.cs
+++ b/toys/StackExchange.Redis.Server/RespServer.cs
@@ -219,7 +219,7 @@ namespace StackExchange.Redis.Server
             }
         }
 
-        private readonly TaskCompletionSource<ShutdownReason> _shutdown = new TaskCompletionSource<ShutdownReason>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<ShutdownReason> _shutdown = TaskSource.Create<ShutdownReason>(null, TaskCreationOptions.RunContinuationsAsynchronously);
         private bool _isShutdown;
         protected void ThrowIfShutdown()
         {


### PR DESCRIPTION
For discussion, see issue #943 

- make transaction inner tasks use `RunContinuationsAsynchronously`
- detect `RunContinuationsAsynchronously` in `ResultBox` completion, and set directly rather than deferred