### PR TITLE
improve error reporting (in particular for timeouts)

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -868,7 +868,7 @@ namespace StackExchange.Redis
         {
             var muxer = new ConnectionMultiplexer(PrepareConfig(configuration));
             connectHandler = null;
-            if(log != null)
+            if (log != null)
             {
                 // create a detachable event-handler to log detailed errors if something happens during connect/handshake
                 connectHandler = (_, a) =>
@@ -2135,21 +2135,27 @@ namespace StackExchange.Redis
                 case WriteResult.NoConnectionAvailable:
                     return ExceptionFactory.NoConnectionAvailable(IncludeDetailInExceptions, IncludePerformanceCountersInExceptions, message.Command, message, server, GetServerSnapshot());
                 case WriteResult.TimeoutBeforeWrite:
-                    string counters = null;
+                    string bridgeCounters = null, connectionState = null;
                     try
                     {
+                        if (message.TryGetPhysicalState(out var state, out var sentDelta, out var receivedDelta))
+                        {
+                            connectionState = (sentDelta >= 0 && receivedDelta >= 0) // these might not always be available
+                                ? $", state={state}, outbound={sentDelta >> 10}KiB, inbound={receivedDelta >> 10}KiB"
+                                : $", state={state}";
+                        }
                         var bridge = server.GetBridge(message.Command, false);
                         if (bridge != null)
                         {
                             var active = bridge.GetActiveMessage();
                             bridge.GetOutstandingCount(out var inst, out var qs, out var @in);
-                            counters = $", inst={inst}, qs={qs}, in={@in}, active={active}";
+                            bridgeCounters = $", inst={inst}, qs={qs}, in={@in}, active={active}";
                         }
                     }
                     catch { }
 
                     return ExceptionFactory.Timeout(this, "The timeout was reached before the message could be written to the output buffer, and it was not sent ("
-                        + Format.ToString(TimeoutMilliseconds) + "ms" + counters + ")", message, server);
+                        + Format.ToString(TimeoutMilliseconds) + "ms" + connectionState + bridgeCounters + ")", message, server);
                 case WriteResult.WriteFailure:
                 default:
                     return ExceptionFactory.ConnectionFailure(IncludeDetailInExceptions, ConnectionFailureType.ProtocolFailure, "An unknown error occurred when writing the message", server);

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -137,7 +137,7 @@ namespace StackExchange.Redis
                     {
                         queue.Enqueue(message);
                     }
-                    message.SetEnqueued();
+                    message.SetEnqueued(null);
                     return WriteResult.Success; // we'll take it...
                 }
                 else
@@ -549,7 +549,7 @@ namespace StackExchange.Redis
         internal WriteResult WriteMessageTakingWriteLock(PhysicalConnection physical, Message message)
         {
             Trace("Writing: " + message);
-            message.SetEnqueued();
+            message.SetEnqueued(physical); // this also records the read/write stats at this point
 
             WriteResult result;
             bool haveLock = false;

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pipelines.Sockets.Unofficial" Version="1.0.7" />
+    <PackageReference Include="Pipelines.Sockets.Unofficial" Version="1.0.9" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.1" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />

--- a/tests/BasicTest/Program.cs
+++ b/tests/BasicTest/Program.cs
@@ -186,7 +186,6 @@ namespace BasicTest
             }
         }
 
-
         /// <summary>
         /// Run StringGet lots of times
         /// </summary>

--- a/toys/TestConsole/Program.cs
+++ b/toys/TestConsole/Program.cs
@@ -4,57 +4,59 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using StackExchange.Redis;
 
-static class Program
+namespace TestConsole
 {
-    private static int taskCount = 10;
-    private static int totalRecords = 100000;
-
-    static void Main()
+    internal static class Program
     {
+        private const int taskCount = 10;
+        private const int totalRecords = 100000;
 
+        private static void Main()
+        {
 #if SEV2
         Pipelines.Sockets.Unofficial.SocketConnection.AssertDependencies();
         Console.WriteLine("We loaded the things...");
         // Console.ReadLine();
 #endif
 
-        Stopwatch stopwatch = new Stopwatch();
-        stopwatch.Start();
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
 
-        var taskList = new List<Task>();
-        var connection = ConnectionMultiplexer.Connect("127.0.0.1");
-        for (int i = 0; i < taskCount; i++)
-        {
-            var i1 = i;
-            var task = new Task(() => Run(i1, connection));
-            task.Start();
-            taskList.Add(task);
+            var taskList = new List<Task>();
+            var connection = ConnectionMultiplexer.Connect("127.0.0.1");
+            for (int i = 0; i < taskCount; i++)
+            {
+                var i1 = i;
+                var task = new Task(() => Run(i1, connection));
+                task.Start();
+                taskList.Add(task);
+            }
+
+            Task.WaitAll(taskList.ToArray());
+
+            stopwatch.Stop();
+
+            Console.WriteLine($"Done. {stopwatch.ElapsedMilliseconds}");
+            Console.ReadLine();
         }
 
-        Task.WaitAll(taskList.ToArray());
-
-        stopwatch.Stop();
-
-        Console.WriteLine($"Done. {stopwatch.ElapsedMilliseconds}");
-        Console.ReadLine();
-    }
-
-    static void Run(int taskId, ConnectionMultiplexer connection)
-    {
-        Console.WriteLine($"{taskId} Started");
-        var database = connection.GetDatabase(0);
-
-        for (int i = 0; i < totalRecords; i++)
+        private static void Run(int taskId, ConnectionMultiplexer connection)
         {
-            database.StringSet(i.ToString(), i.ToString());
-        }
+            Console.WriteLine($"{taskId} Started");
+            var database = connection.GetDatabase(0);
 
-        Console.WriteLine($"{taskId} Insert completed");
+            for (int i = 0; i < totalRecords; i++)
+            {
+                database.StringSet(i.ToString(), i.ToString());
+            }
 
-        for (int i = 0; i < totalRecords; i++)
-        {
-            var result = database.StringGet(i.ToString());
+            Console.WriteLine($"{taskId} Insert completed");
+
+            for (int i = 0; i < totalRecords; i++)
+            {
+                var result = database.StringGet(i.ToString());
+            }
+            Console.WriteLine($"{taskId} Completed");
         }
-        Console.WriteLine($"{taskId} Completed");
     }
 }


### PR DESCRIPTION
 by reporting a: what the *offending physical connection was doing* (if we're trying to get the write lock), and b: how much data has flown on the connection while trying to do it (write lock or timeout waiting for response)

cross-reference: #1006