### PR TITLE
Update lastReadTickCount in ReadFromPipe

### DIFF
--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1325,6 +1325,7 @@ namespace StackExchange.Redis
 
         partial void OnWrapForLogging(ref IDuplexPipe pipe, string name, SocketManager mgr);
 
+        internal void UpdateLastReadTime() => Interlocked.Exchange(ref lastReadTickCount, Environment.TickCount);
         private async Task ReadFromPipe()
         {
             bool allowSyncRead = true, isReading = false;
@@ -1343,6 +1344,7 @@ namespace StackExchange.Redis
                         readResult = await input.ReadAsync().ForAwait();
                     }
                     isReading = false;
+                    UpdateLastReadTime();
 
                     var buffer = readResult.Buffer;
                     int handled = 0;


### PR DESCRIPTION
lastReadTickCount is never updated after the connection is established, which leads to some confusing error messages.