### PR TITLE
Rename index to readme & fix broken documentation links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 StackExchange.Redis
 ===================
 
-[Release Notes](ReleaseNotes)
+[Release Notes](ReleaseNotes.md)
 
 ## Overview
 
@@ -30,17 +30,17 @@ PM> Install-Package StackExchange.Redis
 Documentation
 ---
 
-- [Basic Usage](Basics) - getting started and basic usage
-- [Configuration](Configuration) - options available when connecting to redis
-- [Pipelines and Multiplexers](PipelinesMultiplexers) - what is a multiplexer?
-- [Keys, Values and Channels](KeysValues) - discusses the data-types used on the API
-- [Transactions](Transactions) - how atomic transactions work in redis
-- [Events](Events) - the events available for logging / information purposes
-- [Pub/Sub Message Order](PubSubOrder) - advice on sequential and concurrent processing
-- [Where are `KEYS` / `SCAN` / `FLUSH*`?](KeysScan) - how to use server-based commands
-- [Profiling](Profiling) - profiling interfaces, as well as how to profile in an `async` world
-- [Scripting](Scripting) - running Lua scripts with convenient named parameter replacement
-- [Testing](Testing) - running the `StackExchange.Redis.Tests` suite to validate changes
+- [Basic Usage](Basics.md) - getting started and basic usage
+- [Configuration](Configuration.md) - options available when connecting to redis
+- [Pipelines and Multiplexers](PipelinesMultiplexers.md) - what is a multiplexer?
+- [Keys, Values and Channels](KeysValues.md) - discusses the data-types used on the API
+- [Transactions](Transactions.md) - how atomic transactions work in redis
+- [Events](Events.md) - the events available for logging / information purposes
+- [Pub/Sub Message Order](PubSubOrder.md) - advice on sequential and concurrent processing
+- [Where are `KEYS` / `SCAN` / `FLUSH*`?](KeysScan.md) - how to use server-based commands
+- [Profiling](Profiling.md) - profiling interfaces, as well as how to profile in an `async` world
+- [Scripting](Scripting.md) - running Lua scripts with convenient named parameter replacement
+- [Testing](Testing.md) - running the `StackExchange.Redis.Tests` suite to validate changes
 
 Questions and Contributions
 ---


### PR DESCRIPTION
Documentation links in index are broken (at least on github). And I think it would be better to rename the main documentation file as readme so you don't have to search it.