### PR TITLE
Remove obsolete responseTimeout setting

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -332,7 +332,8 @@ namespace StackExchange.Redis
         /// Specifies the time in milliseconds that the system should allow for responses before concluding that the socket is unhealthy
         /// (defaults to SyncTimeout)
         /// </summary>
-        public int ResponseTimeout { get { return responseTimeout ?? SyncTimeout; } set { responseTimeout = value; } }
+        [Obsolete("This setting no longer has any effect, and should not be used")]
+        public int ResponseTimeout { get { return 0; } set { } }
 
         /// <summary>
         /// The service name used to resolve a service via sentinel.
@@ -694,7 +695,9 @@ namespace StackExchange.Redis
                             Proxy = OptionKeys.ParseProxy(key, value);
                             break;
                         case OptionKeys.ResponseTimeout:
+#pragma warning disable CS0618 // Type or member is obsolete
                             ResponseTimeout = OptionKeys.ParseInt32(key, value, minValue: 1);
+#pragma warning restore CS0618 // Type or member is obsolete
                             break;
                         case OptionKeys.DefaultDatabase:
                             DefaultDatabase = OptionKeys.ParseInt32(key, value);

--- a/tests/StackExchange.Redis.Tests/Deprecated.cs
+++ b/tests/StackExchange.Redis.Tests/Deprecated.cs
@@ -40,6 +40,18 @@ namespace StackExchange.Redis.Tests
             options = ConfigurationOptions.Parse("writeBuffer=8092");
             Assert.Equal(0, options.WriteBuffer);
         }
+
+        [Fact]
+        public void ResponseTimeout()
+        {
+            AssemblyLoadEventArgs.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.ResponseTimeout)), typeof(ObsoleteAttribute)));
+
+            var options = ConfigurationOptions.Parse("name=Hello");
+            Assert.Equal(0, options.ResponseTimeout);
+
+            options = ConfigurationOptions.Parse("responseTimeout=1000");
+            Assert.Equal(0, options.ResponseTimeout);
+        }
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/tests/StackExchange.Redis.Tests/Deprecated.cs
+++ b/tests/StackExchange.Redis.Tests/Deprecated.cs
@@ -44,7 +44,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void ResponseTimeout()
         {
-            AssemblyLoadEventArgs.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.ResponseTimeout)), typeof(ObsoleteAttribute)));
+            Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.ResponseTimeout)), typeof(ObsoleteAttribute)));
 
             var options = ConfigurationOptions.Parse("name=Hello");
             Assert.Equal(0, options.ResponseTimeout);


### PR DESCRIPTION
Addresses #1029 

Alternatively, is there a recommended way of accomplishing what this used to do in v1?