### PR TITLE
ConnectionMultiplexer: Track global counts for debugging

### DIFF
--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -263,6 +263,8 @@ namespace StackExchange.Redis
                 add("Local-CPU", "Local-CPU", PerfCounterHelper.GetSystemCpuPercent());
             }
 
+            add("Multiplexer-Connects", "mc", $"{ConnectionMultiplexer._connectAttemptCount}/{ConnectionMultiplexer._connectCount}/{ConnectionMultiplexer._closeCount}");
+
             add("Version", "v", GetLibVersion());
 
             sb.Append(" (Please take a look at this article for some common client-side issues that can cause timeouts: ");


### PR DESCRIPTION
This adds global tracking connection attempts, actual connects, and closes for debugging purposes to get sanity checks on overall object counts and such.