### PR TITLE
Make SocketManager worker count configurable

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -344,8 +344,8 @@ namespace StackExchange.Redis
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// Gets or sets the SocketManager instance to be used with these options; if this is null a per-multiplexer
-        /// SocketManager is created automatically.
+        /// Gets or sets the SocketManager instance to be used with these options; if this is null a shared cross-multiplexer SocketManager
+        /// is used
         /// </summary>
         public SocketManager SocketManager { get; set; }
 

--- a/src/StackExchange.Redis/SocketManager.cs
+++ b/src/StackExchange.Redis/SocketManager.cs
@@ -20,19 +20,11 @@ namespace StackExchange.Redis
         public string Name { get; }
 
         /// <summary>
-        /// Creates a new (optionally named) <see cref="SocketManager"/> instance
+        /// Creates a new <see cref="SocketManager"/> instance
         /// </summary>
         /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
-        public SocketManager(string name = null)
-            : this(name, false, DEFAULT_WORKERS) { }
-
-        /// <summary>
-        /// Creates a new (optionally named) <see cref="SocketManager"/> instance
-        /// </summary>
-        /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
-        /// <param name="workerCount">the number of dedicated workers for this <see cref="SocketManager"/>.</param>
-        public SocketManager(string name = null, int workerCount = DEFAULT_WORKERS)
-            : this(name, false, workerCount) { }
+        public SocketManager(string name)
+            : this(name, DEFAULT_WORKERS, false) { }
 
         /// <summary>
         /// Creates a new <see cref="SocketManager"/> instance
@@ -40,45 +32,18 @@ namespace StackExchange.Redis
         /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
         /// <param name="useHighPrioritySocketThreads">Whether this <see cref="SocketManager"/> should use high priority sockets.</param>
         public SocketManager(string name, bool useHighPrioritySocketThreads)
-            : this(name, useHighPrioritySocketThreads, DEFAULT_WORKERS) { }
+            : this(name, DEFAULT_WORKERS, useHighPrioritySocketThreads) { }
 
         /// <summary>
-        /// Default / shared socket manager
+        /// Creates a new (optionally named) <see cref="SocketManager"/> instance
         /// </summary>
-        public static SocketManager Shared
-        {
-            get
-            {
-                var shared = _shared;
-                if (shared != null) return _shared;
-                try
-                {
-                    // note: we'll allow a higher max thread count on the shared one
-                    shared = new SocketManager("DefaultSocketManager", false, DEFAULT_WORKERS * 2);
-                    if (Interlocked.CompareExchange(ref _shared, shared, null) == null)
-                        shared = null;
-                }
-                finally { shared?.Dispose(); }
-                return Volatile.Read(ref _shared);
-            }
-        }
-
-        /// <summary>Returns a string that represents the current object.</summary>
-        /// <returns>A string that represents the current object.</returns>
-        public override string ToString()
-        {
-            var scheduler = SchedulerPool;
-
-            return $"scheduler - queue: {scheduler?.TotalServicedByQueue}, pool: {scheduler?.TotalServicedByPool}";
-        }
-
-        private static SocketManager _shared;
-
-        private const int DEFAULT_WORKERS = 5, MINIMUM_SEGMENT_SIZE = 8 * 1024;
-
-        private SocketManager(string name, bool useHighPrioritySocketThreads, int workerCount)
+        /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
+        /// <param name="workerCount">the number of dedicated workers for this <see cref="SocketManager"/>.</param>
+        /// <param name="useHighPrioritySocketThreads">Whether this <see cref="SocketManager"/> should use high priority sockets.</param>
+        public SocketManager(string name = null, int workerCount = 0, bool useHighPrioritySocketThreads = false)
         {
             if (string.IsNullOrWhiteSpace(name)) name = GetType().Name;
+            if (workerCount <= 0) workerCount = DEFAULT_WORKERS;
             Name = name;
 
             const long Receive_PauseWriterThreshold = 4L * 1024 * 1024 * 1024; // receive: let's give it up to 4GiB of buffer for now
@@ -113,6 +78,40 @@ namespace StackExchange.Redis
                 minimumSegmentSize: Math.Max(defaultPipeOptions.MinimumSegmentSize, MINIMUM_SEGMENT_SIZE),
                 useSynchronizationContext: false);
         }
+
+        /// <summary>
+        /// Default / shared socket manager
+        /// </summary>
+        public static SocketManager Shared
+        {
+            get
+            {
+                var shared = _shared;
+                if (shared != null) return _shared;
+                try
+                {
+                    // note: we'll allow a higher max thread count on the shared one
+                    shared = new SocketManager("DefaultSocketManager", DEFAULT_WORKERS * 2, false);
+                    if (Interlocked.CompareExchange(ref _shared, shared, null) == null)
+                        shared = null;
+                }
+                finally { shared?.Dispose(); }
+                return Volatile.Read(ref _shared);
+            }
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            var scheduler = SchedulerPool;
+
+            return $"scheduler - queue: {scheduler?.TotalServicedByQueue}, pool: {scheduler?.TotalServicedByPool}";
+        }
+
+        private static SocketManager _shared;
+
+        private const int DEFAULT_WORKERS = 5, MINIMUM_SEGMENT_SIZE = 8 * 1024;
 
         private DedicatedThreadPoolPipeScheduler _schedulerPool;
         internal readonly PipeOptions SendPipeOptions, ReceivePipeOptions;

--- a/src/StackExchange.Redis/SocketManager.cs
+++ b/src/StackExchange.Redis/SocketManager.cs
@@ -27,6 +27,22 @@ namespace StackExchange.Redis
             : this(name, false, DEFAULT_WORKERS) { }
 
         /// <summary>
+        /// Creates a new (optionally named) <see cref="SocketManager"/> instance
+        /// </summary>
+        /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
+        /// <param name="workerCount">the number of dedicated workers for this <see cref="SocketManager"/>.</param>
+        public SocketManager(string name = null, int workerCount = DEFAULT_WORKERS)
+            : this(name, false, workerCount) { }
+
+        /// <summary>
+        /// Creates a new <see cref="SocketManager"/> instance
+        /// </summary>
+        /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
+        /// <param name="useHighPrioritySocketThreads">Whether this <see cref="SocketManager"/> should use high priority sockets.</param>
+        public SocketManager(string name, bool useHighPrioritySocketThreads)
+            : this(name, useHighPrioritySocketThreads, DEFAULT_WORKERS) { }
+
+        /// <summary>
         /// Default / shared socket manager
         /// </summary>
         public static SocketManager Shared
@@ -57,14 +73,6 @@ namespace StackExchange.Redis
         }
 
         private static SocketManager _shared;
-
-        /// <summary>
-        /// Creates a new <see cref="SocketManager"/> instance
-        /// </summary>
-        /// <param name="name">The name for this <see cref="SocketManager"/>.</param>
-        /// <param name="useHighPrioritySocketThreads">Whether this <see cref="SocketManager"/> should use high priority sockets.</param>
-        public SocketManager(string name, bool useHighPrioritySocketThreads)
-            : this(name, useHighPrioritySocketThreads, DEFAULT_WORKERS) { }
 
         private const int DEFAULT_WORKERS = 5, MINIMUM_SEGMENT_SIZE = 8 * 1024;
 


### PR DESCRIPTION
With async-heavy workloads the default Shared instances' 10 workers are not always enough. With a dedicated SockerManager the worker count is only 5 and not configurable.

This PR
- Adds overload to SocketManager exposing the workerCount so that is configurable.
- Updated ConfigurationOptions XML comment to align with how the SockerManager.Shared implementation works

Should solve https://github.com/StackExchange/StackExchange.Redis/issues/1035