### PR TITLE
fix #1108 - introduce LogProxy...

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -9,6 +9,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using static StackExchange.Redis.ConnectionMultiplexer;
 
 namespace StackExchange.Redis
 {
@@ -523,7 +524,7 @@ namespace StackExchange.Redis
             return false;
         }
 
-        internal async Task ResolveEndPointsAsync(ConnectionMultiplexer multiplexer, TextWriter log)
+        internal async Task ResolveEndPointsAsync(ConnectionMultiplexer multiplexer, LogProxy log)
         {
             var cache = new Dictionary<string, IPAddress>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < EndPoints.Count; i++)
@@ -542,12 +543,12 @@ namespace StackExchange.Redis
                         }
                         else
                         {
-                            multiplexer.LogLocked(log, "Using DNS to resolve '{0}'...", dns.Host);
+                            log?.WriteLine($"Using DNS to resolve '{dns.Host}'...");
                             var ips = await Dns.GetHostAddressesAsync(dns.Host).ObserveErrors().ForAwait();
                             if (ips.Length == 1)
                             {
                                 ip = ips[0];
-                                multiplexer.LogLocked(log, "'{0}' => {1}", dns.Host, ip);
+                                log?.WriteLine($"'{dns.Host}' => {ip}");
                                 cache[dns.Host] = ip;
                                 EndPoints[i] = new IPEndPoint(ip, dns.Port);
                             }
@@ -556,7 +557,7 @@ namespace StackExchange.Redis
                     catch (Exception ex)
                     {
                         multiplexer.OnInternalError(ex);
-                        multiplexer.LogLocked(log, ex.Message);
+                        log?.WriteLine(ex.Message);
                     }
                 }
             }

--- a/src/StackExchange.Redis/DebuggingAids.cs
+++ b/src/StackExchange.Redis/DebuggingAids.cs
@@ -20,7 +20,7 @@ namespace StackExchange.Redis
             Debug.WriteLine(message, Environment.CurrentManagedThreadId + " ~ " + category);
         }
 
-        partial void OnTraceLog(TextWriter log, string caller)
+        partial void OnTraceLog(LogProxy log, string caller)
         {
             lock (UniqueId)
             {

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using static StackExchange.Redis.ConnectionMultiplexer;
 
 #pragma warning disable RCS1231 // Make parameter ref read-only.
 
@@ -320,7 +321,10 @@ namespace StackExchange.Redis
 
         public void MakeMaster(ReplicationChangeOptions options, TextWriter log = null)
         {
-            multiplexer.MakeMaster(server, options, log);
+            using (var proxy = LogProxy.TryCreate(log))
+            {
+                multiplexer.MakeMaster(server, options, proxy);
+            }
         }
 
         public void Save(SaveType type, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -175,7 +175,7 @@ namespace StackExchange.Redis
             {
                 try
                 {
-                    bridge?.Multiplexer?.LogLocked(logging.Log, "Response from {0} / {1}: {2}", bridge, message.CommandAndKey, result);
+                    logging.Log?.WriteLine($"Response from {bridge} / {message.CommandAndKey}: {result}");
                 }
                 catch { }
             }


### PR DESCRIPTION
... as an intermediary between the TextWriter

- all sync-locking now happens against the `LogProxy` (which is non-public etc)
- `LogProxy` can be safely disconnected (`Dispose()`) - after that, all logs no-op
- moved to `log?.WriteLine($"...{...}...");` throughout - is very efficient when `log` is `null`, and when `log` is non-null... meh, we're logging!