### PR TITLE
add optional timeout parameter to allow for XREAD/XREADGROUP BLOCK msec

### DIFF
--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -1681,22 +1681,24 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="position">The position from which to read the stream.</param>
         /// <param name="count">The maximum number of messages to return.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key id.</remarks>
         /// <remarks>https://redis.io/commands/xread</remarks>
-        StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None);
+        StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Read from multiple streams.
         /// </summary>
         /// <param name="streamPositions">Array of streams and the positions from which to begin reading for each stream.</param>
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
         /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key1 key2 id1 id2.</remarks>
         /// <remarks>https://redis.io/commands/xread</remarks>
-        RedisStream[] StreamRead(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None);
+        RedisStream[] StreamRead(StreamPosition[] streamPositions, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Read messages from a stream into an associated consumer group.
@@ -1706,10 +1708,11 @@ namespace StackExchange.Redis
         /// <param name="consumerName">The consumer name.</param>
         /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when null.</param>
         /// <param name="count">The maximum number of messages to return.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>https://redis.io/commands/xreadgroup</remarks>
-        StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, CommandFlags flags = CommandFlags.None);
+        StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Read from multiple streams into the given consumer group. The consumer group with the given <paramref name="groupName"/>
@@ -1719,11 +1722,12 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="consumerName"></param>
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
         /// <remarks>Equivalent of calling XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</remarks>
         /// <remarks>https://redis.io/commands/xreadgroup</remarks>
-        RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, CommandFlags flags = CommandFlags.None);
+        RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Trim the stream to a specified maximum length.

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -1592,22 +1592,24 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="position">The position from which to read the stream.</param>
         /// <param name="count">The maximum number of messages to return.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key id.</remarks>
         /// <remarks>https://redis.io/commands/xread</remarks>
-        Task<StreamEntry[]> StreamReadAsync(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None);
+        Task<StreamEntry[]> StreamReadAsync(RedisKey key, RedisValue position, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Read from multiple streams.
         /// </summary>
         /// <param name="streamPositions">Array of streams and the positions from which to begin reading for each stream.</param>
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
         /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key1 key2 id1 id2.</remarks>
         /// <remarks>https://redis.io/commands/xread</remarks>
-        Task<RedisStream[]> StreamReadAsync(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None);
+        Task<RedisStream[]> StreamReadAsync(StreamPosition[] streamPositions, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Read messages from a stream into an associated consumer group.
@@ -1617,10 +1619,11 @@ namespace StackExchange.Redis
         /// <param name="consumerName">The consumer name.</param>
         /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when null.</param>
         /// <param name="count">The maximum number of messages to return.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>https://redis.io/commands/xreadgroup</remarks>
-        Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, CommandFlags flags = CommandFlags.None);
+        Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Read from multiple streams into the given consumer group. The consumer group with the given <paramref name="groupName"/>
@@ -1630,11 +1633,12 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="consumerName"></param>
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
+        /// <param name="timeout">Optionally wait for the specified number of msec for data to be read.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
         /// <remarks>Equivalent of calling XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</remarks>
         /// <remarks>https://redis.io/commands/xreadgroup</remarks>
-        Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, CommandFlags flags = CommandFlags.None);
+        Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Trim the stream to a specified maximum length.

--- a/src/StackExchange.Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -711,24 +711,24 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.StreamRange(ToInner(key), minId, maxId, count, messageOrder, flags);
         }
 
-        public StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None)
+        public StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamRead(ToInner(key), position, count, flags);
+            return Inner.StreamRead(ToInner(key), position, count, timeout, flags);
         }
 
-        public RedisStream[] StreamRead(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None)
+        public RedisStream[] StreamRead(StreamPosition[] streamPositions, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamRead(streamPositions, countPerStream, flags);
+            return Inner.StreamRead(streamPositions, countPerStream, timeout, flags);
         }
 
-        public StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, CommandFlags flags = CommandFlags.None)
+        public StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamReadGroup(ToInner(key), groupName, consumerName, position, count, flags);
+            return Inner.StreamReadGroup(ToInner(key), groupName, consumerName, position, count, timeout, flags);
         }
 
-        public RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, CommandFlags flags = CommandFlags.None)
+        public RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamReadGroup(streamPositions, groupName, consumerName, countPerStream, flags);
+            return Inner.StreamReadGroup(streamPositions, groupName, consumerName, countPerStream, timeout, flags);
         }
 
         public long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/WrapperBase.cs
@@ -691,24 +691,24 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.StreamRangeAsync(ToInner(key), minId, maxId, count, messageOrder, flags);
         }
 
-        public Task<StreamEntry[]> StreamReadAsync(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None)
+        public Task<StreamEntry[]> StreamReadAsync(RedisKey key, RedisValue position, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamReadAsync(ToInner(key), position, count, flags);
+            return Inner.StreamReadAsync(ToInner(key), position, count, timeout, flags);
         }
 
-        public Task<RedisStream[]> StreamReadAsync(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None)
+        public Task<RedisStream[]> StreamReadAsync(StreamPosition[] streamPositions, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamReadAsync(streamPositions, countPerStream, flags);
+            return Inner.StreamReadAsync(streamPositions, countPerStream, timeout, flags);
         }
 
-        public Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, CommandFlags flags = CommandFlags.None)
+        public Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamReadGroupAsync(ToInner(key), groupName, consumerName, position, count, flags);
+            return Inner.StreamReadGroupAsync(ToInner(key), groupName, consumerName, position, count, timeout, flags);
         }
 
-        public Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, CommandFlags flags = CommandFlags.None)
+        public Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, int? timeout = null, CommandFlags flags = CommandFlags.None)
         {
-            return Inner.StreamReadGroupAsync(streamPositions, groupName, consumerName, countPerStream, flags);
+            return Inner.StreamReadGroupAsync(streamPositions, groupName, consumerName, countPerStream, timeout, flags);
         }
 
         public Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/StreamConstants.cs
+++ b/src/StackExchange.Redis/StreamConstants.cs
@@ -43,6 +43,8 @@ namespace StackExchange.Redis
 
         internal static readonly RedisValue Consumers = "CONSUMERS";
 
+        internal static readonly RedisValue Block = "BLOCK";
+		
         internal static readonly RedisValue Count = "COUNT";
 
         internal static readonly RedisValue Create = "CREATE";

--- a/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -934,30 +934,60 @@ namespace StackExchange.Redis.Tests
         public void StreamRead_1()
         {
             var streamPositions = new StreamPosition[0] { };
-            wrapper.StreamRead(streamPositions, null, CommandFlags.None);
-            mock.Verify(_ => _.StreamRead(streamPositions, null, CommandFlags.None));
+            wrapper.StreamRead(streamPositions, null, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamRead(streamPositions, null, null, CommandFlags.None));
         }
 
         [Fact]
         public void StreamRead_2()
         {
-            wrapper.StreamRead("key", "0-0", null, CommandFlags.None);
-            mock.Verify(_ => _.StreamRead("prefix:key", "0-0", null, CommandFlags.None));
+            wrapper.StreamRead("key", "0-0", null, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamRead("prefix:key", "0-0", null, null, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamRead_3()
+        {
+            var streamPositions = new StreamPosition[0] { };
+            wrapper.StreamRead(streamPositions, null, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamRead(streamPositions, null, 1000, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamRead_4()
+        {
+            wrapper.StreamRead("key", "0-0", null, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamRead("prefix:key", "0-0", null, 1000, CommandFlags.None));
         }
 
         [Fact]
         public void StreamStreamReadGroup_1()
         {
-            wrapper.StreamReadGroup("key", "group", "consumer", "0-0", 10, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadGroup("prefix:key", "group", "consumer", "0-0", 10, CommandFlags.None));
+            wrapper.StreamReadGroup("key", "group", "consumer", "0-0", 10, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroup("prefix:key", "group", "consumer", "0-0", 10, null, CommandFlags.None));
         }
 
         [Fact]
         public void StreamStreamReadGroup_2()
         {
             var streamPositions = new StreamPosition[0] { };
-            wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, CommandFlags.None));
+            wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, null, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamStreamReadGroup_3()
+        {
+            wrapper.StreamReadGroup("key", "group", "consumer", "0-0", 10, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroup("prefix:key", "group", "consumer", "0-0", 10, 1000, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamStreamReadGroup_4()
+        {
+            var streamPositions = new StreamPosition[0] { };
+            wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, 1000, CommandFlags.None));
         }
 
         [Fact]

--- a/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -892,30 +892,60 @@ namespace StackExchange.Redis.Tests
         public void StreamReadAsync_1()
         {
             var streamPositions = new StreamPosition[0] { };
-            wrapper.StreamReadAsync(streamPositions, null, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadAsync(streamPositions, null, CommandFlags.None));
+            wrapper.StreamReadAsync(streamPositions, null, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadAsync(streamPositions, null, null, CommandFlags.None));
         }
 
         [Fact]
         public void StreamReadAsync_2()
         {
-            wrapper.StreamReadAsync("key", "0-0", null, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadAsync("prefix:key", "0-0", null, CommandFlags.None));
+            wrapper.StreamReadAsync("key", "0-0", null, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadAsync("prefix:key", "0-0", null, null, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamReadAsync_3()
+        {
+            var streamPositions = new StreamPosition[0] { };
+            wrapper.StreamReadAsync(streamPositions, null, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadAsync(streamPositions, null, 1000, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamReadAsync_4()
+        {
+            wrapper.StreamReadAsync("key", "0-0", null, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadAsync("prefix:key", "0-0", null, 1000, CommandFlags.None));
         }
 
         [Fact]
         public void StreamReadGroupAsync_1()
         {
-            wrapper.StreamReadGroupAsync("key", "group", "consumer", StreamPosition.Beginning, 10, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadGroupAsync("prefix:key", "group", "consumer", StreamPosition.Beginning, 10, CommandFlags.None));
+            wrapper.StreamReadGroupAsync("key", "group", "consumer", StreamPosition.Beginning, 10, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroupAsync("prefix:key", "group", "consumer", StreamPosition.Beginning, 10, null, CommandFlags.None));
         }
 
         [Fact]
         public void StreamStreamReadGroupAsync_2()
         {
             var streamPositions = new StreamPosition[0] { };
-            wrapper.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, CommandFlags.None));
+            wrapper.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, null, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, null, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamReadGroupAsync_3()
+        {
+            wrapper.StreamReadGroupAsync("key", "group", "consumer", StreamPosition.Beginning, 10, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroupAsync("prefix:key", "group", "consumer", StreamPosition.Beginning, 10, 1000, CommandFlags.None));
+        }
+
+        [Fact]
+        public void StreamStreamReadGroupAsync_4()
+        {
+            var streamPositions = new StreamPosition[0] { };
+            wrapper.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, 1000, CommandFlags.None);
+            mock.Verify(_ => _.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, 1000, CommandFlags.None));
         }
 
         [Fact]


### PR DESCRIPTION
The [XREAD](https://redis.io/commands/xread) and [XREADGROUP](https://redis.io/commands/xreadgroup) commands have an optional Parameter BLOCK which comes handy in cases where a server application just waits for incoming messages to be processed. Without the BLOCK Parameter, the only option is to run a polling loop and waste precious CPU cycles. The current implementation does not support that parameter at all, so here's the patch to add it.