### PR TITLE
Make GeoRadiusResult constructor public to make it mockable

### DIFF
--- a/src/StackExchange.Redis/GeoEntry.cs
+++ b/src/StackExchange.Redis/GeoEntry.cs
@@ -68,7 +68,7 @@ namespace StackExchange.Redis
         /// <param name="distance">Tthe distance from the result.</param>
         /// <param name="hash">The hash of the result.</param>
         /// <param name="position">The geo position of the result.</param>
-        internal GeoRadiusResult(in RedisValue member, double? distance, long? hash, GeoPosition? position)
+        public GeoRadiusResult(in RedisValue member, double? distance, long? hash, GeoPosition? position)
         {
             Member = member;
             Distance = distance;


### PR DESCRIPTION
It's impossible to mock `GeoRadius` and `GeoRadiusAsync` methods now because `GeoRadiusResult` constructor is internal. Given that constructors for all other GEO calls are public I think it's possible to make `GeoRadiusResult` constructor public as well.