### PR TITLE
Accurate timespan if the stopwatch is high resolution

### DIFF
--- a/src/StackExchange.Redis/Profiling/ProfiledCommand.cs
+++ b/src/StackExchange.Redis/Profiling/ProfiledCommand.cs
@@ -19,15 +19,15 @@ namespace StackExchange.Redis.Profiling
 
         public DateTime CommandCreated => MessageCreatedDateTime;
 
-        public TimeSpan CreationToEnqueued => TimeSpan.FromTicks(EnqueuedTimeStamp - MessageCreatedTimeStamp);
+        public TimeSpan CreationToEnqueued => TimeSpanHelper.FromStopwatchTicks(EnqueuedTimeStamp - MessageCreatedTimeStamp);
 
-        public TimeSpan EnqueuedToSending => TimeSpan.FromTicks(RequestSentTimeStamp - EnqueuedTimeStamp);
+        public TimeSpan EnqueuedToSending => TimeSpanHelper.FromStopwatchTicks(RequestSentTimeStamp - EnqueuedTimeStamp);
 
-        public TimeSpan SentToResponse => TimeSpan.FromTicks(ResponseReceivedTimeStamp - RequestSentTimeStamp);
+        public TimeSpan SentToResponse => TimeSpanHelper.FromStopwatchTicks(ResponseReceivedTimeStamp - RequestSentTimeStamp);
 
-        public TimeSpan ResponseToCompletion => TimeSpan.FromTicks(CompletedTimeStamp - ResponseReceivedTimeStamp);
+        public TimeSpan ResponseToCompletion => TimeSpanHelper.FromStopwatchTicks(CompletedTimeStamp - ResponseReceivedTimeStamp);
 
-        public TimeSpan ElapsedTime => TimeSpan.FromTicks(CompletedTimeStamp - MessageCreatedTimeStamp);
+        public TimeSpan ElapsedTime => TimeSpanHelper.FromStopwatchTicks(CompletedTimeStamp - MessageCreatedTimeStamp);
 
         public IProfiledCommand RetransmissionOf => OriginalProfiling;
 

--- a/src/StackExchange.Redis/Profiling/TimeSpanHelper.cs
+++ b/src/StackExchange.Redis/Profiling/TimeSpanHelper.cs
@@ -6,14 +6,14 @@ namespace StackExchange.Redis.Profiling
     /// <summary>
     /// A helper class for dealing with Low/High Resolution Stopwatches and their ticks
     /// </summary>
-    public class TimeSpanHelper
+    internal static class TimeSpanHelper
     {
         /// <summary>
-        ///
+        /// Used to construct a timespan from ticks obtained using Stopwatch.GetTimestamp()
         /// </summary>
         /// <param name="ticks"></param>
-        /// <returns>A TimeSpan represented from the ticks</returns>
-        public static TimeSpan FromStopwatchTicks(long ticks)
+        /// <returns>A TimeSpan constructed from the ticks</returns>
+        internal static TimeSpan FromStopwatchTicks(long ticks)
         {
             return Stopwatch.IsHighResolution ? TimeSpan.FromMilliseconds(ticks / ((double) Stopwatch.Frequency / 1000)) : TimeSpan.FromTicks(ticks);
         }

--- a/src/StackExchange.Redis/Profiling/TimeSpanHelper.cs
+++ b/src/StackExchange.Redis/Profiling/TimeSpanHelper.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Diagnostics;
+
+namespace StackExchange.Redis.Profiling
+{
+    /// <summary>
+    /// A helper class for dealing with Low/High Resolution Stopwatches and their ticks
+    /// </summary>
+    public class TimeSpanHelper
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="ticks"></param>
+        /// <returns>A TimeSpan represented from the ticks</returns>
+        public static TimeSpan FromStopwatchTicks(long ticks)
+        {
+            return Stopwatch.IsHighResolution ? TimeSpan.FromMilliseconds(ticks / ((double) Stopwatch.Frequency / 1000)) : TimeSpan.FromTicks(ticks);
+        }
+    }
+}


### PR DESCRIPTION
We were using profiling, and our durations were crazy high.

We traced it down to this, the stopwatch can be a high or low resolution.

When constructing the timespan, we should check if the stopwatch was high resolution and do some calculations for a more accurate time.