### PR TITLE
add CheckCertificateRevocation of SslStream.AuthenticateAsClient to Configuration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -72,12 +72,12 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | configChannel={string} | `ConfigurationChannel` | `__Booksleeve_MasterChanged` | Broadcast channel name for communicating configuration changes                                            |
 | configCheckSeconds={int} | `ConfigCheckSeconds`  | `60`                         | Time (seconds) to check configuration. This serves as a keep-alive for interactive sockets, if it is supported.     |
 | defaultDatabase={int}  | `DefaultDatabase`      | `null`                       | Default database index, from `0` to `databases - 1`                                                       |
-| keepAlive={int}        | `KeepAlive`            | `-1`                         | Time (seconds) at which to send a message to help keep sockets alive (60 sec default)                            |
+| keepAlive={int}        | `KeepAlive`            | `-1`                         | Time (seconds) at which to send a message to help keep sockets alive (60 sec default)                     |
 | name={string}          | `ClientName`           | `null`                       | Identification for the connection within redis                                                            |
 | password={string}      | `Password`             | `null`                       | Password for the redis server                                                                             |
 | proxy={proxy type}     | `Proxy`                | `Proxy.None`                 | Type of proxy in use (if any); for example "twemproxy"                                                    |
 | resolveDns={bool}      | `ResolveDns`           | `false`                      | Specifies that DNS resolution should be explicit and eager, rather than implicit                          |
-| responseTimeout={int}  | `ResponseTimeout`      | `SyncTimeout`                | Time (ms) to decide whether the socket is unhealthy                                                |
+| responseTimeout={int}  | `ResponseTimeout`      | `SyncTimeout`                | Time (ms) to decide whether the socket is unhealthy                                                       |
 | serviceName={string}   | `ServiceName`          | `null`                       | Not currently implemented (intended for use with sentinel)                                                |
 | ssl={bool}             | `Ssl`                  | `false`                      | Specifies that SSL encryption should be used                                                              |
 | sslHost={string}       | `SslHost`              | `null`                       | Enforces a particular SSL host identity on the server's certificate                                       |
@@ -86,6 +86,7 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | tiebreaker={string}    | `TieBreaker`           | `__Booksleeve_TieBreak`      | Key to use for selecting a server in an ambiguous master scenario                                         |
 | version={string}       | `DefaultVersion`       | (`3.0` in Azure, else `2.0`) | Redis version level (useful when the server does not make this available)                                 |
 | writeBuffer={int}      | `WriteBuffer`          | `4096`                       | Size of the output buffer                                                                                 |
+|                        | `CheckCertificateRevocation` | `true`                 | A Boolean value that specifies whether the certificate revocation list is checked during authentication.  |
 
 Additional code-only options:
 - ReconnectRetryPolicy (`IReconnectRetryPolicy`) - Default: `ReconnectRetryPolicy = LinearRetry(ConnectTimeout);`

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -128,7 +128,7 @@ namespace StackExchange.Redis
             }
         }
 
-        private bool? allowAdmin, abortOnConnectFail, highPrioritySocketThreads, resolveDns, ssl;
+        private bool? allowAdmin, abortOnConnectFail, highPrioritySocketThreads, resolveDns, ssl, checkCertificateRevocation;
 
         private string tieBreaker, sslHost, configChannel;
 
@@ -183,6 +183,11 @@ namespace StackExchange.Redis
         /// Automatically encodes and decodes channels
         /// </summary>
         public RedisChannel ChannelPrefix { get; set; }
+
+        /// <summary>
+        /// A Boolean value that specifies whether the certificate revocation list is checked during authentication.
+        /// </summary>
+        public bool CheckCertificateRevocation {get { return checkCertificateRevocation ?? true; } set { checkCertificateRevocation = value; }}
 
         /// <summary>
         /// Create a certificate validation check that checks against the supplied issuer even if not known by the machine

--- a/src/StackExchange.Redis/ExtensionMethods.cs
+++ b/src/StackExchange.Redis/ExtensionMethods.cs
@@ -148,7 +148,7 @@ namespace StackExchange.Redis
             return Array.ConvertAll(values, x => (string)x);
         }
 
-        internal static void AuthenticateAsClient(this SslStream ssl, string host, SslProtocols? allowedProtocols)
+        internal static void AuthenticateAsClient(this SslStream ssl, string host, SslProtocols? allowedProtocols, bool checkCertificateRevocation)
         {
             if (!allowedProtocols.HasValue)
             {
@@ -158,8 +158,7 @@ namespace StackExchange.Redis
             }
 
             var certificateCollection = new X509CertificateCollection();
-            const bool checkCertRevocation = true;
-            ssl.AuthenticateAsClient(host, certificateCollection, allowedProtocols.Value, checkCertRevocation);
+            ssl.AuthenticateAsClient(host, certificateCollection, allowedProtocols.Value, checkCertificateRevocation);
         }
 
         private static void AuthenticateAsClientUsingDefaultProtocols(SslStream ssl, string host)

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1307,7 +1307,7 @@ namespace StackExchange.Redis
                     {
                         try
                         {
-                            ssl.AuthenticateAsClient(host, config.SslProtocols);
+                            ssl.AuthenticateAsClient(host, config.SslProtocols, config.CheckCertificateRevocation);
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
Hello,

in an enterprise infrastructure there is not always the possibility to check certificates for revocation. The target server from a certificate is not always accessible, e.g. AWS Cloud on Premise. I need to be able to disable the certificate revocation check.

I customized the documentation in the configuration and added the CheckCertificateRevocation attribute. The SslStream is now extended by a variation in the AuthenticateAsClient method. 
The risk that a defect is caused by this change is low. Also there is no breaking change, because the default: CheckCertificateRevocation=true remains the same. 
Please record this changerequest. Thank you.
