### PR TITLE
Fix TestConfig.cs link

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -16,7 +16,7 @@ The unit and integration tests here are fairly straightforward. There are 2 prim
 
 Tests default to `127.0.0.1` as their server, however you can override any of the test IPs/Hostnames and ports by placing a `TestConfig.json` in the `StackExchange.Redis.Tests\` folder. This file is intentionally in `.gitignore` already, as it's for *your* personal overrides. This is useful for testing local or remote servers, different versions, various ports, etc.
 
-You can find all the JSON properties at [TestConfig.cs](Helpers/TestConfig.cs). An example override (everything not specified being a default) would look like this:
+You can find all the JSON properties at [TestConfig.cs](https://github.com/StackExchange/StackExchange.Redis/blob/master/tests/StackExchange.Redis.Tests/Helpers/TestConfig.cs). An example override (everything not specified being a default) would look like this:
 ```json
 {
   "RunLongRunning": true,


### PR DESCRIPTION
The previous link was relative to the document, however, when displayed in GitHub Pages it ends in a 404. I've changed to point to the source file in GitHub UI.