### PR TITLE
fix for #1282: do no-op when adding 0 values to a set

### DIFF
--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -1216,6 +1216,7 @@ namespace StackExchange.Redis
 
         public long SetAdd(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
         {
+            if (values.Length == 0) return 0;
             var msg = Message.Create(Database, flags, RedisCommand.SADD, key, values);
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
@@ -1228,6 +1229,7 @@ namespace StackExchange.Redis
 
         public Task<long> SetAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
         {
+            if (values.Length == 0) return Task.FromResult<long>(0);
             var msg = Message.Create(Database, flags, RedisCommand.SADD, key, values);
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }

--- a/tests/StackExchange.Redis.Tests/Sets.cs
+++ b/tests/StackExchange.Redis.Tests/Sets.cs
@@ -189,5 +189,41 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(10, db.SetLength(key));
             }
         }
+
+        [Fact]
+        public void SetAdd_Zero()
+        {
+            using (var conn = Create())
+            {
+                var db = conn.GetDatabase();
+                var key = Me();
+
+                db.KeyDelete(key, CommandFlags.FireAndForget);
+
+                var result = db.SetAdd(key, new RedisValue[0]);
+                Assert.Equal(0, result);
+
+                Assert.Equal(0, db.SetLength(key));
+            }
+        }
+
+        [Fact]
+        public async Task SetAdd_Zero_Async()
+        {
+            using (var conn = Create())
+            {
+                var db = conn.GetDatabase();
+                var key = Me();
+
+                db.KeyDelete(key, CommandFlags.FireAndForget);
+
+                var t = db.SetAddAsync(key, new RedisValue[0]);
+                Assert.True(t.IsCompleted); // sync
+                var count = await t;
+                Assert.Equal(0, count);
+
+                Assert.Equal(0, db.SetLength(key));
+            }
+        }
     }
 }


### PR DESCRIPTION
This provides a fix for #1282. I hope the tests are sufficient.