### PR TITLE
Fix builds for all packages on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ t8.shakespeare.txt
 launchSettings.json
 *.vsp
 *.diagsession
+TestResults/

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal/2.0.24">
   <ItemGroup>
     <ProjectReference Include="src\**\*.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="$(Packing) != 'true'">
     <ProjectReference Include="tests\**\*.csproj" />
     <ProjectReference Include="toys\**\*.csproj" />
   </ItemGroup>

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.Build.Traversal/2.0.24">
+  <ItemGroup>
+    <ProjectReference Include="src\**\*.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$(Packing) != 'true'">
+    <ProjectReference Include="tests\**\*.csproj" />
+    <ProjectReference Include="toys\**\*.csproj" />
+  </ItemGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,9 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <Copyright>2017 Stack Exchange, Inc.</Copyright>
+    <Copyright>2020 Stack Exchange, Inc.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LibTargetFrameworks>netstandard2.0</LibTargetFrameworks>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StackExchange.Redis.snk</AssemblyOriginatorKeyFile>
     <PackageId>$(AssemblyName)</PackageId>
     <Features>strict</Features>
@@ -25,6 +24,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,6 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <Copyright>2020 Stack Exchange, Inc.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StackExchange.Redis.snk</AssemblyOriginatorKeyFile>
     <PackageId>$(AssemblyName)</PackageId>
     <Features>strict</Features>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <Copyright>$([System.DateTime]::Now.Year) Stack Exchange, Inc.</Copyright>
+    <Copyright>2014 - $([System.DateTime]::Now.Year) Stack Exchange, Inc.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StackExchange.Redis.snk</AssemblyOriginatorKeyFile>
     <PackageId>$(AssemblyName)</PackageId>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://github.com/StackExchange/StackExchange.Redis/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE</PackageLicenseUrl>
 
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/StackExchange.Redis/</RepositoryUrl>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/StackExchange/StackExchange.Redis/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.github.com/StackExchange/StackExchange.Redis/master/LICENSE</PackageLicenseUrl>
 
+    <LangVersion>latest</LangVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/StackExchange.Redis/</RepositoryUrl>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <Copyright>2020 Stack Exchange, Inc.</Copyright>
+    <Copyright>$([System.DateTime]::Now.Year) Stack Exchange, Inc.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StackExchange.Redis.snk</AssemblyOriginatorKeyFile>
     <PackageId>$(AssemblyName)</PackageId>
@@ -24,8 +24,6 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="all" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear/>
     <!--<add key="localNuget" value="c:\code\LocalNuget" />-->
-    <add key="xUnit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     <!--<add key="MyGet" value="https://www.myget.org/F/stackoverflow/api/v3/index.json" />-->
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/StackExchange.Redis.sln
+++ b/StackExchange.Redis.sln
@@ -8,8 +8,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
 		build.cmd = build.cmd
+		Build.csproj = Build.csproj
 		build.ps1 = build.ps1
-		Directory.build.props = Directory.build.props
+		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		NuGet.Config = NuGet.Config
 		docs\ReleaseNotes.md = docs\ReleaseNotes.md
@@ -86,8 +87,15 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KestrelRedisServer", "toys\KestrelRedisServer\KestrelRedisServer.csproj", "{3DA1EEED-E9FE-43D9-B293-E000CFCCD91A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{73A5C363-CA1F-44C4-9A9B-EF791A76BA6A}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+		tests\Directory.Build.targets = tests\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{00CA0876-DA9F-44E8-B0DC-A88716BF347A}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "toys", "toys", "{E25031D3-5C64-430D-B86F-697B66816FD8}"
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,11 @@
 image:
-- Visual Studio 2017
+- Visual Studio 2019
 - Ubuntu
 
 init:
   - git config --global core.autocrlf input
 
 install:
-- cmd: choco install dotnetcore-sdk --version 2.2.401
 - cmd: >-
     cd tests\RedisConfigs\3.0.503
 

--- a/build.ps1
+++ b/build.ps1
@@ -12,27 +12,14 @@ Write-Host "  RunTests: $RunTests"
 Write-Host "  dotnet --version:" (dotnet --version)
 
 $packageOutputFolder = "$PSScriptRoot\.nupkgs"
-$projectsToBuild = @(
-    'StackExchange.Redis',
-    'NRediSearch'
-)
-
-$testsToRun = @(
-    'StackExchange.Redis.Tests'
-)
 
 if ($PullRequestNumber) {
     Write-Host "Building for a pull request (#$PullRequestNumber), skipping packaging." -ForegroundColor Yellow
     $CreatePackages = $false
 }
 
-Write-Host "Building projects..." -ForegroundColor "Magenta"
-foreach ($project in $projectsToBuild) {
-    Write-Host "Building $project (dotnet restore/build)..." -ForegroundColor "Magenta"
-    dotnet restore ".\src\$project\$project.csproj" /p:CI=true
-    dotnet build ".\src\$project\$project.csproj" -c Release /p:CI=true
-    Write-Host ""
-}
+Write-Host "Building all projects (Build.csproj traversal)..." -ForegroundColor "Magenta"
+dotnet build ".\Build.csproj" -c Release /p:CI=true
 Write-Host "Done building." -ForegroundColor "Green"
 
 if ($RunTests) {
@@ -41,36 +28,23 @@ if ($RunTests) {
         & .\RedisConfigs\start-all.cmd
         Write-Host "Servers Started." -ForegroundColor "Green"
     }
-    foreach ($project in $testsToRun) {
-        Write-Host "Running tests: $project (all frameworks)" -ForegroundColor "Magenta"
-        #Push-Location ".\tests\$project"
-        Push-Location ".\tests\$project"
-
-        dotnet test -c Release
-        if ($LastExitCode -ne 0) {
-            Write-Host "Error with tests, aborting build." -Foreground "Red"
-            Pop-Location
-            Exit 1
-        }
-
-        Write-Host "Tests passed!" -ForegroundColor "Green"
-	    Pop-Location
+    Write-Host "Running tests: Build.csproj traversal (all frameworks)" -ForegroundColor "Magenta"
+    dotnet test ".\Build.csproj" -c Release --no-build --logger trx
+    if ($LastExitCode -ne 0) {
+        Write-Host "Error with tests, aborting build." -Foreground "Red"
+        Exit 1
     }
+    Write-Host "Tests passed!" -ForegroundColor "Green"
 }
 
 if ($CreatePackages) {
-    mkdir -Force $packageOutputFolder | Out-Null
+    New-Item -ItemType Directory -Path $packageOutputFolder -Force | Out-Null
     Write-Host "Clearing existing $packageOutputFolder..." -NoNewline
     Get-ChildItem $packageOutputFolder | Remove-Item
     Write-Host "done." -ForegroundColor "Green"
 
     Write-Host "Building all packages" -ForegroundColor "Green"
-
-    foreach ($project in $projectsToBuild) {
-        Write-Host "Packing $project (dotnet pack)..." -ForegroundColor "Magenta"
-        dotnet pack ".\src\$project\$project.csproj" --no-build -c Release /p:PackageOutputPath=$packageOutputFolder /p:NoPackageAnalysis=true /p:CI=true
-        Write-Host ""
-    }
+    dotnet pack ".\Build.csproj" --no-build -c Release /p:Packing=true /p:PackageOutputPath=$packageOutputFolder /p:CI=true
 }
 
 Write-Host "Done."

--- a/build.ps1
+++ b/build.ps1
@@ -44,7 +44,7 @@ if ($CreatePackages) {
     Write-Host "done." -ForegroundColor "Green"
 
     Write-Host "Building all packages" -ForegroundColor "Green"
-    dotnet pack ".\Build.csproj" --no-build -c Release /p:Packing=true /p:PackageOutputPath=$packageOutputFolder /p:CI=true
+    dotnet pack ".\Build.csproj" --no-build -c Release /p:PackageOutputPath=$packageOutputFolder /p:CI=true
 }
 
 Write-Host "Done."

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 
 {
   "sdk": {
-    "version": "2.2.400"
+    "version": "3.0.100",
+    "rollForward": "latestMajor"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 </Project>

--- a/src/NRediSearch/NRediSearch.csproj
+++ b/src/NRediSearch/NRediSearch.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>Redis;Search;Modules;RediSearch</PackageTags>
     <SignAssembly>true</SignAssembly>

--- a/src/NRediSearch/NRediSearch.csproj
+++ b/src/NRediSearch/NRediSearch.csproj
@@ -4,7 +4,6 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>Redis;Search;Modules;RediSearch</PackageTags>
     <SignAssembly>true</SignAssembly>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\StackExchange.Redis\StackExchange.Redis.csproj" />

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -101,6 +101,11 @@ namespace StackExchange.Redis
         public bool MillisecondExpiry => Version >= v2_6_0;
 
         /// <summary>
+        /// Is MODULE available?
+        /// </summary>
+        public bool Module => Version >= v4_0_0;
+
+        /// <summary>
         /// Does SRANDMEMBER support "count"?
         /// </summary>
         public bool MultipleRandom => Version >= v2_5_14;

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- extend the default lib targets for the main lib; mostly because of "vectors" -->
-    <LibTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netstandard2.0;net472</LibTargetFrameworks>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net472</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -9,7 +9,6 @@
     <PackageTags>Async;Redis;Cache;PubSub;Messaging</PackageTags>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <LangVersion>latest</LangVersion>
     <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);VECTOR_SAFE</DefineConstants>
   </PropertyGroup>
 

--- a/tests/BasicTest/BasicTest.csproj
+++ b/tests/BasicTest/BasicTest.csproj
@@ -8,7 +8,6 @@
     <PackageId>BasicTest</PackageId>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BasicTestBaseline/BasicTestBaseline.csproj
+++ b/tests/BasicTestBaseline/BasicTestBaseline.csproj
@@ -8,7 +8,6 @@
     <PackageId>BasicTestBaseline</PackageId>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <LangVersion>latest</LangVersion>
     <DefineConstants>$(DefineConstants);TEST_BASELINE</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+  <PropertyGroup>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
+  </PropertyGroup>
+</Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,4 @@
 <Project>
+  <!-- We could delete this file, but being consistent in structure here -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
-  <PropertyGroup>
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
-  </PropertyGroup>
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
+  </PropertyGroup>
+</Project>

--- a/tests/NRediSearch.Test/Attributes.cs
+++ b/tests/NRediSearch.Test/Attributes.cs
@@ -1,0 +1,7 @@
+﻿namespace NRediSearch.Test
+{
+    // This is only to make the namespace more-local and not need a using at the top of every test file that's easy to forget
+    public class FactAttribute : StackExchange.Redis.Tests.FactAttribute { }
+
+    public class TheoryAttribute : StackExchange.Redis.Tests.TheoryAttribute { }
+}

--- a/tests/NRediSearch.Test/NRediSearch.Test.csproj
+++ b/tests/NRediSearch.Test/NRediSearch.Test.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/NRediSearch.Test/NRediSearch.Test.csproj
+++ b/tests/NRediSearch.Test/NRediSearch.Test.csproj
@@ -9,9 +9,6 @@
     <ProjectReference Include="..\..\src\NRediSearch\NRediSearch.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/NRediSearch.Test/NRediSearch.Test.csproj
+++ b/tests/NRediSearch.Test/NRediSearch.Test.csproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NRediSearch\NRediSearch.csproj" />
+    <ProjectReference Include="..\StackExchange.Redis.Tests\StackExchange.Redis.Tests.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using StackExchange.Redis;
+using StackExchange.Redis.Tests;
 using Xunit.Abstractions;
 
 namespace NRediSearch.Test
@@ -44,10 +45,9 @@ namespace NRediSearch.Test
 
         internal static ConnectionMultiplexer GetWithFT(ITestOutputHelper output)
         {
-            const string ep = "127.0.0.1:6379";
             var options = new ConfigurationOptions
             {
-                EndPoints = { ep },
+                EndPoints = { TestConfig.Current.MasterServerAndPort },
                 AllowAdmin = true,
                 SyncTimeout = 15000,
             };
@@ -56,41 +56,41 @@ namespace NRediSearch.Test
             conn.Connecting += (e, t) => output.WriteLine($"Connecting to {Format.ToString(e)} as {t}");
             conn.Closing += complete => output.WriteLine(complete ? "Closed" : "Closing...");
 
-            var server = conn.GetServer(ep);
-            if (server.Features.Module)
-            {
-                var arr = (RedisResult[])server.Execute("module", "list");
-                bool found = false;
-                foreach (var module in arr)
-                {
-                    var parsed = Parse(module);
-                    if (parsed.TryGetValue("name", out var val) && val == "ft")
-                    {
-                        found = true;
-                        if (parsed.TryGetValue("ver", out val))
-                            output?.WriteLine($"Version: {val}");
-                        break;
-                    }
-                }
+            // If say we're on a 3.x Redis server...bomb out.
+            Skip.IfMissingFeature(conn, nameof(RedisFeatures.Module), r => r.Module);
 
-                if (!found)
+            var server = conn.GetServer(TestConfig.Current.MasterServerAndPort);
+            var arr = (RedisResult[])server.Execute("module", "list");
+            bool found = false;
+            foreach (var module in arr)
+            {
+                var parsed = Parse(module);
+                if (parsed.TryGetValue("name", out var val) && val == "ft")
                 {
-                    output?.WriteLine("Module not found; attempting to load...");
-                    var config = server.Info("server").SelectMany(_ => _).FirstOrDefault(x => x.Key == "config_file").Value;
-                    if (!string.IsNullOrEmpty(config))
+                    found = true;
+                    if (parsed.TryGetValue("ver", out val))
+                        output?.WriteLine($"Version: {val}");
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                output?.WriteLine("Module not found; attempting to load...");
+                var config = server.Info("server").SelectMany(_ => _).FirstOrDefault(x => x.Key == "config_file").Value;
+                if (!string.IsNullOrEmpty(config))
+                {
+                    var i = config.LastIndexOf('/');
+                    var modulePath = config.Substring(0, i + 1) + "redisearch.so";
+                    try
                     {
-                        var i = config.LastIndexOf('/');
-                        var modulePath = config.Substring(0, i + 1) + "redisearch.so";
-                        try
-                        {
-                            var result = server.Execute("module", "load", modulePath);
-                            output?.WriteLine((string)result);
-                        }
-                        catch (RedisServerException err)
-                        {
-                            // *probably* duplicate load; we'll try the tests anyways!
-                            output?.WriteLine(err.Message);
-                        }
+                        var result = server.Execute("module", "load", modulePath);
+                        output?.WriteLine((string)result);
+                    }
+                    catch (RedisServerException err)
+                    {
+                        // *probably* duplicate load; we'll try the tests anyways!
+                        output?.WriteLine(err.Message);
                     }
                 }
             }

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <DebugType>full</DebugType>
-    <LangVersion>latest</LangVersion>
     <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
   </PropertyGroup>
 

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -22,10 +22,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -3,10 +3,8 @@
     <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <DebugType>full</DebugType>
-    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>StackExchange.Redis.Tests</Description>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <DebugType>full</DebugType>
     <LangVersion>latest</LangVersion>
+    <IsTestProject Condition="'$(OS)' != 'Windows_NT' AND $(TargetFramework.StartsWith('net4'))">false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
+++ b/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
@@ -11,7 +11,6 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />

--- a/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
+++ b/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
@@ -11,7 +11,6 @@
     <OutputTypeEx>Library</OutputTypeEx>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
+++ b/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Basic redis server based on StackExchange.Redis</Description>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>StackExchange.Redis.Server</AssemblyName>
     <PackageId>StackExchange.Redis.Server</PackageId>
     <PackageTags>Server;Async;Redis;Cache;PubSub;Messaging</PackageTags>

--- a/toys/TestConsole/TestConsole.csproj
+++ b/toys/TestConsole/TestConsole.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;net461;net462;net47;net472</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
     <DefineConstants>SEV2</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/toys/TestConsoleBaseline/TestConsoleBaseline.csproj
+++ b/toys/TestConsoleBaseline/TestConsoleBaseline.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;net461;net462;net47;net472</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Computername)'=='OCHO' or '$(Computername)'=='SKINK'">


### PR DESCRIPTION
Note that we're only building `StackExchange.Redis` and `NRediSearch` in the CI build so this wasn't apparent as an issue, but it's also easily remedied. Cleaning up the xUnit MyGet feed as well since it was an intermittent issue earlier in testing this...and turns out we don't use any betas or need them anymore, so why not simplify anyhow.

Overall, this is a simpler alternative to #1313 and more build simplification/cleanup:

Total changes:
- Moves to 3.x build SDK (just to update)
  - Moves to `Visual Studio 2019` AppVeyor build image, for 3.x support (removes need to install SDK)
  - Rolls forward to latest version
- Moves to `Build.csproj` for building
  - Simplifies `build.ps1`
- Adds `NRediSearch` to the test suite (on Linux in CI, since Windows is against 3.x)
  - Adds `RedisFeatures.Module` (against v 4.0.0) to guard tests against
  - Makes `NRediSearch.Tests` reference `StackExchange.Redis.Tests` and support test skipping
- Makes copyright year range dynamic for the library
- Moves `LangVersion` to latest and in one place (root `Directory.Build.props`)
- Uses `Microsoft.NETFramework.ReferenceAssemblies` to build `net4x` on Linux
- Uses `IsPackable` to default to excluded then reverses to `true` only for the `src/` directory
- Removes `xUnit` MyGet feed, since we're on stable builds now
- Adds new files (and corrects old) in `.sln`
- Removes `LibTargetFrameworks` to simplify since it's less complex given the above changes

cc @mgravell for eyes - this should be all set now!