### PR TITLE
Cleanup: remove old Sentinel config dupes

### DIFF
--- a/RedisConfigs/Sentinel/redis-7010.conf
+++ b/RedisConfigs/Sentinel/redis-7010.conf
@@ -1,6 +1,0 @@
-port 7010
-maxmemory 100mb
-appendonly no
-dir "../Temp"
-dbfilename "sentinel-target-7010.rdb"
-save ""

--- a/RedisConfigs/Sentinel/redis-7011.conf
+++ b/RedisConfigs/Sentinel/redis-7011.conf
@@ -1,7 +1,0 @@
-port 7011
-maxmemory 100mb
-appendonly no
-dir "../Temp"
-dbfilename "sentinel-target-7011.rdb"
-save ""
-slaveof 127.0.0.1 7010

--- a/RedisConfigs/Sentinel/sentinel-26379.conf
+++ b/RedisConfigs/Sentinel/sentinel-26379.conf
@@ -1,6 +1,0 @@
-port 26379
-sentinel monitor mymaster 127.0.0.1 7010 1
-sentinel down-after-milliseconds mymaster 1000
-sentinel failover-timeout mymaster 2000
-sentinel config-epoch mymaster 0
-dir "../Temp"

--- a/RedisConfigs/Sentinel/sentinel-26380.conf
+++ b/RedisConfigs/Sentinel/sentinel-26380.conf
@@ -1,6 +1,0 @@
-port 26380
-sentinel monitor mymaster 127.0.0.1 7010 1
-sentinel down-after-milliseconds mymaster 1000
-sentinel failover-timeout mymaster 2000
-sentinel config-epoch mymaster 0
-dir "../Temp"


### PR DESCRIPTION
These got left behind in root due to being ignored in git, needed a good 'ol `git rm -r --cached RedisConfigs/Sentinel/` here.