### PR TITLE
Create public contructors for StackExchange.Redis event args for testing purpose

### DIFF
--- a/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
+++ b/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
@@ -7,7 +7,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// Contains information about a server connection failure
     /// </summary>
-    public sealed class ConnectionFailedEventArgs : EventArgs, ICompletable
+    public class ConnectionFailedEventArgs : EventArgs, ICompletable
     {
         private readonly EventHandler<ConnectionFailedEventArgs> handler;
         private readonly object sender;

--- a/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
+++ b/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
@@ -23,7 +23,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The constructor for testing purpose.
+        /// This constructor is only for testing purposes.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="endPoint">Redis endpoint.</param>

--- a/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
+++ b/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
@@ -22,6 +22,20 @@ namespace StackExchange.Redis
             _physicalName = physicalName ?? GetType().Name;
         }
 
+        /// <summary>
+        /// The constructor for testing purpose.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="endPoint">Redis endpoint.</param>
+        /// <param name="connectionType">Redis connection type.</param>
+        /// <param name="failureType">Redis connection failure type.</param>
+        /// <param name="exception">The exception occured.</param>
+        /// <param name="physicalName">Connection physical name.</param>
+        public ConnectionFailedEventArgs(object sender, EndPoint endPoint, ConnectionType connectionType, ConnectionFailureType failureType, Exception exception, string physicalName)
+            : this (null, sender, endPoint, connectionType, failureType, exception, physicalName)
+        {
+        }
+
         private readonly string _physicalName;
 
         /// <summary>

--- a/src/StackExchange.Redis/EndPointEventArgs.cs
+++ b/src/StackExchange.Redis/EndPointEventArgs.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The constructor for testing purpose.
+        /// This constructor is only for testing purposes.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="endpoint">Redis endpoint.</param>

--- a/src/StackExchange.Redis/EndPointEventArgs.cs
+++ b/src/StackExchange.Redis/EndPointEventArgs.cs
@@ -19,6 +19,16 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// The constructor for testing purpose.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="endpoint">Redis endpoint.</param>
+        public EndPointEventArgs(object sender, EndPoint endpoint)
+            : this (null, sender, endpoint)
+        {
+        }
+
+        /// <summary>
         /// The endpoint involved in this event (this can be null)
         /// </summary>
         public EndPoint EndPoint { get; }

--- a/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
+++ b/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
@@ -38,7 +38,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The constructor for testing purpose.
+        /// This constructor is only for testing purposes.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="hashSlot">Hash slot.</param>

--- a/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
+++ b/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
@@ -7,7 +7,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// Contains information about individual hash-slot relocations
     /// </summary>
-    public sealed class HashSlotMovedEventArgs : EventArgs, ICompletable
+    public class HashSlotMovedEventArgs : EventArgs, ICompletable
     {
         private readonly object sender;
         private readonly EventHandler<HashSlotMovedEventArgs> handler;

--- a/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
+++ b/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
@@ -37,6 +37,18 @@ namespace StackExchange.Redis
             NewEndPoint = @new;
         }
 
+        /// <summary>
+        /// The constructor for testing purpose.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="hashSlot">Hash slot.</param>
+        /// <param name="old">Old endpoint.</param>
+        /// <param name="new">New endpoint.</param>
+        public HashSlotMovedEventArgs(object sender, int hashSlot, EndPoint old, EndPoint @new)
+            : this (null, sender, hashSlot, old, @new)
+        {
+        }
+
         bool ICompletable.TryComplete(bool isAsync) => ConnectionMultiplexer.TryCompleteHandler(handler, sender, this, isAsync);
 
         void ICompletable.AppendStormLog(StringBuilder sb)

--- a/src/StackExchange.Redis/InternalErrorEventArgs.cs
+++ b/src/StackExchange.Redis/InternalErrorEventArgs.cs
@@ -22,7 +22,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The constructor for testing purpose.
+        /// This constructor is only for testing purposes.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="endpoint"></param>

--- a/src/StackExchange.Redis/InternalErrorEventArgs.cs
+++ b/src/StackExchange.Redis/InternalErrorEventArgs.cs
@@ -22,6 +22,19 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// The constructor for testing purpose.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="endpoint"></param>
+        /// <param name="connectionType">Redis connection type.</param>
+        /// <param name="exception">The exception occured.</param>
+        /// <param name="origin">Origin.</param>
+        public InternalErrorEventArgs(object sender, EndPoint endpoint, ConnectionType connectionType, Exception exception, string origin)
+            : this (null, sender, endpoint, connectionType, exception, origin)
+        {
+        }
+
+        /// <summary>
         /// Gets the connection-type of the failing connection
         /// </summary>
         public ConnectionType ConnectionType { get; }

--- a/src/StackExchange.Redis/RedisErrorEventArgs.cs
+++ b/src/StackExchange.Redis/RedisErrorEventArgs.cs
@@ -7,7 +7,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// Notification of errors from the redis server
     /// </summary>
-    public sealed class RedisErrorEventArgs : EventArgs, ICompletable
+    public class RedisErrorEventArgs : EventArgs, ICompletable
     {
         private readonly EventHandler<RedisErrorEventArgs> handler;
         private readonly object sender;

--- a/src/StackExchange.Redis/RedisErrorEventArgs.cs
+++ b/src/StackExchange.Redis/RedisErrorEventArgs.cs
@@ -22,7 +22,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The constructor for testing purpose.
+        /// This constructor is only for testing purposes.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="endpoint">Redis endpoint.</param>

--- a/src/StackExchange.Redis/RedisErrorEventArgs.cs
+++ b/src/StackExchange.Redis/RedisErrorEventArgs.cs
@@ -22,6 +22,17 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// The constructor for testing purpose.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="endpoint">Redis endpoint.</param>
+        /// <param name="message">Error message.</param>
+        public RedisErrorEventArgs(object sender, EndPoint endpoint, string message)
+            : this (null, sender, endpoint, message)
+        {
+        }
+
+        /// <summary>
         /// The origin of the message
         /// </summary>
         public EndPoint EndPoint { get; }

--- a/tests/StackExchange.Redis.Tests/EventArgsTests.cs
+++ b/tests/StackExchange.Redis.Tests/EventArgsTests.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using NSubstitute;
+using Xunit;
+
+namespace StackExchange.Redis.Tests
+{
+    public class EventArgsTests
+    {
+        [Fact]
+        public void EventArgsCanBeSubstituted()
+        {
+            EndPointEventArgs endpointArgsMock
+                = Substitute.For<EndPointEventArgs>(default, default);
+
+            RedisErrorEventArgs redisErrorArgsMock
+                = Substitute.For<RedisErrorEventArgs>(default, default, default);
+
+            ConnectionFailedEventArgs connectionFailedArgsMock
+                = Substitute.For<ConnectionFailedEventArgs>(
+                    default, default, default, default, default, default);
+
+            InternalErrorEventArgs internalErrorArgsMock
+                = Substitute.For<InternalErrorEventArgs>(
+                    default, default, default, default, default);
+
+            HashSlotMovedEventArgs hashSlotMovedArgsMock
+                = Substitute.For<HashSlotMovedEventArgs>(
+                    default, default, default, default);
+
+            DiagnosticStub stub = DiagnosticStub.Create();
+
+            stub.ConfigurationChangedBroadcastHandler(default, endpointArgsMock);
+            Assert.Equal(stub.Message,DiagnosticStub.ConfigurationChangedBroadcastHandlerMessage);
+
+            stub.ErrorMessageHandler(default, redisErrorArgsMock);
+            Assert.Equal(stub.Message, DiagnosticStub.ErrorMessageHandlerMessage);
+
+            stub.ConnectionFailedHandler(default, connectionFailedArgsMock);
+            Assert.Equal(stub.Message, DiagnosticStub.ConnectionFailedHandlerMessage);
+
+            stub.InternalErrorHandler(default, internalErrorArgsMock);
+            Assert.Equal(stub.Message, DiagnosticStub.InternalErrorHandlerMessage);
+
+            stub.ConnectionRestoredHandler(default, connectionFailedArgsMock);
+            Assert.Equal(stub.Message, DiagnosticStub.ConnectionRestoredHandlerMessage);
+
+            stub.ConfigurationChangedHandler(default, endpointArgsMock);
+            Assert.Equal(stub.Message, DiagnosticStub.ConfigurationChangedHandlerMessage);
+
+            stub.HashSlotMovedHandler(default, hashSlotMovedArgsMock);
+            Assert.Equal(stub.Message, DiagnosticStub.HashSlotMovedHandlerMessage);
+        }
+
+        public class DiagnosticStub
+        {
+            public const string ConfigurationChangedBroadcastHandlerMessage
+                = "ConfigurationChangedBroadcastHandler invoked";
+
+            public const string ErrorMessageHandlerMessage
+                = "ErrorMessageHandler invoked";
+
+            public const string ConnectionFailedHandlerMessage
+                = "ConnectionFailedHandler invoked";
+
+            public const string InternalErrorHandlerMessage
+                = "InternalErrorHandler invoked";
+
+            public const string ConnectionRestoredHandlerMessage
+                = "ConnectionRestoredHandler invoked";
+
+            public const string ConfigurationChangedHandlerMessage
+                = "ConfigurationChangedHandler invoked";
+
+            public const string HashSlotMovedHandlerMessage
+                = "HashSlotMovedHandler invoked";
+
+            public static DiagnosticStub Create()
+            {
+                DiagnosticStub stub = new DiagnosticStub();
+
+                stub.ConfigurationChangedBroadcastHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = ConfigurationChangedBroadcastHandlerMessage;
+                    };
+
+                stub.ErrorMessageHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = ErrorMessageHandlerMessage;
+                    };
+
+                stub.ConnectionFailedHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = ConnectionFailedHandlerMessage;
+                    };
+
+                stub.InternalErrorHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = InternalErrorHandlerMessage;
+                    };
+
+                stub.ConnectionRestoredHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = ConnectionRestoredHandlerMessage;
+                    };
+
+                stub.ConfigurationChangedHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = ConfigurationChangedHandlerMessage;
+                    };
+
+                stub.HashSlotMovedHandler
+                    = (obj, args) =>
+                    {
+                        stub.Message = HashSlotMovedHandlerMessage;
+                    };
+
+                return stub;
+            }
+
+            public string Message { get; private set; }
+
+            public Action<object, EndPointEventArgs> ConfigurationChangedBroadcastHandler
+            {
+                get;
+                private set;
+            }
+
+            public Action<object, RedisErrorEventArgs> ErrorMessageHandler
+            {
+                get;
+                private set;
+            }
+
+            public Action<object, ConnectionFailedEventArgs> ConnectionFailedHandler
+            {
+                get;
+                private set;
+            }
+
+            public Action<object, InternalErrorEventArgs> InternalErrorHandler
+            {
+                get;
+                private set;
+            }
+
+            public Action<object, ConnectionFailedEventArgs> ConnectionRestoredHandler
+            {
+                get;
+                private set;
+            }
+
+            public Action<object, EndPointEventArgs> ConfigurationChangedHandler
+            {
+                get;
+                private set;
+            }
+
+            public Action<object, HashSlotMovedEventArgs> HashSlotMovedHandler
+            {
+                get;
+                private set;
+            }
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Create public contructors for StackExchange.Redis event args to be able to create tests scenarios based on redis events. Add sealed attribute to other EventArgs for consistency.

Issue with details - https://github.com/StackExchange/StackExchange.Redis/issues/1325