### PR TITLE
Improve pub/sub order documentation

### DIFF
--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -107,7 +107,7 @@ sub.Publish("messages", "hello");
 
 This will (virtually instantaneously) write `"hello"` to the console of the subscribed process. As before, both channel-names and messages can be binary.
 
-Please also see [Pub / Sub Message Order](PubSubOrder) for guidance on sequential versus concurrent message processing.
+Please also see [Pub / Sub Message Order](PubSubOrder.md) for guidance on sequential versus concurrent message processing.
 
 Accessing individual servers
 ---

--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -107,7 +107,7 @@ sub.Publish("messages", "hello");
 
 This will (virtually instantaneously) write `"hello"` to the console of the subscribed process. As before, both channel-names and messages can be binary.
 
-Please also see [Pub / Sub Message Order](PubSubOrder.md) for guidance on sequential versus concurrent message processing.
+Please also see [Pub / Sub Message Order](PubSubOrder) for guidance on sequential versus concurrent message processing.
 
 Accessing individual servers
 ---

--- a/docs/PubSubOrder.md
+++ b/docs/PubSubOrder.md
@@ -7,8 +7,10 @@ Processing them sequentially means that you don't need to worry (quite as much) 
 they will be processed in exactly the same order in which they are received (via a queue) - but as a consequence it means that messages can delay each-other.
 
 ```csharp
-multiplexer.GetSubscriber().SubScribe("messages", (channel, message) => {
-    Console.WriteLine((string)message);
+var channel = multiplexer.GetSubscriber().Subscribe("messages");
+channel.OnMessage(message =>
+{
+    Console.WriteLine((string)message.Message);
 });
 ```
 
@@ -17,9 +19,7 @@ responsible for ensuring that concurrent messages don't corrupt your internal st
 This works *particularly* well if messages are generally unrelated.
 
 ```csharp
-var channelMessageQueue = multiplexer.GetSubscriber().SubScribe("messages");
-channel.OnMessage(message =>
-{
-    Console.WriteLine((string)message.Message);
+multiplexer.GetSubscriber().Subscribe("messages", (channel, message) => {
+    Console.WriteLine((string)message);
 });
 ```


### PR DESCRIPTION
First, the link from Basics doesn't work. Second, the docs code samples appear backward, in addition to the casing of the `Subscribe` method being off.