### PR TITLE
Fixing a bug where READONLY is run before AUTH. 

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1200,15 +1200,20 @@ namespace StackExchange.Redis
 
                 if (!connection.TransactionActive)
                 {
-                    var readmode = connection.GetReadModeCommand(isMasterOnly);
-                    if (readmode != null)
+                    // If we are executing AUTH, it means we are still unauthenticated
+                    // Setting READONLY before AUTH always fails but we think it succeeded since
+                    // we run it as Fire and Forget. 
+                    if (cmd != RedisCommand.AUTH)
                     {
-                        connection.EnqueueInsideWriteLock(readmode);
-                        readmode.WriteTo(connection);
-                        readmode.SetRequestSent();
-                        IncrementOpCount();
+                        var readmode = connection.GetReadModeCommand(isMasterOnly);
+                        if (readmode != null)
+                        {
+                            connection.EnqueueInsideWriteLock(readmode);
+                            readmode.WriteTo(connection);
+                            readmode.SetRequestSent();
+                            IncrementOpCount();
+                        }
                     }
-
                     if (message.IsAsking)
                     {
                         var asking = ReusableAskingCommand;


### PR DESCRIPTION
Fixing a bug where READONLY is run before AUTH when reconnecting to clustered Slaves and since Readonly is run as Fire and Forget we never get an error either. 

This causes MOVED errors until the Multiplexer is recreated (easily seen when NoRedirect is specified) or all MOVED errors are handled internally but this means the Slaves are not at all used to distribute load which can cause connection issues with much smaller loads.