### PR TITLE
PhysicalBridge always returns NoConnection after exception during message write / connection flush

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -638,12 +638,12 @@ namespace StackExchange.Redis
 
         private readonly MutexSlim _singleWriterMutex;
 
-        private Message _activeMesssage;
+        private Message _activeMessage;
 
         private WriteResult WriteMessageInsideLock(PhysicalConnection physical, Message message)
         {
             WriteResult result;
-            var existingMessage = Interlocked.CompareExchange(ref _activeMesssage, message, null);
+            var existingMessage = Interlocked.CompareExchange(ref _activeMessage, message, null);
             if (existingMessage != null)
             {
                 Multiplexer?.OnInfoMessage($"reentrant call to WriteMessageTakingWriteLock for {message.CommandAndKey}, {existingMessage.CommandAndKey} is still active");
@@ -737,12 +737,15 @@ namespace StackExchange.Redis
 #pragma warning restore CS0618
                 }
 
-                UnmarkActiveMessage(message);
                 physical.SetIdle();
                 return result;
             }
             catch (Exception ex) { return HandleWriteException(message, ex); }
-            finally { token.Dispose(); }
+            finally
+            {
+                UnmarkActiveMessage(message);
+                token.Dispose();
+            }
 
         }
 
@@ -887,7 +890,6 @@ namespace StackExchange.Redis
                             }
 
                             _backlogStatus = BacklogStatus.MarkingInactive;
-                            UnmarkActiveMessage(message);
                             if (result != WriteResult.Success)
                             {
                                 _backlogStatus = BacklogStatus.RecordingWriteFailure;
@@ -900,6 +902,10 @@ namespace StackExchange.Redis
                     {
                         _backlogStatus = BacklogStatus.RecordingFault;
                         HandleWriteException(message, ex);
+                    }
+                    finally
+                    {
+                        UnmarkActiveMessage(message);
                     }
                 }
                 _backlogStatus = BacklogStatus.SettingIdle;
@@ -985,8 +991,7 @@ namespace StackExchange.Redis
 
                     result = flush.Result; // we know it was completed, this is fine
                 }
-
-                UnmarkActiveMessage(message);
+                
                 physical.SetIdle();
 
                 return new ValueTask<WriteResult>(result);
@@ -994,12 +999,17 @@ namespace StackExchange.Redis
             catch (Exception ex) { return new ValueTask<WriteResult>(HandleWriteException(message, ex)); }
             finally
             {
-                if (releaseLock & token.Success)
+                if (token.Success)
                 {
+                    UnmarkActiveMessage(message);
+
+                    if (releaseLock)
+                    {
 #if DEBUG
-                    RecordLockDuration(lockTaken);
+                        RecordLockDuration(lockTaken);
 #endif
-                    token.Dispose();
+                        token.Dispose();
+                    }
                 }
             }
         }
@@ -1029,8 +1039,7 @@ namespace StackExchange.Redis
                     {
                         result = await physical.FlushAsync(false).ForAwait();
                     }
-
-                    UnmarkActiveMessage(message);
+                    
                     physical.SetIdle();
 
 #if DEBUG
@@ -1043,6 +1052,10 @@ namespace StackExchange.Redis
             {
                 return HandleWriteException(message, ex);
             }
+            finally
+            {
+                UnmarkActiveMessage(message);
+            }
         }
 
         private async ValueTask<WriteResult> CompleteWriteAndReleaseLockAsync(LockToken lockToken, ValueTask<WriteResult> flush, Message message, int lockTaken)
@@ -1052,7 +1065,6 @@ namespace StackExchange.Redis
                 try
                 {
                     var result = await flush.ForAwait();
-                    UnmarkActiveMessage(message);
                     physical.SetIdle();
                     return result;
                 }
@@ -1072,7 +1084,7 @@ namespace StackExchange.Redis
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UnmarkActiveMessage(Message message)
-            => Interlocked.CompareExchange(ref _activeMesssage, null, message); // remove if it is us
+            => Interlocked.CompareExchange(ref _activeMessage, null, message); // remove if it is us
 
         private State ChangeState(State newState)
         {
@@ -1301,6 +1313,6 @@ namespace StackExchange.Redis
             physical?.RecordConnectionFailed(ConnectionFailureType.SocketFailure);
         }
 
-        internal RedisCommand? GetActiveMessage() => Volatile.Read(ref _activeMesssage)?.Command;
+        internal RedisCommand? GetActiveMessage() => Volatile.Read(ref _activeMessage)?.Command;
     }
 }


### PR DESCRIPTION
We recently encountered an issue where we repeatedly (for several hours) got the exception "No connection is available to service this operation". Using version 2.0.601 (with `AbortOnConnectFail` set to false)  running on asp.net core, in Azure and connecting to an Azure Redis instance. This was only resolved by a restart of the instance, other application instance could connect to the redis instance during this time

The full exception was as follows
```
No connection is available to service this operation: SMEMBERS XXXX; An existing connection was forcibly closed by the remote host; IOCP: (Busy=1,Free=999,Min=2,Max=1000), WORKER: (Busy=0,Free=32767,Min=2,Max=32767), Local-CPU: n/a
SocketFailure on xxx.redis.cache.windows.net:6380/Interactive, Idle/Faulted, last: GET, origin: ReadFromPipe, outstanding: 3, last-read: 0s ago, last-write: 0s ago, unanswered-write: 0s ago, keep-alive: 10s, state: ConnectedEstablished, mgr: 8 of 10 available, in: 0, last-heartbeat: 0s ago, last-mbeat: 0s ago, global: 0s ago, v: 2.0.601.3402
```
I was able to reproduce this situation with a small console app that repeatably writes and reads keys and while this is running i kill the connection from the redis cli `client kill type normal`. This sometimes causes an exception from within one of the `WriteMessage*` methods to be thrown. This in turns causes the `_activeMessage` field in `PhysicalBridge` to not be set back to null and from that point forward the compare exchange logic in `WriteMessageInsideLock` bridge will always return "NoConnection". At this point any request for the `ConnectionMultiplexer` fails and it won't recover (at least in my testing)

I note there have been a number of issues opened that have have a similar error message and symptoms. Looking at the commit history this [commit](https://github.com/StackExchange/StackExchange.Redis/commit/687394109f9b7faa6a25851b3744417bfae5cd51#diff-e9ff80307b03460becea3fe93c80bdf7) changed from clearing `_activeMessage` in `ReleaseSingleWriterLock` which was called from the finally block to the current approach, although obviously along with a significant number of other changes. Version 2.0.519 doesn't include this change and that might explain why people have had some success rolling back to it.

This PR moves back to always clearing `_activeMessage` within the finally block of the three relevant write methods, ensuring it's cleared even in the case of an exception occuring. Happy to try write some tests for this, just wanted to validate the change is acceptable first

Finally for reference a specific example the following exception was thrown during my testing, from `PhysicalBridge.WriteMessageTakingWriteLockAsync` when flushing the PhysicalConnection. 
```
   at Pipelines.Sockets.Unofficial.Internal.Throw.Socket(Int32 errorCode) in C:\Code\Pipelines.Sockets.Unofficial\src\Pipelines.Sockets.Unofficial\Internal\Throw.cs:line 59
   at Pipelines.Sockets.Unofficial.SocketAwaitableEventArgs.GetResult() in C:\Code\Pipelines.Sockets.Unofficial\src\Pipelines.Sockets.Unofficial\SocketAwaitableEventArgs.cs:line 74
   at Pipelines.Sockets.Unofficial.SocketConnection.<DoSendAsync>d__82.MoveNext() in C:\Code\Pipelines.Sockets.Unofficial\src\Pipelines.Sockets.Unofficial\SocketConnection.Send.cs:line 64
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.IO.Pipelines.PipeCompletion.ThrowLatchedException()
   at System.IO.Pipelines.Pipe.GetFlushResult(FlushResult& result)
   at System.IO.Pipelines.Pipe.PrepareFlush(CompletionData& completionData, ValueTask`1& result, CancellationToken cancellationToken)
   at System.IO.Pipelines.Pipe.FlushAsync(CancellationToken cancellationToken)
   at System.IO.Pipelines.Pipe.DefaultPipeWriter.FlushAsync(CancellationToken cancellationToken)
   at Pipelines.Sockets.Unofficial.SocketConnection.WrappedWriter.FlushAsync(CancellationToken cancellationToken) in C:\Code\Pipelines.Sockets.Unofficial\src\Pipelines.Sockets.Unofficial\SocketConnection.cs:line 434
   at StackExchange.Redis.PhysicalConnection.FlushAsync(Boolean throwOnFailure) in C:\Users\XXXX\source\repos\StackExchange.Redis\src\StackExchange.Redis\PhysicalConnection.cs:line 905
   at StackExchange.Redis.PhysicalBridge.WriteMessageTakingWriteLockAsync(PhysicalConnection physical, Message message) in C:\Users\XXXX\source\repos\StackExchange.Redis\src\StackExchange.Redis\PhysicalBridge.cs:line 977
```
