### PR TITLE
fix forgotten clone config attribute CheckCertificateRevocation

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -462,6 +462,7 @@ namespace StackExchange.Redis
                 DefaultDatabase = DefaultDatabase,
                 ReconnectRetryPolicy = reconnectRetryPolicy,
                 SslProtocols = SslProtocols,
+                CheckCertificateRevocation = CheckCertificateRevocation
             };
             foreach (var item in EndPoints)
                 options.EndPoints.Add(item);

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -462,7 +462,7 @@ namespace StackExchange.Redis
                 DefaultDatabase = DefaultDatabase,
                 ReconnectRetryPolicy = reconnectRetryPolicy,
                 SslProtocols = SslProtocols,
-                CheckCertificateRevocation = CheckCertificateRevocation
+                checkCertificateRevocation = checkCertificateRevocation,
             };
             foreach (var item in EndPoints)
                 options.EndPoints.Add(item);


### PR DESCRIPTION
Hi,

i have make a pull request: @https://github.com/StackExchange/StackExchange.Redis/pull/1234
but it has a Bug. When the Config is Clone i have forgot the copy for the attribute CheckCertificateRevocation.
Now this request do that. Sorry for my fail.
