### PR TITLE
Let uses explicty configure ServerSelectionStrategy.ServerType in cases they are using a Redis Cluster.

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1675,6 +1675,10 @@ namespace StackExchange.Redis
                         {
                             ServerSelectionStrategy.ServerType = ServerType.Twemproxy;
                         }
+                        if (RawConfig.Proxy == Proxy.Cluster)
+                        {
+                            ServerSelectionStrategy.ServerType = ServerType.Cluster;
+                        }
                         else if (standaloneCount == 0 && sentinelCount > 0)
                         {
                             ServerSelectionStrategy.ServerType = ServerType.Sentinel;

--- a/src/StackExchange.Redis/Enums/Proxy.cs
+++ b/src/StackExchange.Redis/Enums/Proxy.cs
@@ -12,6 +12,10 @@
         /// <summary>
         /// Communication via <a href="https://github.com/twitter/twemproxy">twemproxy</a>
         /// </summary>
-        Twemproxy
+        Twemproxy,
+        /// <summary>
+        /// Direct communication to the redis cluster
+        /// </summary>
+        Cluster
     }
 }


### PR DESCRIPTION
We are using 1.2.6 version of StackExchange.Redis with Azure Redis cache and occasionally we get bunch of "No connection is available to service this operation" and sometime it goes into a state where it doesn't ever recover from this issue and we are forces to reboot those VMs to fix the problem.

I was looking at [1374](https://github.com/StackExchange/StackExchange.Redis/pull/1374) and using the same setup but using code of 1.2.6 SDK version with actual Azure Redis cache. I was able to repo the problem and noticed that whenever it happens, ConnectionMultiplexer -> ReconfigureAsyc function fails while PINGing Redis Server and as a result the clusterCount remain 0.

![image](https://user-images.githubusercontent.com/32182026/76494391-f6f8f380-63f1-11ea-882c-1c7349cc34c7.png)

Now since we are not sure what type of Redis we are talking to, we default to ServerSelectionStrategy.ServerType i.e. ServerType.Standalone. I didn't went that deep into code, but somehow the endpoint is able to recover but we are still stuck with ServerSelectionStrategy.ServerType as Standalone due to which all subsequent calls fails with "No connection is available to service this operation". Given the part of ReconfigureAsyc I'm talking about is same in latest version as well, I'm pretty sure the problem will exists in there as well. Happy to try it out with latest version as well, just wanted to validate the change is acceptable first.

![image](https://user-images.githubusercontent.com/32182026/76494250-b13c2b00-63f1-11ea-9882-cec15b904f39.png)

By giving option to explicitly specify, I'm thinking that way in case of failure, we don't have to assume about the type of Redis we are talking to and hence more deterministic behavior.