### PR TITLE
NRediSearch Test Suite Fixes

### DIFF
--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -52,6 +52,8 @@ namespace NRediSearch
 
         public sealed class ConfiguredIndexOptions
         {
+            // This news up a enum which results in the 0 equivalent.
+            // It's not used in the library and I'm guessing this isn't intentional.
             public static IndexOptions Default => new IndexOptions();
 
             private IndexOptions _options;
@@ -320,7 +322,7 @@ namespace NRediSearch
             {
                 return (string)DbSync.Execute("FT.ADD", args) == "OK";
             }
-            catch (RedisServerException ex) when (ex.Message == "Document already in index")
+            catch (RedisServerException ex) when (ex.Message == "Document already in index" || ex.Message == "Document already exists")
             {
                 return false;
             }

--- a/src/NRediSearch/Suggestion.cs
+++ b/src/NRediSearch/Suggestion.cs
@@ -96,7 +96,7 @@ namespace NRediSearch
 
                 if (isStringMissing || isScoreOutOfRange)
                 {
-                    throw new RedisCommandException($"Missing required fields: {(isStringMissing ? "string" : string.Empty)} {(isScoreOutOfRange ? "score not within range" : string.Empty)}");
+                    throw new RedisCommandException($"Missing required fields: {(isStringMissing ? "string" : string.Empty)} {(isScoreOutOfRange ? "score not within range" : string.Empty)}: {_score.ToString()}");
                 }
 
                 return new Suggestion(this);


### PR DESCRIPTION
### NRediSearch
- Updated module so we're testing the right thing
- More output in the logging path for diagnosing issues
- Remove all the FLUSHDB calls masking issues
- Handle duplicate documents in latest module

Note: **locally** (on WSL 2), this fixes some issues and introduces stability but *does not* fix 2 scoring issues. Suggestions are coming back with scores > 1.0, which by the documentation is not supposed to happen...so I'm not sure what should be happening here. Here's the local WSL fail:
```
 NRediSearch.Test.ClientTests.ClientTest.TestGetSuggestionWithScore:
  Message: 
    StackExchange.Redis.RedisCommandException : Missing required fields:  score not within range: 2.11660146713257
  Stack Trace: 
    SuggestionBuilder.Build() line 99
    Client.GetSuggestionsWithPayloadAndScores(RedisResult[] results) line 1271
    Client.GetSuggestions(String prefix, SuggestionOptions options) line 796
    ClientTest.TestGetSuggestionWithScore() line 701
```
```
NRediSearch.Test.ClientTests.ClientTest.TestAddSuggestionGetSuggestionPayloadScores:
  Message: 
    StackExchange.Redis.RedisCommandException : Missing required fields:  score not within range: 2.71068739891052
  Stack Trace: 
    SuggestionBuilder.Build() line 99
    Client.GetSuggestionsWithPayloadAndScores(RedisResult[] results) line 1271
    Client.GetSuggestions(String prefix, SuggestionOptions options) line 796
    ClientTest.TestAddSuggestionGetSuggestionPayloadScores() line 642
```

However, the current fixes tidy up the CI pipeline so I recommend merging this as-is, then I'll keep follow-ing up with various local errors and I'm looking at some Docker test options as alternatives to WSL2 so that people can run either.