### PR TITLE
Add F# compatibility enhancements for #831

### DIFF
--- a/src/StackExchange.Redis/RedisKey.cs
+++ b/src/StackExchange.Redis/RedisKey.cs
@@ -14,6 +14,11 @@ namespace StackExchange.Redis
             KeyValue = keyValue;
         }
 
+        /// <summary>
+        /// Creates a <see cref="RedisKey"/> from a string.
+        /// </summary>
+        public RedisKey(string key) : this(null, key) { }
+
         internal RedisKey AsPrefix() => new RedisKey((byte[])this, null);
 
         internal bool IsNull => KeyPrefix == null && KeyValue == null;

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -37,6 +37,11 @@ namespace StackExchange.Redis
             _memory = default;
         }
 
+        /// <summary>
+        /// Creates a <see cref="RedisValue"/> from a string.
+        /// </summary>
+        public RedisValue(string value) : this(0, default, value) { }
+
 #pragma warning disable RCS1085 // Use auto-implemented property.
         internal object DirectObject => _objectOrSentinel;
         internal long DirectOverlappedBits64 => _overlappedBits64;

--- a/tests/StackExchange.Redis.Tests/FSharpCompat.cs
+++ b/tests/StackExchange.Redis.Tests/FSharpCompat.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests
+{
+    public class FSharpCompat : TestBase
+    {
+        public FSharpCompat(ITestOutputHelper output) : base (output) { }
+
+        [Fact]
+        public void RedisKeyConstructor()
+        {
+            Assert.Equal(default, new RedisKey());
+            Assert.Equal((RedisKey)"MyKey", new RedisKey("MyKey"));
+            Assert.Equal((RedisKey)"MyKey2", new RedisKey(null, "MyKey2"));
+        }
+
+        [Fact]
+        public void RedisValueConstructor()
+        {
+            Assert.Equal(default, new RedisValue());
+            Assert.Equal((RedisValue)"MyKey", new RedisValue("MyKey"));
+            Assert.Equal((RedisValue)"MyKey2", new RedisValue("MyKey2", 0));
+        }
+    }
+}


### PR DESCRIPTION
Asked for in #831 and low overhead so why not! I didn't do `RedisChannel` since it already has a constructor available. Tests added to ensure these are used in a way we don't break them.