### PR TITLE
Sentinel: remove Thread.Sleep and throws

### DIFF
--- a/tests/StackExchange.Redis.Tests/Sentinel.cs
+++ b/tests/StackExchange.Redis.Tests/Sentinel.cs
@@ -403,6 +403,7 @@ namespace StackExchange.Redis.Tests
             }
         }
 
+#if DEBUG
         [Fact]
         public async Task GetSentinelMasterConnectionFailoverTest()
         {
@@ -467,6 +468,7 @@ namespace StackExchange.Redis.Tests
             var conn1 = Conn.GetSentinelMasterConnection(ServiceOptions);
             Assert.NotEqual(endpoint, conn1.currentSentinelMasterEndPoint.ToString());
         }
+#endif
 
         [Fact]
         public async Task GetSentinelMasterConnectionWriteReadFailover()


### PR DESCRIPTION
We were throwing in event handlers...that's not good. Also post-thread sleep in timer callbacks.