### PR TITLE
Including SslProtocols in ConfigurationOptions.ToString()

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -509,6 +509,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.TieBreaker, tieBreaker);
             Append(sb, OptionKeys.WriteBuffer, writeBuffer);
             Append(sb, OptionKeys.Ssl, ssl);
+            Append(sb, OptionKeys.SslProtocols, SslProtocols);
             Append(sb, OptionKeys.SslHost, sslHost);
             Append(sb, OptionKeys.HighPrioritySocketThreads, highPrioritySocketThreads);
             Append(sb, OptionKeys.ConfigChannel, configChannel);
@@ -590,6 +591,21 @@ namespace StackExchange.Redis
                 {
                     sb.Append(prefix).Append('=');
                 }
+                sb.Append(s);
+            }
+        }
+
+        private static void Append(StringBuilder sb, string prefix, SslProtocols? sslProtocols)
+        {
+            string s = sslProtocols?.ToString();
+            if (!string.IsNullOrWhiteSpace(s))
+            {
+                if (sb.Length != 0) sb.Append(',');
+                if (!string.IsNullOrEmpty(prefix))
+                {
+                    sb.Append(prefix).Append('=');
+                }
+                s = s.Replace(",", "|");
                 sb.Append(s);
             }
         }

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -509,7 +509,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.TieBreaker, tieBreaker);
             Append(sb, OptionKeys.WriteBuffer, writeBuffer);
             Append(sb, OptionKeys.Ssl, ssl);
-            Append(sb, OptionKeys.SslProtocols, SslProtocols);
+            Append(sb, OptionKeys.SslProtocols, SslProtocols?.ToString().Replace(',', '|'));
             Append(sb, OptionKeys.SslHost, sslHost);
             Append(sb, OptionKeys.HighPrioritySocketThreads, highPrioritySocketThreads);
             Append(sb, OptionKeys.ConfigChannel, configChannel);
@@ -591,21 +591,6 @@ namespace StackExchange.Redis
                 {
                     sb.Append(prefix).Append('=');
                 }
-                sb.Append(s);
-            }
-        }
-
-        private static void Append(StringBuilder sb, string prefix, SslProtocols? sslProtocols)
-        {
-            string s = sslProtocols?.ToString();
-            if (!string.IsNullOrWhiteSpace(s))
-            {
-                if (sb.Length != 0) sb.Append(',');
-                if (!string.IsNullOrEmpty(prefix))
-                {
-                    sb.Append(prefix).Append('=');
-                }
-                s = s.Replace(",", "|");
                 sb.Append(s);
             }
         }

--- a/tests/StackExchange.Redis.Tests/SSL.cs
+++ b/tests/StackExchange.Redis.Tests/SSL.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Reflection;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using StackExchange.Redis.Tests.Helpers;
@@ -458,6 +459,27 @@ namespace StackExchange.Redis.Tests
             {
                 conn.GetDatabase().Ping();
             }
+        }
+
+        [Fact]
+        public void ConfigObject_Issue1407_ToStringIncludesSslProtocols()
+        {
+            var sslProtocols = SslProtocols.Tls12 | SslProtocols.Tls;
+            var sourceOptions = new ConfigurationOptions
+            {
+                AbortOnConnectFail = false,
+                Ssl = true,
+                SslProtocols = sslProtocols,
+                ConnectRetry = 3,
+                ConnectTimeout = 5000,
+                SyncTimeout = 5000,
+                DefaultDatabase = 0,
+                EndPoints = { { "endpoint.test", 6380 } },
+                Password = "123456"
+            };
+
+            var targetOptions = ConfigurationOptions.Parse(sourceOptions.ToString());
+            Assert.Equal(sourceOptions.SslProtocols, targetOptions.SslProtocols);
         }
     }
 }


### PR DESCRIPTION
Currently, SslProtocols is not being included in ConfigurationOptions.ToString(). The PR address the issue.  #1407 