### PR TITLE
allow auth with user (redis 6)

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -76,6 +76,7 @@ namespace StackExchange.Redis
                 HighPrioritySocketThreads = "highPriorityThreads",
                 KeepAlive = "keepAlive",
                 ClientName = "name",
+                User = "user",
                 Password = "password",
                 PreserveAsyncOrder = "preserveAsyncOrder",
                 Proxy = "proxy",
@@ -104,6 +105,7 @@ namespace StackExchange.Redis
                 DefaultDatabase,
                 HighPrioritySocketThreads,
                 KeepAlive,
+                User,
                 Password,
                 PreserveAsyncOrder,
                 Proxy,
@@ -306,6 +308,11 @@ namespace StackExchange.Redis
 #pragma warning restore RCS1128 // Use coalesce expression.
 
         /// <summary>
+        /// The user to use to authenticate with the server.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
         /// The password to use to authenticate with the server.
         /// </summary>
         public string Password { get; set; }
@@ -441,6 +448,7 @@ namespace StackExchange.Redis
                 allowAdmin = allowAdmin,
                 defaultVersion = defaultVersion,
                 connectTimeout = connectTimeout,
+                User = User,
                 Password = Password,
                 tieBreaker = tieBreaker,
                 writeBuffer = writeBuffer,
@@ -505,6 +513,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.AllowAdmin, allowAdmin);
             Append(sb, OptionKeys.Version, defaultVersion);
             Append(sb, OptionKeys.ConnectTimeout, connectTimeout);
+            Append(sb, OptionKeys.User, User);
             Append(sb, OptionKeys.Password, (includePassword || string.IsNullOrEmpty(Password)) ? Password : "*****");
             Append(sb, OptionKeys.TieBreaker, tieBreaker);
             Append(sb, OptionKeys.WriteBuffer, writeBuffer);
@@ -597,9 +606,10 @@ namespace StackExchange.Redis
 
         private void Clear()
         {
-            ClientName = ServiceName = Password = tieBreaker = sslHost = configChannel = null;
+            ClientName = ServiceName = User =Password = tieBreaker = sslHost = configChannel = null;
             keepAlive = syncTimeout = asyncTimeout = connectTimeout = writeBuffer = connectRetry = configCheckSeconds = DefaultDatabase = null;
             allowAdmin = abortOnConnectFail = highPrioritySocketThreads = resolveDns = ssl = null;
+            SslProtocols = null;
             defaultVersion = null;
             EndPoints.Clear();
             commandMap = null;
@@ -685,6 +695,9 @@ namespace StackExchange.Redis
                             break;
                         case OptionKeys.Version:
                             DefaultVersion = OptionKeys.ParseVersion(key, value);
+                            break;
+                        case OptionKeys.User:
+                            User = value;
                             break;
                         case OptionKeys.Password:
                             Password = value;

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -753,8 +753,16 @@ namespace StackExchange.Redis
                 return;
             }
             Message msg;
-            string password = Multiplexer.RawConfig.Password;
-            if (!string.IsNullOrWhiteSpace(password))
+            // note that we need "" (not null) for password in the case of 'nopass' logins
+            string user = Multiplexer.RawConfig.User, password = Multiplexer.RawConfig.Password ?? "";
+            if (!string.IsNullOrWhiteSpace(user))
+            {
+                log?.WriteLine("Authenticating (user/password)");
+                msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.AUTH, (RedisValue)user, (RedisValue)password);
+                msg.SetInternalCall();
+                await WriteDirectOrQueueFireAndForgetAsync(connection, msg, ResultProcessor.DemandOK).ForAwait();
+            }
+            else if (!string.IsNullOrWhiteSpace(password))
             {
                 log?.WriteLine("Authenticating (password)");
                 msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.AUTH, (RedisValue)password);


### PR DESCRIPTION
- adds new config options for cn+pw authentication against redis 6
- currently no inbuilt test, because we need to figure out a redis 6 testing setup
- no support for extended `ACL` command set yet
  1. because they aren't entirely nailed down yet, and
  2. because they aren't critical path to being able to use it, because
  3. everything still works fine via all-encompassing `Execute` fallback