### PR TITLE
Add the ability to remap cluster nodes responses, etc to different hosts/ports

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -357,7 +357,9 @@ namespace StackExchange.Redis
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// A key value pair of address remappings
+        /// A key value pair of server address remappings
+        /// Any key found will be replaced with the value when parsing cluster / sentinel responses
+        /// This allows you to use different addressing, ports and tls settings outside the cluster vs inside
         /// </summary>
         public Dictionary<string, string> AddressRemapping { get; set; }
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -357,6 +357,11 @@ namespace StackExchange.Redis
         public string ServiceName { get; set; }
 
         /// <summary>
+        /// A key value pair of address remappings
+        /// </summary>
+        public Dictionary<string, string> AddressRemapping { get; set; }
+
+        /// <summary>
         /// Gets or sets the SocketManager instance to be used with these options; if this is null a shared cross-multiplexer SocketManager
         /// is used
         /// </summary>
@@ -471,6 +476,7 @@ namespace StackExchange.Redis
                 ReconnectRetryPolicy = reconnectRetryPolicy,
                 SslProtocols = SslProtocols,
                 checkCertificateRevocation = checkCertificateRevocation,
+                AddressRemapping = AddressRemapping
             };
             foreach (var item in EndPoints)
                 options.EndPoints.Add(item);
@@ -618,6 +624,7 @@ namespace StackExchange.Redis
             CertificateValidation = null;
             ChannelPrefix = default(RedisChannel);
             SocketManager = null;
+            AddressRemapping = null;
         }
 
         object ICloneable.Clone() => Clone();

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1146,6 +1146,7 @@ namespace StackExchange.Redis
 
             TimeoutMilliseconds = configuration.SyncTimeout;
             AsyncTimeoutMilliseconds = configuration.AsyncTimeout;
+            addressRemapping = configuration.AddressRemapping;
 
             OnCreateReaderWriter(configuration);
             ServerSelectionStrategy = new ServerSelectionStrategy(this);
@@ -2122,6 +2123,8 @@ namespace StackExchange.Redis
         internal ConfigurationOptions RawConfig { get; }
 
         internal ServerSelectionStrategy ServerSelectionStrategy { get; }
+
+        internal Dictionary<string, string> addressRemapping { get; set; }
 
         internal Timer sentinelMasterReconnectTimer;
 

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -198,6 +198,10 @@ namespace StackExchange.Redis
                     log = false;
                     string[] parts = result.GetString().Split(StringSplits.Space, 3);
                     EndPoint endpoint;
+                    if ((bridge?.Multiplexer?.addressRemapping?.ContainsKey(parts[2])).GetValueOrDefault(false))
+                    {
+                        parts[2]=bridge.Multiplexer.addressRemapping[parts[2]];
+                    }
                     if (Format.TryParseInt32(parts[1], out int hashSlot)
                         && (endpoint = Format.TryParseEndPoint(parts[2])) != null)
                     {
@@ -850,7 +854,7 @@ namespace StackExchange.Redis
                 var bridge = connection.BridgeCouldBeNull;
                 if (bridge == null) throw new ObjectDisposedException(connection.ToString());
                 var server = bridge.ServerEndPoint;
-                var config = new ClusterConfiguration(bridge.Multiplexer.ServerSelectionStrategy, nodes, server.EndPoint);
+                var config = new ClusterConfiguration(bridge.Multiplexer.ServerSelectionStrategy, nodes, server.EndPoint, bridge.Multiplexer.addressRemapping);
                 server.SetClusterConfiguration(config);
                 return config;
             }

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -717,7 +717,12 @@ namespace StackExchange.Redis
                                 }
                                 if (roleSeen)
                                 { // these are in the same section, if presnt
-                                    server.MasterEndPoint = Format.TryParseEndPoint(masterHost, masterPort);
+                                    string masterHostPort = $"{masterHost}:{masterPort}";
+                                    if ((server?.Multiplexer?.addressRemapping?.ContainsKey(masterHostPort)).GetValueOrDefault(false))
+                                    {
+                                        masterHostPort = server.Multiplexer.addressRemapping[masterHostPort];
+                                    }
+                                    server.MasterEndPoint = Format.TryParseEndPoint(masterHostPort);
                                 }
                             }
                         }
@@ -854,7 +859,7 @@ namespace StackExchange.Redis
                 var bridge = connection.BridgeCouldBeNull;
                 if (bridge == null) throw new ObjectDisposedException(connection.ToString());
                 var server = bridge.ServerEndPoint;
-                var config = new ClusterConfiguration(bridge.Multiplexer.ServerSelectionStrategy, nodes, server.EndPoint, bridge.Multiplexer.addressRemapping);
+                var config = new ClusterConfiguration(bridge.Multiplexer.ServerSelectionStrategy, nodes, server.EndPoint, bridge.Multiplexer?.addressRemapping);
                 server.SetClusterConfiguration(config);
                 return config;
             }
@@ -1978,7 +1983,12 @@ The coordinates as a two items x,y array (longitude,latitude).
                         }
                         else if (arr.Length == 2 && Format.TryParseInt32(arr[1], out var port))
                         {
-                            SetResult(message, Format.ParseEndPoint(arr[0], port));
+                            string hostPort = $"{arr[0]}:{port}";
+                            if ((connection.BridgeCouldBeNull?.Multiplexer?.addressRemapping?.ContainsKey(hostPort)).GetValueOrDefault(false))
+                            {
+                                hostPort = connection.BridgeCouldBeNull.Multiplexer.addressRemapping[hostPort];
+                            }
+                            SetResult(message, Format.TryParseEndPoint(hostPort));
                             return true;
                         }
                         else if (arr.Length == 0)
@@ -2025,7 +2035,12 @@ The coordinates as a two items x,y array (longitude,latitude).
 
                             if (ip != null && portStr != null && int.TryParse(portStr, out int port))
                             {
-                                endPoints.Add(Format.ParseEndPoint(ip, port));
+                                string hostPort = $"{ip}:{port}";
+                                if ((connection.BridgeCouldBeNull?.Multiplexer?.addressRemapping?.ContainsKey(hostPort)).GetValueOrDefault(false))
+                                {
+                                    hostPort = connection.BridgeCouldBeNull.Multiplexer.addressRemapping[hostPort];
+                                }
+                                endPoints.Add(Format.TryParseEndPoint(hostPort));
                             }
                         }
                         break;


### PR DESCRIPTION
This is still a bit of WIP but it works and allows you to have TLS with client certificate auth for clients to a cluster behind a load balancer with the cluster talking to itself in the clear on a private network.  I'm open to suggestions as to a better way to do this / if I've missed something (and to name changes/description + doc update requests/tests/etc).

The idea is if you have a cluster with a layer-4 load balancer configured something like this: 
![diagram](https://user-images.githubusercontent.com/770715/78085387-aed54d00-736f-11ea-8ab4-ddcbff96dcc5.png)
e.g. one port (6380 in this case) for discovery (green) talks to any node through stunnel (or a local haproxy/traefik/whatnot proxying to redis) and then a static per-host port mapping for each cluster node (black) through stunnel as well.  The cluster replicates (blue) and does cluster communications in the clear (not shown) via the standard ports.

You could then take a `cluster nodes` output like so 
```
df7927b560da64a5cecc9e95b066640733d0ac91 10.0.0.10:6379@16379 slave 1d9bb9764d233ceda62801b015de78bb04b99a6f 0 1585698945482 18 connected
1d9bb9764d233ceda62801b015de78bb04b99a6f 10.0.0.11:6379@16379 myself,master - 0 1585698945000 18 connected 0-5460
b855ca587f6ff7f223271c1a25f4fdf9e9840074 10.0.0.12:6379@16379 master - 0 1585698946485 2 connected 5461-10922
f778573815de8fb3921ff420f80d288a08eeccef 10.0.0.13:6379@16379 slave b855ca587f6ff7f223271c1a25f4fdf9e9840074 0 1585698944981 2 connected
a303387b3e0129ab405b1d0bd92aef99d8b94159 10.0.0.14:6379@16379 master - 0 1585698946000 3 connected 10923-16383
c174a32d94862a0ec40b8a8fe4722eb688794db6 10.0.0.15:6379@16379 slave a303387b3e0129ab405b1d0bd92aef99d8b94159 0 1585698946084 3 connected
```
and transform it client side to:
```
df7927b560da64a5cecc9e95b066640733d0ac91 myexternal.host.name:6310@16379 slave 1d9bb9764d233ceda62801b015de78bb04b99a6f 0 1585698945482 18 connected
1d9bb9764d233ceda62801b015de78bb04b99a6f myexternal.host.name:6311@16379 myself,master - 0 1585698945000 18 connected 0-5460
b855ca587f6ff7f223271c1a25f4fdf9e9840074 myexternal.host.name:6312@16379 master - 0 1585698946485 2 connected 5461-10922
f778573815de8fb3921ff420f80d288a08eeccef myexternal.host.name:6313@16379 slave b855ca587f6ff7f223271c1a25f4fdf9e9840074 0 1585698944981 2 connected
a303387b3e0129ab405b1d0bd92aef99d8b94159 myexternal.host.name:6314@16379 master - 0 1585698946000 3 connected 10923-16383
c174a32d94862a0ec40b8a8fe4722eb688794db6 myexternal.host.name:6315@16379 slave a303387b3e0129ab405b1d0bd92aef99d8b94159 0 1585698946084 3 connected
```

I have handled remapping for cluster responses and `moved`.  I also added it to the sentinel related responses but haven't confirmed the behavior there.  I wrote a quite test application with a cluster w/load balancer configured as per above and validated it works as expected including in the event of master failures etc.

```csharp
var remapping = new Dictionary<string, string>();
for(int i = 10; i <= 15; i++)
{
    remapping.Add("10.0.0." + i + ":6379", "my.host.name:63" + i);
}
var options = new ConfigurationOptions
{
    ClientName = "testclient-" + Environment.MachineName,
    EndPoints = { { "my.host.name:6380" } },
    Ssl = true,
    AbortOnConnectFail = true, //false 
    AllowAdmin = true,
    AddressRemapping = remapping,
    SslProtocols = System.Security.Authentication.SslProtocols.Tls12, 
    SslHost = "my.host.name"
};

options.CertificateSelection += delegate
{
...return a client cert here
};
ConnectionMultiplexer muxer = ConnectionMultiplexer.Connect(options);
```

Thoughts? Total insanity? 