### PR TITLE
add a new cluster kind for redis-cluster-proxy

### DIFF
--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -21,7 +21,7 @@ namespace StackExchange.Redis
         public static CommandMap Default { get; } = CreateImpl(null, null);
 
         /// <summary>
-        /// The commands available to <a href="twemproxy">https://github.com/twitter/twemproxy</a>
+        /// The commands available to <a href="https://github.com/twitter/twemproxy/">twemproxy</a>
         /// </summary>
         /// <remarks>https://github.com/twitter/twemproxy/blob/master/notes/redis.md</remarks>
         public static CommandMap Twemproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
@@ -51,6 +51,49 @@ namespace StackExchange.Redis
             RedisCommand.BGREWRITEAOF, RedisCommand.BGSAVE, RedisCommand.CLIENT, RedisCommand.CLUSTER, RedisCommand.CONFIG, RedisCommand.DBSIZE,
             RedisCommand.DEBUG, RedisCommand.FLUSHALL, RedisCommand.FLUSHDB, RedisCommand.INFO, RedisCommand.LASTSAVE, RedisCommand.MONITOR, RedisCommand.SAVE,
             RedisCommand.SHUTDOWN, RedisCommand.SLAVEOF, RedisCommand.SLOWLOG, RedisCommand.SYNC, RedisCommand.TIME
+        });
+
+        /// <summary>
+        /// The commands available to <a href="https://github.com/RedisLabs/redis-cluster-proxy/">redis-cluster-proxy</a>
+        /// </summary>
+        /// <remarks>https://github.com/RedisLabs/redis-cluster-proxy/</remarks>
+        public static CommandMap RedisClusterProxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
+        {
+            // via "proxy command unsupported"
+            // RedisCommand.ACL,
+            RedisCommand.ASKING,
+            RedisCommand.CLIENT,
+            RedisCommand.CLUSTER,
+            RedisCommand.CONFIG,
+            RedisCommand.DEBUG,
+            // RedisCommand.HELLO,
+            RedisCommand.INFO,
+            RedisCommand.LATENCY,
+            RedisCommand.MEMORY,
+            RedisCommand.MIGRATE,
+            // RedisCommand.MODULE,
+            RedisCommand.MONITOR,
+            // RedisCommand.PFDEBUG,
+            // RedisCommand.PFSELFTEST,
+            RedisCommand.PSUBSCRIBE,
+            // RedisCommand.PSYNC,
+            RedisCommand.PUBLISH,
+            RedisCommand.PUBSUB,
+            RedisCommand.PUNSUBSCRIBE,
+            RedisCommand.READONLY,
+            RedisCommand.READWRITE,
+            // RedisCommand.REPLCONF,
+            // RedisCommand.REPLICAOF,
+            // RedisCommand.ROLE,
+            RedisCommand.SCRIPT,
+            RedisCommand.SHUTDOWN,
+            RedisCommand.SLAVEOF,
+            RedisCommand.SLOWLOG,
+            RedisCommand.SUBSCRIBE,
+            RedisCommand.SYNC,
+            RedisCommand.TIME,
+            RedisCommand.UNSUBSCRIBE,
+            // RedisCommand.WAIT,
         });
 
         /// <summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -251,6 +251,8 @@ namespace StackExchange.Redis
                 {
                     case Proxy.Twemproxy:
                         return CommandMap.Twemproxy;
+                    case Proxy.RedisClusterProxy:
+                        return CommandMap.RedisClusterProxy;
                     default:
                         return CommandMap.Default;
                 }
@@ -482,7 +484,14 @@ namespace StackExchange.Redis
         /// </summary>
         public void SetDefaultPorts()
         {
-            EndPoints.SetDefaultPorts(Ssl ? 6380 : 6379);
+            if (Proxy == Proxy.RedisClusterProxy && !Ssl)
+            {
+                EndPoints.SetDefaultPorts(7777); // default port for redis-cluster-proxy
+            }
+            else
+            {
+                EndPoints.SetDefaultPorts(Ssl ? 6380 : 6379);
+            }
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1333,7 +1333,6 @@ namespace StackExchange.Redis
             if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
             switch (RawConfig.Proxy)
             {
-                case Proxy.RedisClusterProxy:
                 case Proxy.Twemproxy:
                     throw new NotSupportedException($"The server API is not available via {RawConfig.Proxy}");
             }

--- a/src/StackExchange.Redis/Enums/Proxy.cs
+++ b/src/StackExchange.Redis/Enums/Proxy.cs
@@ -12,6 +12,10 @@
         /// <summary>
         /// Communication via <a href="https://github.com/twitter/twemproxy">twemproxy</a>
         /// </summary>
-        Twemproxy
+        Twemproxy,
+        /// <summary>
+        /// Communication via <a href="https://github.com/RedisLabs/redis-cluster-proxy">redis-cluster-proxy</a>
+        /// </summary>
+        RedisClusterProxy,
     }
 }

--- a/src/StackExchange.Redis/Enums/ServerType.cs
+++ b/src/StackExchange.Redis/Enums/ServerType.cs
@@ -20,6 +20,10 @@
         /// <summary>
         /// Distributed redis installation via <a href="https://github.com/twitter/twemproxy">twemproxy</a>
         /// </summary>
-        Twemproxy
+        Twemproxy,
+        /// <summary>
+        /// Distributed redis installation via <a href="https://github.com/RedisLabs/redis-cluster-proxy">redis-cluster-proxy</a>
+        /// </summary>
+        RedisClusterProxy,
     }
 }

--- a/src/StackExchange.Redis/ExtensionMethods.cs
+++ b/src/StackExchange.Redis/ExtensionMethods.cs
@@ -82,6 +82,38 @@ namespace StackExchange.Redis
         /// Create a dictionary from an array of key/value pairs
         /// </summary>
         /// <param name="pairs">The pairs to convert to a dictionary.</param>
+        public static Dictionary<string, string> ToStringDictionary(this NameValueEntry[] pairs)
+        {
+            if (pairs == null) return null;
+
+            var result = new Dictionary<string, string>(pairs.Length, StringComparer.Ordinal);
+            for (int i = 0; i < pairs.Length; i++)
+            {
+                result.Add(pairs[i].name, pairs[i].value);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Create a dictionary from an array of NameValueEntry values
+        /// </summary>
+        /// <param name="values">The entries to convert to a dictionary.</param>
+        public static Dictionary<RedisValue, RedisValue> ToDictionary(this NameValueEntry[] values)
+        {
+            if (values == null) return null;
+
+            var result = new Dictionary<RedisValue, RedisValue>(values.Length);
+            for (int i = 0; i < values.Length; i++)
+            {
+                result.Add(values[i].name, values[i].value);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Create a dictionary from an array of key/value pairs
+        /// </summary>
+        /// <param name="pairs">The pairs to convert to a dictionary.</param>
         public static Dictionary<string, string> ToStringDictionary(this KeyValuePair<RedisKey, RedisValue>[] pairs)
         {
             if (pairs == null) return null;

--- a/tests/StackExchange.Redis.Tests/RedisClusterProxyTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisClusterProxyTests.cs
@@ -23,10 +23,11 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(expected, actual);
 
                 // check it knows that we're dealing with a cluster
-                var ex = Assert.Throws<NotSupportedException>(() => conn.GetServer("abc"));
-                Assert.Equal("The server API is not available via RedisClusterProxy", ex.Message);
+                var server = conn.GetServer(conn.GetEndPoints()[0]);
+                Assert.Equal(ServerType.RedisClusterProxy, server.ServerType);
+                _  = server.Echo("abc");
 
-                ex = Assert.Throws<NotSupportedException>(() => conn.GetSubscriber("abc"));
+                var ex = Assert.Throws<NotSupportedException>(() => conn.GetSubscriber("abc"));
                 Assert.Equal("The pub/sub API is not available via RedisClusterProxy", ex.Message);
 
                 // test a script

--- a/tests/StackExchange.Redis.Tests/RedisClusterProxyTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisClusterProxyTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests
+{
+    public class RedisClusterProxyTests : TestBase
+    {
+        public RedisClusterProxyTests(ITestOutputHelper output) : base(output) { }
+
+        protected override string GetConfiguration() => "127.0.0.1,proxy=RedisClusterProxy,version=5.0";
+
+        [Fact(Skip = "No CI build for this yet")]
+        public void CanConnectToClusterProxy()
+        {
+            using (var conn = Create())
+            {
+                var expected = Guid.NewGuid().ToString();
+                var db = conn.GetDatabase();
+                RedisKey key = Me();
+                db.StringSet(key, expected);
+                var actual = (string)db.StringGet(key);
+                Assert.Equal(expected, actual);
+
+                // check it knows that we're dealing with a cluster
+                var ex = Assert.Throws<NotSupportedException>(() => conn.GetServer("abc"));
+                Assert.Equal("The server API is not available via RedisClusterProxy", ex.Message);
+
+                ex = Assert.Throws<NotSupportedException>(() => conn.GetSubscriber("abc"));
+                Assert.Equal("The pub/sub API is not available via RedisClusterProxy", ex.Message);
+
+                // test a script
+                const string LUA_SCRIPT = "return redis.call('info')";
+                var name = (string)db.ScriptEvaluate(LUA_SCRIPT);
+                Log($"client: {name}");
+                // run it twice to check we didn't rely on script hashing (SCRIPT is disabled)
+                _ = db.ScriptEvaluate(LUA_SCRIPT);
+            }
+        }
+    }
+}


### PR DESCRIPTION
in most ways it is similar to twemproxy, and you can make it just about work by manually configuring things in the config, but this makes everything better integrated, so all you need to do is use a config like `"127.0.0.1,proxy=RedisClusterProxy"`, and everything else clicks into place automatically.

In particular:
- configure the command map
- default the port to 7777
- disable the subscriber/server APIs
- set a minimum redis version of 3 (because: cluster)
- only work with DB zero (again, because: cluster)

work todo:

- [x] consider `PROXY MULTIPLEXING on`
  - [x] find out whether `MULTI` *resets* `MULTIPLEXING` *afterwards* (it disables it during)
- [ ] look into `*SCAN` cursor change

(it turns out that `PROXY MULTIPLEXING on` isn't a thing; it is on by default, and you can turn it *off*, or it gets turned off when you do the first `MULTI`; conclusion: just let the server worry about it)