### PR TITLE
Apply default database rules on `IServer`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## pending
+
+- fix: the `IServer` commands that are database-specific (`DBSIZE`, `FLUSHDB`, `KEYS`, `SCAN`) now respect the default database on the config (#1460)
+
 ## 2.1.39
 
 - fix: mutex around connection was not "fair"; in specific scenario could lead to out-of-order commands (#1440)

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -209,7 +209,7 @@ namespace StackExchange.Redis
         /// <param name="database">The database ID.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/dbsize</remarks>
-        long DatabaseSize(int database = 0, CommandFlags flags = CommandFlags.None);
+        long DatabaseSize(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the number of keys in the database.
@@ -217,7 +217,7 @@ namespace StackExchange.Redis
         /// <param name="database">The database ID.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/dbsize</remarks>
-        Task<long> DatabaseSizeAsync(int database = 0, CommandFlags flags = CommandFlags.None);
+        Task<long> DatabaseSizeAsync(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the same message passed in.
@@ -301,7 +301,7 @@ namespace StackExchange.Redis
         /// <param name="database">The database ID.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/flushdb</remarks>
-        void FlushDatabase(int database = 0, CommandFlags flags = CommandFlags.None);
+        void FlushDatabase(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Delete all the keys of the database.
@@ -309,7 +309,7 @@ namespace StackExchange.Redis
         /// <param name="database">The database ID.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/flushdb</remarks>
-        Task FlushDatabaseAsync(int database = 0, CommandFlags flags = CommandFlags.None);
+        Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Get summary statistics associates with this server
@@ -371,7 +371,7 @@ namespace StackExchange.Redis
         /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
         /// <remarks>https://redis.io/commands/keys</remarks>
         /// <remarks>https://redis.io/commands/scan</remarks>
-        IEnumerable<RedisKey> Keys(int database = 0, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
+        IEnumerable<RedisKey> Keys(int database = -1, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns all keys matching pattern; the KEYS or SCAN commands will be used based on the server capabilities; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
@@ -385,7 +385,7 @@ namespace StackExchange.Redis
         /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
         /// <remarks>https://redis.io/commands/keys</remarks>
         /// <remarks>https://redis.io/commands/scan</remarks>
-        IAsyncEnumerable<RedisKey> KeysAsync(int database = 0, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
+        IAsyncEnumerable<RedisKey> KeysAsync(int database = -1, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the time of the last DB save executed with success. A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command and checking at regular intervals every N seconds if LASTSAVE changed.

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -201,15 +201,15 @@ namespace StackExchange.Redis
             return task;
         }
 
-        public long DatabaseSize(int database = 0, CommandFlags flags = CommandFlags.None)
+        public long DatabaseSize(int database = -1, CommandFlags flags = CommandFlags.None)
         {
-            var msg = Message.Create(database, flags, RedisCommand.DBSIZE);
+            var msg = Message.Create(multiplexer.ApplyDefaultDatabase(database), flags, RedisCommand.DBSIZE);
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
 
-        public Task<long> DatabaseSizeAsync(int database = 0, CommandFlags flags = CommandFlags.None)
+        public Task<long> DatabaseSizeAsync(int database = -1, CommandFlags flags = CommandFlags.None)
         {
-            var msg = Message.Create(database, flags, RedisCommand.DBSIZE);
+            var msg = Message.Create(multiplexer.ApplyDefaultDatabase(database), flags, RedisCommand.DBSIZE);
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
@@ -237,15 +237,15 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.DemandOK);
         }
 
-        public void FlushDatabase(int database = 0, CommandFlags flags = CommandFlags.None)
+        public void FlushDatabase(int database = -1, CommandFlags flags = CommandFlags.None)
         {
-            var msg = Message.Create(database, flags, RedisCommand.FLUSHDB);
+            var msg = Message.Create(multiplexer.ApplyDefaultDatabase(database), flags, RedisCommand.FLUSHDB);
             ExecuteSync(msg, ResultProcessor.DemandOK);
         }
 
-        public Task FlushDatabaseAsync(int database = 0, CommandFlags flags = CommandFlags.None)
+        public Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None)
         {
-            var msg = Message.Create(database, flags, RedisCommand.FLUSHDB);
+            var msg = Message.Create(multiplexer.ApplyDefaultDatabase(database), flags, RedisCommand.FLUSHDB);
             return ExecuteAsync(msg, ResultProcessor.DemandOK);
         }
 
@@ -298,6 +298,7 @@ namespace StackExchange.Redis
 
         private CursorEnumerable<RedisKey> KeysAsync(int database, RedisValue pattern, int pageSize, long cursor, int pageOffset, CommandFlags flags)
         {
+            database = multiplexer.ApplyDefaultDatabase(database);
             if (pageSize <= 0) throw new ArgumentOutOfRangeException(nameof(pageSize));
             if (CursorUtils.IsNil(pattern)) pattern = RedisLiterals.Wildcard;
 

--- a/tests/StackExchange.Redis.Tests/Databases.cs
+++ b/tests/StackExchange.Redis.Tests/Databases.cs
@@ -22,7 +22,7 @@ namespace StackExchange.Redis.Tests
                 server.FlushDatabase(db1Id, CommandFlags.FireAndForget);
                 server.FlushDatabase(db2Id, CommandFlags.FireAndForget);
             }
-            using (var muxer = Create())
+            using (var muxer = Create(defaultDatabase: db2Id))
             {
                 Skip.IfMissingDatabase(muxer, db1Id);
                 Skip.IfMissingDatabase(muxer, db2Id);
@@ -36,9 +36,11 @@ namespace StackExchange.Redis.Tests
                 var server = GetAnyMaster(muxer);
                 var c0 = server.DatabaseSizeAsync(db1Id);
                 var c1 = server.DatabaseSizeAsync(db2Id);
+                var c2 = server.DatabaseSizeAsync(); // using default DB, which is db2Id
 
                 Assert.Equal(2, await c0);
                 Assert.Equal(1, await c1);
+                Assert.Equal(1, await c2);
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -224,7 +224,7 @@ namespace StackExchange.Redis.Tests
             bool checkConnect = true, string failMessage = null,
             string channelPrefix = null, Proxy? proxy = null,
             string configuration = null, bool logTransactionData = true,
-            bool shared = true,
+            bool shared = true, int? defaultDatabase = null,
             [CallerMemberName] string caller = null)
         {
             if (Output == null)
@@ -233,7 +233,7 @@ namespace StackExchange.Redis.Tests
             }
 
             if (shared && _fixture != null && _fixture.IsEnabled && enabledCommands == null && disabledCommands == null && fail && channelPrefix == null && proxy == null
-                && configuration == null && password == null && tieBreaker == null && (allowAdmin == null || allowAdmin == true) && expectedFailCount == 0)
+                && configuration == null && password == null && tieBreaker == null && defaultDatabase == null && (allowAdmin == null || allowAdmin == true) && expectedFailCount == 0)
             {
                 configuration = GetConfiguration();
                 if (configuration == _fixture.Configuration)
@@ -250,7 +250,7 @@ namespace StackExchange.Redis.Tests
                 checkConnect, failMessage,
                 channelPrefix, proxy,
                 configuration ?? GetConfiguration(),
-                logTransactionData, caller);
+                logTransactionData, defaultDatabase, caller);
             muxer.InternalError += OnInternalError;
             muxer.ConnectionFailed += OnConnectionFailed;
             return muxer;
@@ -264,6 +264,7 @@ namespace StackExchange.Redis.Tests
             bool checkConnect = true, string failMessage = null,
             string channelPrefix = null, Proxy? proxy = null,
             string configuration = null, bool logTransactionData = true,
+            int? defaultDatabase = null,
 
             [CallerMemberName] string caller = null)
         {
@@ -299,6 +300,7 @@ namespace StackExchange.Redis.Tests
                 if (keepAlive != null) config.KeepAlive = keepAlive.Value;
                 if (connectTimeout != null) config.ConnectTimeout = connectTimeout.Value;
                 if (proxy != null) config.Proxy = proxy.Value;
+                if (defaultDatabase != null) config.DefaultDatabase = defaultDatabase.Value;
                 var watch = Stopwatch.StartNew();
                 var task = ConnectionMultiplexer.ConnectAsync(config, log);
                 if (!task.Wait(config.ConnectTimeout >= (int.MaxValue / 2) ? int.MaxValue : config.ConnectTimeout * 2))


### PR DESCRIPTION
- impacts `DBSIZE`, `FLUSHDB`, `KEYS`, `SCAN`
- changes default parameter value from 0 to -1 (needs rebuild of caller to recognize, this is fine)
- adds a helper method to standardize the behavior between call-sites