### PR TITLE
add last-delivered-id to StreamGroupInfo

### DIFF
--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1566,18 +1566,23 @@ The coordinates as a two items x,y array (longitude,latitude).
                 //    4) (integer)2
                 //    5) pending
                 //    6) (integer)2
+                //    7) last-delivered-id
+                //    8) "1588152489012-0"
                 // 2) 1) name
                 //    2) "some-other-group"
                 //    3) consumers
                 //    4) (integer)1
                 //    5) pending
                 //    6) (integer)0
+                //    7) last - delivered - id
+                //    8) "1588152498034-0"
 
                 var arr = result.GetItems();
 
                 return new StreamGroupInfo(name: arr[1].AsRedisValue(),
                     consumerCount: (int)arr[3].AsRedisValue(),
-                    pendingMessageCount: (int)arr[5].AsRedisValue());
+                    pendingMessageCount: (int)arr[5].AsRedisValue(),
+                    lastDeliveredId: arr[7].AsRedisValue());
             }
         }
 

--- a/src/StackExchange.Redis/StreamGroupInfo.cs
+++ b/src/StackExchange.Redis/StreamGroupInfo.cs
@@ -6,11 +6,12 @@ namespace StackExchange.Redis
     /// </summary>
     public readonly struct StreamGroupInfo
     {
-        internal StreamGroupInfo(string name, int consumerCount, int pendingMessageCount)
+        internal StreamGroupInfo(string name, int consumerCount, int pendingMessageCount, string lastDeliveredId)
         {
             Name = name;
             ConsumerCount = consumerCount;
             PendingMessageCount = pendingMessageCount;
+            LastDeliveredId = lastDeliveredId;
         }
 
         /// <summary>
@@ -28,5 +29,10 @@ namespace StackExchange.Redis
         /// received by a consumer but not yet acknowledged.
         /// </summary>
         public int PendingMessageCount { get; }
+
+        /// <summary>
+        /// The Id of the last message delivered to the group
+        /// </summary>
+        public string LastDeliveredId { get; }
     }
 }


### PR DESCRIPTION
"last-delivered-id" was added to XINFO GROUPS in the 5.0 timeframe.
It can be useful as a proxy for stream lag when compared to StreamInfo,LastGeneratedId
However, the redis-doc wasn't updated (see https://github.com/antirez/redis-doc/pull/1318)

This PR simply adds the field to the StreamGroupInfo response.
