### PR TITLE
Change processModel docs link on Timeouts page

### DIFF
--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -63,7 +63,7 @@ Given the above information, in 1.* it's recommend to set the minimum configurat
 
 How to configure this setting:
 
- - In ASP.NET, use the ["minIoThreads" configuration setting](https://msdn.microsoft.com/en-us/library/7w2sway1(v=vs.71).aspx) under the `<processModel>` configuration element in `machine.config`. According to Microsoft, you can't change this value per site by editing your web.config (even when you could do it in the past), so the value that you choose here is the value that all your .NET sites will use. Please note that you don't need to add every property if you put autoConfig in false, just putting autoConfig="false" and overriding the value is enough:
+ - In ASP.NET, use the ["minIoThreads" configuration setting](https://msdn.microsoft.com/en-us/library/7w2sway1(v=vs.100).aspx) under the `<processModel>` configuration element in `machine.config`. According to Microsoft, you can't change this value per site by editing your web.config (even when you could do it in the past), so the value that you choose here is the value that all your .NET sites will use. Please note that you don't need to add every property if you put autoConfig in false, just putting autoConfig="false" and overriding the value is enough:
 
 ```xml
 <processModel autoConfig="false" minIoThreads="250" />


### PR DESCRIPTION
The previous link redirected the user to the .NET 1.1 docs (`vs.71`) for `<processModel>`. This page did not contain any references to `minIoThreads`. I've corrected this by changing the link to point to .NET 4.0 (`vs.100`) which contains the relevant documentation.

No code was harmed in the making of this PR - only the [`Timeouts`](https://stackexchange.github.io/StackExchange.Redis/Timeouts) documents page was changed. :)