### PR TITLE
Builds & Local: Move NRedisSearch to :6385 and Docker

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,41 @@ services:
 
 install:
 - cmd: >-
-    choco install docker-compose
+    cd tests\RedisConfigs\3.0.503
 
-    cd tests\RedisConfigs
+    redis-server.exe --service-install --service-name "redis-6379" "..\Basic\master-6379.conf"
 
-    docker-compose up -d
+    redis-server.exe --service-install --service-name "redis-6380" "..\Basic\slave-6380.conf"
 
-    cd ../..
+    redis-server.exe --service-install --service-name "redis-6381" "..\Basic\secure-6381.conf"
+
+    redis-server.exe --service-install --service-name "redis-6382" "..\Failover\master-6382.conf"
+
+    redis-server.exe --service-install --service-name "redis-6383" "..\Failover\slave-6383.conf"
+
+    redis-server.exe --service-install --service-name "redis-7000" "..\Cluster\cluster-7000.conf" --dir "..\Cluster"
+
+    redis-server.exe --service-install --service-name "redis-7001" "..\Cluster\cluster-7001.conf" --dir "..\Cluster"
+
+    redis-server.exe --service-install --service-name "redis-7002" "..\Cluster\cluster-7002.conf" --dir "..\Cluster"
+
+    redis-server.exe --service-install --service-name "redis-7003" "..\Cluster\cluster-7003.conf" --dir "..\Cluster"
+
+    redis-server.exe --service-install --service-name "redis-7004" "..\Cluster\cluster-7004.conf" --dir "..\Cluster"
+
+    redis-server.exe --service-install --service-name "redis-7005" "..\Cluster\cluster-7005.conf" --dir "..\Cluster"
+
+    redis-server.exe --service-install --service-name "redis-7010" "..\Sentinel\redis-7010.conf"
+
+    redis-server.exe --service-install --service-name "redis-7011" "..\Sentinel\redis-7011.conf"
+
+    redis-server.exe --service-install --service-name "redis-26379" "..\Sentinel\sentinel-26379.conf" --sentinel
+
+    redis-server.exe --service-install --service-name "redis-26380" "..\Sentinel\sentinel-26380.conf" --sentinel
+    
+    redis-server.exe --service-install --service-name "redis-26381" "..\Sentinel\sentinel-26381.conf" --sentinel
+
+    cd ..\..\..
 - sh: >-
     sudo curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 
@@ -29,6 +57,10 @@ install:
     docker-compose up -d
 
     cd ../..
+- ps: >-
+    if (Get-Command "Start-Service" -errorAction SilentlyContinue) {
+      Start-Service redis-*
+    }
 
 skip_branch_with_pr: true
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,41 +10,13 @@ services:
 
 install:
 - cmd: >-
-    cd tests\RedisConfigs\3.0.503
+    choco install docker-compose
 
-    redis-server.exe --service-install --service-name "redis-6379" "..\Basic\master-6379.conf"
+    cd tests\RedisConfigs
 
-    redis-server.exe --service-install --service-name "redis-6380" "..\Basic\slave-6380.conf"
+    docker-compose up -d
 
-    redis-server.exe --service-install --service-name "redis-6381" "..\Basic\secure-6381.conf"
-
-    redis-server.exe --service-install --service-name "redis-6382" "..\Failover\master-6382.conf"
-
-    redis-server.exe --service-install --service-name "redis-6383" "..\Failover\slave-6383.conf"
-
-    redis-server.exe --service-install --service-name "redis-7000" "..\Cluster\cluster-7000.conf" --dir "..\Cluster"
-
-    redis-server.exe --service-install --service-name "redis-7001" "..\Cluster\cluster-7001.conf" --dir "..\Cluster"
-
-    redis-server.exe --service-install --service-name "redis-7002" "..\Cluster\cluster-7002.conf" --dir "..\Cluster"
-
-    redis-server.exe --service-install --service-name "redis-7003" "..\Cluster\cluster-7003.conf" --dir "..\Cluster"
-
-    redis-server.exe --service-install --service-name "redis-7004" "..\Cluster\cluster-7004.conf" --dir "..\Cluster"
-
-    redis-server.exe --service-install --service-name "redis-7005" "..\Cluster\cluster-7005.conf" --dir "..\Cluster"
-
-    redis-server.exe --service-install --service-name "redis-7010" "..\Sentinel\redis-7010.conf"
-
-    redis-server.exe --service-install --service-name "redis-7011" "..\Sentinel\redis-7011.conf"
-
-    redis-server.exe --service-install --service-name "redis-26379" "..\Sentinel\sentinel-26379.conf" --sentinel
-
-    redis-server.exe --service-install --service-name "redis-26380" "..\Sentinel\sentinel-26380.conf" --sentinel
-    
-    redis-server.exe --service-install --service-name "redis-26381" "..\Sentinel\sentinel-26381.conf" --sentinel
-
-    cd ..\..\..
+    cd ../..
 - sh: >-
     sudo curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 
@@ -57,10 +29,6 @@ install:
     docker-compose up -d
 
     cd ../..
-- ps: >-
-    if (Get-Command "Start-Service" -errorAction SilentlyContinue) {
-      Start-Service redis-*
-    }
 
 skip_branch_with_pr: true
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,9 @@ image:
 init:
   - git config --global core.autocrlf input
 
+services: 
+- docker 
+
 install:
 - cmd: >-
     cd tests\RedisConfigs\3.0.503
@@ -43,12 +46,11 @@ install:
 
     cd ..\..\..
 - sh: >-
+    sudo curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
     cd tests/RedisConfigs
-
-    chmod +x start-all.sh
-
-    ./start-all.sh
-
+    docker-compose up -d
     cd ../..
 - ps: >-
     if (Get-Command "Start-Service" -errorAction SilentlyContinue) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,10 +47,15 @@ install:
     cd ..\..\..
 - sh: >-
     sudo curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+
     sudo chmod +x /usr/local/bin/docker-compose
+
     sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
     cd tests/RedisConfigs
+
     docker-compose up -d
+
     cd ../..
 - ps: >-
     if (Get-Command "Start-Service" -errorAction SilentlyContinue) {

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -644,7 +644,7 @@ namespace NRediSearch.Test.ClientTests
             var payloads = cl.GetSuggestions(suggestion.String.Substring(0, 3), SuggestionOptions.Builder.With(WithOptions.PayloadsAndScores).Build());
             Assert.Equal(4, payloads.Length);
             Assert.True(payloads[2].Payload.Length > 0);
-            Assert.True(payloads[1].Score < .299);
+            Assert.True(payloads[1].Score < .299, "Actual score: " + payloads[1].Score);
         }
 
         [Fact]
@@ -699,7 +699,7 @@ namespace NRediSearch.Test.ClientTests
 
             cl.AddSuggestion(Suggestion.Builder.String("DIFF_WORD").Score(0.4).Payload("PAYLOADS ROCK ").Build(), true);
             var list = cl.GetSuggestions("DIF", SuggestionOptions.Builder.Max(2).With(WithOptions.Scores).Build());
-            Assert.True(list[0].Score <= .2);
+            Assert.True(list[0].Score <= .2, "Actual score: " + list[0].Score);
         }
 
         [Fact]

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -75,23 +75,42 @@ namespace NRediSearch.Test
             }
         }
 
+        private static bool instanceMissing = false;
+
         internal static ConnectionMultiplexer GetWithFT(ITestOutputHelper output)
         {
             var options = new ConfigurationOptions
             {
-                EndPoints = { TestConfig.Current.MasterServerAndPort },
+                EndPoints = { TestConfig.Current.RediSearchServerAndPort },
                 AllowAdmin = true,
+                ConnectTimeout = 2000,
                 SyncTimeout = 15000,
             };
-            var conn = ConnectionMultiplexer.Connect(options);
-            conn.MessageFaulted += (msg, ex, origin) => output.WriteLine($"Faulted from '{origin}': '{msg}' - '{(ex == null ? "(null)" : ex.Message)}'");
-            conn.Connecting += (e, t) => output.WriteLine($"Connecting to {Format.ToString(e)} as {t}");
-            conn.Closing += complete => output.WriteLine(complete ? "Closed" : "Closing...");
+            static void InstanceMissing() => Skip.Inconclusive("NRedisSearch instance available at " + TestConfig.Current.RediSearchServerAndPort);
+            // Don't timeout every single test - optimization
+            if (instanceMissing)
+            {
+                InstanceMissing();
+            }
+
+            ConnectionMultiplexer conn = null;
+            try
+            {
+                conn = ConnectionMultiplexer.Connect(options);
+                conn.MessageFaulted += (msg, ex, origin) => output.WriteLine($"Faulted from '{origin}': '{msg}' - '{(ex == null ? "(null)" : ex.Message)}'");
+                conn.Connecting += (e, t) => output.WriteLine($"Connecting to {Format.ToString(e)} as {t}");
+                conn.Closing += complete => output.WriteLine(complete ? "Closed" : "Closing...");
+            }
+            catch (RedisConnectionException)
+            {
+                instanceMissing = true;
+                InstanceMissing();
+            }
 
             // If say we're on a 3.x Redis server...bomb out.
             Skip.IfMissingFeature(conn, nameof(RedisFeatures.Module), r => r.Module);
 
-            var server = conn.GetServer(TestConfig.Current.MasterServerAndPort);
+            var server = conn.GetServer(TestConfig.Current.RediSearchServerAndPort);
             var arr = (RedisResult[])server.Execute("module", "list");
             bool found = false;
             foreach (var module in arr)
@@ -108,23 +127,8 @@ namespace NRediSearch.Test
 
             if (!found)
             {
-                output?.WriteLine("Module not found; attempting to load...");
-                var config = server.Info("server").SelectMany(_ => _).FirstOrDefault(x => x.Key == "config_file").Value;
-                if (!string.IsNullOrEmpty(config))
-                {
-                    var i = config.LastIndexOf('/');
-                    var modulePath = config.Substring(0, i + 1) + "redisearch.so";
-                    try
-                    {
-                        var result = server.Execute("module", "load", modulePath);
-                        output?.WriteLine((string)result);
-                    }
-                    catch (RedisServerException err)
-                    {
-                        // *probably* duplicate load; we'll try the tests anyways!
-                        output?.WriteLine(err.Message);
-                    }
-                }
+                output?.WriteLine("Module not found.");
+                throw new RedisException("NRedisSearch module missing on " + TestConfig.Current.RediSearchServerAndPort);
             }
             return conn;
         }

--- a/tests/RedisConfigs/docker-compose.yml
+++ b/tests/RedisConfigs/docker-compose.yml
@@ -1,6 +1,10 @@
 version: '2.4'
 
 services:
+  redisearch:
+    image: redislabs/redisearch
+    ports:
+      - 6385:6379
   redis:
     build:
       context: .

--- a/tests/StackExchange.Redis.Tests/Helpers/TestConfig.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/TestConfig.cs
@@ -69,6 +69,10 @@ namespace StackExchange.Redis.Tests
             public int FailoverSlavePort { get; set; } = 6383;
             public string FailoverSlaveServerAndPort => FailoverSlaveServer + ":" + FailoverSlavePort.ToString();
 
+            public string RediSearchServer { get; set; } = "127.0.0.1";
+            public int RediSearchPort { get; set; } = 6385;
+            public string RediSearchServerAndPort => RediSearchServer + ":" + RediSearchPort.ToString();
+
             public string IPv4Server { get; set; } = "127.0.0.1";
             public int IPv4Port { get; set; } = 6379;
             public string IPv6Server { get; set; } = "::1";


### PR DESCRIPTION
This moves NRedisSearch to docker-compose, and also moves AppVeyor Unbuntu builds to use docker-compose. Unfortunately we can't do this on Windows due to how the build VMs are setup. If we're comfortable doing Docker-only (we didn't want to jump in there), we could cleanup the `.sh` files afterwards.

Additionally, this removes the `redisearch.so` module from our repo and the code to install it (only in tests). Since this broke with every server mismatch, using their official Docker image that'll always work is much saner and simpler.

Fixes NRedisSearch test failures in #1488, but also `master` branch.