### PR TITLE
Fix sentinel default port when connecting with configuration string

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -488,7 +488,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Sets default config settings required for sentinel usage
         /// </summary>
-        public void SetSentinelDefaults()
+        internal void SetSentinelDefaults()
         {
             // this is required when connecting to sentinel servers
             TieBreaker = "";

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -486,6 +486,19 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// Sets default config settings required for sentinel usage
+        /// </summary>
+        public void SetSentinelDefaults()
+        {
+            // this is required when connecting to sentinel servers
+            TieBreaker = "";
+            CommandMap = CommandMap.Sentinel;
+
+            // use default sentinel port
+            EndPoints.SetDefaultPorts(26379);
+        }
+
+        /// <summary>
         /// Returns the effective configuration string for this configuration, including Redis credentials.
         /// </summary>
         /// <remarks>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -840,7 +840,7 @@ namespace StackExchange.Redis
         public static Task<ConnectionMultiplexer> ConnectAsync(string configuration, TextWriter log = null)
         {
             SocketConnection.AssertDependencies();
-            return ConnectAsync(PrepareConfig(configuration), log);
+            return ConnectAsync(ConfigurationOptions.Parse(configuration), log);
         }
 
         private static async Task<ConnectionMultiplexer> ConnectImplAsync(ConfigurationOptions configuration, TextWriter log = null)
@@ -918,12 +918,7 @@ namespace StackExchange.Redis
 
             if (sentinel)
             {
-                // this is required when connecting to sentinel servers
-                config.TieBreaker = "";
-                config.CommandMap = CommandMap.Sentinel;
-
-                // use default sentinel port
-                config.EndPoints.SetDefaultPorts(26379);
+                config.SetSentinelDefaults();
 
                 return config;
             }
@@ -1017,7 +1012,7 @@ namespace StackExchange.Redis
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
         public static ConnectionMultiplexer Connect(string configuration, TextWriter log = null)
         {
-            return Connect(PrepareConfig(configuration), log);
+            return Connect(ConfigurationOptions.Parse(configuration), log);
         }
 
         /// <summary>

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -261,10 +261,10 @@ namespace StackExchange.Redis.Tests
             {
                 var server = GetAnyMaster(muxer);
                 var serverTime = server.Time();
-                Log(serverTime.ToString());
-                var delta = Math.Abs((DateTime.UtcNow - serverTime).TotalSeconds);
-
-                Assert.True(delta < 5);
+                var localTime = DateTime.UtcNow;
+                Log("Server: " + serverTime.ToString());
+                Log("Local: " + localTime.ToString());
+                Assert.Equal(localTime, serverTime, TimeSpan.FromSeconds(10));
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/Sentinel.cs
+++ b/tests/StackExchange.Redis.Tests/Sentinel.cs
@@ -57,7 +57,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void MasterConnectTest()
         {
-            var connectionString = $"{TestConfig.Current.SentinelServer}:{TestConfig.Current.SentinelPortA},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
+            var connectionString = $"{TestConfig.Current.SentinelServer},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
             var conn = ConnectionMultiplexer.Connect(connectionString);
 
             var db = conn.GetDatabase();
@@ -93,7 +93,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public async Task MasterConnectAsyncTest()
         {
-            var connectionString = $"{TestConfig.Current.SentinelServer}:{TestConfig.Current.SentinelPortA},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
+            var connectionString = $"{TestConfig.Current.SentinelServer},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
             var conn = await ConnectionMultiplexer.ConnectAsync(connectionString);
 
             var db = conn.GetDatabase();


### PR DESCRIPTION
This makes it so that when using a configuration string to connect that we only parse the configuration string and not set any defaults on it until it is forwarded on to the connect methods that take `ConfigurationOptions`