### PR TITLE
Fix for #1512

### DIFF
--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -2057,19 +2057,14 @@ The coordinates as a two items x,y array (longitude,latitude).
                                 endPoints.Add(Format.ParseEndPoint(ip, port));
                             }
                         }
-                        break;
+                        SetResult(message, endPoints.ToArray());
+                        return true;
 
                     case ResultType.SimpleString:
                         //We don't want to blow up if the master is not found
                         if (result.IsNull)
                             return true;
                         break;
-                }
-
-                if (endPoints.Count > 0)
-                {
-                    SetResult(message, endPoints.ToArray());
-                    return true;
                 }
 
                 return false;


### PR DESCRIPTION
The assumption in the result processor was that it must have results to be valid, but that's not correct. If a sentinel has 0 replicas (only 1 master), that's a perfectly valid state. This adjusts the result processor logic to be more correct.