### PR TITLE
JRediSearch version 1.8 Sync Up

### DIFF
--- a/src/NRediSearch/AddOptions.cs
+++ b/src/NRediSearch/AddOptions.cs
@@ -27,6 +27,7 @@ namespace NRediSearch
         public string Language { get; set; }
         public bool NoSave { get; set; }
         public ReplacementPolicy ReplacePolicy { get; set; }
+        public string Filter { get; set; }
 
         /// <summary>
         /// Create a new DocumentOptions object. Methods can later be chained via a builder-like pattern
@@ -57,9 +58,11 @@ namespace NRediSearch
         /// Indicate the behavior for the existing document.
         /// </summary>
         /// <param name="mode">One of the replacement modes.</param>
-        public AddOptions SetReplacementPolicy(ReplacementPolicy mode)
+        /// <param name="filter">Updates the document only if a boolean expression applies to the document</param>
+        public AddOptions SetReplacementPolicy(ReplacementPolicy mode, string filter = null)
         {
             ReplacePolicy = mode;
+            Filter = filter;
             return this;
         }
     }

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -287,7 +287,7 @@ namespace NRediSearch
                 pipelinedQueryResults[i] = SearchAsync(queries[i]);
             }
 
-            await Task.WhenAll(pipelinedQueryResults);
+            await Task.WhenAll(pipelinedQueryResults).ConfigureAwait(false);
 
             return pipelinedQueryResults.Select(qr => qr.Result).ToArray();
         }

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -492,7 +492,7 @@ namespace NRediSearch
         /// <param name="fields">The document fields.</param>
         /// <param name="score">The new score.</param>
         /// <param name="payload">The new payload.</param>
-         /// <param name="filter">replaces the document only if a boolean expression applies to the document</param>
+        /// <param name="filter">replaces the document only if a boolean expression applies to the document</param>
         public bool ReplaceDocument(string docId, Dictionary<string, RedisValue> fields, double score = 1.0, byte[] payload = null, string filter = null)
             => AddDocument(docId, fields, score, false, true, payload, filter);
 
@@ -1299,6 +1299,46 @@ namespace NRediSearch
         {
             var args = BuildAddDocumentArgs(docId, fields, score, false, AddOptions.ReplacementPolicy.Partial, null, null, filter);
             return (string)await _db.ExecuteAsync("FT.ADD", args).ConfigureAwait(false) == "OK";
+        }
+
+        /// <summary>
+        /// Set a runtime configuration option.
+        /// </summary>
+        /// <param name="option">The option to set.</param>
+        /// <param name="value">The value for the option.</param>
+        public bool SetConfig(ConfigOption option, string value)
+        {
+            return (string)DbSync.Execute("FT.CONFIG", "SET".Literal(), option.Value, value) == "OK";
+        }
+
+        /// <summary>
+        /// Set a runtime configuration option.
+        /// </summary>
+        /// <param name="option">The option to set.</param>
+        /// <param name="value">The value for the option.</param>
+        public async Task<bool> SetConfigAsync(ConfigOption option, string value)
+        {
+            return (string)await _db.ExecuteAsync("FT.CONFIG", "SET".Literal(), option.Value, value) == "OK";
+        }
+
+        public Dictionary<ConfigOption, string> GetAllConfig()
+        {
+            return default;
+        }
+
+        public Task<Dictionary<ConfigOption, string>> GetAllConfigAsync()
+        {
+            return default;
+        }
+
+        public string GetConfig(ConfigOption option)
+        {
+            return default;
+        }
+
+        public Task<string> GetConfigAsync(ConfigOption option)
+        {
+            return default;
         }
 
         private static Suggestion[] GetSuggestionsNoOptions(RedisResult[] results)

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -465,7 +465,15 @@ namespace NRediSearch
             foreach (var ent in fields)
             {
                 args.Add(ent.Key);
-                args.Add(ent.Value);
+
+                if (ent.Value == RedisValue.Null)
+                {
+                    throw new NullReferenceException($"Document attribute '{ent.Key}' is null. (Remove it, or set a value)");
+                }
+                else
+                {
+                    args.Add(ent.Value);
+                }
             }
             return args;
         }

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -720,13 +720,13 @@ namespace NRediSearch
         }
 
         /// <summary>
-        /// Get the size of an autoc-complete suggestion dictionary
+        /// Get the size of an auto-complete suggestion dictionary
         /// </summary>
         public long CountSuggestions()
             => (long)DbSync.Execute("FT.SUGLEN", _boxedIndexName);
 
         /// <summary>
-        /// Get the size of an autoc-complete suggestion dictionary
+        /// Get the size of an auto-complete suggestion dictionary
         /// </summary>
         public async Task<long> CountSuggestionsAsync()
             => (long)await _db.ExecuteAsync("FT.SUGLEN", _boxedIndexName).ConfigureAwait(false);

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -355,7 +355,7 @@ namespace NRediSearch
         /// <returns>true if the operation succeeded, false otherwise</returns>
         public bool AddDocument(Document doc, AddOptions options = null)
         {
-            var args = BuildAddDocumentArgs(doc.Id, doc._properties, doc.Score, options?.NoSave ?? false, options?.ReplacePolicy ?? AddOptions.ReplacementPolicy.None, doc.Payload, options?.Language, null);
+            var args = BuildAddDocumentArgs(doc.Id, doc._properties, doc.Score, options?.NoSave ?? false, options?.ReplacePolicy ?? AddOptions.ReplacementPolicy.None, doc.Payload, options?.Language, options?.Filter);
 
             try
             {
@@ -376,7 +376,7 @@ namespace NRediSearch
         /// <returns>true if the operation succeeded, false otherwise. Note that if the operation fails, an exception will be thrown</returns>
         public async Task<bool> AddDocumentAsync(Document doc, AddOptions options = null)
         {
-            var args = BuildAddDocumentArgs(doc.Id, doc._properties, doc.Score, options?.NoSave ?? false, options?.ReplacePolicy ?? AddOptions.ReplacementPolicy.None, doc.Payload, options?.Language, null);
+            var args = BuildAddDocumentArgs(doc.Id, doc._properties, doc.Score, options?.NoSave ?? false, options?.ReplacePolicy ?? AddOptions.ReplacementPolicy.None, doc.Payload, options?.Language, options?.Filter);
             return (string)await _db.ExecuteAsync("FT.ADD", args).ConfigureAwait(false) == "OK";
         }
 

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -1361,6 +1361,60 @@ namespace NRediSearch
             return (string)((RedisResult[])result[0])[1];
         }
 
+        /// <summary>
+        /// Add an alias to the current index. 
+        /// </summary>
+        /// <param name="name">Name of the alias.</param>
+        public bool AddAlias(string name)
+        {
+            return (string)DbSync.Execute("FT.ALIASADD", name, IndexName) == "OK";
+        }
+
+        /// <summary>
+        /// Add an alias to the current index.
+        /// </summary>
+        /// <param name="name">Name of the alias.</param>
+        public async Task<bool> AddAliasAsync(string name)
+        {
+            return (string)await _db.ExecuteAsync("FT.ALIASADD", name, IndexName).ConfigureAwait(false) == "OK";
+        }
+
+        /// <summary>
+        /// Update an alias on the current index.
+        /// </summary>
+        /// <param name="name">Name of the alias.</param>
+        public bool UpdateAlias(string name)
+        {
+            return (string)DbSync.Execute("FT.ALIASUPDATE", name, IndexName) == "OK";
+        }
+
+        /// <summary>
+        /// Update an alias on the current index.
+        /// </summary>
+        /// <param name="name">Name of the alias.</param>
+        public async Task<bool> UpdateAliasAsync(string name)
+        {
+            return (string)await _db.ExecuteAsync("FT.ALIASUPDATE", name, IndexName).ConfigureAwait(false) == "OK";
+        }
+
+        /// <summary>
+        /// Delete an alias on the current index.
+        /// </summary>
+        /// <param name="name">Name of the alias.</param>
+        public bool DeleteAlias(string name)
+        {
+            return (string)DbSync.Execute("FT.ALIASDEL", name) == "OK";
+        }
+
+        /// <summary>
+        /// Delete an alias on the current index.
+        /// </summary>
+        /// <param name="name">Name of the alias.</param>
+        public async Task<bool> DeleteAliasAsync(string name)
+        {
+            return (string)await _db.ExecuteAsync("FT.ALIASDEL", name).ConfigureAwait(false) == "OK";
+        }
+
         private static Suggestion[] GetSuggestionsNoOptions(RedisResult[] results)
         {
             var suggestions = new Suggestion[results.Length];

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -1422,11 +1422,9 @@ namespace NRediSearch
         /// <returns>ID of the synonym group.</returns>
         public long AddSynonym(params string[] terms)
         {
-            var args = new object[terms.Length + 1];
+            var args = new List<object> { _boxedIndexName };
 
-            args[0] = _boxedIndexName;
-
-            Array.Copy(terms, 0, args, 1, terms.Length);
+            args.AddRange(terms);
 
             return (long)DbSync.Execute("FT.SYNADD", args);
         }
@@ -1438,11 +1436,9 @@ namespace NRediSearch
         /// <returns>ID of the synonym group.</returns>
         public async Task<long> AddSynonymAsync(params string[] terms)
         {
-            var args = new object[terms.Length + 1];
+            var args = new List<object> { _boxedIndexName };
 
-            args[0] = _boxedIndexName;
-
-            Array.Copy(terms, 0, args, 1, terms.Length);
+            args.AddRange(terms);
 
             return (long)await _db.ExecuteAsync("FT.SYNADD", args).ConfigureAwait(false);
         }
@@ -1454,12 +1450,9 @@ namespace NRediSearch
         /// <param name="term">Additional terms to add.</param>
         public bool UpdateSynonym(long groupId, params string[] terms)
         {
-            var args = new object[terms.Length + 2];
+            var args = new List<object> { _boxedIndexName, groupId };
 
-            args[0] = IndexName;
-            args[1] = groupId;
-
-            Array.Copy(terms, 0, args, 2, terms.Length);
+            args.AddRange(terms);
 
             return (string)DbSync.Execute("FT.SYNUPDATE", args) == "OK";
         }
@@ -1471,12 +1464,9 @@ namespace NRediSearch
         /// <param name="term">Additionals terms to add.</param>
         public async Task<bool> UpdateSynonymAsync(long groupId, params string[] terms)
         {
-            var args = new object[terms.Length + 2];
+            var args = new List<object> { _boxedIndexName, groupId };
 
-            args[0] = _boxedIndexName;
-            args[1] = groupId;
-
-            Array.Copy(terms, 0, args, 2, terms.Length);
+            args.AddRange(terms);
 
             return (string)await _db.ExecuteAsync("FT.SYNUPDATE", args).ConfigureAwait(false) == "OK";
         }

--- a/src/NRediSearch/ConfigOption.cs
+++ b/src/NRediSearch/ConfigOption.cs
@@ -1,4 +1,6 @@
-﻿namespace NRediSearch
+﻿using StackExchange.Redis;
+
+namespace NRediSearch
 {
     public sealed class ConfigOption
     {
@@ -15,6 +17,27 @@
         private ConfigOption(string value)
         {
             Value = value.Literal();
+        }
+
+        internal static ConfigOption FromRedisResult(RedisResult value)
+        {
+            switch((string)value)
+            {
+                case nameof(NOGC):
+                    return NOGC;
+                case nameof(MINPREFIX):
+                    return MINPREFIX;
+                case nameof(MAXEXPANSIONS):
+                    return MAXEXPANSIONS;
+                case nameof(TIMEOUT):
+                    return TIMEOUT;
+                case nameof(ON_TIMEOUT):
+                    return ON_TIMEOUT;
+                case nameof(MIN_PHONETIC_TERM_LEN):
+                    return MIN_PHONETIC_TERM_LEN;
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/src/NRediSearch/ConfigOption.cs
+++ b/src/NRediSearch/ConfigOption.cs
@@ -1,0 +1,20 @@
+﻿namespace NRediSearch
+{
+    public sealed class ConfigOption
+    {
+        public static readonly ConfigOption NOGC = new ConfigOption(nameof(NOGC));
+        public static readonly ConfigOption MINPREFIX = new ConfigOption(nameof(MINPREFIX));
+        public static readonly ConfigOption MAXEXPANSIONS = new ConfigOption(nameof(MAXEXPANSIONS));
+        public static readonly ConfigOption TIMEOUT = new ConfigOption(nameof(TIMEOUT));
+        public static readonly ConfigOption ON_TIMEOUT = new ConfigOption(nameof(ON_TIMEOUT));
+        public static readonly ConfigOption MIN_PHONETIC_TERM_LEN = new ConfigOption(nameof(MIN_PHONETIC_TERM_LEN));
+        public static readonly ConfigOption ALL = new ConfigOption("*");
+
+        public object Value { get; }
+
+        private ConfigOption(string value)
+        {
+            Value = value.Literal();
+        }
+    }
+}

--- a/src/NRediSearch/Document.cs
+++ b/src/NRediSearch/Document.cs
@@ -1,4 +1,4 @@
-﻿// .NET port of https://github.com/RedisLabs/JRediSearch/
+﻿  // .NET port of https://github.com/RedisLabs/JRediSearch/
 
 using System.Collections.Generic;
 using StackExchange.Redis;

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -197,5 +197,17 @@ namespace NRediSearch
             Fields.Add(new TagField(name, separator));
             return this;
         }
+
+        /// <summary>
+        /// Add a TAG field that can be sorted on.
+        /// </summary>
+        /// <param name="name">The field's name.</param>
+        /// <param name="seperator">The tag separator.</param>
+        /// <returns>The <see cref="Schema"/> object.</returns>
+        public Schema AddSortableTagField(string name, string seperator = ",")
+        {
+            Fields.Add(new TagField(name, seperator, true));
+            return this;
+        }
     }
 }

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -52,6 +52,9 @@ namespace NRediSearch
                 if (Sortable) { args.Add("SORTABLE".Literal()); }
                 if (NoIndex) { args.Add("NOINDEX".Literal()); }
             }
+
+            public override string ToString() =>
+                $"Field{{name='{Name}', type={Type}, sortable={Sortable}, noindex={NoIndex}}}";
         }
 
         public class TextField : Field

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -87,7 +87,7 @@ namespace NRediSearch
 
                 if (Phonetic != null)
                 {
-                    args.Add("PHOENETIC".Literal());
+                    args.Add("PHONETIC".Literal());
                     args.Add(Phonetic);
                 }
             }

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -166,7 +166,8 @@ namespace NRediSearch
         public class TagField : Field
         {
             public string Separator { get; }
-            internal TagField(string name, string separator = ",") : base(name, FieldType.Tag, false)
+
+            internal TagField(string name, string separator = ",", bool sortable = false) : base(name, FieldType.Tag, sortable)
             {
                 Separator = separator;
             }
@@ -180,6 +181,9 @@ namespace NRediSearch
                     args.Add(Separator);
                 }
             }
+
+            public override string ToString() =>
+                $"TagField{{name='{Name}', type={Type}, sortable={Sortable}, noindex={NoIndex}, separator='{Separator}'}}";
         }
 
         /// <summary>

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -88,6 +88,9 @@ namespace NRediSearch
                     args.Add(Phonetic);
                 }
             }
+
+            public override string ToString() =>
+                $"TextField{{name='{Name}', type={Type}, sortable={Sortable}, noindex={NoIndex}, weight={Weight}, nostem={NoStem}, phoenetic='{Phonetic}'}}";
         }
 
         public List<Field> Fields { get; } = new List<Field>();

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -58,22 +58,35 @@ namespace NRediSearch
         {
             public double Weight { get; }
             public bool NoStem { get; }
+            public string Phonetic { get; }
 
-            public TextField(string name, double weight = 1.0, bool sortable = false, bool noStem = false, bool noIndex = false) : base(name, FieldType.FullText, sortable, noIndex)
+            public TextField(string name, double weight = 1.0, bool sortable = false, bool noStem = false, bool noIndex = false, string phonetic = null) : base(name, FieldType.FullText, sortable, noIndex)
             {
                 Weight = weight;
                 NoStem = noStem;
+                Phonetic = phonetic;
             }
 
             internal override void SerializeRedisArgs(List<object> args)
             {
                 base.SerializeRedisArgs(args);
+
                 if (Weight != 1.0)
                 {
                     args.Add("WEIGHT".Literal());
                     args.Add(Weight);
                 }
-                if (NoStem) args.Add("NOSTEM".Literal());
+
+                if (NoStem)
+                {
+                    args.Add("NOSTEM".Literal());
+                }
+                    
+                if (Phonetic != null)
+                {
+                    args.Add("PHOENETIC".Literal());
+                    args.Add(Phonetic);
+                }
             }
         }
 

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -81,7 +81,7 @@ namespace NRediSearch
                 {
                     args.Add("NOSTEM".Literal());
                 }
-                    
+
                 if (Phonetic != null)
                 {
                     args.Add("PHOENETIC".Literal());
@@ -209,5 +209,8 @@ namespace NRediSearch
             Fields.Add(new TagField(name, seperator, true));
             return this;
         }
+
+        public override string ToString() =>
+            $"Schema{{fields=[{string.Join(",", Fields)}]}}";
     }
 }

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using StackExchange.Redis;
@@ -7,7 +7,6 @@ using Xunit.Abstractions;
 using static NRediSearch.Client;
 using static NRediSearch.Schema;
 using static NRediSearch.SuggestionOptions;
-using System;
 
 namespace NRediSearch.Test.ClientTests
 {
@@ -890,6 +889,34 @@ namespace NRediSearch.Test.ClientTests
 
             var none = cl.GetSuggestions("DIF", SuggestionOptions.Builder.Max(3).With(WithOptions.Scores).Build());
             Assert.Empty(none);
+        }
+
+        [Fact]
+        public void TestAddSuggestionDeleteSuggestionLength()
+        {
+            Client cl = GetClient();
+            cl.AddSuggestion(Suggestion.Builder.String("TOPIC OF WORDS").Score(1).Build(), true);
+            cl.AddSuggestion(Suggestion.Builder.String("ANOTHER ENTRY").Score(1).Build(), true);
+
+            long result = cl.DeleteSuggestion("ANOTHER ENTRY");
+            Assert.Equal(1, result);
+            Assert.Equal(1, cl.GetSuggestionLength());
+
+            result = cl.DeleteSuggestion("ANOTHER ENTRY THAT IS NOT PRESENT");
+            Assert.Equal(0, result);
+            Assert.Equal(1, cl.GetSuggestionLength());
+        }
+
+        [Fact]
+        public void TestAddSuggtionGetSuggestionLength()
+        {
+            Client cl = GetClient();
+            cl.AddSuggestion(Suggestion.Builder.String("TOPIC OF WORDS").Score(1).Build(), true);
+            cl.AddSuggestion(Suggestion.Builder.String("ANOTHER ENTRY").Score(1).Build(), true);
+            Assert.Equal(2, cl.GetSuggestionLength());
+
+            cl.AddSuggestion(Suggestion.Builder.String("FINAL ENTRY").Score(1).Build(), true);
+            Assert.True(3, cl.GetSuggestionLength()); 
         }
 
         [Fact]

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -1117,47 +1117,45 @@ namespace NRediSearch.Test.ClientTests
             Assert.False(cl.SetConfig(ConfigOption.ON_TIMEOUT, "null"));
         }
 
-        //[Fact]
-        //public void TestAlias()
-        //{
-        //    Client cl = GetClient();
+        [Fact]
+        public void TestAlias()
+        {
+            Client cl = GetClient();
 
-        //    Reset(cl);
+            Reset(cl);
 
+            Schema sc = new Schema().AddTextField("field1", 1.0);
+            Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
+            var doc = new Dictionary<string, RedisValue>();
+            doc.Add("field1", "value");
+            Assert.True(cl.AddDocument("doc1", doc));
 
-        //    Schema sc = new Schema().AddTextField("field1", 1.0);
-        //    Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
-        //    var doc = new Dictionary<string, RedisValue>();
-        //    doc.Add("field1", "value");
-        //    Assert.True(cl.AddDocument("doc1", doc));
+            Assert.True(cl.AddAlias("ALIAS1:TestAlias"));
+            Client alias1 = GetClient("ALIAS1", reset: false);
+            SearchResult res1 = alias1.Search(new Query("*").ReturnFields("field1"));
+            Assert.Equal(1, res1.TotalResults);
+            Assert.Equal("value", res1.Documents[0]["field1"]);
 
-        //    Assert.True(cl.AddAlias("ALIAS1"));
-        //    Client alias1 = GetClient("ALIAS1");
-        //    SearchResult res1 = alias1.Search(new Query("*").ReturnFields("field1"));
-        //    Assert.Equal(1, res1.TotalResults);
-        //    Assert.Equal("value", res1.Documents[0]["field1"]);
+            Assert.True(cl.UpdateAlias("ALIAS2:TestAlias"));
+            Client alias2 = GetClient("ALIAS2", reset: false);
+            SearchResult res2 = alias2.Search(new Query("*").ReturnFields("field1"));
+            Assert.Equal(1, res2.TotalResults);
+            Assert.Equal("value", res2.Documents[0]["field1"]);
 
-        //    Assert.True(cl.UpdateAlias("ALIAS2"));
-        //    Client alias2 = GetClient("ALIAS2");
-        //    SearchResult res2 = alias2.Search(new Query("*").ReturnFields("field1"));
-        //    Assert.Equal(1, res2.TotalResults);
-        //    Assert.Equal("value", res2.Documents[0]["field1"]);
+            Assert.Throws<RedisServerException>(() =>
+            {
+                // Should throw because the alias doesn't exist. 
+                cl.DeleteAlias("ALIAS3:TestAlias");
+            });
 
+            Assert.True(cl.DeleteAlias("ALIAS2:TestAlias"));
 
-        //    Assert.Throws<RedisServerException>(() =>
-        //    {
-        //        // Should throw because the alias doesn't exist. 
-        //        cl.DeleteAlias("ALIAS3");
-        //    });
-
-        //    Assert.True(cl.DeleteAlias("ALIAS2"));
-
-        //    Assert.Throws<RedisServerException>(() =>
-        //    {
-        //        // Should throw because the alias doesn't exist.
-        //        cl.DeleteAlias("ALIAS2");
-        //    });
-        //}
+            Assert.Throws<RedisServerException>(() =>
+            {
+                // Should throw because the alias doesn't exist.
+                cl.DeleteAlias("ALIAS2:TestAlias");
+            });
+        }
 
         //[Fact]
         //public void TestSyn()

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using System.Text;
 using StackExchange.Redis;
 using Xunit;
@@ -90,14 +91,6 @@ namespace NRediSearch.Test.ClientTests
             Assert.Equal(50, res[0].TotalResults);
             Assert.Equal(50, res[1].TotalResults);
             Assert.Equal(5, res[0].Documents.Count);
-
-            foreach(var d in res[0].Documents)
-            {
-                Assert.StartsWith("doc", d.Id);
-                Assert.True(d.Score < 100);
-
-                Assert.Equal($"{{\"id\":\"{d.Id}\",\"score\":{d.Score},\"properties\":{{\"title\":\"hello world\",\"body\":\"lorem ipsum\"}}", d.ToString());
-            }
         }
 
         [Fact]

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -1090,7 +1090,7 @@ namespace NRediSearch.Test.ClientTests
             Assert.True(cl.AddDocument("doc1", doc));
 
             // Query
-            SearchResult res = cl.Search(new Query("value"), false);
+            SearchResult res = cl.Search(new Query("value"));
 
             Assert.Equal(1, res.TotalResults);
             Assert.Equal("doc1", res.Documents[0].Id);

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -778,6 +778,9 @@ namespace NRediSearch.Test.ClientTests
         public void TestAddSuggestionGetSuggestionFuzzy()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
+
             Suggestion suggestion = Suggestion.Builder.String("TOPIC OF WORDS").Score(1).Build();
             // test can add a suggestion string
             Assert.True(cl.AddSuggestion(suggestion, true) > 0, $"{suggestion} insert should of returned at least 1");
@@ -791,6 +794,9 @@ namespace NRediSearch.Test.ClientTests
         public void TestAddSuggestionGetSuggestion()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
+
             Suggestion suggestion = Suggestion.Builder.String("ANOTHER_WORD").Score(1).Build();
             Suggestion noMatch = Suggestion.Builder.String("_WORD MISSED").Score(1).Build();
 
@@ -811,6 +817,8 @@ namespace NRediSearch.Test.ClientTests
         {
             Client cl = GetClient();
 
+            Db.KeyDelete(cl.IndexName);
+
             Suggestion suggestion = Suggestion.Builder.String("COUNT_ME TOO").Payload("PAYLOADS ROCK ").Score(0.2).Build();
             Assert.True(cl.AddSuggestion(suggestion, false) > 0, $"{suggestion.ToString()} insert should of at least returned 1");
             Assert.True(cl.AddSuggestion(suggestion.ToBuilder().String("COUNT").Payload("My PAYLOAD is better").Build(), false) > 1, "Count single added should return more than 1");
@@ -829,6 +837,9 @@ namespace NRediSearch.Test.ClientTests
         public void TestAddSuggestionGetSuggestionPayload()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
+
             cl.AddSuggestion(Suggestion.Builder.String("COUNT_ME TOO").Payload("PAYLOADS ROCK ").Build(), false);
             cl.AddSuggestion(Suggestion.Builder.String("COUNT").Payload("ANOTHER PAYLOAD ").Build(), false);
             cl.AddSuggestion(Suggestion.Builder.String("COUNTNO PAYLOAD OR COUNT").Build(), false);
@@ -842,6 +853,8 @@ namespace NRediSearch.Test.ClientTests
         public void TestGetSuggestionNoPayloadTwoOnly()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
 
             cl.AddSuggestion(Suggestion.Builder.String("DIFF_WORD").Score(0.4).Payload("PAYLOADS ROCK ").Build(), false);
             cl.AddSuggestion(Suggestion.Builder.String("DIFF wording").Score(0.5).Payload("ANOTHER PAYLOAD ").Build(), false);
@@ -859,6 +872,8 @@ namespace NRediSearch.Test.ClientTests
         {
             Client cl = GetClient();
 
+            Db.KeyDelete(cl.IndexName);
+
             cl.AddSuggestion(Suggestion.Builder.String("DIFF_WORD").Score(0.4).Payload("PAYLOADS ROCK ").Build(), false);
             cl.AddSuggestion(Suggestion.Builder.String("DIFF wording").Score(0.5).Payload("ANOTHER PAYLOAD ").Build(), false);
             cl.AddSuggestion(Suggestion.Builder.String("DIFFERENT").Score(0.7).Payload("I am a payload").Build(), false);
@@ -875,6 +890,8 @@ namespace NRediSearch.Test.ClientTests
         {
             Client cl = GetClient();
 
+            Db.KeyDelete(cl.IndexName);
+
             cl.AddSuggestion(Suggestion.Builder.String("DIFF_WORD").Score(0.4).Payload("PAYLOADS ROCK ").Build(), true);
             var list = cl.GetSuggestions("DIF", SuggestionOptions.Builder.Max(2).With(WithOptions.Scores).Build());
             Assert.True(list[0].Score <= .2, "Actual score: " + list[0].Score);
@@ -884,6 +901,8 @@ namespace NRediSearch.Test.ClientTests
         public void TestGetSuggestionAllNoHit()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
 
             cl.AddSuggestion(Suggestion.Builder.String("NO WORD").Score(0.4).Build(), false);
 
@@ -895,6 +914,9 @@ namespace NRediSearch.Test.ClientTests
         public void TestAddSuggestionDeleteSuggestionLength()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
+
             cl.AddSuggestion(Suggestion.Builder.String("TOPIC OF WORDS").Score(1).Build(), true);
             cl.AddSuggestion(Suggestion.Builder.String("ANOTHER ENTRY").Score(1).Build(), true);
 
@@ -909,6 +931,13 @@ namespace NRediSearch.Test.ClientTests
         public void TestAddSuggtionGetSuggestionLength()
         {
             Client cl = GetClient();
+
+            Db.KeyDelete(cl.IndexName);
+
+            cl.DeleteSuggestion("TOPIC OF WORDS");
+            cl.DeleteSuggestion("ANOTHER ENTRY");
+            cl.DeleteSuggestion("FINAL ENTRY");
+
             cl.AddSuggestion(Suggestion.Builder.String("TOPIC OF WORDS").Score(1).Build(), true);
             cl.AddSuggestion(Suggestion.Builder.String("ANOTHER ENTRY").Score(1).Build(), true);
             Assert.Equal(2, cl.CountSuggestions());
@@ -1157,36 +1186,31 @@ namespace NRediSearch.Test.ClientTests
             });
         }
 
-        //[Fact]
-        //public void TestSyn()
-        //{
-        //    Client cl = GetClient();
-        //    Reset(cl);
+        [Fact]
+        public void TestSyn()
+        {
+            Client cl = GetClient();
+            Reset(cl);
 
-        //    Schema sc = new Schema().AddTextField("name", 1.0).AddTextField("addr", 1.0);
-        //    Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
+            Schema sc = new Schema().AddTextField("name", 1.0).AddTextField("addr", 1.0);
+            Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
 
 
-        //    long group1 = cl.AddSynonym("girl", "baby");
-        //    Assert.True(cl.UpdateSynonym(group1, "child"));
+            long group1 = cl.AddSynonym("girl", "baby");
+            Assert.True(cl.UpdateSynonym(group1, "child"));
 
-        //    long group2 = cl.AddSynonym("child");
+            long group2 = cl.AddSynonym("child");
 
-        //    Assert.NotEqual(group1, group2);
+            Assert.NotEqual(group1, group2);
 
-        //    //Map<String, List<Long>> dump = cl.dumpSynonym();
-        //    Dictionary<string, List<long>> dump = cl.DumpSynonym();
+            Dictionary<string, long[]> dump = cl.DumpSynonym();
 
-        //    //Map<String, List<Long>> expected = new HashMap<>();
-        //    Dictionary<string, List<long>> expected = new Dictionary<string, List<long>>();
-        //    //expected.put("girl", Arrays.asList(group1));
-        //    expected.Add("girl", new List<long> { group1 });
-        //    //expected.put("baby", Arrays.asList(group1));
-        //    expected.Add("baby", new List<long> { group1 });
-        //    //expected.put("child", Arrays.asList(group1, group2));
-        //    expected.Add("child", new List<long> { group1, group2 });
+            Dictionary<string, long[]> expected = new Dictionary<string, long[]>();
+            expected.Add("girl", new[] { group1 });
+            expected.Add("baby", new[] { group1 });
+            expected.Add("child", new[] { group1, group2 });
 
-        //    Assert.Equal(expected, dump);
-        //}
+            Assert.Equal(expected, dump);
+        }
     }
 }

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -1098,24 +1098,24 @@ namespace NRediSearch.Test.ClientTests
             Assert.Equal(blob, (byte[])res.Documents[0]["field2"]);
         }
 
-        //[Fact]
-        //public void TestConfig()
-        //{
-        //    Client cl = GetClient();
+        [Fact]
+        public void TestConfig()
+        {
+            Client cl = GetClient();
 
-        //    Reset(cl);
+            Reset(cl);
 
-        //    Assert.True(cl.SetConfig(ConfigOption.TIMEOUT, "100"));
+            Assert.True(cl.SetConfig(ConfigOption.TIMEOUT, "100"));
 
-        //    Dictionary<string, string> configMap = cl.GetAllConfig();
-        //    Assert.Equal("100", configMap[ConfigOption.TIMEOUT]);
-        //    Assert.Equal("100", cl.GetConfig(ConfigOption.TIMEOUT));
+            Dictionary<ConfigOption, string> configMap = cl.GetAllConfig();
+            Assert.Equal("100", configMap[ConfigOption.TIMEOUT]);
+            Assert.Equal("100", cl.GetConfig(ConfigOption.TIMEOUT));
 
-        //    cl.SetConfig(ConfigOption.ON_TIMEOUT, "fail");
-        //    Assert.Equal("fail", cl.GetConfig(ConfigOption.ON_TIMEOUT));
+            cl.SetConfig(ConfigOption.ON_TIMEOUT, "fail");
+            Assert.Equal("fail", cl.GetConfig(ConfigOption.ON_TIMEOUT));
 
-        //    Assert.False(cl.SetConfig(ConfigOption.ON_TIMEOUT, "null"));
-        //}
+            Assert.False(cl.SetConfig(ConfigOption.ON_TIMEOUT, "null"));
+        }
 
         //[Fact]
         //public void TestAlias()

--- a/tests/NRediSearch.Test/QueryBuilder/BuilderTest.cs
+++ b/tests/NRediSearch.Test/QueryBuilder/BuilderTest.cs
@@ -76,11 +76,16 @@ namespace NRediSearch.Test.QueryBuilder
             Assert.Equal("(@name:(mark|dvir) @time:[100.0 200.0] -@created:[-inf (1000.0])", n.ToString());
         }
 
-        private static string GetArgsString(AggregationRequest request)
+        [Fact]
+        public void TestOptional()
         {
-            var args = new List<object>();
-            request.SerializeRedisArgs(args);
-            return string.Join(" ", args);
+            var n = Optional("name", Tags("foo", "bar"));
+
+            Assert.Equal("~@name:{foo | bar}", n.ToString());
+
+            n = Optional(n, n);
+
+            Assert.Equal("~(~@name:{foo | bar} ~@name:{foo | bar})", n.ToString());
         }
 
         [Fact]
@@ -135,6 +140,13 @@ namespace NRediSearch.Test.QueryBuilder
                 .SortBy(Descending("@count"))
                 .Limit(0, 2);
             Assert.Equal("* LOAD 1 @count APPLY @count%1000 AS thousands SORTBY 2 @count DESC LIMIT 0 2", r3.GetArgsString());
+        }
+
+        private static string GetArgsString(AggregationRequest request)
+        {
+            var args = new List<object>();
+            request.SerializeRedisArgs(args);
+            return string.Join(" ", args);
         }
     }
 }

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using StackExchange.Redis;
 using StackExchange.Redis.Tests;
@@ -62,6 +61,7 @@ namespace NRediSearch.Test
             try
             {
                 var result = client.DropIndex(); // tests create them
+
                 Output.WriteLine("  Result: " + result);
                 return result;
             }

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -27,7 +27,7 @@ namespace NRediSearch.Test
             Db = null;
         }
 
-        protected Client GetClient([CallerFilePath] string filePath = null, [CallerMemberName] string caller = null)
+        protected Client GetClient([CallerFilePath] string filePath = null, [CallerMemberName] string caller = null, bool reset = true)
         {
             // Remove all that extra pathing
             var offset = filePath?.IndexOf("NRediSearch.Test");
@@ -42,8 +42,17 @@ namespace NRediSearch.Test
             Output.WriteLine("Key existed: " + exists);
 
             var client = new Client(indexName, Db);
-            var wasReset = Reset(client);
-            Output.WriteLine("Index was reset?: " + wasReset);
+
+            if (reset)
+            {
+                var wasReset = Reset(client);
+                Output.WriteLine("Index was reset?: " + wasReset);
+            }
+            else
+            {
+                Output.WriteLine("Index was reset?: False");
+            }
+
             return client;
         }
 

--- a/tests/NRediSearch.Test/SchemaTest.cs
+++ b/tests/NRediSearch.Test/SchemaTest.cs
@@ -7,19 +7,18 @@ namespace NRediSearch.Test
         [Fact]
         public void PrintSchemaTest()
         {
-            var sc = new Schema();
-
-            sc.AddTextField("title", 5.0);
-            sc.AddSortableTextField("plot", 1.0);
-            sc.AddSortableTagField("genre", ",");
-            sc.AddSortableNumericField("release_year");
-            sc.AddSortableNumericField("rating");
-            sc.AddSortableNumericField("votes");
+            var sc = new Schema()
+                .AddTextField("title", 5.0)
+                .AddSortableTextField("plot", 1.0)
+                .AddSortableTagField("genre", ",")
+                .AddSortableNumericField("release_year")
+                .AddSortableNumericField("rating")
+                .AddSortableNumericField("votes");
 
             var schemaPrint = sc.ToString();
 
             Assert.StartsWith("Schema{fields=[TextField{name='title'", schemaPrint);
-            Assert.Contains("{name='release_year', type=Numeric, sortable=true, noindex=false}", schemaPrint);
+            Assert.Contains("{name='release_year', type=Numeric, sortable=True, noindex=False}", schemaPrint);
         }
     }
 }

--- a/tests/NRediSearch.Test/SchemaTest.cs
+++ b/tests/NRediSearch.Test/SchemaTest.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+
+namespace NRediSearch.Test
+{
+    public class SchemaTest
+    {
+        [Fact]
+        public void PrintSchemaTest()
+        {
+            var sc = new Schema();
+
+            sc.AddTextField("title", 5.0);
+            sc.AddSortableTextField("plot", 1.0);
+            sc.AddSortableTagField("genre", ",");
+            sc.AddSortableNumericField("release_year");
+            sc.AddSortableNumericField("rating");
+            sc.AddSortableNumericField("votes");
+
+            var schemaPrint = sc.ToString();
+
+            Assert.StartsWith("Schema{fields=[TextField{name='title'", schemaPrint);
+            Assert.Contains("{name='release_year', type=Numeric, sortable=true, noindex=false}", schemaPrint);
+        }
+    }
+}


### PR DESCRIPTION
So here is my stab at another sync up with JRediSearch. 

There's one change that I didn't migrate over and it's their `toString` override on the `Document` class. They introduced `com.google.gson.Gson` in order to serialize the instance and I figured we wouldn't want to introduce a JSON serializer as a new dependency. 

Another thing that I noticed is the tests that involve "autosuggest" worked fine... once. Turns out that the "autosuggest" indexes aren't "regular" RediSearch indexes but presented more like standard Redis keys. You'll notice that in the tests that exercise the "autosuggest" functionality I added calls to `Db.KeyDelete(cl.IndexName);` instead of augmenting the `Reset` method because I figured it was just five or so tests. 

In any event the new functionality added here is:

- Support for `IF {condition}` when updating a document. 
- Executing batches of search queries (leveraging pipelining).
- Support for retrieving and setting RediSearch configuration at runtime.
- Support for index aliases. 
- Support for managing synonyms. 
