### PR TITLE
Implement ROLE command

### DIFF
--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -72,7 +72,7 @@ namespace StackExchange.Redis
         /// <remarks>https://redis.io/topics/sentinel</remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {
             // see https://redis.io/topics/sentinel
-            "auth", "ping", "info", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);
+            "auth", "ping", "info", "role", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);
 
         /// <summary>
         /// Create a new CommandMap, customizing some commands

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2407,7 +2407,7 @@ namespace StackExchange.Redis
 
                 // verify role is master according to:
                 // https://redis.io/topics/sentinel-clients
-                if (connection.GetServer(newMasterEndPoint)?.Role() == RedisLiterals.master)
+                if (connection.GetServer(newMasterEndPoint)?.Role().Value == RedisLiterals.master)
                 {
                     success = true;
                     break;

--- a/src/StackExchange.Redis/Enums/RedisCommand.cs
+++ b/src/StackExchange.Redis/Enums/RedisCommand.cs
@@ -122,6 +122,7 @@
         RENAMENX,
         REPLICAOF,
         RESTORE,
+        ROLE,
         RPOP,
         RPOPLPUSH,
         RPUSH,

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -330,6 +330,7 @@ namespace StackExchange.Redis
         /// Get summary statistics associates with this server
         /// </summary>
         ServerCounters GetCounters();
+
         /// <summary>
         /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
         /// </summary>
@@ -422,6 +423,18 @@ namespace StackExchange.Redis
         /// <param name="options">The options to use for this topology change.</param>
         /// <param name="log">The log to write output to.</param>
         void MakeMaster(ReplicationChangeOptions options, TextWriter log = null);
+
+        /// <summary>
+        /// Returns the role info for the current server.
+        /// </summary>
+        /// <remarks>https://redis.io/commands/role</remarks>
+        ServerRole RoleGet();
+
+        /// <summary>
+        /// Returns the role info for the current server.
+        /// </summary>
+        /// <remarks>https://redis.io/commands/role</remarks>
+        Task<ServerRole> RoleGetAsync();
 
         /// <summary>
         /// Explicitly request the database to persist the current state to disk

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -428,13 +428,13 @@ namespace StackExchange.Redis
         /// Returns the role info for the current server.
         /// </summary>
         /// <remarks>https://redis.io/commands/role</remarks>
-        ServerRole RoleGet();
+        Role Role(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Returns the role info for the current server.
         /// </summary>
         /// <remarks>https://redis.io/commands/role</remarks>
-        Task<ServerRole> RoleGetAsync();
+        Task<Role> RoleAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Explicitly request the database to persist the current state to disk
@@ -1055,14 +1055,5 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="server">The server to simulate failure on.</param>
         public static void SimulateConnectionFailure(this IServer server) => (server as RedisServer)?.SimulateConnectionFailure();
-
-        public static string Role(this IServer server)
-        {
-            var result = (RedisResult[])server.Execute("ROLE");
-            if (result != null && result.Length > 0)
-                return result[0].ToString();
-
-            return null;
-        }
     }
 }

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -198,6 +198,7 @@ namespace StackExchange.Redis
                     case RedisCommand.KEYS:
                     case RedisCommand.MONITOR:
                     case RedisCommand.REPLICAOF:
+                    case RedisCommand.ROLE:
                     case RedisCommand.SAVE:
                     case RedisCommand.SHUTDOWN:
                     case RedisCommand.SLAVEOF:
@@ -573,6 +574,7 @@ namespace StackExchange.Redis
                 case RedisCommand.READONLY:
                 case RedisCommand.READWRITE:
                 case RedisCommand.REPLICAOF:
+                case RedisCommand.ROLE:
                 case RedisCommand.SAVE:
                 case RedisCommand.SCRIPT:
                 case RedisCommand.SHUTDOWN:

--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -371,11 +371,9 @@ namespace StackExchange.Redis
             return Format.TryParseDouble(GetString(), out val);
         }
 
-        private bool CanContainInt64 => !IsNull && !Payload.IsEmpty && Payload.Length <= PhysicalConnection.MaxInt64TextLen;
-
         internal bool TryGetInt64(out long value)
         {
-            if (!CanContainInt64)
+            if (IsNull || Payload.IsEmpty || Payload.Length > PhysicalConnection.MaxInt64TextLen)
             {
                 value = 0;
                 return false;
@@ -386,21 +384,6 @@ namespace StackExchange.Redis
             Span<byte> span = stackalloc byte[(int)Payload.Length]; // we already checked the length was <= MaxInt64TextLen
             Payload.CopyTo(span);
             return Format.TryParseInt64(span, out value);
-        }
-
-        internal bool TryGetUInt64(out ulong value)
-        {
-            if (!CanContainInt64)
-            {
-                value = 0;
-                return false;
-            }
-
-            if (Payload.IsSingleSegment) return Format.TryParseUInt64(Payload.First.Span, out value);
-
-            Span<byte> span = stackalloc byte[(int)Payload.Length]; // we already checked the length was <= MaxInt64TextLen
-            Payload.CopyTo(span);
-            return Format.TryParseUInt64(span, out value);
         }
     }
 }

--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -371,9 +371,11 @@ namespace StackExchange.Redis
             return Format.TryParseDouble(GetString(), out val);
         }
 
+        private bool CanContainInt64 => !IsNull && !Payload.IsEmpty && Payload.Length <= PhysicalConnection.MaxInt64TextLen;
+
         internal bool TryGetInt64(out long value)
         {
-            if(IsNull || Payload.IsEmpty || Payload.Length > PhysicalConnection.MaxInt64TextLen)
+            if (!CanContainInt64)
             {
                 value = 0;
                 return false;
@@ -384,6 +386,21 @@ namespace StackExchange.Redis
             Span<byte> span = stackalloc byte[(int)Payload.Length]; // we already checked the length was <= MaxInt64TextLen
             Payload.CopyTo(span);
             return Format.TryParseInt64(span, out value);
+        }
+
+        internal bool TryGetUInt64(out ulong value)
+        {
+            if (!CanContainInt64)
+            {
+                value = 0;
+                return false;
+            }
+
+            if (Payload.IsSingleSegment) return Format.TryParseUInt64(Payload.First.Span, out value);
+
+            Span<byte> span = stackalloc byte[(int)Payload.Length]; // we already checked the length was <= MaxInt64TextLen
+            Payload.CopyTo(span);
+            return Format.TryParseUInt64(span, out value);
         }
     }
 }

--- a/src/StackExchange.Redis/RedisLiterals.cs
+++ b/src/StackExchange.Redis/RedisLiterals.cs
@@ -113,6 +113,14 @@ namespace StackExchange.Redis
             REMOVE = "REMOVE",
             //            SET = "SET",
 
+            // replication states
+            connect = "connect",
+            connected = "connected",
+            connecting = "connecting",
+            handshake = "handshake",
+            none = "none",
+            sync = "sync",
+
             MinusSymbol = "-",
             PlusSumbol = "+",
             Wildcard = "*",

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -340,6 +340,18 @@ namespace StackExchange.Redis
             }
         }
 
+        public Role Role(CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(-1, flags, RedisCommand.ROLE);
+            return ExecuteSync(msg, ResultProcessor.Role);
+        }
+
+        public Task<Role> RoleAsync(CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(-1, flags, RedisCommand.ROLE);
+            return ExecuteAsync(msg, ResultProcessor.Role);
+        }
+
         public void Save(SaveType type, CommandFlags flags = CommandFlags.None)
         {
             var msg = GetSaveMessage(type, flags);

--- a/src/StackExchange.Redis/Role.cs
+++ b/src/StackExchange.Redis/Role.cs
@@ -28,8 +28,7 @@ namespace StackExchange.Redis
             /// <summary>
             /// The replication offset. To be consumed by replica nodes.
             /// </summary>
-            [CLSCompliant(false)]
-            public ulong ReplicationOffset { get; }
+            public long ReplicationOffset { get; }
 
             /// <summary>
             /// Connected replica nodes.
@@ -49,25 +48,24 @@ namespace StackExchange.Redis
                 /// <summary>
                 /// The port number of this replica node.
                 /// </summary>
-                public string Port { get; }
+                public int Port { get; }
 
                 /// <summary>
                 /// The last replication offset acked by this replica node.
                 /// </summary>
-                [CLSCompliant(false)]
-                public ulong ReplicationOffset { get; }
+                public long ReplicationOffset { get; }
 
-                internal Replica(string ip, string port, ulong replicationOffset)
+                internal Replica(string ip, int port, long offset)
                 {
                     Ip = ip;
                     Port = port;
-                    ReplicationOffset = replicationOffset;
+                    ReplicationOffset = offset;
                 }
             }
 
-            internal Master(ulong replicationOffset, ICollection<Replica> replicas) : base(RedisLiterals.master)
+            internal Master(long offset, ICollection<Replica> replicas) : base(RedisLiterals.master)
             {
-                ReplicationOffset = replicationOffset;
+                ReplicationOffset = offset;
                 Replicas = replicas;
             }
         }
@@ -86,47 +84,24 @@ namespace StackExchange.Redis
             /// <summary>
             /// The port number of the master node for this replica.
             /// </summary>
-            public string MasterPort { get; }
+            public int MasterPort { get; }
 
             /// <summary>
             /// This replica's replication state.
             /// </summary>
-            public ReplicationState State { get; }
+            public string State { get; }
 
             /// <summary>
             /// The last replication offset received by this replica.
             /// </summary>
-            [CLSCompliant(false)]
-            public ulong ReceivedReplicationOffset { get; }
+            public long ReplicationOffset { get; }
 
-            /// <summary>
-            /// The state of a replica node.
-            /// </summary>
-            public enum ReplicationState
+            internal Replica(string role, string ip, int port, string state, long offset) : base(role)
             {
-                /// <summary>
-                /// Not connected to the master node.
-                /// </summary>
-                NotConnected,
-
-                /// <summary>
-                /// Attempting to connect to the master node.
-                /// </summary>
-                Connecting,
-
-                /// <summary>
-                /// Connected to the master node and syncing commands to catch up.
-                /// </summary>
-                Syncing,
-
-                /// <summary>
-                /// Connected to the master node and up-to-date.
-                /// </summary>
-                Connected,
-            }
-
-            internal Replica() : base(RedisLiterals.slave)
-            {
+                MasterIp = ip;
+                MasterPort = port;
+                State = state;
+                ReplicationOffset = offset;
             }
         }
 
@@ -141,9 +116,18 @@ namespace StackExchange.Redis
             /// </summary>
             public ICollection<string> MonitoredMasters { get; }
 
-            internal Sentinel() : base(RedisLiterals.sentinel)
+            internal Sentinel(ICollection<string> masters) : base(RedisLiterals.sentinel)
             {
+                MonitoredMasters = masters;
             }
+        }
+
+        /// <summary>
+        /// An unexpected result of the ROLE command.
+        /// </summary>
+        public sealed class Unknown : Role
+        {
+            internal Unknown(string role) : base(role) { }
         }
     }
 }

--- a/src/StackExchange.Redis/Role.cs
+++ b/src/StackExchange.Redis/Role.cs
@@ -10,18 +10,26 @@ namespace StackExchange.Redis
     /// Result of the ROLE command. Values depend on the role: master, replica, or sentinel.
     /// </summary>
     /// <remarks>https://redis.io/commands/role</remarks>
-    public abstract class ServerRole
+    public abstract class Role
     {
+        /// <summary>
+        /// One of "master", "slave" (aka replica), or "sentinel".
+        /// </summary>
+        public string Value { get; }
+
+        private Role(string role) => Value = role;
+
         /// <summary>
         /// Result of the ROLE command for a master node.
         /// </summary>
         /// <remarks>https://redis.io/commands/role#master-output</remarks>
-        public sealed class Master : ServerRole
+        public sealed class Master : Role
         {
             /// <summary>
             /// The replication offset. To be consumed by replica nodes.
             /// </summary>
-            public long ReplicationOffset { get; }
+            [CLSCompliant(false)]
+            public ulong ReplicationOffset { get; }
 
             /// <summary>
             /// Connected replica nodes.
@@ -41,12 +49,26 @@ namespace StackExchange.Redis
                 /// <summary>
                 /// The port number of this replica node.
                 /// </summary>
-                public int Port { get; }
+                public string Port { get; }
 
                 /// <summary>
                 /// The last replication offset acked by this replica node.
                 /// </summary>
-                public long ReplicationOffset { get; }
+                [CLSCompliant(false)]
+                public ulong ReplicationOffset { get; }
+
+                internal Replica(string ip, string port, ulong replicationOffset)
+                {
+                    Ip = ip;
+                    Port = port;
+                    ReplicationOffset = replicationOffset;
+                }
+            }
+
+            internal Master(ulong replicationOffset, ICollection<Replica> replicas) : base(RedisLiterals.master)
+            {
+                ReplicationOffset = replicationOffset;
+                Replicas = replicas;
             }
         }
 
@@ -54,7 +76,7 @@ namespace StackExchange.Redis
         /// Result of the ROLE command for a replica node.
         /// </summary>
         /// <remarks>https://redis.io/commands/role#output-of-the-command-on-replicas</remarks>
-        public sealed class Replica : ServerRole
+        public sealed class Replica : Role
         {
             /// <summary>
             /// The IP address of the master node for this replica.
@@ -64,17 +86,18 @@ namespace StackExchange.Redis
             /// <summary>
             /// The port number of the master node for this replica.
             /// </summary>
-            public int MasterPort { get; }
+            public string MasterPort { get; }
 
             /// <summary>
-            /// This replica's replication state as known by the master node.
+            /// This replica's replication state.
             /// </summary>
             public ReplicationState State { get; }
 
             /// <summary>
-            /// Data received from the master node relative to the master's replication offset.
+            /// The last replication offset received by this replica.
             /// </summary>
-            public long Received { get; }
+            [CLSCompliant(false)]
+            public ulong ReceivedReplicationOffset { get; }
 
             /// <summary>
             /// The state of a replica node.
@@ -101,20 +124,26 @@ namespace StackExchange.Redis
                 /// </summary>
                 Connected,
             }
+
+            internal Replica() : base(RedisLiterals.slave)
+            {
+            }
         }
 
         /// <summary>
         /// Result of the ROLE command for a sentinel node.
         /// </summary>
         /// <remarks>https://redis.io/commands/role#sentinel-output</remarks>
-        public sealed class Sentinel : ServerRole
+        public sealed class Sentinel : Role
         {
             /// <summary>
             /// Master names monitored by this sentinel node.
             /// </summary>
             public ICollection<string> MonitoredMasters { get; }
-        }
 
-        private ServerRole() { } // prevent other derived types
+            internal Sentinel() : base(RedisLiterals.sentinel)
+            {
+            }
+        }
     }
 }

--- a/src/StackExchange.Redis/ServerRole.cs
+++ b/src/StackExchange.Redis/ServerRole.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis
+{
+    /// <summary>
+    /// Result of the ROLE command. Values depend on the role: master, replica, or sentinel.
+    /// </summary>
+    /// <remarks>https://redis.io/commands/role</remarks>
+    public abstract class ServerRole
+    {
+        /// <summary>
+        /// Result of the ROLE command for a master node.
+        /// </summary>
+        /// <remarks>https://redis.io/commands/role#master-output</remarks>
+        public sealed class Master : ServerRole
+        {
+            /// <summary>
+            /// The replication offset. To be consumed by replica nodes.
+            /// </summary>
+            public long ReplicationOffset { get; }
+
+            /// <summary>
+            /// Connected replica nodes.
+            /// </summary>
+            public ICollection<Replica> Replicas { get; }
+
+            /// <summary>
+            /// A connected replica node.
+            /// </summary>
+            public new readonly struct Replica
+            {
+                /// <summary>
+                /// The IP address of this replica node.
+                /// </summary>
+                public string Ip { get; }
+
+                /// <summary>
+                /// The port number of this replica node.
+                /// </summary>
+                public int Port { get; }
+
+                /// <summary>
+                /// The last replication offset acked by this replica node.
+                /// </summary>
+                public long ReplicationOffset { get; }
+            }
+        }
+
+        /// <summary>
+        /// Result of the ROLE command for a replica node.
+        /// </summary>
+        /// <remarks>https://redis.io/commands/role#output-of-the-command-on-replicas</remarks>
+        public sealed class Replica : ServerRole
+        {
+            /// <summary>
+            /// The IP address of the master node for this replica.
+            /// </summary>
+            public string MasterIp { get; }
+
+            /// <summary>
+            /// The port number of the master node for this replica.
+            /// </summary>
+            public int MasterPort { get; }
+
+            /// <summary>
+            /// This replica's replication state as known by the master node.
+            /// </summary>
+            public ReplicationState State { get; }
+
+            /// <summary>
+            /// Data received from the master node relative to the master's replication offset.
+            /// </summary>
+            public long Received { get; }
+
+            /// <summary>
+            /// The state of a replica node.
+            /// </summary>
+            public enum ReplicationState
+            {
+                /// <summary>
+                /// Not connected to the master node.
+                /// </summary>
+                NotConnected,
+
+                /// <summary>
+                /// Attempting to connect to the master node.
+                /// </summary>
+                Connecting,
+
+                /// <summary>
+                /// Connected to the master node and syncing commands to catch up.
+                /// </summary>
+                Syncing,
+
+                /// <summary>
+                /// Connected to the master node and up-to-date.
+                /// </summary>
+                Connected,
+            }
+        }
+
+        /// <summary>
+        /// Result of the ROLE command for a sentinel node.
+        /// </summary>
+        /// <remarks>https://redis.io/commands/role#sentinel-output</remarks>
+        public sealed class Sentinel : ServerRole
+        {
+            /// <summary>
+            /// Master names monitored by this sentinel node.
+            /// </summary>
+            public ICollection<string> MonitoredMasters { get; }
+        }
+
+        private ServerRole() { } // prevent other derived types
+    }
+}

--- a/tests/StackExchange.Redis.Tests/Roles.cs
+++ b/tests/StackExchange.Redis.Tests/Roles.cs
@@ -8,22 +8,50 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests
 {
+    [Collection(SharedConnectionFixture.Key)]
     public class Roles : TestBase
     {
-        public Roles(ITestOutputHelper output) : base(output) { }
+        public Roles(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
 
         [Fact]
         public void MasterRole()
         {
-            var connectionString = $"{TestConfig.Current.MasterServer}:{TestConfig.Current.MasterPort},allowAdmin=true";
-            var conn = ConnectionMultiplexer.Connect(connectionString);
-            var server = conn.GetServer(TestConfig.Current.MasterServerAndPort);
+            using var muxer = Create(allowAdmin: true);
+            var server = muxer.GetServer(TestConfig.Current.MasterServerAndPort);
 
             var role = server.Role();
             Assert.NotNull(role);
             Assert.Equal(role.Value, RedisLiterals.master);
-            var masterRole = role as Role.Master;
-            Assert.NotNull(masterRole);
+            var master = role as Role.Master;
+            Assert.NotNull(master);
+            Assert.NotNull(master.Replicas);
+            Assert.Contains(master.Replicas, r =>
+                r.Ip == TestConfig.Current.ReplicaServer &&
+                r.Port == TestConfig.Current.ReplicaPort);
+        }
+
+        [Fact]
+        public void ReplicaRole()
+        {
+            var connString = $"{TestConfig.Current.ReplicaServerAndPort},allowAdmin=true";
+            using var muxer = ConnectionMultiplexer.Connect(connString);
+            var server = muxer.GetServer(TestConfig.Current.ReplicaServerAndPort);
+
+            var role = server.Role();
+            Assert.NotNull(role);
+            var replica = role as Role.Replica;
+            Assert.NotNull(replica);
+            Assert.Equal(replica.MasterIp, TestConfig.Current.MasterServer);
+            Assert.Equal(replica.MasterPort, TestConfig.Current.MasterPort);
+        }
+
+        [Fact]
+        public void RoleRequiresAdmin()
+        {
+            using var muxer = Create(allowAdmin: false);
+            var server = muxer.GetServer(TestConfig.Current.MasterServerAndPort);
+
+            Assert.Throws<RedisCommandException>(() => server.Role());
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/Roles.cs
+++ b/tests/StackExchange.Redis.Tests/Roles.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests
+{
+    public class Roles : TestBase
+    {
+        public Roles(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void MasterRole()
+        {
+            var connectionString = $"{TestConfig.Current.MasterServer}:{TestConfig.Current.MasterPort},allowAdmin=true";
+            var conn = ConnectionMultiplexer.Connect(connectionString);
+            var server = conn.GetServer(TestConfig.Current.MasterServerAndPort);
+
+            var role = server.Role();
+            Assert.NotNull(role);
+            Assert.Equal(role.Value, RedisLiterals.master);
+            var masterRole = role as Role.Master;
+            Assert.NotNull(masterRole);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/Sentinel.cs
+++ b/tests/StackExchange.Redis.Tests/Sentinel.cs
@@ -220,6 +220,18 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public void SentinelRole()
+        {
+            foreach (var server in SentinelsServers)
+            {
+                var role = server.Role();
+                Assert.Equal(role.Value, RedisLiterals.sentinel);
+                var sentinel = role as Role.Sentinel;
+                Assert.NotNull(sentinel);
+            }
+        }
+
+        [Fact]
         public void PingTest()
         {
             var test = SentinelServerA.Ping();

--- a/tests/StackExchange.Redis.Tests/Sentinel.cs
+++ b/tests/StackExchange.Redis.Tests/Sentinel.cs
@@ -600,7 +600,7 @@ namespace StackExchange.Redis.Tests
             {
                 try
                 {
-                    if (server.Role() == role)
+                    if (server.Role().Value == role)
                     {
                         Log($"Done waiting for server ({server.EndPoint}) role to be \"{role}\"");
                         return;


### PR DESCRIPTION
This PR implements the ROLE command (#1451): https://redis.io/commands/role#sentinel-output . Redis implementation: https://github.com/redis/redis/blob/unstable/src/replication.c#L2672

Because the result format is pretty different for each instance type, we return a base Role type that the caller has to type check to get to the values specific to the instance type.

I've tested the master and replica cases locally. I haven't tested sentinel, but that one is the most straightforward.