### PR TITLE
Tests: cleanup & perf pass

### DIFF
--- a/tests/BasicTest/Program.cs
+++ b/tests/BasicTest/Program.cs
@@ -8,7 +8,6 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.InProcess;
 using BenchmarkDotNet.Validators;
 using StackExchange.Redis;
 
@@ -42,7 +41,6 @@ namespace BasicTest
             => j.WithLaunchCount(1)
                 .WithWarmupCount(1)
                 .WithIterationCount(5);
-        public SlowConfig() { }
     }
     /// <summary>
     /// The tests

--- a/tests/NRediSearch.Test/ClientTests/AggregationBuilderTests.cs
+++ b/tests/NRediSearch.Test/ClientTests/AggregationBuilderTests.cs
@@ -17,7 +17,7 @@ namespace NRediSearch.Test.ClientTests
         [Fact]
         public void TestAggregations()
         {
-            /**
+            /*
                  127.0.0.1:6379> FT.CREATE test_index SCHEMA name TEXT SORTABLE count NUMERIC SORTABLE
                  OK
                  127.0.0.1:6379> FT.ADD test_index data1 1.0 FIELDS name abc count 10
@@ -63,7 +63,7 @@ namespace NRediSearch.Test.ClientTests
         [Fact]
         public void TestApplyAndFilterAggregations()
         {
-            /**
+            /*
                  127.0.0.1:6379> FT.CREATE test_index SCHEMA name TEXT SORTABLE subj1 NUMERIC SORTABLE subj2 NUMERIC SORTABLE
                  OK
                  127.0.0.1:6379> FT.ADD test_index data1 1.0 FIELDS name abc subj1 20 subj2 70
@@ -115,7 +115,7 @@ namespace NRediSearch.Test.ClientTests
         [Fact]
         public void TestCursor()
         {
-            /**
+            /*
                  127.0.0.1:6379> FT.CREATE test_index SCHEMA name TEXT SORTABLE count NUMERIC SORTABLE
                  OK
                  127.0.0.1:6379> FT.ADD test_index data1 1.0 FIELDS name abc count 10

--- a/tests/NRediSearch.Test/ClientTests/AggregationTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/AggregationTest.cs
@@ -15,7 +15,7 @@ namespace NRediSearch.Test.ClientTests
         [Obsolete]
         public void TestAggregations()
         {
-            /**
+            /*
              127.0.0.1:6379> FT.CREATE test_index SCHEMA name TEXT SORTABLE count NUMERIC SORTABLE
              OK
              127.0.0.1:6379> FT.ADD test_index data1 1.0 FIELDS name abc count 10

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -230,7 +230,7 @@ namespace NRediSearch.Test.ClientTests
             {
                 Assert.StartsWith("doc", d.Id);
                 Assert.True(d.Score != 1.0);
-                Assert.StartsWith("hello world", (string)d["title"]);
+                Assert.StartsWith("hello world", d["title"]);
             }
 
             q = new Query("hello").SetNoContent();
@@ -616,8 +616,8 @@ namespace NRediSearch.Test.ClientTests
             Suggestion suggestion = Suggestion.Builder.String("ANOTHER_WORD").Score(1).Build();
             Suggestion noMatch = Suggestion.Builder.String("_WORD MISSED").Score(1).Build();
 
-            Assert.True(cl.AddSuggestion(suggestion, false) > 0, $"{suggestion.ToString()} should of inserted at least 1");
-            Assert.True(cl.AddSuggestion(noMatch, false) > 0, $"{noMatch.ToString()} should of inserted at least 1");
+            Assert.True(cl.AddSuggestion(suggestion, false) > 0, $"{suggestion} should of inserted at least 1");
+            Assert.True(cl.AddSuggestion(noMatch, false) > 0, $"{noMatch} should of inserted at least 1");
 
             // test that with a partial part of that string will have the entire word returned SuggestionOptions.builder().build()
             Assert.Single(cl.GetSuggestions(suggestion.String.Substring(0, 3), SuggestionOptions.Builder.Fuzzy().Build()));
@@ -634,7 +634,7 @@ namespace NRediSearch.Test.ClientTests
             Client cl = GetClient();
 
             Suggestion suggestion = Suggestion.Builder.String("COUNT_ME TOO").Payload("PAYLOADS ROCK ").Score(0.2).Build();
-            Assert.True(cl.AddSuggestion(suggestion, false) > 0, $"{suggestion.ToString()} insert should of at least returned 1");
+            Assert.True(cl.AddSuggestion(suggestion, false) > 0, $"{suggestion} insert should of at least returned 1");
             Assert.True(cl.AddSuggestion(suggestion.ToBuilder().String("COUNT").Payload("My PAYLOAD is better").Build(), false) > 1, "Count single added should return more than 1");
             Assert.True(cl.AddSuggestion(suggestion.ToBuilder().String("COUNT_ANOTHER").Score(1).Payload(null).Build(), false) > 1, "Count single added should return more than 1");
 

--- a/tests/NRediSearch.Test/ExampleUsage.cs
+++ b/tests/NRediSearch.Test/ExampleUsage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using StackExchange.Redis;
 using Xunit;
@@ -17,7 +16,7 @@ namespace NRediSearch.Test
         {
             var client = GetClient();
 
-            try { client.DropIndex(); } catch { } // reset DB
+            try { client.DropIndex(); } catch { /* Intentionally ignored */ } // reset DB
 
             // Defining a schema for an index and creating it:
             var sc = new Schema()
@@ -35,8 +34,8 @@ namespace NRediSearch.Test
                 // TODO: Convert to Skip
                 if (ex.Message == "ERR unknown command 'FT.CREATE'")
                 {
-                    Console.WriteLine(ex.Message);
-                    Console.WriteLine("Module not installed, aborting");
+                    Output.WriteLine(ex.Message);
+                    Output.WriteLine("Module not installed, aborting");
                 }
                 throw;
             }
@@ -73,8 +72,8 @@ namespace NRediSearch.Test
             Assert.True(item.HasProperty("price"));
             Assert.False(item.HasProperty("blap"));
 
-            Assert.Equal("hello world", (string)item["title"]);
-            Assert.Equal("lorem ipsum", (string)item["body"]);
+            Assert.Equal("hello world", item["title"]);
+            Assert.Equal("lorem ipsum", item["body"]);
             Assert.Equal(1337, (int)item["price"]);
         }
 
@@ -83,13 +82,13 @@ namespace NRediSearch.Test
         {
             var client = GetClient();
 
-            try { client.DropIndex(); } catch { } // reset DB
+            try { client.DropIndex(); } catch { /* Intentionally ignored */ } // reset DB
 
             CreateSchema(client);
 
             var term = "petit*";
 
-            var query = new NRediSearch.Query(term);
+            var query = new Query(term);
             query.Limit(0, 10);
             query.WithScores = true;
 
@@ -108,13 +107,13 @@ namespace NRediSearch.Test
         {
             var client = GetClient();
 
-            try { client.DropIndex(); } catch { } // reset DB
+            try { client.DropIndex(); } catch { /* Intentionally ignored */ } // reset DB
 
             CreateSchema(client);
 
             var term = "petit*";
 
-            var query = new NRediSearch.Query(term);
+            var query = new Query(term);
             query.Limit(0, 10);
             query.WithScores = true;
             query.Scoring = "TFIDF";
@@ -138,13 +137,13 @@ namespace NRediSearch.Test
         {
             var client = GetClient();
 
-            try { client.DropIndex(); } catch { } // reset DB
+            try { client.DropIndex(); } catch { /* Intentionally ignored */ } // reset DB
 
             CreateSchema(client);
 
             var term = "petit*";
 
-            var query = new NRediSearch.Query(term);
+            var query = new Query(term);
             query.Limit(0, 10);
             query.WithScores = true;
             query.Scoring = "TFIDF.DOCNORM";
@@ -165,7 +164,7 @@ namespace NRediSearch.Test
 
         private void CreateSchema(Client client)
         {
-            var schema = new NRediSearch.Schema();
+            var schema = new Schema();
 
             schema
                 .AddSortableTextField("title")
@@ -176,7 +175,7 @@ namespace NRediSearch.Test
 
             client.CreateIndex(schema, new ConfiguredIndexOptions());
 
-            var doc = new NRediSearch.Document("1");
+            var doc = new Document("1");
 
             doc
                 .Set("title", "Le Petit Prince")

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using StackExchange.Redis;
 using StackExchange.Redis.Tests;
@@ -75,7 +74,7 @@ namespace NRediSearch.Test
             }
         }
 
-        private static bool instanceMissing = false;
+        private static bool instanceMissing;
 
         internal static ConnectionMultiplexer GetWithFT(ITestOutputHelper output)
         {

--- a/tests/StackExchange.Redis.Tests/AggresssiveTests.cs
+++ b/tests/StackExchange.Redis.Tests/AggresssiveTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,7 +30,6 @@ namespace StackExchange.Redis.Tests
                 for (int i = 0; i < tasks.Length; i++)
                 {
                     var scopedDb = muxers[i % Muxers].GetDatabase();
-                    var rand = new Random(i);
                     tasks[i] = Task.Run(async () =>
                     {
                         for (int j = 0; j < PerThread; j++)
@@ -67,7 +65,8 @@ namespace StackExchange.Redis.Tests
             {
                 for (int i = 0; i < muxers.Length; i++)
                 {
-                    try { muxers[i]?.Dispose(); } catch { }
+                    try { muxers[i]?.Dispose(); }
+                    catch { /* Don't care */ }
                 }
             }
         }

--- a/tests/StackExchange.Redis.Tests/AsyncTests.cs
+++ b/tests/StackExchange.Redis.Tests/AsyncTests.cs
@@ -66,7 +66,7 @@ namespace StackExchange.Redis.Tests
                 var ms = Stopwatch.StartNew();
                 var ex = await Assert.ThrowsAsync<RedisTimeoutException>(async () =>
                 {
-                    var actual = await db.StringGetAsync(key).ForAwait(); // but *subsequent* operations are paused
+                    await db.StringGetAsync(key).ForAwait(); // but *subsequent* operations are paused
                     ms.Stop();
                     Writer.WriteLine($"Unexpectedly succeeded after {ms.ElapsedMilliseconds}ms");
                 }).ForAwait();

--- a/tests/StackExchange.Redis.Tests/BasicOps.cs
+++ b/tests/StackExchange.Redis.Tests/BasicOps.cs
@@ -191,7 +191,7 @@ namespace StackExchange.Redis.Tests
                 Assert.Null((string)g1);
                 Assert.True(g1.IsNull);
 
-                Assert.Equal("123", (string)g2);
+                Assert.Equal("123", g2);
                 Assert.Equal(123, (int)g2);
                 Assert.False(g2.IsNull);
                 Assert.True(d2);
@@ -222,10 +222,10 @@ namespace StackExchange.Redis.Tests
 
                 if (exists)
                 {
-                    Assert.Equal("val", (string)asyncResult.Value);
+                    Assert.Equal("val", asyncResult.Value);
                     Assert.Equal(hasExpiry, asyncResult.Expiry.HasValue);
                     if (hasExpiry) Assert.True(asyncResult.Expiry.Value.TotalMinutes >= 4.9 && asyncResult.Expiry.Value.TotalMinutes <= 5);
-                    Assert.Equal("val", (string)syncResult.Value);
+                    Assert.Equal("val", syncResult.Value);
                     Assert.Equal(hasExpiry, syncResult.Expiry.HasValue);
                     if (hasExpiry) Assert.True(syncResult.Expiry.Value.TotalMinutes >= 4.9 && syncResult.Expiry.Value.TotalMinutes <= 5);
                 }
@@ -246,14 +246,14 @@ namespace StackExchange.Redis.Tests
             {
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
-                var del = db.KeyDeleteAsync(key);
-                var add = db.SetAddAsync(key, "abc");
+                _ = db.KeyDeleteAsync(key);
+                _ = db.SetAddAsync(key, "abc");
                 var ex = await Assert.ThrowsAsync<RedisServerException>(async () =>
                 {
                     try
                     {
                         Log("Key: " + (string)key);
-                        var async = await db.StringGetWithExpiryAsync(key).ForAwait();
+                        await db.StringGetWithExpiryAsync(key).ForAwait();
                     }
                     catch (AggregateException e)
                     {
@@ -289,7 +289,7 @@ namespace StackExchange.Redis.Tests
             using (var muxer = Create(allowAdmin: true))
             {
                 var db = muxer.GetDatabase();
-                string key = Guid.NewGuid().ToString();
+                string key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
                 db.StringSet(key, key, flags: CommandFlags.FireAndForget);
                 var server = GetServer(muxer);
@@ -435,7 +435,7 @@ namespace StackExchange.Redis.Tests
             {
                 var db = muxer.GetDatabase();
                 var key = Me();
-                var ss = db.StringSetAsync(key, "Heyyyyy");
+                _ = db.StringSetAsync(key, "Heyyyyy");
                 var ke1 = db.KeyExistsAsync(key).ForAwait();
                 var ku1 = db.KeyDelete(key);
                 var ke2 = db.KeyExistsAsync(key).ForAwait();
@@ -452,7 +452,7 @@ namespace StackExchange.Redis.Tests
             {
                 var db = muxer.GetDatabase();
                 var key = Me();
-                var ss = db.StringSetAsync(key, "Heyyyyy");
+                _ = db.StringSetAsync(key, "Heyyyyy");
                 var ke1 = db.KeyExistsAsync(key).ForAwait();
                 var ku1 = db.KeyDeleteAsync(key).ForAwait();
                 var ke2 = db.KeyExistsAsync(key).ForAwait();
@@ -471,8 +471,8 @@ namespace StackExchange.Redis.Tests
                 var key1 = Me();
                 var key2 = Me() + "2";
                 var key3 = Me() + "3";
-                var ss = db.StringSetAsync(key1, "Heyyyyy");
-                var ss2 = db.StringSetAsync(key2, "Heyyyyy");
+                _ = db.StringSetAsync(key1, "Heyyyyy");
+                _ = db.StringSetAsync(key2, "Heyyyyy");
                 // key 3 not set
                 var ku1 = db.KeyDelete(new RedisKey[] { key1, key2, key3 });
                 var ke1 = db.KeyExistsAsync(key1).ForAwait();
@@ -492,8 +492,8 @@ namespace StackExchange.Redis.Tests
                 var key1 = Me();
                 var key2 = Me() + "2";
                 var key3 = Me() + "3";
-                var ss = db.StringSetAsync(key1, "Heyyyyy");
-                var ss2 = db.StringSetAsync(key2, "Heyyyyy");
+                _ = db.StringSetAsync(key1, "Heyyyyy");
+                _ = db.StringSetAsync(key2, "Heyyyyy");
                 // key 3 not set
                 var ku1 = db.KeyDeleteAsync(new RedisKey[] { key1, key2, key3 }).ForAwait();
                 var ke1 = db.KeyExistsAsync(key1).ForAwait();

--- a/tests/StackExchange.Redis.Tests/BatchWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/BatchWrapperTests.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using StackExchange.Redis.KeyspaceIsolation;
 using System.Text;
-using Xunit;
 
 namespace StackExchange.Redis.Tests
 {

--- a/tests/StackExchange.Redis.Tests/Batches.cs
+++ b/tests/StackExchange.Redis.Tests/Batches.cs
@@ -20,13 +20,12 @@ namespace StackExchange.Redis.Tests
                 var key = Me();
                 conn.KeyDeleteAsync(key);
                 conn.StringSetAsync(key, "batch-not-sent");
-                var tasks = new List<Task>();
                 var batch = conn.CreateBatch();
 
-                tasks.Add(batch.KeyDeleteAsync(key));
-                tasks.Add(batch.SetAddAsync(key, "a"));
-                tasks.Add(batch.SetAddAsync(key, "b"));
-                tasks.Add(batch.SetAddAsync(key, "c"));
+                batch.KeyDeleteAsync(key);
+                batch.SetAddAsync(key, "a");
+                batch.SetAddAsync(key, "b");
+                batch.SetAddAsync(key, "c");
 
                 Assert.Equal("batch-not-sent", conn.StringGet(key));
             }

--- a/tests/StackExchange.Redis.Tests/BoxUnbox.cs
+++ b/tests/StackExchange.Redis.Tests/BoxUnbox.cs
@@ -50,9 +50,9 @@ namespace StackExchange.Redis.Tests
             Assert.Equal(expected, actual);
         }
 
-        static readonly byte[] s_abc = Encoding.UTF8.GetBytes("abc");
+        private static readonly byte[] s_abc = Encoding.UTF8.GetBytes("abc");
         public static IEnumerable<object[]> RoundTripValues
-            => new object[][]
+            => new []
             {
                 new object[] { RedisValue.Null },
                 new object[] { RedisValue.EmptyString },
@@ -94,7 +94,7 @@ namespace StackExchange.Redis.Tests
             };
 
         public static IEnumerable<object[]> UnboxValues
-            => new object[][]
+            => new []
             {
                 new object[] { null, RedisValue.Null },
                 new object[] { "", RedisValue.EmptyString },

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
@@ -6,7 +7,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Threading.Tasks;
-using Pipelines.Sockets.Unofficial;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,14 +20,14 @@ namespace StackExchange.Redis.Tests
         public void SslProtocols_SingleValue()
         {
             var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11");
-            Assert.Equal(SslProtocols.Tls11, options.SslProtocols.Value);
+            Assert.Equal(SslProtocols.Tls11, options.SslProtocols.GetValueOrDefault());
         }
 
         [Fact]
         public void SslProtocols_MultipleValues()
         {
             var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11|Tls12");
-            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.Value);
+            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace StackExchange.Redis.Tests
             // but the OS has been patched with support
             const int integerValue = (int)(SslProtocols.Tls11 | SslProtocols.Tls12);
             var options = ConfigurationOptions.Parse("myhost,sslProtocols=" + integerValue);
-            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.Value);
+            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
         }
 
         [Fact]
@@ -261,7 +261,7 @@ namespace StackExchange.Redis.Tests
             {
                 var server = GetAnyMaster(muxer);
                 var serverTime = server.Time();
-                Log(serverTime.ToString());
+                Log(serverTime.ToString(CultureInfo.InvariantCulture));
                 var delta = Math.Abs((DateTime.UtcNow - serverTime).TotalSeconds);
 
                 Assert.True(delta < 5);
@@ -345,7 +345,7 @@ namespace StackExchange.Redis.Tests
             using (var muxer = Create(allowAdmin: true))
             {
                 var server = GetAnyMaster(muxer);
-                var slowlog = server.SlowlogGet();
+                server.SlowlogGet();
                 server.SlowlogReset();
             }
         }
@@ -358,7 +358,7 @@ namespace StackExchange.Redis.Tests
             {
                 try
                 {
-                    var conn = configMuxer.GetDatabase();
+                    configMuxer.GetDatabase();
                     var srv = GetAnyMaster(configMuxer);
                     oldTimeout = srv.ConfigGet("timeout")[0].Value;
                     srv.ConfigSet("timeout", 5);

--- a/tests/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -25,7 +24,7 @@ namespace StackExchange.Redis.Tests
                     ConnectTimeout = timeout
                 };
 
-                using (var muxer = ConnectionMultiplexer.Connect(config, Writer))
+                using (ConnectionMultiplexer.Connect(config, Writer))
                 {
                     await Task.Delay(10000).ForAwait();
                 }
@@ -46,7 +45,7 @@ namespace StackExchange.Redis.Tests
         {
             var ex = Assert.Throws<RedisConnectionException>(() =>
             {
-                using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,connectTimeout=1000", Writer)) { }
+                using (ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,connectTimeout=1000", Writer)) { }
             });
             Log(ex.ToString());
         }
@@ -56,7 +55,7 @@ namespace StackExchange.Redis.Tests
         {
             var ex = await Assert.ThrowsAsync<RedisConnectionException>(async () =>
             {
-                using (var conn = await ConnectionMultiplexer.ConnectAsync($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,connectTimeout=1000", Writer).ForAwait()) { }
+                using (await ConnectionMultiplexer.ConnectAsync($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,connectTimeout=1000", Writer).ForAwait()) { }
             }).ForAwait();
             Log(ex.ToString());
         }

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -110,7 +110,7 @@ namespace StackExchange.Redis.Tests
                 muxer.ConnectionFailed += delegate { Interlocked.Increment(ref failCount); };
                 muxer.ConnectionRestored += delegate { Interlocked.Increment(ref restoreCount); };
 
-                var db = muxer.GetDatabase();
+                muxer.GetDatabase();
                 Assert.Equal(0, Volatile.Read(ref failCount));
                 Assert.Equal(0, Volatile.Read(ref restoreCount));
 

--- a/tests/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Security.Authentication;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -29,7 +28,7 @@ namespace StackExchange.Redis.Tests
 
             using (var connection = ConnectionMultiplexer.Connect(options))
             {
-                connection.ConnectionFailed += (object sender, ConnectionFailedEventArgs e) =>
+                connection.ConnectionFailed += (sender, e) =>
                     Assert.Equal(ConnectionFailureType.AuthenticationFailure, e.FailureType);
                 if (!isCertValidationSucceeded)
                 {
@@ -68,7 +67,7 @@ namespace StackExchange.Redis.Tests
             options.CertificateValidation += SSL.ShowCertFailures(Writer);
             using (var muxer = ConnectionMultiplexer.Connect(options))
             {
-                muxer.ConnectionFailed += (object sender, ConnectionFailedEventArgs e) =>
+                muxer.ConnectionFailed += (sender, e) =>
                 {
                     if (e.FailureType == ConnectionFailureType.SocketFailure) Skip.Inconclusive("socket fail"); // this is OK too
                     Assert.Equal(ConnectionFailureType.AuthenticationFailure, e.FailureType);
@@ -160,7 +159,7 @@ namespace StackExchange.Redis.Tests
             {
                 using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
                 {
-                    var conn = muxer.GetDatabase();
+                    muxer.GetDatabase();
                     var server = muxer.GetServer(muxer.GetEndPoints()[0]);
 
                     muxer.AllowConnect = false;

--- a/tests/StackExchange.Redis.Tests/ConnectionShutdown.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionShutdown.cs
@@ -20,12 +20,12 @@ namespace StackExchange.Redis.Tests
                 Stopwatch watch = Stopwatch.StartNew();
                 conn.ConnectionFailed += (sender, args) =>
                 {
-                    Log(watch.Elapsed + ": failed: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args.ToString());
+                    Log(watch.Elapsed + ": failed: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args);
                     Interlocked.Increment(ref failed);
                 };
                 conn.ConnectionRestored += (sender, args) =>
                 {
-                    Log(watch.Elapsed + ": restored: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args.ToString());
+                    Log(watch.Elapsed + ": restored: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args);
                     Interlocked.Increment(ref restored);
                 };
                 var db = conn.GetDatabase();

--- a/tests/StackExchange.Redis.Tests/Constraints.cs
+++ b/tests/StackExchange.Redis.Tests/Constraints.cs
@@ -41,7 +41,7 @@ namespace StackExchange.Redis.Tests
             var tran = connection.CreateTransaction();
             { // check hasn't changed
                 tran.AddCondition(Condition.StringEqual(key, oldVal));
-                var t = tran.StringSetAsync(key, newVal);
+                _ = tran.StringSetAsync(key, newVal);
                 if (!await tran.ExecuteAsync().ForAwait()) return null; // aborted
                 return newVal;
             }

--- a/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -918,7 +918,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void StreamMessagesDelete()
         {
-            var messageIds = new RedisValue[0] { };
+            var messageIds = new RedisValue[] { };
             wrapper.StreamDelete("key", messageIds, CommandFlags.None);
             mock.Verify(_ => _.StreamDelete("prefix:key", messageIds, CommandFlags.None));
         }
@@ -961,7 +961,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void StreamRead_1()
         {
-            var streamPositions = new StreamPosition[0] { };
+            var streamPositions = new StreamPosition[] { };
             wrapper.StreamRead(streamPositions, null, CommandFlags.None);
             mock.Verify(_ => _.StreamRead(streamPositions, null, CommandFlags.None));
         }
@@ -983,7 +983,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void StreamStreamReadGroup_2()
         {
-            var streamPositions = new StreamPosition[0] { };
+            var streamPositions = new StreamPosition[] { };
             wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
             mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None));
         }

--- a/tests/StackExchange.Redis.Tests/Databases.cs
+++ b/tests/StackExchange.Redis.Tests/Databases.cs
@@ -148,7 +148,7 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal("b", await b); // db:1
 
                 var server = GetServer(muxer);
-                var swap = server.SwapDatabasesAsync(db0id, db1id).ForAwait();
+                _ = server.SwapDatabasesAsync(db0id, db1id).ForAwait();
 
                 var aNew = db1.StringGetAsync(key);
                 var bNew = db0.StringGetAsync(key);

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -13,7 +13,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
             {
-                var conn = muxer.GetDatabase();
+                muxer.GetDatabase();
                 Assert.Null(muxer.GetServerSnapshot()[0].LastException);
                 var ex = ExceptionFactory.NoConnectionAvailable(muxer as ConnectionMultiplexer, null, null);
                 Assert.Null(ex.InnerException);
@@ -35,7 +35,7 @@ namespace StackExchange.Redis.Tests
             {
                 using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false))
                 {
-                    var conn = muxer.GetDatabase();
+                    muxer.GetDatabase();
                     muxer.AllowConnect = false;
 
                     foreach (var endpoint in muxer.GetEndPoints())
@@ -65,7 +65,7 @@ namespace StackExchange.Redis.Tests
             {
                 using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false))
                 {
-                    var conn = muxer.GetDatabase();
+                    muxer.GetDatabase();
                     muxer.AllowConnect = false;
 
                     muxer.GetServer(muxer.GetEndPoints()[0]).SimulateConnectionFailure();
@@ -89,7 +89,7 @@ namespace StackExchange.Redis.Tests
             {
                 using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
                 {
-                    var conn = muxer.GetDatabase();
+                    muxer.GetDatabase();
                     muxer.AllowConnect = false;
                     var ex = ExceptionFactory.NoConnectionAvailable(muxer as ConnectionMultiplexer, null, null);
                     Assert.IsType<RedisConnectionException>(ex);
@@ -122,7 +122,7 @@ namespace StackExchange.Redis.Tests
                     // Ensure our pipe numbers are in place
                     Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
                     Assert.Contains("mc: 1/1/0", ex.Message);
-                    Assert.Contains("serverEndpoint: " + server.EndPoint.ToString(), ex.Message);
+                    Assert.Contains("serverEndpoint: " + server.EndPoint, ex.Message);
                     Assert.DoesNotContain("Unspecified/", ex.Message);
                     Assert.EndsWith(" (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)", ex.Message);
                     Assert.Null(ex.InnerException);

--- a/tests/StackExchange.Redis.Tests/Failover.cs
+++ b/tests/StackExchange.Redis.Tests/Failover.cs
@@ -73,7 +73,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public async Task ConfigVerifyReceiveConfigChangeBroadcast()
         {
-            var config = GetConfiguration();
+            _ = GetConfiguration();
             using (var sender = Create(allowAdmin: true))
             using (var receiver = Create(syncTimeout: 2000))
             {
@@ -350,7 +350,7 @@ namespace StackExchange.Redis.Tests
                         a.GetServer(TestConfig.Current.FailoverMasterServerAndPort).MakeMaster(ReplicationChangeOptions.All);
                         await Task.Delay(1000).ForAwait();
                     }
-                    catch { }
+                    catch { /* Don't bomb here */ }
                 }
             }
         }

--- a/tests/StackExchange.Redis.Tests/FloatingPoint.cs
+++ b/tests/StackExchange.Redis.Tests/FloatingPoint.cs
@@ -151,12 +151,12 @@ namespace StackExchange.Redis.Tests
                 double sum = 0;
                 foreach (var value in incr)
                 {
-                    var t = db.HashIncrementAsync(key, field, value);
+                    _ = db.HashIncrementAsync(key, field, value);
                     sum += value;
                 }
                 foreach (var value in decr)
                 {
-                    var t = db.HashDecrementAsync(key, field, value);
+                    _ = db.HashDecrementAsync(key, field, value);
                     sum -= value;
                 }
                 var val = (double)await db.HashGetAsync(key, field).ForAwait();

--- a/tests/StackExchange.Redis.Tests/GeoTests.cs
+++ b/tests/StackExchange.Redis.Tests/GeoTests.cs
@@ -29,12 +29,12 @@ namespace StackExchange.Redis.Tests
 
                 // add while not there
                 Assert.True(db.GeoAdd(key, cefalù.Longitude, cefalù.Latitude, cefalù.Member));
-                Assert.Equal(2, db.GeoAdd(key, new GeoEntry[] { palermo, catania }));
+                Assert.Equal(2, db.GeoAdd(key, new [] { palermo, catania }));
                 Assert.True(db.GeoAdd(key, agrigento));
 
                 // now add again
                 Assert.False(db.GeoAdd(key, cefalù.Longitude, cefalù.Latitude, cefalù.Member));
-                Assert.Equal(0, db.GeoAdd(key, new GeoEntry[] { palermo, catania }));
+                Assert.Equal(0, db.GeoAdd(key, new [] { palermo, catania }));
                 Assert.False(db.GeoAdd(key, agrigento));
 
                 // Validate
@@ -57,7 +57,6 @@ namespace StackExchange.Redis.Tests
                 db.GeoAdd(key, all, CommandFlags.FireAndForget);
                 var val = db.GeoDistance(key, "Palermo", "Catania", GeoUnit.Meters);
                 Assert.True(val.HasValue);
-                var rounded = Math.Round(val.Value, 10);
                 Assert.Equal(166274.1516, val);
 
                 val = db.GeoDistance(key, "Palermo", "Nowhere", GeoUnit.Meters);

--- a/tests/StackExchange.Redis.Tests/Helpers/redis-sharp.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/redis-sharp.cs
@@ -625,7 +625,7 @@ namespace RedisSharp
         public string[] GetKeys(string pattern)
         {
             if (pattern == null)
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException(nameof(pattern));
             var keys = SendExpectData(null, "KEYS {0}\r\n", pattern);
             if (keys.Length == 0)
                 return new string[0];
@@ -635,7 +635,7 @@ namespace RedisSharp
         public byte[][] GetKeys(params string[] keys)
         {
             if (keys == null)
-                throw new ArgumentNullException("key1");
+                throw new ArgumentNullException(nameof(keys));
             if (keys.Length == 0)
                 throw new ArgumentException("keys");
 

--- a/tests/StackExchange.Redis.Tests/Issues/Issue25.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue25.cs
@@ -23,14 +23,14 @@ namespace StackExchange.Redis.Tests.Issues
         [Fact]
         public void UnkonwnKeywordHandling_Ignore()
         {
-            var options = ConfigurationOptions.Parse("ssl2=true", true);
+            ConfigurationOptions.Parse("ssl2=true", true);
         }
 
         [Fact]
         public void UnkonwnKeywordHandling_ExplicitFail()
         {
             var ex = Assert.Throws<ArgumentException>(() => {
-                var options = ConfigurationOptions.Parse("ssl2=true", false);
+                ConfigurationOptions.Parse("ssl2=true", false);
             });
             Assert.Equal("Keyword 'ssl2' is not supported", ex.Message);
         }
@@ -39,7 +39,7 @@ namespace StackExchange.Redis.Tests.Issues
         public void UnkonwnKeywordHandling_ImplicitFail()
         {
             var ex = Assert.Throws<ArgumentException>(() => {
-                var options = ConfigurationOptions.Parse("ssl2=true");
+                ConfigurationOptions.Parse("ssl2=true");
             });
             Assert.Equal("Keyword 'ssl2' is not supported", ex.Message);
         }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue6.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue6.cs
@@ -1,5 +1,4 @@
-﻿using Xunit;
-using Xunit.Abstractions;
+﻿using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests.Issues
 {

--- a/tests/StackExchange.Redis.Tests/Issues/SO10825542.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO10825542.cs
@@ -19,9 +19,9 @@ namespace StackExchange.Redis.Tests.Issues
 
                 var con = muxer.GetDatabase();
                 // set the field value and expiration
-                var hsa = con.HashSetAsync(key, "field1", Encoding.UTF8.GetBytes("hello world"));
-                var kea = con.KeyExpireAsync(key, TimeSpan.FromSeconds(7200));
-                var hsa2 = con.HashSetAsync(key, "field2", "fooobar");
+                _ = con.HashSetAsync(key, "field1", Encoding.UTF8.GetBytes("hello world"));
+                _ = con.KeyExpireAsync(key, TimeSpan.FromSeconds(7200));
+                _ = con.HashSetAsync(key, "field2", "fooobar");
                 var result = await con.HashGetAllAsync(key).ForAwait();
 
                 Assert.Equal(2, result.Length);

--- a/tests/StackExchange.Redis.Tests/Issues/SO24807536.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO24807536.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/StackExchange.Redis.Tests/Keys.cs
+++ b/tests/StackExchange.Redis.Tests/Keys.cs
@@ -81,31 +81,31 @@ namespace StackExchange.Redis.Tests
                 // simple
                 RedisKey key = "world";
                 var ret = key.Prepend("hello");
-                Assert.Equal("helloworld", (string)ret);
+                Assert.Equal("helloworld", ret);
             }
 
             {
                 RedisKey key1 = "world";
                 RedisKey key2 = Encoding.UTF8.GetBytes("hello");
                 var key3 = key1.Prepend(key2);
-                Assert.True(object.ReferenceEquals(key1.KeyValue, key3.KeyValue));
-                Assert.True(object.ReferenceEquals(key2.KeyValue, key3.KeyPrefix));
-                Assert.Equal("helloworld", (string)key3);
+                Assert.True(ReferenceEquals(key1.KeyValue, key3.KeyValue));
+                Assert.True(ReferenceEquals(key2.KeyValue, key3.KeyPrefix));
+                Assert.Equal("helloworld", key3);
             }
 
             {
                 RedisKey key = "hello";
                 var ret = key.Append("world");
-                Assert.Equal("helloworld", (string)ret);
+                Assert.Equal("helloworld", ret);
             }
 
             {
                 RedisKey key1 = Encoding.UTF8.GetBytes("hello");
                 RedisKey key2 = "world";
                 var key3 = key1.Append(key2);
-                Assert.True(object.ReferenceEquals(key2.KeyValue, key3.KeyValue));
-                Assert.True(object.ReferenceEquals(key1.KeyValue, key3.KeyPrefix));
-                Assert.Equal("helloworld", (string)key3);
+                Assert.True(ReferenceEquals(key2.KeyValue, key3.KeyValue));
+                Assert.True(ReferenceEquals(key1.KeyValue, key3.KeyPrefix));
+                Assert.Equal("helloworld", key3);
             }
         }
 
@@ -205,7 +205,7 @@ namespace StackExchange.Redis.Tests
             using (var muxer = Create())
             {
                 Skip.IfMissingFeature(muxer, nameof(RedisFeatures.KeyTouch), r => r.KeyTouch);
-                
+
                 RedisKey key = Me();
                 var db = muxer.GetDatabase();
                 db.KeyDelete(key, CommandFlags.FireAndForget);

--- a/tests/StackExchange.Redis.Tests/KeysAndValues.cs
+++ b/tests/StackExchange.Redis.Tests/KeysAndValues.cs
@@ -139,9 +139,10 @@ namespace StackExchange.Redis.Tests
             Assert.Equal((byte)'2', blob[1]);
             Assert.Equal((byte)'3', blob[2]);
 
-            Assert.Equal((double)123, Convert.ToDouble(o));
+            Assert.Equal(123, Convert.ToDouble(o));
 
             IConvertible c = (IConvertible)o;
+            // ReSharper disable RedundantCast
             Assert.Equal((short)123, c.ToInt16(CultureInfo.InvariantCulture));
             Assert.Equal((int)123, c.ToInt32(CultureInfo.InvariantCulture));
             Assert.Equal((long)123, c.ToInt64(CultureInfo.InvariantCulture));

--- a/tests/StackExchange.Redis.Tests/Latency.cs
+++ b/tests/StackExchange.Redis.Tests/Latency.cs
@@ -33,10 +33,10 @@ namespace StackExchange.Redis.Tests
             {
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
                 _ = server.LatencyReset();
-                var count = await server.LatencyResetAsync(new string[] { "command" });
+                var count = await server.LatencyResetAsync(new [] { "command" });
                 Assert.Equal(0, count);
 
-                count = await server.LatencyResetAsync(new string[] { "command", "fast-command" });
+                count = await server.LatencyResetAsync(new [] { "command", "fast-command" });
                 Assert.Equal(0, count);
             }
         }

--- a/tests/StackExchange.Redis.Tests/Lex.cs
+++ b/tests/StackExchange.Redis.Tests/Lex.cs
@@ -18,7 +18,7 @@ namespace StackExchange.Redis.Tests
                 db.KeyDelete(key, CommandFlags.FireAndForget);
 
                 db.SortedSetAdd(key,
-                    new SortedSetEntry[]
+                    new []
                 {
                     new SortedSetEntry("a", 0),
                     new SortedSetEntry("b", 0),
@@ -62,7 +62,7 @@ namespace StackExchange.Redis.Tests
                 db.KeyDelete(key, CommandFlags.FireAndForget);
 
                 db.SortedSetAdd(key,
-                    new SortedSetEntry[]
+                    new []
                 {
                     new SortedSetEntry("aaaa", 0),
                     new SortedSetEntry("b", 0),
@@ -71,7 +71,7 @@ namespace StackExchange.Redis.Tests
                     new SortedSetEntry("e", 0),
                 }, CommandFlags.FireAndForget);
                 db.SortedSetAdd(key,
-                    new SortedSetEntry[]
+                    new []
                 {
                     new SortedSetEntry("foo", 0),
                     new SortedSetEntry("zap", 0),
@@ -97,7 +97,7 @@ namespace StackExchange.Redis.Tests
             Assert.Equal(expected.Length, actual.Length);
             for (int i = 0; i < actual.Length; i++)
             {
-                Assert.Equal(expected[i], (string)actual[i]);
+                Assert.Equal(expected[i], actual[i]);
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/Locking.cs
+++ b/tests/StackExchange.Redis.Tests/Locking.cs
@@ -215,13 +215,13 @@ namespace StackExchange.Redis.Tests
                 var key = Me();
                 for (int i = 0; i < LOOP; i++)
                 {
-                    var d = db.KeyDeleteAsync(key);
+                    _ = db.KeyDeleteAsync(key);
                     taken = db.LockTakeAsync(key, "new-value", TimeSpan.FromSeconds(10));
                     newValue = db.StringGetAsync(key);
                     ttl = db.KeyTimeToLiveAsync(key);
                 }
                 Assert.True(await taken, "taken");
-                Assert.Equal("new-value", (string)await newValue);
+                Assert.Equal("new-value", await newValue);
                 var ttlValue = (await ttl).Value.TotalSeconds;
                 Assert.True(ttlValue >= 8 && ttlValue <= 10, "ttl");
 
@@ -243,7 +243,7 @@ namespace StackExchange.Redis.Tests
                 var ttl = db.KeyTimeToLiveAsync(key);
 
                 Assert.False(await taken, "taken");
-                Assert.Equal("old-value", (string)await newValue);
+                Assert.Equal("old-value", await newValue);
                 var ttlValue = (await ttl).Value.TotalSeconds;
                 Assert.True(ttlValue >= 18 && ttlValue <= 20, "ttl");
             }

--- a/tests/StackExchange.Redis.Tests/MassiveOps.cs
+++ b/tests/StackExchange.Redis.Tests/MassiveOps.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -24,7 +23,7 @@ namespace StackExchange.Redis.Tests
                 for (var i = 0; i < 200; i++)
                 {
                     var val = await db.StringGetAsync(key).ForAwait();
-                    Assert.Equal("test value", (string)val);
+                    Assert.Equal("test value", val);
                     await Task.Delay(50).ForAwait();
                 }
             }
@@ -37,7 +36,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                RedisKey key = "MBOA";
+                RedisKey key = Me();
                 var conn = muxer.GetDatabase();
                 await conn.PingAsync().ForAwait();
                 void nonTrivial(Task _)
@@ -69,7 +68,7 @@ namespace StackExchange.Redis.Tests
             int workPerThread = SyncOpsQty / threads;
             using (var muxer = Create(syncTimeout: 30000))
             {
-                RedisKey key = "MBOS";
+                RedisKey key = Me();
                 var conn = muxer.GetDatabase();
                 conn.KeyDelete(key, CommandFlags.FireAndForget);
                 var timeTaken = RunConcurrent(delegate
@@ -94,7 +93,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create(syncTimeout: 30000))
             {
-                RedisKey key = "MBOF";
+                RedisKey key = Me();
                 var conn = muxer.GetDatabase();
                 conn.Ping();
 

--- a/tests/StackExchange.Redis.Tests/MultiMaster.cs
+++ b/tests/StackExchange.Redis.Tests/MultiMaster.cs
@@ -32,7 +32,7 @@ namespace StackExchange.Redis.Tests
         public void TestMultiNoTieBreak()
         {
             using (var log = new StringWriter())
-            using (var conn = Create(log: log, tieBreaker: ""))
+            using (Create(log: log, tieBreaker: ""))
             {
                 Log(log.ToString());
                 Assert.Contains("Choosing master arbitrarily", log.ToString());
@@ -69,7 +69,7 @@ namespace StackExchange.Redis.Tests
 
             // see what happens
             using (var log = new StringWriter())
-            using (var conn = Create(log: log, tieBreaker: TieBreak))
+            using (Create(log: log, tieBreaker: TieBreak))
             {
                 string text = log.ToString();
                 Log(text);

--- a/tests/StackExchange.Redis.Tests/Naming.cs
+++ b/tests/StackExchange.Redis.Tests/Naming.cs
@@ -149,24 +149,6 @@ namespace StackExchange.Redis.Tests
 
                 if (name.EndsWith("Async")) huntName = name.Substring(0, name.Length - 5);
                 else huntName = name + "Async";
-
-                Type huntType;
-                if (method.ReturnType == null || method.ReturnType == typeof(void))
-                {
-                    huntType = typeof(Task);
-                }
-                else if (method.ReturnType == typeof(Task))
-                {
-                    huntType = null;
-                }
-                else if (method.ReturnType.IsSubclassOf(typeof(Task)))
-                {
-                    huntType = method.ReturnType.GetGenericArguments()[0];
-                }
-                else
-                {
-                    huntType = typeof(Task<>).MakeGenericType(method.ReturnType);
-                }
                 var pFrom = method.GetParameters();
                 Type[] args = pFrom.Select(x => x.ParameterType).ToArray();
                 Log("Checking: {0}.{1}", from.Name, method.Name);

--- a/tests/StackExchange.Redis.Tests/Profiling.cs
+++ b/tests/StackExchange.Redis.Tests/Profiling.cs
@@ -32,7 +32,7 @@ namespace StackExchange.Redis.Tests
                 var result = db.ScriptEvaluate(LuaScript.Prepare("return redis.call('get', @key)"), new { key = (RedisKey)key });
                 Assert.Equal("world", result.AsString());
                 var val = db.StringGet(key);
-                Assert.Equal("world", (string)val);
+                Assert.Equal("world", val);
                 var s = (string)db.Execute("ECHO", "fii");
                 Assert.Equal("fii", s);
 
@@ -261,7 +261,7 @@ namespace StackExchange.Redis.Tests
                     Assert.True(e.MoveNext());
                     var j = e.Current;
 
-                    Assert.True(object.ReferenceEquals(i, j));
+                    Assert.True(ReferenceEquals(i, j));
                 }
 
                 Assert.Equal(OuterLoop, res.Count(r => r.Command == "GET" && r.Db > 0));

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -7,6 +7,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+// ReSharper disable AccessToModifiedClosure
 
 namespace StackExchange.Redis.Tests
 {
@@ -72,7 +73,7 @@ namespace StackExchange.Redis.Tests
                         }
                         else
                         {
-                            Log((string)channel);
+                            Log(channel);
                         }
                     }
                 }
@@ -127,7 +128,7 @@ namespace StackExchange.Redis.Tests
                 var pub = GetAnyMaster(muxer);
                 var sub = muxer.GetSubscriber();
 
-                RedisChannel key = Guid.NewGuid().ToString();
+                RedisChannel key = Me() + Guid.NewGuid();
                 HashSet<string> received = new HashSet<string>();
                 int secondHandler = 0;
                 await PingAsync(muxer, pub, sub).ForAwait();
@@ -380,7 +381,8 @@ namespace StackExchange.Redis.Tests
 
                 lock (syncLock)
                 {
-                    Task.Run(RunLoop);
+                    // Intentionally not awaited - running in parallel
+                    _ = Task.Run(RunLoop);
                     for (int i = 0; i < count; i++)
                     {
                         sub.Publish(channel, i.ToString());
@@ -408,7 +410,7 @@ namespace StackExchange.Redis.Tests
                 Log("Completion awaited.");
                 await Assert.ThrowsAsync<ChannelClosedException>(async delegate
                 {
-                    var final = await subChannel.ReadAsync().ForAwait();
+                    await subChannel.ReadAsync().ForAwait();
                 }).ForAwait();
                 Log("End of muxer.");
             }
@@ -477,7 +479,7 @@ namespace StackExchange.Redis.Tests
                 Assert.True(subChannel.Completion.IsCompleted);
                 await Assert.ThrowsAsync<ChannelClosedException>(async delegate
                 {
-                    var final = await subChannel.ReadAsync().ForAwait();
+                    await subChannel.ReadAsync().ForAwait();
                 }).ForAwait();
                 Log("End of muxer.");
             }
@@ -547,7 +549,7 @@ namespace StackExchange.Redis.Tests
                 Assert.True(subChannel.Completion.IsCompleted);
                 await Assert.ThrowsAsync<ChannelClosedException>(async delegate
                 {
-                    var final = await subChannel.ReadAsync().ForAwait();
+                    await subChannel.ReadAsync().ForAwait();
                 }).ForAwait();
                 Log("End of muxer.");
             }

--- a/tests/StackExchange.Redis.Tests/PubSubCommand.cs
+++ b/tests/StackExchange.Redis.Tests/PubSubCommand.cs
@@ -23,7 +23,7 @@ namespace StackExchange.Redis.Tests
                 var channels = server.SubscriptionChannels(Me() + "*");
                 Assert.DoesNotContain(channel, channels);
 
-                long justWork = server.SubscriptionPatternCount();
+                _ = server.SubscriptionPatternCount();
                 var count = server.SubscriptionSubscriberCount(channel);
                 Assert.Equal(0, count);
                 conn.GetSubscriber().Subscribe(channel, delegate { });
@@ -46,7 +46,7 @@ namespace StackExchange.Redis.Tests
                 var channels = await server.SubscriptionChannelsAsync(Me() + "*").WithTimeout(2000);
                 Assert.DoesNotContain(channel, channels);
 
-                long justWork = await server.SubscriptionPatternCountAsync().WithTimeout(2000);
+                _ = await server.SubscriptionPatternCountAsync().WithTimeout(2000);
                 var count = await server.SubscriptionSubscriberCountAsync(channel).WithTimeout(2000);
                 Assert.Equal(0, count);
                 await conn.GetSubscriber().SubscribeAsync(channel, delegate { }).WithTimeout(2000);

--- a/tests/StackExchange.Redis.Tests/RawResultTests.cs
+++ b/tests/StackExchange.Redis.Tests/RawResultTests.cs
@@ -21,7 +21,7 @@ namespace StackExchange.Redis.Tests
             var value = result.AsRedisValue();
 
             Assert.True(value.IsNull);
-            string s = (string)value;
+            string s = value;
             Assert.Null(s);
 
             byte[] arr = (byte[])value;

--- a/tests/StackExchange.Redis.Tests/RealWorld.cs
+++ b/tests/StackExchange.Redis.Tests/RealWorld.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/StackExchange.Redis.Tests/RedisResultTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisResultTests.cs
@@ -35,7 +35,7 @@ namespace StackExchange.Redis.Tests
         public void ToDictionaryWorksWhenNested()
         {
             var redisArrayResult = RedisResult.Create(
-                new RedisResult[]
+                new []
                 {
                     RedisResult.Create((RedisValue)"one"),
                     RedisResult.Create(new RedisValue[]{"two", 2, "three", 3}),

--- a/tests/StackExchange.Redis.Tests/SSL.cs
+++ b/tests/StackExchange.Redis.Tests/SSL.cs
@@ -145,7 +145,7 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(AsyncLoop, value);
                 Log("F&F: {0} INCR, {1:###,##0}ms, {2} ops/s; final value: {3}",
                     AsyncLoop,
-                    (long)watch.ElapsedMilliseconds,
+                    watch.ElapsedMilliseconds,
                     (long)(AsyncLoop / watch.Elapsed.TotalSeconds),
                     value);
 
@@ -366,7 +366,7 @@ namespace StackExchange.Redis.Tests
 
                     var fields = typeof(ConfigurationOptions).GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                     Writer.WriteLine($"Comparing {fields.Length} fields...");
-                    Array.Sort(fields, (x, y) => string.Compare(x.Name, y.Name));
+                    Array.Sort(fields, (x, y) => string.CompareOrdinal(x.Name, y.Name));
                     foreach (var field in fields)
                     {
                         Check(field.Name, field.GetValue(a), field.GetValue(b));
@@ -406,7 +406,7 @@ namespace StackExchange.Redis.Tests
         public static RemoteCertificateValidationCallback ShowCertFailures(TextWriterOutputHelper output) {
             if (output == null) return null;
 
-            return (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            return (sender, certificate, chain, sslPolicyErrors) =>
             {
                 void WriteStatus(X509ChainStatus[] status)
                 {

--- a/tests/StackExchange.Redis.Tests/Scans.cs
+++ b/tests/StackExchange.Redis.Tests/Scans.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace StackExchange.Redis.Tests
 {
@@ -133,7 +134,7 @@ namespace StackExchange.Redis.Tests
                     }
                     if (i >= 57)
                     {
-                        expected.Add((string)key);
+                        expected.Add(key);
                     }
                     i++;
                 }
@@ -177,7 +178,7 @@ namespace StackExchange.Redis.Tests
                 int count = 0;
                 foreach (var key in seq)
                 {
-                    expected.Remove((string)key);
+                    expected.Remove(key);
                     count++;
                 }
                 Assert.Empty(expected);
@@ -202,9 +203,9 @@ namespace StackExchange.Redis.Tests
                 db.SetAdd(key, "c", CommandFlags.FireAndForget);
                 var arr = db.SetScan(key).ToArray();
                 Assert.Equal(3, arr.Length);
-                Assert.True(arr.Contains("a"), "a");
-                Assert.True(arr.Contains("b"), "b");
-                Assert.True(arr.Contains("c"), "c");
+                Assert.Contains((RedisValue)"a", arr);
+                Assert.Contains((RedisValue)"b", arr);
+                Assert.Contains((RedisValue)"c", arr);
             }
         }
 
@@ -366,7 +367,7 @@ namespace StackExchange.Redis.Tests
             var found = false;
             var response = db.HashScan(key);
             var cursor = ((IScanningCursor)response);
-            foreach (var i in response)
+            foreach (var _ in response)
             {
                 if (cursor.Cursor > 0)
                 {

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -29,7 +29,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = GetScriptConn())
             {
-                var result = conn.GetDatabase().ScriptEvaluate("return redis.call('info','server')", null, null);
+                _ = conn.GetDatabase().ScriptEvaluate("return redis.call('info','server')", null, null);
             }
         }
 
@@ -112,7 +112,7 @@ namespace StackExchange.Redis.Tests
                 conn.StringSet(key + "foo", "bar", flags: CommandFlags.FireAndForget);
                 var result = (long)conn.ScriptEvaluate(@"
 redis.call('psetex', KEYS[1], 60000, 'timing')
-for i = 1,100000 do
+for i = 1,10000 do
     redis.call('set', 'ignore','abc')
 end
 local timeTaken = 60000 - redis.call('pttl', KEYS[1])
@@ -329,7 +329,7 @@ return timeTaken
         {
             if (!task.IsCompleted)
             {
-                try { task.Wait(200); } catch { }
+                try { task.Wait(200); } catch { /* But don't error */ }
             }
             return task;
         }
@@ -390,12 +390,12 @@ return timeTaken
                 db.HashSet(key, "id", 123, flags: CommandFlags.FireAndForget);
 
                 var wasSet = (bool)db.ScriptEvaluate("if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end",
-                    new RedisKey[] { key }, new RedisValue[] { newId });
+                    new [] { key }, new [] { newId });
 
                 Assert.True(wasSet);
 
                 wasSet = (bool)db.ScriptEvaluate("if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end",
-                    new RedisKey[] { key }, new RedisValue[] { newId });
+                    new [] { key }, new [] { newId });
                 Assert.False(wasSet);
             }
         }
@@ -603,7 +603,7 @@ return timeTaken
                 Assert.Equal(123, (int)val);
 
                 // no super clean way to extract this; so just abuse InternalsVisibleTo
-                script.ExtractParameters(p, null, out RedisKey[] keys, out RedisValue[] args);
+                script.ExtractParameters(p, null, out RedisKey[] keys, out _);
                 Assert.NotNull(keys);
                 Assert.Single(keys);
                 Assert.Equal(key, keys[0]);
@@ -718,7 +718,7 @@ return timeTaken
                 Assert.Equal(123, (int)val);
 
                 // no super clean way to extract this; so just abuse InternalsVisibleTo
-                prepared.Original.ExtractParameters(p, null, out RedisKey[] keys, out RedisValue[] args);
+                prepared.Original.ExtractParameters(p, null, out RedisKey[] keys, out _);
                 Assert.NotNull(keys);
                 Assert.Single(keys);
                 Assert.Equal(key, keys[0]);
@@ -839,7 +839,7 @@ return timeTaken
             {
                 Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
                 var db = conn.GetDatabase();
-                var wrappedDb = KeyspaceIsolation.DatabaseExtensions.WithKeyPrefix(db, "prefix-");
+                var wrappedDb = DatabaseExtensions.WithKeyPrefix(db, "prefix-");
                 var key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
 
@@ -865,7 +865,7 @@ return timeTaken
             {
                 Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
                 var db = conn.GetDatabase();
-                var wrappedDb = KeyspaceIsolation.DatabaseExtensions.WithKeyPrefix(db, "prefix-");
+                var wrappedDb = DatabaseExtensions.WithKeyPrefix(db, "prefix-");
                 var key = Me();
                 await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
 
@@ -891,7 +891,7 @@ return timeTaken
             {
                 Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
                 var db = conn.GetDatabase();
-                var wrappedDb = KeyspaceIsolation.DatabaseExtensions.WithKeyPrefix(db, "prefix2-");
+                var wrappedDb = DatabaseExtensions.WithKeyPrefix(db, "prefix2-");
                 var key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
 
@@ -918,7 +918,7 @@ return timeTaken
             {
                 Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
                 var db = conn.GetDatabase();
-                var wrappedDb = KeyspaceIsolation.DatabaseExtensions.WithKeyPrefix(db, "prefix2-");
+                var wrappedDb = DatabaseExtensions.WithKeyPrefix(db, "prefix2-");
                 var key = Me();
                 await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
 
@@ -952,9 +952,9 @@ arr[3] = @z;
 return arr;
 ");
                 var result = (RedisValue[])p.ScriptEvaluate(script, args);
-                Assert.Equal("abc", (string)result[0]);
-                Assert.Equal("prefix/def", (string)result[1]);
-                Assert.Equal("123", (string)result[2]);
+                Assert.Equal("abc", result[0]);
+                Assert.Equal("prefix/def", result[1]);
+                Assert.Equal("123", result[2]);
             }
         }
 
@@ -965,7 +965,6 @@ return arr;
             {
                 var p = conn.GetDatabase().WithKeyPrefix("prefix/");
 
-                var args = new { x = "abc", y = (RedisKey)"def", z = 123 };
                 const string script = @"
 local arr = {};
 arr[1] = ARGV[1];
@@ -974,9 +973,9 @@ arr[3] = ARGV[2];
 return arr;
 ";
                 var result = (RedisValue[])p.ScriptEvaluate(script, new RedisKey[] { "def" }, new RedisValue[] { "abc", 123 });
-                Assert.Equal("abc", (string)result[0]);
-                Assert.Equal("prefix/def", (string)result[1]);
-                Assert.Equal("123", (string)result[2]);
+                Assert.Equal("abc", result[0]);
+                Assert.Equal("prefix/def", result[1]);
+                Assert.Equal("123", result[2]);
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -112,7 +112,7 @@ namespace StackExchange.Redis.Tests
                 conn.StringSet(key + "foo", "bar", flags: CommandFlags.FireAndForget);
                 var result = (long)conn.ScriptEvaluate(@"
 redis.call('psetex', KEYS[1], 60000, 'timing')
-for i = 1,10000 do
+for i = 1,5000 do
     redis.call('set', 'ignore','abc')
 end
 local timeTaken = 60000 - redis.call('pttl', KEYS[1])

--- a/tests/StackExchange.Redis.Tests/Secure.cs
+++ b/tests/StackExchange.Redis.Tests/Secure.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +18,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                RedisKey key = "MBOF";
+                RedisKey key = Me();
                 var conn = muxer.GetDatabase();
                 conn.Ping();
 

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -313,8 +313,8 @@ namespace StackExchange.Redis.Tests
 
         public void Teardown(TextWriter output)
         {
-            var privateFailCount = Interlocked.Exchange(ref this.privateFailCount, 0);
-            if (privateFailCount != 0)
+            var innerPrivateFailCount = Interlocked.Exchange(ref privateFailCount, 0);
+            if (innerPrivateFailCount != 0)
             {
                 lock (privateExceptions)
                 {

--- a/tests/StackExchange.Redis.Tests/Sockets.cs
+++ b/tests/StackExchange.Redis.Tests/Sockets.cs
@@ -14,7 +14,7 @@ namespace StackExchange.Redis.Tests
             const int count = 2000;
             for (var i = 0; i < count; i++)
             {
-                using (var conn = Create(clientName: "Test: " + i))
+                using (var _ = Create(clientName: "Test: " + i))
                 {
                     // Intentionally just creating and disposing to leak sockets here
                     // ...so we can figure out what's happening.

--- a/tests/StackExchange.Redis.Tests/Streams.cs
+++ b/tests/StackExchange.Redis.Tests/Streams.cs
@@ -53,7 +53,7 @@ namespace StackExchange.Redis.Tests
 
                 var key = GetUniqueKey("multiple_value_pairs");
 
-                var fields = new NameValueEntry[]
+                var fields = new []
                 {
                     new NameValueEntry("field1", "value1"),
                     new NameValueEntry("field2", "value2")
@@ -103,7 +103,7 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var fields = new NameValueEntry[]
+                var fields = new []
                 {
                     new NameValueEntry("field1", "value1"),
                     new NameValueEntry("field2", "value2")
@@ -341,7 +341,7 @@ namespace StackExchange.Redis.Tests
                 var id1 = db.StreamAdd(key, "field1", "value1");
                 var id2 = db.StreamAdd(key, "field2", "value2");
                 var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                _ = db.StreamAdd(key, "field4", "value4");
 
                 // Start reading after id1.
                 db.StreamCreateConsumerGroup(key, groupName, id1);
@@ -384,7 +384,7 @@ namespace StackExchange.Redis.Tests
                 var oneAck = db.StreamAcknowledge(key, groupName, id1);
 
                 // Multiple message Id overload.
-                var twoAck = db.StreamAcknowledge(key, groupName, new RedisValue[] { id3, id4 });
+                var twoAck = db.StreamAcknowledge(key, groupName, new [] { id3, id4 });
 
                 // Read the group again, it should only return the unacknowledged message.
                 var notAcknowledged = db.StreamReadGroup(key, groupName, consumer, "0-0");
@@ -411,10 +411,10 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                _ = db.StreamAdd(key, "field1", "value1");
+                _ = db.StreamAdd(key, "field2", "value2");
+                _ = db.StreamAdd(key, "field3", "value3");
+                _ = db.StreamAdd(key, "field4", "value4");
 
                 db.StreamCreateConsumerGroup(key, groupName, "0-0");
 
@@ -462,7 +462,7 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
+                _ = db.StreamAdd(key, "field1", "value1");
                 var id2 = db.StreamAdd(key, "field2", "value2");
                 var id3 = db.StreamAdd(key, "field3", "value3");
                 var id4 = db.StreamAdd(key, "field4", "value4");
@@ -470,10 +470,10 @@ namespace StackExchange.Redis.Tests
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
 
                 // Read a single message into the first consumer.
-                var consumer1Messages = db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
+                _ = db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
 
                 // Read the remaining messages into the second consumer.
-                var consumer2Messages = db.StreamReadGroup(key, groupName, consumer2);
+                _ = db.StreamReadGroup(key, groupName, consumer2);
 
                 // Claim the 3 messages consumed by consumer2 for consumer1.
 
@@ -530,7 +530,7 @@ namespace StackExchange.Redis.Tests
                 db.StreamCreateConsumerGroup(stream2, groupName, StreamPosition.Beginning);
 
                 // Read for both streams from the beginning. We shouldn't get anything back for stream1.
-                var pairs = new StreamPosition[]
+                var pairs = new []
                 {
                     // StreamPosition.NewMessages will send ">" which indicates "Undelivered" messages.
                     new StreamPosition(stream1, StreamPosition.NewMessages),
@@ -566,7 +566,7 @@ namespace StackExchange.Redis.Tests
                 db.StreamCreateConsumerGroup(stream2, groupName);
 
                 // We shouldn't get anything for either stream.
-                var pairs = new StreamPosition[]
+                var pairs = new []
                 {
                     new StreamPosition(stream1, StreamPosition.Beginning),
                     new StreamPosition(stream2, StreamPosition.Beginning)
@@ -607,7 +607,7 @@ namespace StackExchange.Redis.Tests
                 var id2 = db.StreamAdd(stream2, "field2-2", "value2-2");
 
                 // Read the new messages (messages created after the group was created).
-                var pairs = new StreamPosition[]
+                var pairs = new []
                 {
                     new StreamPosition(stream1, StreamPosition.NewMessages),
                     new StreamPosition(stream2, StreamPosition.NewMessages)
@@ -641,14 +641,14 @@ namespace StackExchange.Redis.Tests
                 var id1_2 = db.StreamAdd(stream1, "field1-2", "value1-2");
 
                 var id2_1 = db.StreamAdd(stream2, "field2-1", "value2-1");
-                var id2_2 = db.StreamAdd(stream2, "field2-2", "value2-2");
-                var id2_3 = db.StreamAdd(stream2, "field2-3", "value2-3");
+                _ = db.StreamAdd(stream2, "field2-2", "value2-2");
+                _ = db.StreamAdd(stream2, "field2-3", "value2-3");
 
                 // Set the initial read point in each stream, *after* the first ID in both streams.
                 db.StreamCreateConsumerGroup(stream1, groupName, id1_1);
                 db.StreamCreateConsumerGroup(stream2, groupName, id2_1);
 
-                var pairs = new StreamPosition[]
+                var pairs = new []
                 {
                     // Read after the first id in both streams
                     new StreamPosition(stream1, StreamPosition.NewMessages),
@@ -678,7 +678,7 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field1", "value1");
 
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
 
@@ -704,7 +704,7 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field1", "value1");
 
                 db.StreamCreateConsumerGroup(key, groupName, "0-0");
 
@@ -733,17 +733,17 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
+                db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
                 var id4 = db.StreamAdd(key, "field4", "value4");
 
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
 
                 // Read a single message into the first consumer.
-                var consumer1Messages = db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
+                db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
 
                 // Read the remaining messages into the second consumer.
-                var consumer2Messages = db.StreamReadGroup(key, groupName, consumer2);
+                db.StreamReadGroup(key, groupName, consumer2);
 
                 var pendingInfo = db.StreamPending(key, groupName);
 
@@ -775,17 +775,17 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
+                db.StreamAdd(key, "field4", "value4");
 
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
 
                 // Read a single message into the first consumer.
-                var consumer1Messages = db.StreamReadGroup(key, groupName, consumer1, count: 1);
+                db.StreamReadGroup(key, groupName, consumer1, count: 1);
 
                 // Read the remaining messages into the second consumer.
-                var consumer2Messages = db.StreamReadGroup(key, groupName, consumer2);
+                _ = db.StreamReadGroup(key, groupName, consumer2) ?? throw new ArgumentNullException(nameof(consumer2), "db.StreamReadGroup(key, groupName, consumer2)");
 
                 await Task.Delay(10).ForAwait();
 
@@ -815,18 +815,18 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
+                db.StreamAdd(key, "field4", "value4");
 
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
 
                 // Read a single message into the first consumer.
-                var consumer1Messages = db.StreamReadGroup(key, groupName, consumer1, count: 1);
+                db.StreamReadGroup(key, groupName, consumer1, count: 1);
 
                 // Read the remaining messages into the second consumer.
-                var consumer2Messages = db.StreamReadGroup(key, groupName, consumer2);
+                db.StreamReadGroup(key, groupName, consumer2);
 
                 // Get the pending info about the messages themselves.
                 var pendingMessageInfoList = db.StreamPendingMessages(key,
@@ -854,7 +854,7 @@ namespace StackExchange.Redis.Tests
 
                 // Add a message to create the stream.
                 db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "fiedl2", "value2");
+                db.StreamAdd(key, "field2", "value2");
 
                 // Create a consumer group and read the message.
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
@@ -918,12 +918,12 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field2", "value2");
                 var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field4", "value4");
 
-                var deletedCount = db.StreamDelete(key, new RedisValue[] { id3 });
+                var deletedCount = db.StreamDelete(key, new [] { id3 });
                 var messages = db.StreamRange(key);
 
                 Assert.Equal(1, deletedCount);
@@ -942,12 +942,12 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field1", "value1");
                 var id2 = db.StreamAdd(key, "field2", "value2");
                 var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field4", "value4");
 
-                var deletedCount = db.StreamDelete(key, new RedisValue[] { id2, id3 }, CommandFlags.None);
+                var deletedCount = db.StreamDelete(key, new [] { id2, id3 }, CommandFlags.None);
                 var messages = db.StreamRange(key);
 
                 Assert.Equal(2, deletedCount);
@@ -971,19 +971,19 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
                 db.KeyDelete(key);
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
+                db.StreamAdd(key, "field4", "value4");
 
                 db.StreamCreateConsumerGroup(key, group1, StreamPosition.Beginning);
                 db.StreamCreateConsumerGroup(key, group2, StreamPosition.Beginning);
 
                 // Read a single message into the first consumer.
-                var consumer1Messages = db.StreamReadGroup(key, group1, consumer1, count: 1);
+                db.StreamReadGroup(key, group1, consumer1, count: 1);
 
                 // Read the remaining messages into the second consumer.
-                var consumer2Messages = db.StreamReadGroup(key, group2, consumer2);
+                db.StreamReadGroup(key, group2, consumer2);
 
                 var groupInfoList = db.StreamGroupInfo(key);
 
@@ -1020,10 +1020,10 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field1", "value1");
+                db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
+                db.StreamAdd(key, "field4", "value4");
 
                 db.StreamCreateConsumerGroup(key, group, StreamPosition.Beginning);
                 db.StreamReadGroup(key, group, consumer1, count: 1);
@@ -1054,8 +1054,8 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
+                db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
                 var id4 = db.StreamAdd(key, "field4", "value4");
 
                 var streamInfo = db.StreamInfo(key);
@@ -1084,7 +1084,7 @@ namespace StackExchange.Redis.Tests
                 // and last-entry messages should be null.
 
                 var id = db.StreamAdd(key, "field1", "value1");
-                db.StreamDelete(key, new RedisValue[] { id });
+                db.StreamDelete(key, new [] { id });
 
                 Assert.Equal(0, db.StreamLength(key));
 
@@ -1128,7 +1128,7 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id = db.StreamAdd(key, "field1", "value1");
-                db.StreamDelete(key, new RedisValue[] { id });
+                db.StreamDelete(key, new [] { id });
 
                 db.StreamCreateConsumerGroup(key, groupName, "0-0");
 
@@ -1190,7 +1190,7 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key, "field2", "value2");
                 var id3 = db.StreamAdd(key, "field3", "value3");
 
                 // Read the entire stream from the beginning.
@@ -1218,7 +1218,7 @@ namespace StackExchange.Redis.Tests
                 var id1 = db.StreamAdd(key, "field1", "value1");
 
                 // Delete the key to empty the stream.
-                db.StreamDelete(key, new RedisValue[] { id1 });
+                db.StreamDelete(key, new [] { id1 });
                 var len = db.StreamLength(key);
 
                 // Read the entire stream from the beginning.
@@ -1246,8 +1246,8 @@ namespace StackExchange.Redis.Tests
                 var id2 = db.StreamAdd(key2, "field2", "value2");
 
                 // Delete the key to empty the stream.
-                db.StreamDelete(key1, new RedisValue[] { id1 });
-                db.StreamDelete(key2, new RedisValue[] { id2 });
+                db.StreamDelete(key1, new [] { id1 });
+                db.StreamDelete(key2, new [] { id2 });
 
                 var len1 = db.StreamLength(key1);
                 var len2 = db.StreamLength(key2);
@@ -1271,7 +1271,7 @@ namespace StackExchange.Redis.Tests
             {
                 Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
 
-                var streamPositions = new StreamPosition[]
+                var streamPositions = new []
                 {
                     new StreamPosition("key1", "0-0"),
                     new StreamPosition("key2", "0-0")
@@ -1336,12 +1336,12 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key1, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key1, "field2", "value2");
                 var id3 = db.StreamAdd(key2, "field3", "value3");
                 var id4 = db.StreamAdd(key2, "field4", "value4");
 
                 // Read from both streams at the same time.
-                var streamList = new StreamPosition[2]
+                var streamList = new []
                 {
                     new StreamPosition(key1, "0-0"),
                     new StreamPosition(key2, "0-0")
@@ -1376,11 +1376,11 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key1, "fiedl2", "value2");
+                db.StreamAdd(key1, "field2", "value2");
                 var id3 = db.StreamAdd(key2, "field3", "value3");
-                var id4 = db.StreamAdd(key2, "field4", "value4");
+                db.StreamAdd(key2, "field4", "value4");
 
-                var streamList = new StreamPosition[2]
+                var streamList = new []
                 {
                     new StreamPosition(key1, "0-0"),
                     new StreamPosition(key2, "0-0")
@@ -1413,12 +1413,12 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key1, "fiedl2", "value2");
-                var id3 = db.StreamAdd(key2, "field3", "value3");
+                db.StreamAdd(key1, "field1", "value1");
+                db.StreamAdd(key1, "field2", "value2");
+                db.StreamAdd(key2, "field3", "value3");
                 var id4 = db.StreamAdd(key2, "field4", "value4");
 
-                var streamList = new StreamPosition[]
+                var streamList = new []
                 {
                     new StreamPosition(key1, "0-0"),
 
@@ -1448,12 +1448,12 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key1, "fiedl2", "value2");
-                var id3 = db.StreamAdd(key2, "field3", "value3");
+                db.StreamAdd(key1, "field1", "value1");
+                var id2 = db.StreamAdd(key1, "field2", "value2");
+                db.StreamAdd(key2, "field3", "value3");
                 var id4 = db.StreamAdd(key2, "field4", "value4");
 
-                var streamList = new StreamPosition[]
+                var streamList = new []
                 {
                     // Read past the end of both streams.
                     new StreamPosition(key1, id2),
@@ -1478,8 +1478,8 @@ namespace StackExchange.Redis.Tests
 
                 var db = conn.GetDatabase();
 
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                db.StreamAdd(key, "field1", "value1");
+                var id2 = db.StreamAdd(key, "field2", "value2");
 
                 // Read after the final ID in the stream, we expect an empty array as a response.
 
@@ -1501,7 +1501,7 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key, "field2", "value2");
 
                 var entries = db.StreamRange(key);
 
@@ -1523,9 +1523,9 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key, "field2", "value2");
 
-                var deleted = db.StreamDelete(key, new RedisValue[] { id1, id2 });
+                var deleted = db.StreamDelete(key, new [] { id1, id2 });
 
                 var entries = db.StreamRange(key);
 
@@ -1547,7 +1547,7 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                db.StreamAdd(key, "field2", "value2");
 
                 var entries = db.StreamRange(key, count: 1);
 
@@ -1568,7 +1568,7 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key, "field2", "value2");
 
                 var entries = db.StreamRange(key, messageOrder: Order.Descending);
 
@@ -1590,7 +1590,7 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key, "field2", "value2");
 
                 var entries = db.StreamRange(key, id1, id2, 1, Order.Descending);
 
@@ -1611,8 +1611,8 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
+                var id2 = db.StreamAdd(key, "field2", "value2");
+                db.StreamAdd(key, "field3", "value3");
 
                 // Only read a single item from the stream.
                 var entries = db.StreamRead(key, id1, 1);
@@ -1634,9 +1634,9 @@ namespace StackExchange.Redis.Tests
                 var db = conn.GetDatabase();
 
                 var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "fiedl2", "value2");
+                var id2 = db.StreamAdd(key, "field2", "value2");
                 var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
+                db.StreamAdd(key, "field4", "value4");
 
                 // Read multiple items from the stream.
                 var entries = db.StreamRead(key, id1, 2);
@@ -1660,7 +1660,7 @@ namespace StackExchange.Redis.Tests
 
                 // Add a couple items and check length.
                 db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "fiedl2", "value2");
+                db.StreamAdd(key, "field2", "value2");
                 db.StreamAdd(key, "field3", "value3");
                 db.StreamAdd(key, "field4", "value4");
 
@@ -1685,7 +1685,7 @@ namespace StackExchange.Redis.Tests
 
                 // Add a couple items and check length.
                 db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "fiedl2", "value2");
+                db.StreamAdd(key, "field2", "value2");
 
                 var len = db.StreamLength(key);
 
@@ -1739,7 +1739,7 @@ namespace StackExchange.Redis.Tests
 
                 db.StreamCreateConsumerGroup(key, groupName, StreamPosition.NewMessages);
 
-                var messages = db.StreamReadGroup(key,
+                db.StreamReadGroup(key,
                     groupName,
                     consumer,
                     StreamPosition.NewMessages,
@@ -1774,8 +1774,8 @@ namespace StackExchange.Redis.Tests
                 db.StreamCreateConsumerGroup(key1, groupName, StreamPosition.NewMessages);
                 db.StreamCreateConsumerGroup(key2, groupName, StreamPosition.NewMessages);
 
-                var messages = db.StreamReadGroup(
-                    new StreamPosition[]
+                db.StreamReadGroup(
+                    new []
                     {
                         new StreamPosition(key1, StreamPosition.NewMessages),
                         new StreamPosition(key2, StreamPosition.NewMessages)

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -88,7 +88,7 @@ namespace StackExchange.Redis.Tests
 #if VERBOSE
         protected const int AsyncOpsQty = 100, SyncOpsQty = 10;
 #else
-        protected const int AsyncOpsQty = 10000, SyncOpsQty = 10000;
+        protected const int AsyncOpsQty = 2000, SyncOpsQty = 2000;
 #endif
 
         static TestBase()
@@ -237,7 +237,7 @@ namespace StackExchange.Redis.Tests
             {
                 configuration = GetConfiguration();
                 if (configuration == _fixture.Configuration)
-                {   // only if the 
+                {   // only if the
                     return _fixture.Connection;
                 }
             }
@@ -311,8 +311,7 @@ namespace StackExchange.Redis.Tests
                         {
                             GC.KeepAlive(x.Exception);
                         }
-                        catch
-                        { }
+                        catch { /* No boom */ }
                     }, TaskContinuationOptions.OnlyOnFaulted);
                     throw new TimeoutException("Connect timeout");
                 }

--- a/tests/StackExchange.Redis.Tests/TestInfoReplicationChecks.cs
+++ b/tests/StackExchange.Redis.Tests/TestInfoReplicationChecks.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/StackExchange.Redis.Tests/Transactions.cs
+++ b/tests/StackExchange.Redis.Tests/Transactions.cs
@@ -1,9 +1,6 @@
 ﻿#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'.
 
 using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -38,7 +35,6 @@ namespace StackExchange.Redis.Tests
             using (var muxer = Create())
             {
                 var db = muxer.GetDatabase();
-                object asyncState = new object();
                 var tran = db.CreateTransaction();
                 var redisTransaction = Assert.IsType<RedisTransaction>(tran);
                 Assert.Throws<NotSupportedException>(() => redisTransaction.CreateTransaction(null));
@@ -73,7 +69,7 @@ namespace StackExchange.Redis.Tests
                 {
                     Assert.True(await exec, "eq: exec");
                     Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr                    
+                    Assert.Equal(1, await incr); // eq: incr
                     Assert.Equal(1, (long)get); // eq: get
                 }
                 else
@@ -109,7 +105,7 @@ namespace StackExchange.Redis.Tests
 
                 if (value != null) db.StringSet(key2, value, flags: CommandFlags.FireAndForget);
                 Assert.False(db.KeyExists(key));
-                Assert.Equal(value, (string)db.StringGet(key2));
+                Assert.Equal(value, db.StringGet(key2));
 
                 var tran = db.CreateTransaction();
                 var cond = tran.AddCondition(expectEqual ? Condition.StringEqual(key2, expected) : Condition.StringNotEqual(key2, expected));
@@ -201,7 +197,7 @@ namespace StackExchange.Redis.Tests
                 RedisValue hashField = "field";
                 if (value != null) db.HashSet(key2, hashField, value, flags: CommandFlags.FireAndForget);
                 Assert.False(db.KeyExists(key));
-                Assert.Equal(value, (string)db.HashGet(key2, hashField));
+                Assert.Equal(value, db.HashGet(key2, hashField));
 
                 var tran = db.CreateTransaction();
                 var cond = tran.AddCondition(expectEqual ? Condition.HashEqual(key2, hashField, expected) : Condition.HashNotEqual(key2, hashField, expected));
@@ -278,7 +274,7 @@ namespace StackExchange.Redis.Tests
                     Assert.True(await exec, "eq: exec");
                     Assert.True(cond.WasSatisfied, "eq: was satisfied");
                     Assert.Equal(1, await push); // eq: push
-                    Assert.Equal("any value", (string)get); // eq: get
+                    Assert.Equal("any value", get); // eq: get
                 }
                 else
                 {
@@ -313,7 +309,7 @@ namespace StackExchange.Redis.Tests
 
                 if (value != null) db.ListRightPush(key2, value, flags: CommandFlags.FireAndForget);
                 Assert.False(db.KeyExists(key));
-                Assert.Equal(value, (string)db.ListGetByIndex(key2, 0));
+                Assert.Equal(value, db.ListGetByIndex(key2, 0));
 
                 var tran = db.CreateTransaction();
                 var cond = tran.AddCondition(expectEqual ? Condition.ListIndexEqual(key2, 0, expected) : Condition.ListIndexNotEqual(key2, 0, expected));
@@ -1217,12 +1213,12 @@ namespace StackExchange.Redis.Tests
                 {
                     RedisKey key = Me();
                     await db.KeyDeleteAsync(key);
-                    HashEntry[] hashEntries = new HashEntry[]
+                    HashEntry[] hashEntries = new []
                     {
                         new HashEntry("blah", DateTime.UtcNow.ToString("R"))
                     };
                     ITransaction transaction = db.CreateTransaction();
-                    ConditionResult keyNotExists = transaction.AddCondition(Condition.KeyNotExists(key));
+                    transaction.AddCondition(Condition.KeyNotExists(key));
                     Task hashSetTask = transaction.HashSetAsync(key, hashEntries);
                     Task<bool> expireTask = transaction.KeyExpireAsync(key, TimeSpan.FromSeconds(30));
                     bool committed = await transaction.ExecuteAsync();

--- a/tests/StackExchange.Redis.Tests/Values.cs
+++ b/tests/StackExchange.Redis.Tests/Values.cs
@@ -37,15 +37,15 @@ namespace StackExchange.Redis.Tests
             var arr = Encoding.UTF8.GetBytes("hello world");
             var ms = new MemoryStream(arr);
             var val = RedisValue.CreateFrom(ms);
-            Assert.Equal("hello world", (string)val);
+            Assert.Equal("hello world", val);
 
             ms = new MemoryStream(arr, 1, 6, false, false);
             val = RedisValue.CreateFrom(ms);
-            Assert.Equal("ello w", (string)val);
+            Assert.Equal("ello w", val);
 
             ms = new MemoryStream(arr, 2, 6, false, true);
             val = RedisValue.CreateFrom(ms);
-            Assert.Equal("llo wo", (string)val);
+            Assert.Equal("llo wo", val);
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/WithKeyPrefixTests.cs
+++ b/tests/StackExchange.Redis.Tests/WithKeyPrefixTests.cs
@@ -37,11 +37,9 @@ namespace StackExchange.Redis.Tests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                using (var conn = Create())
-                {
-                    var raw = conn.GetDatabase();
-                    var prefixed = raw.WithKeyPrefix((byte[])null);
-                }
+                using var conn = Create();
+                var raw = conn.GetDatabase();
+                raw.WithKeyPrefix((byte[])null);
             });
         }
 
@@ -50,11 +48,9 @@ namespace StackExchange.Redis.Tests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                using (var conn = Create())
-                {
-                    var raw = conn.GetDatabase();
-                    var prefixed = raw.WithKeyPrefix((string)null);
-                }
+                using var conn = Create();
+                var raw = conn.GetDatabase();
+                raw.WithKeyPrefix((string)null);
             });
         }
 
@@ -67,7 +63,7 @@ namespace StackExchange.Redis.Tests
             Assert.Throws<ArgumentNullException>(() =>
             {
                 IDatabase raw = null;
-                var prefixed = raw.WithKeyPrefix(prefix);
+                raw.WithKeyPrefix(prefix);
             });
         }
 
@@ -91,16 +87,16 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(s, val); // fooBasicSmokeTest
 
                 foobar.StringSet(key, t, flags: CommandFlags.FireAndForget);
-                val = (string)foobar.StringGet(key);
+                val = foobar.StringGet(key);
                 Assert.Equal(t, val); // foobarBasicSmokeTest
 
-                val = (string)foo.StringGet("bar" + key);
+                val = foo.StringGet("bar" + key);
                 Assert.Equal(t, val); // foobarBasicSmokeTest
 
-                val = (string)raw.StringGet(prefix + key);
+                val = raw.StringGet(prefix + key);
                 Assert.Equal(s, val); // fooBasicSmokeTest
 
-                val = (string)raw.StringGet(prefix + "bar" + key);
+                val = raw.StringGet(prefix + "bar" + key);
                 Assert.Equal(t, val); // foobarBasicSmokeTest
             }
         }

--- a/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -130,14 +130,14 @@ namespace StackExchange.Redis.Tests
             wrapper.HashSetAsync("key", "hashField", "value", When.Exists, CommandFlags.None);
             mock.Verify(_ => _.HashSetAsync("prefix:key", "hashField", "value", When.Exists, CommandFlags.None));
         }
-        
+
         [Fact]
         public void HashStringLengthAsync()
         {
             wrapper.HashStringLengthAsync("key","field", CommandFlags.None);
             mock.Verify(_ => _.HashStringLengthAsync("prefix:key", "field", CommandFlags.None));
         }
-        
+
         [Fact]
         public void HashValuesAsync()
         {
@@ -855,7 +855,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void StreamMessagesDeleteAsync()
         {
-            var messageIds = new RedisValue[0] { };
+            var messageIds = new RedisValue[] { };
             wrapper.StreamDeleteAsync("key", messageIds, CommandFlags.None);
             mock.Verify(_ => _.StreamDeleteAsync("prefix:key", messageIds, CommandFlags.None));
         }
@@ -898,7 +898,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void StreamReadAsync_1()
         {
-            var streamPositions = new StreamPosition[0] { };
+            var streamPositions = new StreamPosition[] { };
             wrapper.StreamReadAsync(streamPositions, null, CommandFlags.None);
             mock.Verify(_ => _.StreamReadAsync(streamPositions, null, CommandFlags.None));
         }
@@ -920,7 +920,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void StreamStreamReadGroupAsync_2()
         {
-            var streamPositions = new StreamPosition[0] { };
+            var streamPositions = new StreamPosition[] { };
             wrapper.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
             mock.Verify(_ => _.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, false, CommandFlags.None));
         }

--- a/toys/KestrelRedisServer/Program.cs
+++ b/toys/KestrelRedisServer/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Server.Kestrel.Transport;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 
 namespace KestrelRedisServer

--- a/toys/KestrelRedisServer/Startup.cs
+++ b/toys/KestrelRedisServer/Startup.cs
@@ -30,7 +30,7 @@ namespace KestrelRedisServer
                         ((IApplicationLifetime)s).StopApplication();
                     }
                 }
-                catch { }
+                catch { /* Don't go boom on shutdown */ }
             }, lifetime);
 
             if (env.IsDevelopment()) app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Yet another attempt to stabilize testing on CI.

Overall:
- Code cleanup (thanks Rider)
- Reduces some load of the more busy tests.
   - HackyGetPerf() in Scripting.cs for 100,000 iterations in existing
   - Overal AsyncOpsQty/SyncOpsQty 10,000 -> 2,000
- Uniques some keys that weren't yet, causing simultaneous framework runs to collide