### PR TITLE
ForceReplication during failovers to reduce errors in clustered scenarios

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2904,6 +2904,14 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The <see cref="RedisKey"/> to determine the hash slot for.</param>
         public int GetHashSlot(RedisKey key) => ServerSelectionStrategy.HashSlot(key);
+
+        internal void MarkServerEndpointsForReplicationRoleRefresh()
+        {
+            foreach (var s in servers.Values)
+            {
+                ((ServerEndPoint)s).ForceReplicationCheck = true;
+            }
+        }
     }
 
     internal enum WriteResult

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -429,6 +429,8 @@ namespace StackExchange.Redis
             oldState = default(State); // only defined when isCurrent = true
             if (isCurrent = (physical == connection))
             {
+                Multiplexer.MarkServerEndpointsForReplicationRoleRefresh();
+
                 Trace("Bridge noting disconnect from active connection" + (isDisposed ? " (disposed)" : ""));
                 oldState = ChangeState(State.Disconnected);
                 physical = null;
@@ -540,7 +542,7 @@ namespace StackExchange.Redis
                                 checkConfigSeconds = Multiplexer.RawConfig.ConfigCheckSeconds;
 
                             if (state == (int)State.ConnectedEstablished && ConnectionType == ConnectionType.Interactive
-                                && checkConfigSeconds > 0 && ServerEndPoint.LastInfoReplicationCheckSecondsAgo >= checkConfigSeconds
+                                && ((checkConfigSeconds > 0 && ServerEndPoint.LastInfoReplicationCheckSecondsAgo >= checkConfigSeconds) || ServerEndPoint.ForceReplicationCheck)
                                 && ServerEndPoint.CheckInfoReplication())
                             {
                                 // that serves as a keep-alive, if it is accepted

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -540,6 +540,7 @@ namespace StackExchange.Redis
         internal bool CheckInfoReplication()
         {
             lastInfoReplicationCheckTicks = Environment.TickCount;
+            ForceReplicationCheck = false;
             PhysicalBridge bridge;
             if (version >= RedisFeatures.v2_8_0 && Multiplexer.CommandMap.IsAvailable(RedisCommand.INFO)
                 && (bridge = GetBridge(ConnectionType.Interactive, false)) != null)
@@ -555,6 +556,7 @@ namespace StackExchange.Redis
         }
 
         private int lastInfoReplicationCheckTicks;
+        internal volatile bool ForceReplicationCheck;
 
         private int _heartBeatActive;
         internal void OnHeartbeat()


### PR DESCRIPTION
Multiple people had previously complained that whenever there is a cluster failover, they experience Connection Exceptions for at least close to a minute. 
During investigation, @joroda  found that this is due to the fact that config check is done roughly every 60 seconds by default and during failover it has to be done almost immediately to eliminate the errors. 

This fix shows significant improvement from the tests we did. it reduces errors to around 2 seconds for the 90th percentile case compared to around 56 seconds of errors for 90th percentile right now. 