### PR TITLE
Do not invert the range if the `max` value is `default(RedisValue)`

### DIFF
--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3522,7 +3522,7 @@ namespace StackExchange.Redis
 
         private static void ReverseLimits(Order order, ref Exclude exclude, ref RedisValue start, ref RedisValue stop)
         {
-            bool reverseLimits = (order == Order.Ascending) == start.CompareTo(stop) > 0;
+            bool reverseLimits = (order == Order.Ascending) == (stop != default(RedisValue) && start.CompareTo(stop) > 0);
             if (reverseLimits)
             {
                 var tmp = start;

--- a/tests/StackExchange.Redis.Tests/Lex.cs
+++ b/tests/StackExchange.Redis.Tests/Lex.cs
@@ -49,6 +49,10 @@ namespace StackExchange.Redis.Tests
 
                 set = db.SortedSetRangeByValue(key, "g", "aaa", Exclude.Start, Order.Descending, 1, 3);
                 Equate(set, set.Length, "e", "d", "c");
+
+                set = db.SortedSetRangeByValue(key, "e", default(RedisValue));
+                count = db.SortedSetLengthByValue(key, "e", default(RedisValue));
+                Equate(set, count, "e", "f", "g");
             }
         }
 


### PR DESCRIPTION
If the `stop` value is `default(RedisValue)` and is compared against a `start` value that isn't the result from `start.CompareTo(stop)` is `1`, which would reverse the range, which would cause the library to emit an incorrect query to Redis. 

I figured this change would have far fewer impacts than changing how `RedisValue.CompareTo` works. 

This should close issue #992 