### PR TITLE
Revert misleading change to documentation

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -339,7 +339,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Indicates whether endpoints should be resolved via DNS before connecting.
-        /// If enabled the ConnectionMultiplexer will re-resolve DNS
+        /// If enabled the ConnectionMultiplexer will not re-resolve DNS
         /// when attempting to re-connect after a connection failure.
         /// </summary>
         public bool ResolveDns { get { return resolveDns.GetValueOrDefault(); } set { resolveDns = value; } }


### PR DESCRIPTION
I believe the change [from this old 2018 PR](https://github.com/StackExchange/StackExchange.Redis/commit/e4d3a782d27e8f02a4dec261f69acda5b1aa8066) is incorrect -- at least with today's behavior.

To determine this revert is required I setup two Redis instances and ran "SET environment first" on one and "SET environment second" on the other. I used the computer's hostfile to control which IP my DnsEndpoint resolved to. I briefly disconnected my network to trigger reconnection code. 

```
 while (true) {
                try {
                    var environment = await connection.GetDatabase().StringGetAsync("environment");
                    programLogger.LogInformation(environment);
                } catch (Exception) {
                    // squelch
                } finally {
                    await Task.Delay(TimeSpan.FromSeconds(5));
                }
            }
```

Here are the behaviors I see if I use a DnsEndpoint and the IPs for the Redis instance change with ResolveDns set to **true**:

```
// host file points to "first" instance
[01:37:52 INF] first
[01:37:57 INF] first
[01:38:02 INF] first
[01:38:07 INF] first
// disconnect network, change host file to point to "second" instance
[01:39:01 INF] first
[01:39:06 INF] first
[01:39:11 INF] first
```

Here are the behaviors I see if I use a DnsEndpoint and the IPs for the Redis instance change with ResolveDns set to **false**:

```
// host file points to "first" instance
[01:42:49 INF] first
[01:42:54 INF] first
[01:42:59 INF] first
[01:43:04 INF] first
// disconnect network, change host file to point to "second" instance
[01:44:04 INF] second
[01:44:09 INF] second
[01:44:14 INF] second
[01:44:19 INF] second
```
