### PR TITLE
fix for mutex slim being released too early during flush operation

### DIFF
--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -892,6 +892,7 @@ namespace StackExchange.Redis
                         {
                             ThrowTimeout();
                         }
+                        throw;
                     }
                 }
                 return flush.Result;


### PR DESCRIPTION
Fixes #1438 

When flushing during FlushSync we are specifying a timeout to the Task, but when this timeout gets hit the underlying task is still running. The thread that invoked FlushSync continues and releases the MutexSlim that is protecting the io pipe allowing another thread to obtain the MutexSlim and try to run operations on the pipe. 

To fix use the cancellation token that can be passed to PipeWriter.FlushAsync. 

An alternative to this is to not specify a timeout. There are 2 additional locations that flush the pipe neither of those locations specify a timeout they just simply await the Task.    Generally the timeouts are driven by how long an operation waits to obtain the MutexSlim