### PR TITLE
Allow CheckCertificateRevocation to be set on connection string

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -75,6 +75,7 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | abortConnect={bool}    | `AbortOnConnectFail`   | `true` (`false` on Azure)    | If true, `Connect` will not create a connection while no servers are available                            |
 | allowAdmin={bool}      | `AllowAdmin`           | `false`                      | Enables a range of commands that are considered risky                                                     |
 | channelPrefix={string} | `ChannelPrefix`        | `null`                       | Optional channel prefix for all pub/sub operations                                                        |
+| checkCertificateRevocation={bool} | `CheckCertificateRevocation`        | `true`                       | A Boolean value that specifies whether the certificate revocation list is checked during authentication.                                                        |
 | connectRetry={int}     | `ConnectRetry`         | `3`                          | The number of times to repeat connect attempts during initial `Connect`                                   |
 | connectTimeout={int}   | `ConnectTimeout`       | `5000`                       | Timeout (ms) for connect operations                                                                       |
 | configChannel={string} | `ConfigurationChannel` | `__Booksleeve_MasterChanged` | Broadcast channel name for communicating configuration changes                                            |

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -535,6 +535,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.WriteBuffer, writeBuffer);
             Append(sb, OptionKeys.Ssl, ssl);
             Append(sb, OptionKeys.SslProtocols, SslProtocols?.ToString().Replace(',', '|'));
+            Append(sb, OptionKeys.CheckCertificateRevocation, checkCertificateRevocation);
             Append(sb, OptionKeys.SslHost, sslHost);
             Append(sb, OptionKeys.HighPrioritySocketThreads, highPrioritySocketThreads);
             Append(sb, OptionKeys.ConfigChannel, configChannel);

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -89,7 +89,9 @@ namespace StackExchange.Redis
                 SyncTimeout = "syncTimeout",
                 TieBreaker = "tiebreaker",
                 Version = "version",
-                WriteBuffer = "writeBuffer";
+                WriteBuffer = "writeBuffer",
+                CheckCertificateRevocation = "checkCertificateRevocation";
+
 
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
@@ -118,6 +120,7 @@ namespace StackExchange.Redis
                 TieBreaker,
                 Version,
                 WriteBuffer,
+                CheckCertificateRevocation
             }.ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
             public static string TryNormalize(string value)
@@ -189,7 +192,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// A Boolean value that specifies whether the certificate revocation list is checked during authentication.
         /// </summary>
-        public bool CheckCertificateRevocation {get { return checkCertificateRevocation ?? true; } set { checkCertificateRevocation = value; }}
+        public bool CheckCertificateRevocation { get { return checkCertificateRevocation ?? true; } set { checkCertificateRevocation = value; } }
 
         /// <summary>
         /// Create a certificate validation check that checks against the supplied issuer even if not known by the machine
@@ -619,7 +622,7 @@ namespace StackExchange.Redis
 
         private void Clear()
         {
-            ClientName = ServiceName = User =Password = tieBreaker = sslHost = configChannel = null;
+            ClientName = ServiceName = User = Password = tieBreaker = sslHost = configChannel = null;
             keepAlive = syncTimeout = asyncTimeout = connectTimeout = writeBuffer = connectRetry = configCheckSeconds = DefaultDatabase = null;
             allowAdmin = abortOnConnectFail = highPrioritySocketThreads = resolveDns = ssl = null;
             SslProtocols = null;
@@ -667,6 +670,9 @@ namespace StackExchange.Redis
 
                     switch (OptionKeys.TryNormalize(key))
                     {
+                        case OptionKeys.CheckCertificateRevocation:
+                            CheckCertificateRevocation = OptionKeys.ParseBoolean(key, value);
+                            break;
                         case OptionKeys.SyncTimeout:
                             SyncTimeout = OptionKeys.ParseInt32(key, value, minValue: 1);
                             break;

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -30,6 +30,16 @@ namespace StackExchange.Redis.Tests
             Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
         }
 
+        [Theory]
+        [InlineData("host,checkCertificateRevocation=false", false)]
+        [InlineData("host,checkCertificateRevocation=true", true)]
+        [InlineData("host", true)]
+        public void ConfigurationOption_CheckCertificateRevocation(string conString, bool expectedValue)
+        {
+            var options = ConfigurationOptions.Parse(conString);
+            Assert.Equal(expectedValue, options.CheckCertificateRevocation);
+        }
+
         [Fact]
         public void SslProtocols_UsingIntegerValue()
         {

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -31,13 +31,15 @@ namespace StackExchange.Redis.Tests
         }
 
         [Theory]
-        [InlineData("host,checkCertificateRevocation=false", false)]
-        [InlineData("host,checkCertificateRevocation=true", true)]
-        [InlineData("host", true)]
+        [InlineData("checkCertificateRevocation=false", false)]
+        [InlineData("checkCertificateRevocation=true", true)]
+        [InlineData("", true)]
         public void ConfigurationOption_CheckCertificateRevocation(string conString, bool expectedValue)
         {
-            var options = ConfigurationOptions.Parse(conString);
+            var options = ConfigurationOptions.Parse($"host,{conString}");
             Assert.Equal(expectedValue, options.CheckCertificateRevocation);
+            var toString = options.ToString();
+            Assert.True(toString.IndexOf(conString, StringComparison.CurrentCultureIgnoreCase) >= 0);
         }
 
         [Fact]


### PR DESCRIPTION
This configuration setting can't be set right now using connection string. 
Usage example: 
"redishost:6380,ssl=True,checkCertificateRevocation=false"


