### PR TITLE
GitHub Actions logging

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -22,8 +22,6 @@ jobs:
       working-directory: ./tests/RedisConfigs
       run: docker-compose -f docker-compose.yml up -d
     - name: .NET Test
-      run: dotnet test Build.csproj -c Release --no-build /p:CI=true
-      env:
-        EnableTestLogging: true
+      run: dotnet test Build.csproj -c Release --logger GitHubActions /p:CI=true
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -21,7 +21,9 @@ jobs:
     - name: Start Redis Services
       working-directory: ./tests/RedisConfigs
       run: docker-compose -f docker-compose.yml up -d
-    - name: .NET Test
-      run: dotnet test Build.csproj -c Release --logger GitHubActions /p:CI=true
+    - name: StackExchange.Redis.Tests
+      run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger GitHubActions /p:CI=true
+    - name: NRedisSearch.Tests
+      run: dotnet test tests/NRediSearch.Test/NRediSearch.Test.csproj -c Release --logger GitHubActions /p:CI=true
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,8 +8,9 @@
   </ItemGroup>
   <ItemGroup>
       <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
+      <PackageReference Update="GitHubActionsTestLogger" Version="1.1.0" />
       <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
-      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.0" />
       <PackageReference Update="Moq" Version="4.14.1" />
       <PackageReference Update="NSubstitute" Version="4.2.1" />
       <PackageReference Update="Pipelines.Sockets.Unofficial" Version="2.1.16" />

--- a/tests/NRediSearch.Test/NRediSearch.Test.csproj
+++ b/tests/NRediSearch.Test/NRediSearch.Test.csproj
@@ -3,10 +3,12 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NRediSearch\NRediSearch.csproj" />
     <ProjectReference Include="..\StackExchange.Redis.Tests\StackExchange.Redis.Tests.csproj" />
+    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 </Project>

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -5,7 +5,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>
     <DebugType>full</DebugType>
-    <LangVersion>8.0</LangVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />
+    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
Getting some Actions error logging up in here, logs where the test failures are in the diff (if the change is present), color codes the console, and splits the tests into steps for the 2 projects so that it's easier to see what went wrong. See the action run on this PR to see. Good to merge for helping us get `main` back green.