### PR TITLE
NRediSearch build fixes

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -39,9 +39,6 @@ jobs:
       uses: actions/checkout@v1
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
-    - name: Start Redis Services
-      working-directory: ./tests/RedisConfigs
-      run: docker-compose -f docker-compose.yml up -d
     - name: NRedisSearch.Tests
       run: dotnet test tests/NRediSearch.Test/NRediSearch.Test.csproj -c Release --logger GitHubActions /p:CI=true
     - name: .NET Lib Pack

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -10,8 +10,8 @@ on:
     - '!/docs/*' # Don't run workflow when files are only in the /docs directory
 
 jobs:
-  build:
-    name: Ubuntu
+  main:
+    name: StackExchange.Redis (Ubuntu)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -23,7 +23,26 @@ jobs:
       run: docker-compose -f docker-compose.yml up -d
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger GitHubActions /p:CI=true
+    - name: .NET Lib Pack
+      run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
+
+  nredisearch:
+    name: NRediSearch (Ubuntu)
+    runs-on: ubuntu-latest
+    services:
+      redisearch:
+        image: redislabs/redisearch:latest
+        ports:
+          - 6385:6379
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: .NET Build
+      run: dotnet build Build.csproj -c Release /p:CI=true
+    - name: Start Redis Services
+      working-directory: ./tests/RedisConfigs
+      run: docker-compose -f docker-compose.yml up -d
     - name: NRedisSearch.Tests
       run: dotnet test tests/NRediSearch.Test/NRediSearch.Test.csproj -c Release --logger GitHubActions /p:CI=true
     - name: .NET Lib Pack
-      run: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
+      run: dotnet pack src/NRediSearch/NRediSearch.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -300,7 +300,15 @@ namespace NRediSearch.Test.ClientTests
             Db.KeyDelete(hashKey);
             Db.HashSet(hashKey, "title", "hello world");
 
-            Assert.True(cl.AddHash(hashKey, 1, false));
+            try
+            {
+                Assert.True(cl.AddHash(hashKey, 1, false));
+            }
+            catch (RedisServerException e)
+            {
+                Assert.StartsWith("ERR unknown command `FT.ADDHASH`", e.Message);
+                return; // Starting from RediSearch 2.0 this command is not supported anymore
+            }
             SearchResult res = cl.Search(new Query("hello world").SetVerbatim());
             Assert.Equal(1, res.TotalResults);
             Assert.Equal(hashKey, res.Documents[0].Id);

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using StackExchange.Redis;
 using StackExchange.Redis.Tests;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace NRediSearch.Test
 {
+    [Collection(nameof(NonParallelCollection))]
     public abstract class RediSearchTestBase : IDisposable
     {
         protected readonly ITestOutputHelper Output;
@@ -157,4 +159,7 @@ namespace NRediSearch.Test
                 || ex.Message.Contains("no such index", StringComparison.InvariantCultureIgnoreCase);
         }
     }
+
+    [CollectionDefinition(nameof(NonParallelCollection), DisableParallelization = true)]
+    public class NonParallelCollection { }
 }

--- a/tests/NRediSearch.Test/RediSearchTestBase.cs
+++ b/tests/NRediSearch.Test/RediSearchTestBase.cs
@@ -15,6 +15,8 @@ namespace NRediSearch.Test
             muxer = GetWithFT(output);
             Output = output;
             Db = muxer.GetDatabase();
+            var server = muxer.GetServer(muxer.GetEndPoints()[0]);
+            server.FlushDatabase();
         }
         private ConnectionMultiplexer muxer;
         protected IDatabase Db { get; private set; }

--- a/tests/RedisConfigs/docker-compose.yml
+++ b/tests/RedisConfigs/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '2.4'
+version: '2.5'
 
 services:
   redisearch:
-    image: redislabs/redisearch
+    image: redislabs/redisearch:latest
     ports:
       - 6385:6379
   redis:


### PR DESCRIPTION
Fundamentally, JRediSearch is doing this, and bases test assumptions on it. To get back to a decent/matching state, we need to do the same. It also brings in the hash failure check from https://github.com/RediSearch/JRediSearch/blob/f1d7e2ed64a18e99b31b3b7fe48bb972c00e3999/src/test/java/io/redisearch/client/ClientTest.java#L403-L408