### PR TITLE
Builds: AppVeyor: remove Ubuntu

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,8 @@
 image:
 - Visual Studio 2019
-- Ubuntu
 
 init:
   - git config --global core.autocrlf input
-
-services: 
-- docker 
 
 install:
 - cmd: >-
@@ -45,18 +41,6 @@ install:
     redis-server.exe --service-install --service-name "redis-26381" "..\Sentinel\sentinel-26381.conf" --sentinel
 
     cd ..\..\..
-- sh: >-
-    sudo curl -L https://github.com/docker/compose/releases/download/1.26.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-
-    sudo chmod +x /usr/local/bin/docker-compose
-
-    sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-
-    cd tests/RedisConfigs
-
-    docker-compose up -d
-
-    cd ../..
 - ps: >-
     if (Get-Command "Start-Service" -errorAction SilentlyContinue) {
       Start-Service redis-*


### PR DESCRIPTION
This is covered by Actions now, and AppVeyor is currently flipping out due to something on their end...let's kill it.