### PR TITLE
GitHub Actions: add .NET 5.x install

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Setup .Net
+    - name: Setup .NET Core 3.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Setup .NET 5.x
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
@@ -41,7 +45,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Setup .Net
+    - name: Setup .NET Core 3.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Setup .NET 5.x
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
@@ -58,7 +66,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Setup .Net
+    - name: Setup .NET Core 3.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Setup .NET 5.x
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
+    - name: Setup .Net
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (docker-compose)
@@ -37,6 +41,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
+    - name: Setup .Net
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: NRedisSearch.Tests
@@ -50,6 +58,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
+    - name: Setup .Net
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (v3.0.503)


### PR DESCRIPTION
This fixes the .NET 5 SDK issue on GitHub Actions builds (the few errors here are transient server issues).
We can revert this once it lands on the Actions images.