### PR TITLE
add support for parsing and formatting unix domain sockets

### DIFF
--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -115,18 +115,14 @@ namespace StackExchange.Redis
         {
             for (int i = 0; i < Count; i++)
             {
-                var endpoint = this[i];
-                var dns = endpoint as DnsEndPoint;
-                if (dns?.Port == 0)
+                switch (this[i])
                 {
-                    this[i] = new DnsEndPoint(dns.Host, defaultPort, dns.AddressFamily);
-                    continue;
-                }
-                var ip = endpoint as IPEndPoint;
-                if (ip?.Port == 0)
-                {
-                    this[i] = new IPEndPoint(ip.Address, defaultPort);
-                    continue;
+                    case DnsEndPoint dns when dns.Port == 0:
+                        this[i] = new DnsEndPoint(dns.Host, defaultPort, dns.AddressFamily);
+                        break;
+                    case IPEndPoint ip when ip.Port == 0:
+                        this[i] = new IPEndPoint(ip.Address, defaultPort);
+                        break;
                 }
             }
         }

--- a/src/StackExchange.Redis/Format.cs
+++ b/src/StackExchange.Redis/Format.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Globalization;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -78,17 +79,21 @@ namespace StackExchange.Redis
 
         internal static string ToString(EndPoint endpoint)
         {
-            if (endpoint is DnsEndPoint dns)
+            switch (endpoint)
             {
-                if (dns.Port == 0) return dns.Host;
-                return dns.Host + ":" + Format.ToString(dns.Port);
+                case DnsEndPoint dns:
+                    if (dns.Port == 0) return dns.Host;
+                    return dns.Host + ":" + Format.ToString(dns.Port);
+                case IPEndPoint ip:
+                    if (ip.Port == 0) return ip.Address.ToString();
+                    return ip.Address + ":" + Format.ToString(ip.Port);
+#if UNIX_SOCKET
+                case UnixDomainSocketEndPoint uds:
+                    return "!" + uds.ToString();
+#endif
+                default:
+                    return endpoint?.ToString() ?? "";
             }
-            if (endpoint is IPEndPoint ip)
-            {
-                if (ip.Port == 0) return ip.Address.ToString();
-                return ip.Address + ":" + Format.ToString(ip.Port);
-            }
-            return endpoint?.ToString() ?? "";
         }
 
         internal static string ToStringHostOnly(EndPoint endpoint)
@@ -233,6 +238,16 @@ namespace StackExchange.Redis
             string portPart = null;
             if (string.IsNullOrEmpty(addressWithPort)) return null;
 
+            if (addressWithPort[0]=='!')
+            {
+                if (addressWithPort.Length == 1) return null;
+
+#if UNIX_SOCKET
+                return new UnixDomainSocketEndPoint(addressWithPort.Substring(1));
+#else
+                throw new PlatformNotSupportedException("Unix domain sockets require .NET Core 3 or above");
+#endif
+            }
             var lastColonIndex = addressWithPort.LastIndexOf(':');
             if (lastColonIndex > 0)
             {

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -10,6 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);VECTOR_SAFE</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0'">$(DefineConstants);UNIX_SOCKET</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -143,6 +143,22 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public void CanParseAndFormatUnixDomainSocket()
+        {
+            const string ConfigString = "!/some/path,allowAdmin=True";
+#if NET472
+            var ex = Assert.Throws<PlatformNotSupportedException>(() => ConfigurationOptions.Parse(ConfigString));
+            Assert.Equal("Unix domain sockets require .NET Core 3 or above", ex.Message);
+#else
+            var config = ConfigurationOptions.Parse(ConfigString);
+            Assert.True(config.AllowAdmin);
+            var ep = Assert.IsType<UnixDomainSocketEndPoint>(Assert.Single(config.EndPoints));
+            Assert.Equal("/some/path", ep.ToString());
+            Assert.Equal(ConfigString, config.ToString());
+#endif
+        }
+
+        [Fact]
         public void TalkToNonsenseServer()
         {
             var config = new ConfigurationOptions

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -30,6 +30,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- marked by a leading `!` in the configuration string, i.e. `!/foo` connects to `/foo` over a unix domain socket
- only available on .builds for NET Core 3.1 and above; in theory we could also support .NET Standard 2.1, but I kinda don't want to add that as a TFM

(the actual work to *connect* via unix domain sockets has worked for a long time - `Socket` deals with it)