### PR TITLE
corrects wording of HashIncrement/HashDecrement summaries

### DIFF
--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -177,7 +177,7 @@ namespace StackExchange.Redis
         GeoRadiusResult[] GeoRadius(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the number stored at field in the hash stored at key by decrement. If key does not exist, a new key holding a hash is created. If field does not exist or holds a string that cannot be interpreted as integer, the value is set to 0 before the operation is performed.
+        /// Decrements the number stored at field in the hash stored at key by decrement. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to decrement.</param>
@@ -271,7 +271,7 @@ namespace StackExchange.Redis
         HashEntry[] HashGetAll(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. If field does not exist or holds a string that cannot be interpreted as integer, the value is set to 0 before the operation is performed.
+        /// Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to increment.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -165,7 +165,7 @@ namespace StackExchange.Redis
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the number stored at field in the hash stored at key by decrement. If key does not exist, a new key holding a hash is created. If field does not exist or holds a string that cannot be interpreted as integer, the value is set to 0 before the operation is performed.
+        /// Decrements the number stored at field in the hash stored at key by decrement. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to decrement.</param>
@@ -259,7 +259,7 @@ namespace StackExchange.Redis
         Task<HashEntry[]> HashGetAllAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. If field does not exist or holds a string that cannot be interpreted as integer, the value is set to 0 before the operation is performed.
+        /// Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to increment.</param>


### PR DESCRIPTION
I experienced an unexpected behaviour when using HashIncrementAsync on a hashset field that was a string.
I was using FireAndForget which initially hid my error... however I was relying on the wording of the intellisense which stated;
```
If field does not exist **or holds a string that cannot be interpreted as integer**, the value is set to 0 before the operation is performed.
```

So I (wrongly) assumed my below test would work and "abc" would be reset to "0" and then incremented by 1.
```csharp
[Fact]
public async Task dtHashSet()
{
    await _redisCacheSvc.db.HashSetAsync("prefix:key", new HashEntry[] { new HashEntry("hashField", "abc") });
    var before = await _redisCacheSvc.db.HashGetAsync("prefix:key", "hashField");
    Assert.Equal("abc", before);
    var after = await _redisCacheSvc.db.HashIncrementAsync("prefix:key", "hashField", 1);
    Assert.Equal(1, after);
}
```
Maybe I missed something obvious here?
But either way thanks for a great library :)