### PR TITLE
PhysicalBridge ConcurrentQueue refactor 

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -136,8 +136,11 @@ namespace StackExchange.Redis
                 // you can go in the queue, but we won't be starting
                 // a worker, because the handshake has not completed
                 message.SetEnqueued(null);
-                message.SetBacklogState(_backlog.Count, null);
-                _backlog.Enqueue(message);
+                lock (_backlog)
+                {
+                    message.SetBacklogState(_backlog.Count, null);
+                    _backlog.Enqueue(message);
+                }
                 return WriteResult.Success; // we'll take it...
             }
             else

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -755,7 +755,7 @@ namespace StackExchange.Redis
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void StartBacklogProcessor()
         {
-            if (0 == Interlocked.CompareExchange(ref _backlogProcessorIsRunning, 1, 0))
+            if (Interlocked.CompareExchange(ref _backlogProcessorIsRunning, 1, 0) == 0)
             {
                 
 #if DEBUG
@@ -922,7 +922,7 @@ namespace StackExchange.Redis
                 token.Dispose();
 
                 // Do this in finally block, so that thread aborts can't convince us the backlog processor is running forever
-                if (Interlocked.CompareExchange(ref _backlogProcessorIsRunning, 1, 0) != 1)
+                if (Interlocked.CompareExchange(ref _backlogProcessorIsRunning, 0, 1) != 1)
                 {
                     throw new Exception("Bug detection, couldn't indicate shutdown of backlog processor");
                 }


### PR DESCRIPTION
A 'data-structure-refactor' that changes the `_backlog` queue to support writing concurrently with reading, which can reduce both read and write thread blocking.

I originally wanted to do this as a way to reduce contention between threads adding to the backlog - which was secondary and mainly happens due to pre-existing contention on the write lock (which I haven't tried to eliminate). This was motivated by having too-many-threads logs that I saw while testing some other changes I'm testing for `PhysicalBridge`. 

I haven't been able to fully reduce contention between competing reads and competing writes, but by reducing contention between reads and writes, I think therefore this now requires lower max worker threads in general, and makes thread-blocking less likely in total, and worker thread usage lower overall.

The CLR's `ConcurrentQueue` is used because it is mostly non-blocking, and I was hoping it would eliminate needs for `lock()` statement on writes in enqueue scenarios, and even reads.

However, I found that for overall correctness of the backlog management, we are still required to use `lock()` statement on it in deqeueing scenarios, so that we can avoid e.g. dequeueing a message which was not the one we saw with `peek()` (for timeout processing).

And also in order prevent races where `StartProcessingBacklog()` could fail to be called when the queue is not empty, we end up needing to enhance the logic for checking whether to start processing the backlog with some extra synchronization.

[Note, this change is complex and will need some more testing than I have done so far before merge, though it passes the 'build' tests for me pretty well so far, but I think its ready for some review and feedback.]