### PR TITLE
Improving ConfigCheckSeconds for a faster failover detection

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2901,14 +2901,6 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The <see cref="RedisKey"/> to determine the hash slot for.</param>
         public int GetHashSlot(RedisKey key) => ServerSelectionStrategy.HashSlot(key);
-
-        internal void MarkServerEndpointsForReplicationRoleRefresh()
-        {
-            foreach (var s in servers.Values)
-            {
-                ((ServerEndPoint)s).ForceReplicationCheck = true;
-            }
-        }
     }
 
     internal enum WriteResult

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -433,7 +433,7 @@ namespace StackExchange.Redis
                     // more frequently on it's replica with exponential increments
                     foreach (var r in ServerEndPoint.Replicas)
                     {
-                        r.ForceExponentiallyReplicationCheck();
+                        r.ForceExponentialBackoffReplicationCheck();
                     }
                 }
 

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -562,7 +562,7 @@ namespace StackExchange.Redis
 
 
         // Forces frequent replication check starting from 1 second upto max ConfigCheckSeconds with an exponential increment
-        internal void ForceExponentiallyReplicationCheck()
+        internal void ForceExponentialBackoffReplicationCheck()
         {
             ConfigCheckSeconds = 1;  // start checking info replication more frequently
         }


### PR DESCRIPTION
Fixes info command storm on a disconnect
After a master node disconnect performs ConfigCheckSeconds on replica nodes with an exponential backoff