### PR TITLE
Closing initial cluster discovery connection

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1837,18 +1837,17 @@ namespace StackExchange.Redis
                                         encounteredConnectedClusterServer = true;
                                         updatedClusterEndpointCollection = await GetEndpointsFromClusterNodes(server, log).ForAwait();
 
-                                        if (first && updatedClusterEndpointCollection?.Count > 0 && server.EndPoint != null)
+                                        if (first && updatedClusterEndpointCollection?.Count > 0 && server?.EndPoint != null)
                                         {
-                                            // close the initial cluster discovery connection as it's no longer needed
-                                            Task[] closeTask = new Task[2];
-                                            closeTask[0] = server.Close(ConnectionType.Interactive);
-                                            closeTask[1] = server.Close(ConnectionType.Subscription);
-                                            await Task.WhenAll(closeTask);
-
-                                            // if discovery endpoint is not in the list of endpoints close it
+                                            // if it's a discovery endpoint close it (i.e. endpoint is not in the list of ips returned by cluster nodes command)
                                             var endpointInClusterNodes = updatedClusterEndpointCollection.FirstOrDefault( endpoint => server.EndPoint.Equals(endpoint));
                                             if (endpointInClusterNodes == null)
                                             {
+                                                // close the initial cluster discovery connection as it's no longer needed
+                                                Task[] closeTask = new Task[2];
+                                                closeTask[0] = server.Close(ConnectionType.Interactive);
+                                                closeTask[1] = server.Close(ConnectionType.Subscription);
+                                                await Task.WhenAll(closeTask);
                                                 // server cleanup
                                                 lock (this.servers)
                                                 {

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1837,7 +1837,7 @@ namespace StackExchange.Redis
                                         encounteredConnectedClusterServer = true;
                                         updatedClusterEndpointCollection = await GetEndpointsFromClusterNodes(server, log).ForAwait();
 
-                                        if (first && updatedClusterEndpointCollection?.Count > 0 && server?.EndPoint != null)
+                                        if (updatedClusterEndpointCollection?.Count > 0 && server?.EndPoint != null)
                                         {
                                             // if it's a discovery endpoint close it (i.e. endpoint is not in the list of ips returned by cluster nodes command)
                                             var endpointInClusterNodes = updatedClusterEndpointCollection.FirstOrDefault( endpoint => server.EndPoint.Equals(endpoint));


### PR DESCRIPTION
A mux to a clustered cache is created by specifying one of the endpoints in the cluster. SE.Redis then runs the CLUSTER NODES command to connect to individual nodes of the cluster.  The initial connection to discover cluster nodes is not used for any client application commands after the initial discovery. This PR proposes to close this connection after discovery of the nodes in the cluster, which will help to reduce the total number of connections from each of the multiplexer when running at scale.