### PR TITLE
Proposed fix for #1719

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,7 @@
 
 - performance optimization for PING accuracy (#1714 via eduardobr)
 - improvement to reconnect logic (exponential backoff) (#1735 via deepakverma)
+- fix messages sent out of order when they are written through PhysicalBridge bypassing backlogged messages (#1749 via TimLovellSmith)
 
 ## 2.2.4
 


### PR DESCRIPTION
After struggling quite a while with why a simple fix for #1719 wouldn't pass tests, and making some tweaks to improve test reliability which I'll PR separately, I eventually realized its all because StackExchange.Redis currently *relies* on out of order message delivery by PhysicalBridge in certain scenarios. A particular set of tests which would reliably fail because of that were the ones doing Tiebreaker with a secure server and needing to authenticate. Instead of being able to fetch tie tiebreaker key, they would fail with NOAUTH.

So this is here the simplest fix I can propose for #1719 which doesn't break the existing ways of doing things. But before you merge... I wonder if there might be an even better factoring. Because to be honest, I am a little nervous about two aspects:

1. the blanket categorization that ALL internal calls should be delivered out of order, as soon as they can get the lock. Mainly because there might be a set of existing bugs related to internal calls getting unexpectedly reordered, and if so, this approach will not fix them! And I couldn't be sure that there won't also later turn out to be cases where ordering of internal calls versus user operations matters .

2. I hypothesize that because this particular fix leaves the policy asALWAYS_USE_BACKLOG_IF_CANNOT_GET_SYNC_LOCK = true, then this means that internal calls are still in a _race_ to acquire the lock with other writers, which could be a source of existing reliability bugs (and test issues). I.e. due to a race acquiring the write lock, internal calls could rarely *fail to jump the queue in the usual way*, resulting in failures similar to the ones seen in the tiebreaker scenario tests. So it might be better to set `ALWAYS_USE_BACKLOG_IF_CANNOT_GET_SYNC_LOCK = !message.IsInternalCall` - but what do you think?