### PR TITLE
For Issue1748: Thread.Sleep fixes

### DIFF
--- a/tests/NRediSearch.Test/ClientTests/AggregationBuilderTests.cs
+++ b/tests/NRediSearch.Test/ClientTests/AggregationBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using NRediSearch.Aggregation;
 using NRediSearch.Aggregation.Reducers;
 using StackExchange.Redis;
@@ -113,7 +114,7 @@ namespace NRediSearch.Test.ClientTests
         }
 
         [Fact]
-        public void TestCursor()
+        public async Task TestCursor()
         {
             /*
                  127.0.0.1:6379> FT.CREATE test_index SCHEMA name TEXT SORTABLE count NUMERIC SORTABLE
@@ -172,7 +173,7 @@ namespace NRediSearch.Test.ClientTests
                 .SortBy(10, SortedField.Descending("@sum"))
                 .Cursor(1, 1000);
 
-            Thread.Sleep(1000);
+            await Task.Delay(1000).ForAwait();
 
             try
             {

--- a/tests/StackExchange.Redis.Tests/Failover.cs
+++ b/tests/StackExchange.Redis.Tests/Failover.cs
@@ -7,11 +7,17 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests
 {
-    public class Failover : TestBase
+    public class Failover : TestBase, IAsyncLifetime
     {
         protected override string GetConfiguration() => GetMasterReplicaConfig().ToString();
 
         public Failover(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        public async Task InitializeAsync()
         {
             using (var mutex = Create())
             {
@@ -27,7 +33,7 @@ namespace StackExchange.Redis.Tests
                 {
                     Log(shouldBeReplica.EndPoint + " should be a replica, fixing...");
                     shouldBeReplica.ReplicaOf(shouldBeMaster.EndPoint);
-                    Thread.Sleep(2000);
+                    await Task.Delay(2000).ForAwait();
                 }
             }
         }

--- a/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
+++ b/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +21,7 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact(Skip = "needs investigation on netcoreapp3.1")]
-        public void MuxerIsCollected()
+        public async Task MuxerIsCollected()
         {
 #if DEBUG
             Skip.Inconclusive("Only predictable in release builds");
@@ -41,7 +42,7 @@ namespace StackExchange.Redis.Tests
             muxer = null;
 
             ForceGC();
-            Thread.Sleep(2000); // GC is twitchy
+            await Task.Delay(2000).ForAwait(); // GC is twitchy
             ForceGC();
 
             // should be collectable


### PR DESCRIPTION
This is a partial fix for Issue #1748. While debugging the issue further, I found that one cause of test worker threads being blocked for a long time was bad old `Thread.Sleep()`.

This fix eliminates all the `Thread.Sleep()`s from test code.

(With this fix there is only one remaining sleep call now in the product code, in GetSentinelMasterConnection(), which is a public synchronous API. It would probably be a good idea to deprecate that API and encourage people to use an Async API instead.)