### PR TITLE
For test reliability and 1748:- don't parallelize Moq tests.

### DIFF
--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -75,11 +75,11 @@ How to configure this setting:
 
 - In .Net Core, add Environment Variable COMPlus_ThreadPool_ForceMinWorkerThreads to overwrite default MinThreads setting, according to [Environment/Registry Configuration Knobs](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/clr-configuration-knobs.md) - You can also use the same ThreadPool.SetMinThreads() Method as described above.
 
-Explanation for abbrivations appearing in exception messages
+Explanation for abbreviations appearing in exception messages
 ---
 By default Redis Timeout exception(s) includes useful information, which can help in uderstanding & diagnosing the timeouts. Some of the abbrivations are as follows:
 
-| Abbrivation   | Long Name | Meaning |
+| Abbreviation   | Long Name | Meaning |
 | ------------- | ---------------------- | ---------------------------- | 
 | inst    |  OpsSinceLastHeartbeat : {int}  | |  
 |qu | Queue-Awaiting-Write : {int}|There are x operations currently waiting in queue to write to the redis server.| 

--- a/tests/StackExchange.Redis.Tests/BatchWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/BatchWrapperTests.cs
@@ -1,9 +1,11 @@
 ﻿using Moq;
 using StackExchange.Redis.KeyspaceIsolation;
 using System.Text;
+using Xunit;
 
 namespace StackExchange.Redis.Tests
 {
+    [Collection(nameof(MoqDependentCollection))]
     public sealed class BatchWrapperTests
     {
         private readonly Mock<IBatch> mock;

--- a/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -9,6 +9,11 @@ using Xunit;
 
 namespace StackExchange.Redis.Tests
 {
+
+    [CollectionDefinition(nameof(MoqDependentCollection), DisableParallelization = true)]
+    public class MoqDependentCollection { }
+
+    [Collection(nameof(MoqDependentCollection))]
     public sealed class DatabaseWrapperTests
     {
         private readonly Mock<IDatabase> mock;

--- a/tests/StackExchange.Redis.Tests/TransactionWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/TransactionWrapperTests.cs
@@ -1,10 +1,12 @@
 ﻿using System.Text;
 using Moq;
 using StackExchange.Redis.KeyspaceIsolation;
+using Xunit;
 
 namespace StackExchange.Redis.Tests
 {
-#pragma warning disable RCS1047 // Non-asynchronous method name should not end with 'Async'.
+#pragma warning disable RCS1047 // Non-asynchronous method name should not end with 'Async'. 
+    [Collection(nameof(MoqDependentCollection))]
     public sealed class TransactionWrapperTests
     {
         private readonly Mock<ITransaction> mock;

--- a/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace StackExchange.Redis.Tests
 {
+    [Collection(nameof(MoqDependentCollection))]
     public sealed class WrapperBaseTests
     {
         private readonly Mock<IDatabaseAsync> mock;


### PR DESCRIPTION
This PR is also a *partial* fix for #1748.

I found that another common cause of too many blocked worker threads while running tests is the code for dynamic generation of mock object Types. This code hits contention due to exclusive locking i.e. the test threads block waiting for each other, all to take turns being the one to then use a hefty amount of CPU to generate some types dynamically. (And once one thread gets unblocks, it then goes busy generating another type, and continues to block all the other Moq threads...)

The proposed solution is to ensure we only run one Moq-dependent test at a time, so that the Moq-dependent tests don't actually have to wait to acquire the lock.