### PR TITLE
Increase timeouts for ConfigVerifyReceiveConfigChangeBroadcast test

### DIFF
--- a/tests/StackExchange.Redis.Tests/Failover.cs
+++ b/tests/StackExchange.Redis.Tests/Failover.cs
@@ -87,7 +87,7 @@ namespace StackExchange.Redis.Tests
                 long count = sender.PublishReconfigure();
                 GetServer(receiver).Ping();
                 GetServer(receiver).Ping();
-                await Task.Delay(100).ConfigureAwait(false);
+                await Task.Delay(1000).ConfigureAwait(false);
                 Assert.True(count == -1 || count >= 2, "subscribers");
                 Assert.True(Interlocked.CompareExchange(ref total, 0, 0) >= 1, "total (1st)");
 
@@ -97,7 +97,7 @@ namespace StackExchange.Redis.Tests
                 var server = GetServer(sender);
                 if (server.IsReplica) Skip.Inconclusive("didn't expect a replica");
                 server.MakeMaster(ReplicationChangeOptions.Broadcast);
-                await Task.Delay(100).ConfigureAwait(false);
+                await Task.Delay(1000).ConfigureAwait(false);
                 GetServer(receiver).Ping();
                 GetServer(receiver).Ping();
                 Assert.True(Interlocked.CompareExchange(ref total, 0, 0) >= 1, "total (2nd)");


### PR DESCRIPTION
This is not a deeply-analyzed change, but based on one test run on my machine, I suspect these timeouts are probably just a little too short to be reliable while running tests in parallel.