### PR TITLE
For test reliability - use TaskCreationOptions LongRunning hint for 'failed connection' tests

### DIFF
--- a/tests/StackExchange.Redis.Tests/ConnectFailTimeout.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectFailTimeout.cs
@@ -16,20 +16,26 @@ namespace StackExchange.Redis.Tests
             using (var conn = Create(allowAdmin: true))
             {
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
-                conn.ConnectionFailed += (s, a) =>
-                    Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
-                conn.ConnectionRestored += (s, a) =>
-                    Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
 
-                // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
-                conn.IgnoreConnect = true;
-                Log("simulating failure");
-                server.SimulateConnectionFailure();
-                Log("simulated failure");
-                conn.IgnoreConnect = false;
-                Log("pinging - expect failure");
-                Assert.Throws<RedisConnectionException>(() => server.Ping());
-                Log("pinged");
+                await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+                void innerScenario()
+                {
+                    conn.ConnectionFailed += (s, a) =>
+                        Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
+                    conn.ConnectionRestored += (s, a) =>
+                        Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
+
+                    // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
+                    conn.IgnoreConnect = true;
+                    Log("simulating failure");
+                    server.SimulateConnectionFailure();
+                    Log("simulated failure");
+                    conn.IgnoreConnect = false;
+                    Log("pinging - expect failure");
+                    Assert.Throws<RedisConnectionException>(() => server.Ping());
+                    Log("pinged");
+                }
+
                 // Heartbeat should reconnect by now
                 await UntilCondition(TimeSpan.FromSeconds(10), () => server.IsConnected);
 

--- a/tests/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
@@ -41,13 +41,17 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public void CanNotOpenNonsenseConnection_IP()
+        public async Task CanNotOpenNonsenseConnection_IP()
         {
-            var ex = Assert.Throws<RedisConnectionException>(() =>
+            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+            void innerScenario()
             {
-                using (ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,connectTimeout=1000", Writer)) { }
-            });
-            Log(ex.ToString());
+                var ex = Assert.Throws<RedisConnectionException>(() =>
+                {
+                    using (ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,connectTimeout=1000", Writer)) { }
+                });
+                Log(ex.ToString());
+            }
         }
 
         [Fact]
@@ -61,22 +65,30 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public void CreateDisconnectedNonsenseConnection_IP()
+        public async Task CreateDisconnectedNonsenseConnection_IP()
         {
-            using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,abortConnect=false,connectTimeout=1000", Writer))
+            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+            void innerScenario()
             {
-                Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
-                Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
+                using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.MasterServer + ":6500,abortConnect=false,connectTimeout=1000", Writer))
+                {
+                    Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
+                    Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
+                }
             }
         }
 
         [Fact]
-        public void CreateDisconnectedNonsenseConnection_DNS()
+        public async Task CreateDisconnectedNonsenseConnection_DNS()
         {
-            using (var conn = ConnectionMultiplexer.Connect($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,abortConnect=false,connectTimeout=1000", Writer))
+            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+            void innerScenario()
             {
-                Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
-                Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
+                using (var conn = ConnectionMultiplexer.Connect($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,abortConnect=false,connectTimeout=1000", Writer))
+                {
+                    Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
+                    Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
+                }
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -35,6 +35,11 @@ namespace StackExchange.Redis.Tests
             ClearAmbientFailures();
         }
 
+        /// <summary> Useful to temporarily get extra worker threads for an otherwise synchronous test case which will 'block' the thread, on a synchronous API like Task.Wait() or Task.Result</summary>
+        /// <note> Must NOT be used for test cases which *goes async*, as then the inferred return type will become 'async void', and we will fail to observe the result of  the async part</note>
+        /// <remarks>See 'ConnectFailTimeout' class for example usage.</remarks>
+        protected Task RunBlockingSynchronousWithExtraThreadAsync(Action testScenario) => Task.Factory.StartNew(testScenario, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+
         protected void LogNoTime(string message) => LogNoTime(Writer, message);
         internal static void LogNoTime(TextWriter output, string message)
         {


### PR DESCRIPTION
Also for #1748. Using TaskCreationOptions.LongRunning can give us a temporary boost in thread numbers for those tests which want to block the thread in failed connection scenarios (these tend to block the thread for a while, which can lead to connectivity issues from exhausting the worker thread pool for other tests).