### PR TITLE
Unselectable flag race fix

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1863,7 +1863,7 @@ namespace StackExchange.Redis
                         var preferred = await NominatePreferredMaster(log, servers, useTieBreakers, tieBreakers, masters).ObserveErrors().ForAwait();
                         foreach (var master in masters)
                         {
-                            if (master == preferred)
+                            if (master == preferred || master.IsReplica)
                             {
                                 master.ClearUnselectable(UnselectableFlags.RedundantMaster);
                             }


### PR DESCRIPTION
In short, we could get in a state where `IsReplica` could be true, but we couldn't use it because it was unselectable via this path, especially on a reconnect race. This caused failures in other Sentinel testing, specifically the `NoConnectionAvailable` variety on `DemandMaster` sanity check gets, because we had a replica, it was connected, but the flags said we couldn't use it. That should _never_ be the case and this additional check at the flag set site ensures it.

In testing, it looked like this (local changes here are logging this condition):

![image](https://user-images.githubusercontent.com/454813/122651716-abf78100-d108-11eb-931e-a28daa76efa6.png)
