### PR TITLE
Fixes for #1762 & Don't fail on *reporting*

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,7 @@ jobs:
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
     - uses: dorny/test-reporter@v1
+      continue-on-error: true
       if: success() || failure()
       with:
         name: StackExchange.Redis.Tests - Results
@@ -64,6 +65,7 @@ jobs:
     - name: NRedisSearch.Tests
       run: dotnet test tests/NRediSearch.Test/NRediSearch.Test.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
     - uses: dorny/test-reporter@v1
+      continue-on-error: true
       if: success() || failure()
       with:
         name: NRedisSearch.Tests - Results
@@ -111,6 +113,7 @@ jobs:
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
     - uses: dorny/test-reporter@v1
+      continue-on-error: true
       if: success() || failure()
       with:
         name: StackExchange.Redis.Tests (Windows Server 2019) - Results

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       continue-on-error: true
       if: success() || failure()
       with:
-        name: StackExchange.Redis.Tests - Results
+        name: StackExchange.Redis.Tests (Ubuntu) - Results
         path: 'test-results/*.trx'
         reporter: dotnet-trx
     - name: .NET Lib Pack

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -739,6 +739,14 @@ namespace StackExchange.Redis
                 var allTasks = Task.WhenAll(tasks).ObserveErrors();
                 bool all = await allTasks.TimeoutAfter(timeoutMs: remaining).ObserveErrors().ForAwait();
                 LogWithThreadPoolStats(log, all ? $"All {tasks.Length} {name} tasks completed cleanly" : $"Not all {name} tasks completed cleanly (from {caller}#{callerLineNumber}, timeout {timeoutMilliseconds}ms)", out _);
+                // If we failed, log the details...
+                if (!all)
+                {
+                    for (var i = 0; i < tasks.Length; i++)
+                    {
+                        log?.WriteLine($"  Task[{i}] Status: {tasks[i].Status}");
+                    }
+                }
                 return all;
             }
             catch

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -725,7 +725,7 @@ namespace StackExchange.Redis
             }
 
             var watch = Stopwatch.StartNew();
-            LogWithThreadPoolStats(log, $"Awaiting {tasks.Length} {name} task completion(s)", out _);
+            LogWithThreadPoolStats(log, $"Awaiting {tasks.Length} {name} task completion(s) for {timeoutMilliseconds}ms", out _);
             try
             {
                 // if none error, great

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -336,7 +336,6 @@ namespace StackExchange.Redis
             {
                 case ConnectionType.Interactive:
                     msg = ServerEndPoint.GetTracerMessage(false);
-                    msg.Flags |= CommandFlags.FireAndForget; // in this case, we're not awaiting the result
                     msg.SetSource(ResultProcessor.Tracer, null);
                     break;
                 case ConnectionType.Subscription:
@@ -432,7 +431,7 @@ namespace StackExchange.Redis
                         r.ForceExponentialBackoffReplicationCheck();
                     }
                 }
-                ServerEndPoint.OnDisconnected();
+                ServerEndPoint.OnDisconnected(this);
 
                 if (!isDisposed && Interlocked.Increment(ref failConnectCount) == 1)
                 {

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -85,6 +85,7 @@ namespace StackExchange.Redis
         {
             async Task<string> IfConnectedAsync(LogProxy log, bool sendTracerIfConnected, bool autoConfigureIfConnected)
             {
+                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed (already connected)");
                 if (autoConfigureIfConnected)
                 {
                     await AutoConfigureAsync(null, log);
@@ -99,6 +100,7 @@ namespace StackExchange.Redis
             if (!IsConnected)
             {
                 var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+                tcs.Task.ContinueWith(t => log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed ({t.Result})"));
                 lock (_pendingConnectionMonitors)
                 {
                     _pendingConnectionMonitors.Add(tcs);
@@ -109,7 +111,6 @@ namespace StackExchange.Redis
                         _pendingConnectionMonitors.Remove(tcs);
                     }
                 }
-                tcs.Task.ContinueWith(t => log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed ({t.Result})"));
                 return tcs.Task;
             }
             return IfConnectedAsync(log, sendTracerIfConnected, autoConfigureIfConnected);

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -579,10 +579,7 @@ namespace StackExchange.Redis
                     {
                         Multiplexer.ResendSubscriptions(this);
                     }
-                    Multiplexer.OnConnectionRestored(EndPoint, bridge.ConnectionType, connection?.ToString());
-
-                    // Only finish connecting on the interactive completion
-                    if (bridge.ConnectionType == ConnectionType.Interactive)
+                    else if (bridge == interactive)
                     {
                         lock (_pendingConnectionMonitors)
                         {
@@ -593,6 +590,8 @@ namespace StackExchange.Redis
                             _pendingConnectionMonitors.Clear();
                         }
                     }
+
+                    Multiplexer.OnConnectionRestored(EndPoint, bridge.ConnectionType, connection?.ToString());                    
                 }
             }
             catch (Exception ex)

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -85,7 +85,6 @@ namespace StackExchange.Redis
         {
             async Task<string> IfConnectedAsync(LogProxy log, bool sendTracerIfConnected, bool autoConfigureIfConnected)
             {
-                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed (already connected)");
                 if (autoConfigureIfConnected)
                 {
                     await AutoConfigureAsync(null, log);
@@ -94,6 +93,7 @@ namespace StackExchange.Redis
                 {
                     await SendTracer(log);
                 }
+                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed (already connected)");
                 return "Already connected";
             }
 

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -581,7 +581,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void SimpleProfiling()
         {
-            using (var conn = Create())
+            using (var conn = Create(log: Writer))
             {
                 var profiler = new ProfilingSession();
                 var key = Me();

--- a/tests/StackExchange.Redis.Tests/Helpers/TextWriterOutputHelper.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/TextWriterOutputHelper.cs
@@ -8,7 +8,7 @@ namespace StackExchange.Redis.Tests.Helpers
     public class TextWriterOutputHelper : TextWriter
     {
         private StringBuilder Buffer { get; } = new StringBuilder(2048);
-        private StringWriter Echo { get; set; }
+        private StringBuilder Echo { get; set; }
         public override Encoding Encoding => Encoding.UTF8;
         private readonly ITestOutputHelper Output;
         private readonly bool ToConsole;
@@ -18,7 +18,7 @@ namespace StackExchange.Redis.Tests.Helpers
             ToConsole = echoToConsole;
         }
 
-        public void EchoTo(StringWriter sb) => Echo = sb;
+        public void EchoTo(StringBuilder sb) => Echo = sb;
 
         public override void WriteLine(string value)
         {
@@ -65,7 +65,7 @@ namespace StackExchange.Redis.Tests.Helpers
         {
             var text = Buffer.ToString();
             Output.WriteLine(text);
-            Echo?.WriteLine(text);
+            Echo?.AppendLine(text);
             if (ToConsole)
             {
                 Console.WriteLine(text);

--- a/tests/StackExchange.Redis.Tests/Helpers/TextWriterOutputHelper.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/TextWriterOutputHelper.cs
@@ -8,6 +8,7 @@ namespace StackExchange.Redis.Tests.Helpers
     public class TextWriterOutputHelper : TextWriter
     {
         private StringBuilder Buffer { get; } = new StringBuilder(2048);
+        private StringWriter Echo { get; set; }
         public override Encoding Encoding => Encoding.UTF8;
         private readonly ITestOutputHelper Output;
         private readonly bool ToConsole;
@@ -16,6 +17,8 @@ namespace StackExchange.Redis.Tests.Helpers
             Output = outputHelper;
             ToConsole = echoToConsole;
         }
+
+        public void EchoTo(StringWriter sb) => Echo = sb;
 
         public override void WriteLine(string value)
         {
@@ -62,6 +65,7 @@ namespace StackExchange.Redis.Tests.Helpers
         {
             var text = Buffer.ToString();
             Output.WriteLine(text);
+            Echo?.WriteLine(text);
             if (ToConsole)
             {
                 Console.WriteLine(text);

--- a/tests/StackExchange.Redis.Tests/Migrate.cs
+++ b/tests/StackExchange.Redis.Tests/Migrate.cs
@@ -38,8 +38,8 @@ namespace StackExchange.Redis.Tests
                 // the redis folks
                 await UntilCondition(TimeSpan.FromSeconds(5), () => !fromDb.KeyExists(key) && toDb.KeyExists(key));
 
-                Assert.False(fromDb.KeyExists(key));
-                Assert.True(toDb.KeyExists(key));
+                Assert.False(fromDb.KeyExists(key), "Exists at source");
+                Assert.True(toDb.KeyExists(key), "Exists at destination");
                 string s = toDb.StringGet(key);
                 Assert.Equal("foo", s);
             }

--- a/tests/StackExchange.Redis.Tests/MultiMaster.cs
+++ b/tests/StackExchange.Redis.Tests/MultiMaster.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -68,7 +69,7 @@ namespace StackExchange.Redis.Tests
             }
 
             // see what happens
-            using var log = new StringWriter();
+            var log = new StringBuilder();
             Writer.EchoTo(log);
 
             using (Create(log: Writer, tieBreaker: TieBreak))

--- a/tests/StackExchange.Redis.Tests/MultiMaster.cs
+++ b/tests/StackExchange.Redis.Tests/MultiMaster.cs
@@ -68,11 +68,12 @@ namespace StackExchange.Redis.Tests
             }
 
             // see what happens
-            using (var log = new StringWriter())
-            using (Create(log: log, tieBreaker: TieBreak))
+            using var log = new StringWriter();
+            Writer.EchoTo(log);
+
+            using (Create(log: Writer, tieBreaker: TieBreak))
             {
                 string text = log.ToString();
-                Log(text);
                 Assert.False(text.Contains("failed to nominate"), "failed to nominate");
                 if (elected != null)
                 {


### PR DESCRIPTION
In GitHub CI if a person doesn't have permissions (to this repo) then the CI fails from trying to *report* test results. It's fine if tests fail and blow us up as intended, but inability to report them shouldn't. We don't see pretty test results when this happens, but every fork won't be red for no reason either.

In removing the fire and forget flags from the primary tracer path to await it, I've realized that write path _won't actually complete_ until the buffer fires, creating a deadlock (we should re-evaluate that path, give we write _but don't observe the result_). The tracers purpose here is to ensure the connection is still working, as a sort of keep-alive, mechanisms elsewhere will handle failure and reconnect if so determined (e.g. via `ReconfigureIfNeeded` paths). In short: we want to just fire off a tracer to subsequently check the state of the world. This change restores that behavior.

Overall changes:
- Don't error for non-repo members on test result additions (build infrastructure, not library)
- More connection logging
- Restore `CommandFlags.FireAndForget` to base `GetTracerMessage`
- Only fire task handlers for `OnConnectedAsync` for interactive disconnections (was still doing subscriptions)
- DRY down to `CompletePendingConnectionMonitors`
- Convert `WriteDirectAsync_Awaited` to a local method (cleans up the namespace and normalizes)
- Fix `Cluster` logging (to help a flaky test for `SimpleProfiling`, though it's a hard repro atm)
- Adds a `EchoTo` option on the test `Writer`, for using a `StringBuilder` to dupe output and check it for assertions
- Messages on `Migrate` tests covering which end failed

Mostly this is the flags change to remediate the `MultiMaster` (heavy connection re-use, in a theory here) from #1762 and other misc. cleanup.