### PR TITLE
More connection/logging tweaks

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -739,14 +739,6 @@ namespace StackExchange.Redis
                 var allTasks = Task.WhenAll(tasks).ObserveErrors();
                 bool all = await allTasks.TimeoutAfter(timeoutMs: remaining).ObserveErrors().ForAwait();
                 LogWithThreadPoolStats(log, all ? $"All {tasks.Length} {name} tasks completed cleanly" : $"Not all {name} tasks completed cleanly (from {caller}#{callerLineNumber}, timeout {timeoutMilliseconds}ms)", out _);
-                // If we failed, log the details...
-                if (!all)
-                {
-                    for (var i = 0; i < tasks.Length; i++)
-                    {
-                        log?.WriteLine($"  Task[{i}] Status: {tasks[i].Status}");
-                    }
-                }
                 return all;
             }
             catch
@@ -1744,7 +1736,19 @@ namespace StackExchange.Redis
                         var remaining = RawConfig.ConnectTimeout - checked((int)watch.ElapsedMilliseconds);
                         log?.WriteLine($"Allowing {available.Length} endpoint(s) {TimeSpan.FromMilliseconds(remaining)} to respond...");
                         Trace("Allowing endpoints " + TimeSpan.FromMilliseconds(remaining) + " to respond...");
-                        await WaitAllIgnoreErrorsAsync("available", available, remaining, log).ForAwait();
+                        var allConnected = await WaitAllIgnoreErrorsAsync("available", available, remaining, log).ForAwait();
+
+                        if (!allConnected)
+                        {
+                            // If we failed, log the details so we can debug why per connection
+                            for (var i = 0; i < servers.Length; i++)
+                            {
+                                var server = servers[i];
+                                var task = available[i];
+                                server.GetOutstandingCount(RedisCommand.PING, out int inst, out int qs, out long @in, out int qu, out bool aw, out long toRead, out long toWrite, out var bs, out var rs, out var ws);
+                                log?.WriteLine($"  Server[{i}] ({Format.ToString(server)}) Status: {task.Status} (inst: {inst}, qs: {qs}, in: {@in}, qu: {qu}, aw: {aw}, in-pipe: {toRead}, out-pipe: {toWrite}, bw: {bs}, rs: {rs}. ws: {ws})");
+                            }
+                        }
 
                         // Log current state after await
                         foreach (var server in servers)
@@ -1755,6 +1759,7 @@ namespace StackExchange.Redis
                         // After we've successfully connected (and authenticated), kickoff tie breakers if needed
                         if (useTieBreakers)
                         {
+                            log?.WriteLine($"Election: Gathering tie-breakers...");
                             for (int i = 0; i < available.Length; i++)
                             {
                                 var server = servers[i];
@@ -1880,7 +1885,7 @@ namespace StackExchange.Redis
                             ServerSelectionStrategy.ServerType = ServerType.Standalone;
                         }
 
-                        var preferred = await NominatePreferredMaster(log, servers, useTieBreakers, tieBreakers, masters).ObserveErrors().ForAwait();
+                        var preferred = await NominatePreferredMaster(log, servers, useTieBreakers, tieBreakers, masters, timeoutMs: RawConfig.ConnectTimeout - checked((int)watch.ElapsedMilliseconds)).ObserveErrors().ForAwait();
                         foreach (var master in masters)
                         {
                             if (master == preferred || master.IsReplica)
@@ -2010,14 +2015,14 @@ namespace StackExchange.Redis
         partial void OnTraceLog(LogProxy log, [CallerMemberName] string caller = null);
 #pragma warning restore IDE0060
 
-        private async Task<ServerEndPoint> NominatePreferredMaster(LogProxy log, ServerEndPoint[] servers, bool useTieBreakers, Task<string>[] tieBreakers, List<ServerEndPoint> masters)
+        private async Task<ServerEndPoint> NominatePreferredMaster(LogProxy log, ServerEndPoint[] servers, bool useTieBreakers, Task<string>[] tieBreakers, List<ServerEndPoint> masters, int timeoutMs)
         {
             Dictionary<string, int> uniques = null;
             if (useTieBreakers)
             {   // count the votes
                 uniques = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                 log?.WriteLine("Waiting for tiebreakers...");
-                await WaitAllIgnoreErrorsAsync("tiebreaker", tieBreakers, 50, log).ForAwait();
+                await WaitAllIgnoreErrorsAsync("tiebreaker", tieBreakers, Math.Max(timeoutMs, 200), log).ForAwait();
                 for (int i = 0; i < tieBreakers.Length; i++)
                 {
                     var ep = servers[i].EndPoint;

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -183,7 +183,7 @@ namespace StackExchange.Redis
             {
                 try
                 {
-                    logging.Log?.WriteLine($"Response from {bridge} / {message.CommandAndKey}: {result}");
+                    logging.Log?.WriteLine($"Response from {bridge?.Name} / {message.CommandAndKey}: {result}");
                 }
                 catch { }
             }

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -85,25 +85,24 @@ namespace StackExchange.Redis
         {
             async Task<string> IfConnectedAsync(LogProxy log, bool sendTracerIfConnected, bool autoConfigureIfConnected)
             {
-                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed (already connected start)");
+                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync already connected start");
                 if (autoConfigureIfConnected)
                 {
-                    await AutoConfigureAsync(null, log);
+                    await AutoConfigureAsync(null, log).ForAwait();
                 }
                 if (sendTracerIfConnected)
                 {
-                    await SendTracer(log);
+                    await SendTracer(log).ForAwait();
                 }
-                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed (already connected end)");
+                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync already connected end");
                 return "Already connected";
             }
 
-            log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync init (State={interactive?.ConnectionState})");
-
             if (!IsConnected)
             {
+                log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync init (State={interactive?.ConnectionState})");
                 var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-                tcs.Task.ContinueWith(t => log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed ({t.Result})"));
+                _ = tcs.Task.ContinueWith(t => log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed ({t.Result})"));
                 lock (_pendingConnectionMonitors)
                 {
                     _pendingConnectionMonitors.Add(tcs);

--- a/tests/StackExchange.Redis.Tests/Migrate.cs
+++ b/tests/StackExchange.Redis.Tests/Migrate.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,8 +18,8 @@ namespace StackExchange.Redis.Tests
         {
             var fromConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.SecureServer, TestConfig.Current.SecurePort } }, Password = TestConfig.Current.SecurePassword, AllowAdmin = true };
             var toConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.MasterServer, TestConfig.Current.MasterPort } }, AllowAdmin = true };
-            using (var from = ConnectionMultiplexer.Connect(fromConfig))
-            using (var to = ConnectionMultiplexer.Connect(toConfig))
+            using (var from = ConnectionMultiplexer.Connect(fromConfig, Writer))
+            using (var to = ConnectionMultiplexer.Connect(toConfig, Writer))
             {
                 if (await IsWindows(from) || await IsWindows(to))
                     Skip.Inconclusive("'migrate' is unreliable on redis-64");

--- a/tests/StackExchange.Redis.Tests/Migrate.cs
+++ b/tests/StackExchange.Redis.Tests/Migrate.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,13 +30,15 @@ namespace StackExchange.Redis.Tests
                 toDb.KeyDelete(key, CommandFlags.FireAndForget);
                 fromDb.StringSet(key, "foo", flags: CommandFlags.FireAndForget);
                 var dest = to.GetEndPoints(true).Single();
+                Log("Migrating key...");
                 fromDb.KeyMigrate(key, dest, migrateOptions: MigrateOptions.Replace);
+                Log("Migration command complete");
 
                 // this is *meant* to be synchronous at the redis level, but
                 // we keep seeing it fail on the CI server where the key has *left* the origin, but
                 // has *not* yet arrived at the destination; adding a pause while we investigate with
                 // the redis folks
-                await UntilCondition(TimeSpan.FromSeconds(5), () => !fromDb.KeyExists(key) && toDb.KeyExists(key));
+                await UntilCondition(TimeSpan.FromSeconds(15), () => !fromDb.KeyExists(key) && toDb.KeyExists(key));
 
                 Assert.False(fromDb.KeyExists(key), "Exists at source");
                 Assert.True(toDb.KeyExists(key), "Exists at destination");

--- a/tests/StackExchange.Redis.Tests/Sentinel.cs
+++ b/tests/StackExchange.Redis.Tests/Sentinel.cs
@@ -329,7 +329,7 @@ namespace StackExchange.Redis.Tests
         {
             var masterConfigs = SentinelServerA.SentinelMasters();
             Assert.Single(masterConfigs);
-            Assert.True(masterConfigs[0].ToDictionary().ContainsKey("name"));
+            Assert.True(masterConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
             Assert.Equal(ServiceName, masterConfigs[0].ToDictionary()["name"]);
             Assert.StartsWith("master", masterConfigs[0].ToDictionary()["flags"]);
             foreach (var config in masterConfigs)
@@ -346,7 +346,7 @@ namespace StackExchange.Redis.Tests
         {
             var masterConfigs = await SentinelServerA.SentinelMastersAsync().ForAwait();
             Assert.Single(masterConfigs);
-            Assert.True(masterConfigs[0].ToDictionary().ContainsKey("name"));
+            Assert.True(masterConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
             Assert.Equal(ServiceName, masterConfigs[0].ToDictionary()["name"]);
             Assert.StartsWith("master", masterConfigs[0].ToDictionary()["flags"]);
             foreach (var config in masterConfigs)
@@ -362,8 +362,8 @@ namespace StackExchange.Redis.Tests
         public void SentinelReplicasTest()
         {
             var replicaConfigs = SentinelServerA.SentinelReplicas(ServiceName);
-            Assert.True(replicaConfigs.Length > 0);
-            Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"));
+            Assert.True(replicaConfigs.Length > 0, "Has replicaConfigs");
+            Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
             Assert.StartsWith("slave", replicaConfigs[0].ToDictionary()["flags"]);
 
             foreach (var config in replicaConfigs)
@@ -379,8 +379,8 @@ namespace StackExchange.Redis.Tests
         public async Task SentinelReplicasAsyncTest()
         {
             var replicaConfigs = await SentinelServerA.SentinelReplicasAsync(ServiceName).ForAwait();
-            Assert.True(replicaConfigs.Length > 0);
-            Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"));
+            Assert.True(replicaConfigs.Length > 0, "Has replicaConfigs");
+            Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
             Assert.StartsWith("slave", replicaConfigs[0].ToDictionary()["flags"]);
             foreach (var config in replicaConfigs)
             {


### PR DESCRIPTION
`await SendTracer(log);` in `OnConnectedAsync` is still hanging sometimes (the log line after it doesn't fire), and the task from that overall local fun is in `WaitingForActivation` status. This happens in the already-connected case and I'm not sure why. This causes the `MultiMaster` sporadic test failure when it occurs.

I'm not spotting the race just yet, but close to a full solution here if we can nail it down.

/cc @TimLovellSmith @mgravell for eyes please - run MultiMaster tests *with the whole suite* to get a failure locally, but I'd say the chances are maybe 1 in 10 of a repro here...better in CI.