### PR TITLE
Sentinel: fix for #1783

### DIFF
--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -2278,8 +2278,14 @@ The coordinates as a two items x,y array (longitude,latitude).
                         var returnArray = result.ToArray<KeyValuePair<string, string>[], StringPairInterleavedProcessor>(
                             (in RawResult rawInnerArray, in StringPairInterleavedProcessor proc) =>
                             {
-                                proc.TryParse(rawInnerArray, out KeyValuePair<string, string>[] kvpArray);
-                                return kvpArray;
+                                if (proc.TryParse(rawInnerArray, out KeyValuePair<string, string>[] kvpArray))
+                                {
+                                    return kvpArray;
+                                }
+                                else
+                                {
+                                    throw new ArgumentOutOfRangeException(nameof(rawInnerArray), $"Error processing {message.CommandAndKey}, could not decode array '{rawInnerArray}'");
+                                }
                             }, innerProcessor);
 
                         SetResult(message, returnArray);

--- a/tests/StackExchange.Redis.Tests/SentinelBase.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelBase.cs
@@ -76,7 +76,7 @@ namespace StackExchange.Redis.Tests
             {
                 while (sw.Elapsed < duration.Value)
                 {
-                    await Task.Delay(1000).ForAwait();
+                    await Task.Delay(200).ForAwait();
                     try
                     {
                         master = SentinelServerA.SentinelGetMasterAddressByName(ServiceName);
@@ -100,6 +100,8 @@ namespace StackExchange.Redis.Tests
             var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
             if (replicas.Length > 0)
             {
+                await Task.Delay(1000).ForAwait();
+                replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
                 await WaitForRoleAsync(checkConn.GetServer(replicas[0]), "slave", duration.Value.Subtract(sw.Elapsed)).ForAwait();
             }
 
@@ -130,7 +132,7 @@ namespace StackExchange.Redis.Tests
                     // ignore
                 }
 
-                await Task.Delay(1000).ForAwait();
+                await Task.Delay(100).ForAwait();
             }
 
             throw new RedisException($"Timeout waiting for server ({server.EndPoint}) to have expected role (\"{role}\") assigned");

--- a/tests/StackExchange.Redis.Tests/SentinelBase.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelBase.cs
@@ -80,7 +80,7 @@ namespace StackExchange.Redis.Tests
             {
                 while (sw.Elapsed < duration.Value)
                 {
-                    await Task.Delay(200).ForAwait();
+                    await Task.Delay(1000).ForAwait();
                     try
                     {
                         master = SentinelServerA.SentinelGetMasterAddressByName(ServiceName);
@@ -136,7 +136,7 @@ namespace StackExchange.Redis.Tests
                     // ignore
                 }
 
-                await Task.Delay(100).ForAwait();
+                await Task.Delay(500).ForAwait();
             }
 
             throw new RedisException($"Timeout waiting for server ({server.EndPoint}) to have expected role (\"{role}\") assigned");

--- a/tests/StackExchange.Redis.Tests/SentinelBase.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelBase.cs
@@ -64,22 +64,6 @@ namespace StackExchange.Redis.Tests
             public int GetHashCode(string obj) => obj.GetHashCode();
         }
 
-        protected async Task DoFailoverAsync()
-        {
-            await WaitForReadyAsync();
-
-            // capture current replica
-            var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
-
-            Log("Starting failover...");
-            var sw = Stopwatch.StartNew();
-            SentinelServerA.SentinelFailover(ServiceName);
-
-            // wait until the replica becomes the master
-            await WaitForReadyAsync(expectedMaster: replicas[0]);
-            Log($"Time to failover: {sw.Elapsed}");
-        }
-
         protected async Task WaitForReadyAsync(EndPoint expectedMaster = null, bool waitForReplication = false, TimeSpan? duration = null)
         {
             duration ??= TimeSpan.FromSeconds(30);

--- a/tests/StackExchange.Redis.Tests/SentinelBase.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelBase.cs
@@ -109,10 +109,11 @@ namespace StackExchange.Redis.Tests
                 throw new RedisException($"Master was expected to be {expectedMaster}");
             Log($"Master is {master}");
 
-            var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
             var checkConn = Conn.GetSentinelMasterConnection(ServiceOptions);
 
             await WaitForRoleAsync(checkConn.GetServer(master), "master", duration.Value.Subtract(sw.Elapsed)).ForAwait();
+
+            var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
             if (replicas.Length > 0)
             {
                 await WaitForRoleAsync(checkConn.GetServer(replicas[0]), "slave", duration.Value.Subtract(sw.Elapsed)).ForAwait();

--- a/tests/StackExchange.Redis.Tests/SentinelBase.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelBase.cs
@@ -39,10 +39,14 @@ namespace StackExchange.Redis.Tests
 
             for (var i = 0; i < 150; i++)
             {
-                await Task.Delay(20).ForAwait();
-                if (Conn.IsConnected && Conn.GetSentinelMasterConnection(options, Writer).IsConnected)
+                await Task.Delay(100).ForAwait();
+                if (Conn.IsConnected)
                 {
-                    break;
+                    using var checkConn = Conn.GetSentinelMasterConnection(options, Writer);
+                    if (checkConn.IsConnected)
+                    {
+                        break;
+                    }
                 }
             }
             Assert.True(Conn.IsConnected);
@@ -93,7 +97,7 @@ namespace StackExchange.Redis.Tests
                 throw new RedisException($"Master was expected to be {expectedMaster}");
             Log($"Master is {master}");
 
-            var checkConn = Conn.GetSentinelMasterConnection(ServiceOptions);
+            using var checkConn = Conn.GetSentinelMasterConnection(ServiceOptions);
 
             await WaitForRoleAsync(checkConn.GetServer(master), "master", duration.Value.Subtract(sw.Elapsed)).ForAwait();
 


### PR DESCRIPTION
This should help the flakiness in this test, it's a race described in #1783, but in the test not the functionality.