### PR TITLE
Code cleanup: Phase 1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -67,6 +67,10 @@ csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
+# Disable range operator suggestions
+csharp_style_prefer_range_operator = false:none
+csharp_style_prefer_index_operator = false:none
+
 # Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -66,6 +66,7 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
+csharp_prefer_simple_using_statement = true:silent
 
 # Disable range operator suggestions
 csharp_style_prefer_range_operator = false:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -48,8 +48,8 @@ dotnet_style_explicit_tuple_names = true:suggestion
 # Ignore silly if statements
 dotnet_style_prefer_conditional_expression_over_return = false:none
 
-# Don't warn on Roslynator
-dotnet_remove_unnecessary_suppression_exclusions = CA1009,CA1063,CA1416,CA1816,CA2202,CS0618,RCS1047,RCS1085,RCS1090,RCS1194,RCS1231
+# Don't warn on things that actually need suppressing
+dotnet_remove_unnecessary_suppression_exclusions = CA1009,CA1063,CA1416,CA1816,CA1822,CA2202,CS0618,IDE0060,RCS1047,RCS1085,RCS1090,RCS1194,RCS1231
 
 # CSharp code style settings:
 [*.cs]

--- a/.editorconfig
+++ b/.editorconfig
@@ -49,7 +49,7 @@ dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = false:none
 
 # Don't warn on things that actually need suppressing
-dotnet_remove_unnecessary_suppression_exclusions = CA1009,CA1063,CA1416,CA1816,CA1822,CA2202,CS0618,IDE0060,RCS1047,RCS1085,RCS1090,RCS1194,RCS1231
+dotnet_remove_unnecessary_suppression_exclusions = CA1009,CA1063,CA1069,CA1416,CA1816,CA1822,CA2202,CS0618,IDE0060,IDE0062,RCS1047,RCS1085,RCS1090,RCS1194,RCS1231
 
 # CSharp code style settings:
 [*.cs]

--- a/.editorconfig
+++ b/.editorconfig
@@ -48,6 +48,9 @@ dotnet_style_explicit_tuple_names = true:suggestion
 # Ignore silly if statements
 dotnet_style_prefer_conditional_expression_over_return = false:none
 
+# Don't warn on Roslynator
+dotnet_remove_unnecessary_suppression_exclusions = CA1009,CA1063,CA1416,CA1816,CA2202,CS0618,RCS1047,RCS1085,RCS1090,RCS1194,RCS1231
+
 # CSharp code style settings:
 [*.cs]
 # Prefer method-like constructs to have a expression-body

--- a/src/NRediSearch/Aggregation/AggregationRequest.cs
+++ b/src/NRediSearch/Aggregation/AggregationRequest.cs
@@ -94,7 +94,7 @@ namespace NRediSearch.Aggregation
             return this;
         }
 
-        public AggregationRequest GroupBy(String field, params Reducer[] reducers)
+        public AggregationRequest GroupBy(string field, params Reducer[] reducers)
         {
             return GroupBy(new string[] { field }, reducers);
         }

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -1276,7 +1276,7 @@ namespace NRediSearch
         {
             if (docIds.Length == 0)
             {
-                return new Document[] { };
+                return Array.Empty<Document>();
             }
 
             var args = new List<object>

--- a/src/NRediSearch/Client.cs
+++ b/src/NRediSearch/Client.cs
@@ -134,7 +134,7 @@ namespace NRediSearch
             public static IndexOptions Default => new IndexOptions();
 
             private IndexOptions _options;
-            private IndexDefinition _definition;
+            private readonly IndexDefinition _definition;
             private string[] _stopwords;
 
             public ConfiguredIndexOptions(IndexOptions options = IndexOptions.Default)

--- a/src/NRediSearch/Extensions.cs
+++ b/src/NRediSearch/Extensions.cs
@@ -23,16 +23,13 @@ namespace NRediSearch
                 return value.ToString(forceDecimal ? "#.0" : "G17", NumberFormatInfo.InvariantInfo);
             }
         }
-        internal static string AsRedisString(this GeoUnit value)
+        internal static string AsRedisString(this GeoUnit value) => value switch
         {
-            switch (value)
-            {
-                case GeoUnit.Feet: return "ft";
-                case GeoUnit.Kilometers: return "km";
-                case GeoUnit.Meters: return "m";
-                case GeoUnit.Miles: return "mi";
-                default: throw new InvalidOperationException($"Unknown unit: {value}");
-            }
-        }
+            GeoUnit.Feet => "ft",
+            GeoUnit.Kilometers => "km",
+            GeoUnit.Meters => "m",
+            GeoUnit.Miles => "mi",
+            _ => throw new InvalidOperationException($"Unknown unit: {value}"),
+        };
     }
 }

--- a/src/NRediSearch/QueryBuilder/GeoValue.cs
+++ b/src/NRediSearch/QueryBuilder/GeoValue.cs
@@ -21,9 +21,9 @@ namespace NRediSearch.QueryBuilder
         public override string ToString()
         {
             return new StringBuilder("[")
-                    .Append(_lon.AsRedisString(true)).Append(" ")
-                    .Append(_lat.AsRedisString(true)).Append(" ")
-                    .Append(_radius.AsRedisString(true)).Append(" ")
+                    .Append(_lon.AsRedisString(true)).Append(' ')
+                    .Append(_lat.AsRedisString(true)).Append(' ')
+                    .Append(_radius.AsRedisString(true)).Append(' ')
                     .Append(_unit.AsRedisString())
                     .Append("]").ToString();
         }

--- a/src/NRediSearch/QueryBuilder/GeoValue.cs
+++ b/src/NRediSearch/QueryBuilder/GeoValue.cs
@@ -25,7 +25,7 @@ namespace NRediSearch.QueryBuilder
                     .Append(_lat.AsRedisString(true)).Append(' ')
                     .Append(_radius.AsRedisString(true)).Append(' ')
                     .Append(_unit.AsRedisString())
-                    .Append("]").ToString();
+                    .Append(']').ToString();
         }
 
         public override bool IsCombinable() => false;

--- a/src/NRediSearch/QueryBuilder/QueryNode.cs
+++ b/src/NRediSearch/QueryBuilder/QueryNode.cs
@@ -80,7 +80,7 @@ namespace NRediSearch.QueryBuilder
 
             if (ShouldUseParens(mode))
             {
-                sb.Append("(");
+                sb.Append('(');
             }
             var sj = new StringJoiner(sb, GetJoinString());
             foreach (var n in children)
@@ -89,7 +89,7 @@ namespace NRediSearch.QueryBuilder
             }
             if (ShouldUseParens(mode))
             {
-                sb.Append(")");
+                sb.Append(')');
             }
             return sb.ToString();
         }

--- a/src/NRediSearch/QueryBuilder/RangeValue.cs
+++ b/src/NRediSearch/QueryBuilder/RangeValue.cs
@@ -15,7 +15,7 @@ namespace NRediSearch.QueryBuilder
         {
             if (!inclusive)
             {
-                sb.Append("(");
+                sb.Append('(');
             }
             sb.Append(n.AsRedisString(true));
         }
@@ -23,11 +23,11 @@ namespace NRediSearch.QueryBuilder
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append("[");
+            sb.Append('[');
             AppendNum(sb, from, inclusiveMin);
-            sb.Append(" ");
+            sb.Append(' ');
             AppendNum(sb, to, inclusiveMax);
-            sb.Append("]");
+            sb.Append(']');
             return sb.ToString();
         }
 

--- a/src/NRediSearch/QueryBuilder/ValueNode.cs
+++ b/src/NRediSearch/QueryBuilder/ValueNode.cs
@@ -40,7 +40,7 @@ namespace NRediSearch.QueryBuilder
             StringBuilder sb = new StringBuilder(FormatField());
             if (_values.Length > 1 || mode == ParenMode.Always)
             {
-                sb.Append("(");
+                sb.Append('(');
             }
             var sj = new StringJoiner(sb, _joinString);
             foreach (var v in _values)
@@ -49,7 +49,7 @@ namespace NRediSearch.QueryBuilder
             }
             if (_values.Length > 1 || mode == ParenMode.Always)
             {
-                sb.Append(")");
+                sb.Append(')');
             }
             return sb.ToString();
         }
@@ -64,7 +64,7 @@ namespace NRediSearch.QueryBuilder
             var sb = new StringBuilder();
             if (useParen)
             {
-                sb.Append("(");
+                sb.Append('(');
             }
             var sj = new StringJoiner(sb, _joinString);
             foreach (var v in _values)
@@ -73,7 +73,7 @@ namespace NRediSearch.QueryBuilder
             }
             if (useParen)
             {
-                sb.Append(")");
+                sb.Append(')');
             }
             return sb.ToString();
         }

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -36,17 +36,14 @@ namespace NRediSearch
 
             internal virtual void SerializeRedisArgs(List<object> args)
             {
-                static object GetForRedis(FieldType type)
+                static object GetForRedis(FieldType type) => type switch
                 {
-                    switch (type)
-                    {
-                        case FieldType.FullText: return "TEXT".Literal();
-                        case FieldType.Geo: return "GEO".Literal();
-                        case FieldType.Numeric: return "NUMERIC".Literal();
-                        case FieldType.Tag: return "TAG".Literal();
-                        default: throw new ArgumentOutOfRangeException(nameof(type));
-                    }
-                }
+                    FieldType.FullText => "TEXT".Literal(),
+                    FieldType.Geo => "GEO".Literal(),
+                    FieldType.Numeric => "NUMERIC".Literal(),
+                    FieldType.Tag => "TAG".Literal(),
+                    _ => throw new ArgumentOutOfRangeException(nameof(type)),
+                };
                 args.Add(Name);
                 args.Add(GetForRedis(Type));
                 if (Sortable) { args.Add("SORTABLE".Literal()); }

--- a/src/NRediSearch/Suggestion.cs
+++ b/src/NRediSearch/Suggestion.cs
@@ -91,6 +91,7 @@ namespace NRediSearch
 
             public Suggestion Build() => Build(false);
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0071:Simplify interpolation", Justification = "Allocations (string.Concat vs. string.Format)")]
             internal Suggestion Build(bool fromServer)
             {
                 bool isStringMissing = _string == null;

--- a/src/StackExchange.Redis/CommandBytes.cs
+++ b/src/StackExchange.Redis/CommandBytes.cs
@@ -136,7 +136,7 @@ namespace StackExchange.Redis
 
         public unsafe CommandBytes(in ReadOnlySequence<byte> value)
         {
-            if (value.Length > MaxLength) throw new ArgumentOutOfRangeException("Maximum command length exceeed");
+            if (value.Length > MaxLength) throw new ArgumentOutOfRangeException(nameof(value), "Maximum command length exceeed");
             int len = unchecked((int)value.Length);
             _0 = _1 = _2 = _3 = 0L;
             fixed (ulong* uPtr = &_0)

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -130,7 +130,7 @@ namespace StackExchange.Redis
                     {
                         if (Enum.TryParse(command, true, out RedisCommand parsed))
                         {
-                            (exclusions ?? (exclusions = new HashSet<RedisCommand>())).Add(parsed);
+                            (exclusions ??= new HashSet<RedisCommand>()).Add(parsed);
                         }
                     }
                 }

--- a/src/StackExchange.Redis/Condition.cs
+++ b/src/StackExchange.Redis/Condition.cs
@@ -438,23 +438,13 @@ namespace StackExchange.Redis
                 }
                 else
                 {
-                    switch (type)
+                    cmd = type switch
                     {
-                        case RedisType.Hash:
-                            cmd = RedisCommand.HEXISTS;
-                            break;
-
-                        case RedisType.Set:
-                            cmd = RedisCommand.SISMEMBER;
-                            break;
-
-                        case RedisType.SortedSet:
-                            cmd = RedisCommand.ZSCORE;
-                            break;
-
-                        default:
-                            throw new ArgumentException(nameof(type));
-                    }
+                        RedisType.Hash => RedisCommand.HEXISTS,
+                        RedisType.Set => RedisCommand.SISMEMBER,
+                        RedisType.SortedSet => RedisCommand.ZSCORE,
+                        _ => throw new ArgumentException(nameof(type)),
+                    };
                 }
             }
 
@@ -522,19 +512,12 @@ namespace StackExchange.Redis
                 this.expectedEqual = expectedEqual;
                 this.expectedValue = expectedValue;
                 this.type = type;
-                switch (type)
+                cmd = type switch
                 {
-                    case RedisType.Hash:
-                        cmd = memberName.IsNull ? RedisCommand.GET : RedisCommand.HGET;
-                        break;
-
-                    case RedisType.SortedSet:
-                        cmd = RedisCommand.ZSCORE;
-                        break;
-
-                    default:
-                        throw new ArgumentException(nameof(type));
-                }
+                    RedisType.Hash => memberName.IsNull ? RedisCommand.GET : RedisCommand.HGET,
+                    RedisType.SortedSet => RedisCommand.ZSCORE,
+                    _ => throw new ArgumentException(nameof(type)),
+                };
             }
 
             public override string ToString()
@@ -685,31 +668,15 @@ namespace StackExchange.Redis
                 this.compareToResult = compareToResult;
                 this.expectedLength = expectedLength;
                 this.type = type;
-                switch (type)
+                cmd = type switch
                 {
-                    case RedisType.Hash:
-                        cmd = RedisCommand.HLEN;
-                        break;
-
-                    case RedisType.Set:
-                        cmd = RedisCommand.SCARD;
-                        break;
-
-                    case RedisType.List:
-                        cmd = RedisCommand.LLEN;
-                        break;
-
-                    case RedisType.SortedSet:
-                        cmd = RedisCommand.ZCARD;
-                        break;
-
-                    case RedisType.String:
-                        cmd = RedisCommand.STRLEN;
-                        break;
-
-                    default:
-                        throw new ArgumentException(nameof(type));
-                }
+                    RedisType.Hash => RedisCommand.HLEN,
+                    RedisType.Set => RedisCommand.SCARD,
+                    RedisType.List => RedisCommand.LLEN,
+                    RedisType.SortedSet => RedisCommand.ZCARD,
+                    RedisType.String => RedisCommand.STRLEN,
+                    _ => throw new ArgumentException(nameof(type)),
+                };
             }
 
             public override string ToString()

--- a/src/StackExchange.Redis/Condition.cs
+++ b/src/StackExchange.Redis/Condition.cs
@@ -427,7 +427,7 @@ namespace StackExchange.Redis
 
             public ExistsCondition(in RedisKey key, RedisType type, in RedisValue expectedValue, bool expectedResult)
             {
-                if (key.IsNull) throw new ArgumentException("key");
+                if (key.IsNull) throw new ArgumentNullException(nameof(key));
                 this.key = key;
                 this.type = type;
                 this.expectedValue = expectedValue;
@@ -444,7 +444,7 @@ namespace StackExchange.Redis
                         RedisType.Hash => RedisCommand.HEXISTS,
                         RedisType.Set => RedisCommand.SISMEMBER,
                         RedisType.SortedSet => RedisCommand.ZSCORE,
-                        _ => throw new ArgumentException(nameof(type)),
+                        _ => throw new ArgumentException($"Type {type} is not recognized", nameof(type)),
                     };
                 }
             }
@@ -507,7 +507,7 @@ namespace StackExchange.Redis
 
             public EqualsCondition(in RedisKey key, RedisType type, in RedisValue memberName, bool expectedEqual, in RedisValue expectedValue)
             {
-                if (key.IsNull) throw new ArgumentException("key");
+                if (key.IsNull) throw new ArgumentNullException(nameof(key));
                 this.key = key;
                 this.memberName = memberName;
                 this.expectedEqual = expectedEqual;
@@ -517,7 +517,7 @@ namespace StackExchange.Redis
                 {
                     RedisType.Hash => memberName.IsNull ? RedisCommand.GET : RedisCommand.HGET,
                     RedisType.SortedSet => RedisCommand.ZSCORE,
-                    _ => throw new ArgumentException(nameof(type)),
+                    _ => throw new ArgumentException($"Unknown type: {type}", nameof(type)),
                 };
             }
 
@@ -594,7 +594,7 @@ namespace StackExchange.Redis
             private readonly RedisKey key;
             public ListCondition(in RedisKey key, long index, bool expectedResult, in RedisValue? expectedValue)
             {
-                if (key.IsNull) throw new ArgumentException(nameof(key));
+                if (key.IsNull) throw new ArgumentNullException(nameof(key));
                 this.key = key;
                 this.index = index;
                 this.expectedResult = expectedResult;
@@ -664,7 +664,7 @@ namespace StackExchange.Redis
 
             public LengthCondition(in RedisKey key, RedisType type, int compareToResult, long expectedLength)
             {
-                if (key.IsNull) throw new ArgumentException(nameof(key));
+                if (key.IsNull) throw new ArgumentNullException(nameof(key));
                 this.key = key;
                 this.compareToResult = compareToResult;
                 this.expectedLength = expectedLength;
@@ -676,7 +676,7 @@ namespace StackExchange.Redis
                     RedisType.List => RedisCommand.LLEN,
                     RedisType.SortedSet => RedisCommand.ZCARD,
                     RedisType.String => RedisCommand.STRLEN,
-                    _ => throw new ArgumentException(nameof(type)),
+                    _ => throw new ArgumentException($"Type {type} isn't recognized", nameof(type)),
                 };
             }
 
@@ -742,7 +742,7 @@ namespace StackExchange.Redis
 
             public SortedSetRangeLengthCondition(in RedisKey key, RedisValue min, RedisValue max, int compareToResult, long expectedLength)
             {
-                if (key.IsNull) throw new ArgumentException(nameof(key));
+                if (key.IsNull) throw new ArgumentNullException(nameof(key));
                 this.key = key;
                 this.min = min;
                 this.max = max;
@@ -812,7 +812,7 @@ namespace StackExchange.Redis
             {
                 if (key.IsNull)
                 {
-                    throw new ArgumentException("key");
+                    throw new ArgumentNullException(nameof(key));
                 }
 
                 this.key = key;

--- a/src/StackExchange.Redis/Condition.cs
+++ b/src/StackExchange.Redis/Condition.cs
@@ -357,6 +357,7 @@ namespace StackExchange.Redis
                 return new ConditionMessage(condition, db, flags, command, key, value, value1);
             }
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0071:Simplify interpolation", Justification = "Allocations (string.Concat vs. string.Format)")]
             protected override bool SetResultCore(PhysicalConnection connection, Message message, in RawResult result)
             {
                 connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog($"condition '{message.CommandAndKey}' got '{result.ToString()}'");

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -250,13 +250,11 @@ namespace StackExchange.Redis
             get
             {
                 if (commandMap != null) return commandMap;
-                switch (Proxy)
+                return Proxy switch
                 {
-                    case Proxy.Twemproxy:
-                        return CommandMap.Twemproxy;
-                    default:
-                        return CommandMap.Default;
-                }
+                    Proxy.Twemproxy => CommandMap.Twemproxy,
+                    _ => CommandMap.Default,
+                };
             }
             set
             {

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -306,9 +306,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Specifies the time in seconds at which connections should be pinged to ensure validity
         /// </summary>
-#pragma warning disable RCS1128
         public int KeepAlive { get { return keepAlive.GetValueOrDefault(-1); } set { keepAlive = value; } }
-#pragma warning restore RCS1128 // Use coalesce expression.
 
         /// <summary>
         /// The user to use to authenticate with the server.
@@ -383,9 +381,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)
         /// </summary>
-#pragma warning disable RCS1128
         public int SyncTimeout { get { return syncTimeout.GetValueOrDefault(5000); } set { syncTimeout = value; } }
-#pragma warning restore RCS1128
 
         /// <summary>
         /// Tie-breaker used to choose between masters (must match the endpoint exactly)
@@ -405,9 +401,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Check configuration every n seconds (every minute by default)
         /// </summary>
-#pragma warning disable RCS1128
         public int ConfigCheckSeconds { get { return configCheckSeconds.GetValueOrDefault(60); } set { configCheckSeconds = value; } }
-#pragma warning restore RCS1128
 
         /// <summary>
         /// Parse the configuration from a comma-delimited configuration string

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2778,6 +2778,7 @@ namespace StackExchange.Redis
             _ => ExceptionFactory.ConnectionFailure(IncludeDetailInExceptions, ConnectionFailureType.ProtocolFailure, "An unknown error occurred when writing the message", server),
         };
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Intentional observation")]
         internal static void ThrowFailed<T>(TaskCompletionSource<T> source, Exception unthrownException)
         {
             try

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -709,7 +709,7 @@ namespace StackExchange.Redis
             return true;
         }
 
-        private async Task<bool> WaitAllIgnoreErrorsAsync(string name, Task[] tasks, int timeoutMilliseconds, LogProxy log, [CallerMemberName] string caller = null, [CallerLineNumber] int callerLineNumber = 0)
+        private static async Task<bool> WaitAllIgnoreErrorsAsync(string name, Task[] tasks, int timeoutMilliseconds, LogProxy log, [CallerMemberName] string caller = null, [CallerLineNumber] int callerLineNumber = 0)
         {
             if (tasks == null) throw new ArgumentNullException(nameof(tasks));
             if (tasks.Length == 0)
@@ -2010,7 +2010,7 @@ namespace StackExchange.Redis
         partial void OnTraceLog(LogProxy log, [CallerMemberName] string caller = null);
 #pragma warning restore IDE0060
 
-        private async Task<ServerEndPoint> NominatePreferredMaster(LogProxy log, ServerEndPoint[] servers, bool useTieBreakers, Task<string>[] tieBreakers, List<ServerEndPoint> masters)
+        private static async Task<ServerEndPoint> NominatePreferredMaster(LogProxy log, ServerEndPoint[] servers, bool useTieBreakers, Task<string>[] tieBreakers, List<ServerEndPoint> masters)
         {
             Dictionary<string, int> uniques = null;
             if (useTieBreakers)
@@ -2118,7 +2118,7 @@ namespace StackExchange.Redis
             return masters[0];
         }
 
-        private ServerEndPoint SelectServerByElection(ServerEndPoint[] servers, string endpoint, LogProxy log)
+        private static ServerEndPoint SelectServerByElection(ServerEndPoint[] servers, string endpoint, LogProxy log)
         {
             if (servers == null || string.IsNullOrWhiteSpace(endpoint)) return null;
             for (int i = 0; i < servers.Length; i++)

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2770,20 +2770,13 @@ namespace StackExchange.Redis
             return tcs == null ? default(T) : await tcs.Task.ForAwait();
         }
 
-        internal Exception GetException(WriteResult result, Message message, ServerEndPoint server)
+        internal Exception GetException(WriteResult result, Message message, ServerEndPoint server) => result switch
         {
-            switch (result)
-            {
-                case WriteResult.Success: return null;
-                case WriteResult.NoConnectionAvailable:
-                    return ExceptionFactory.NoConnectionAvailable(this, message, server);
-                case WriteResult.TimeoutBeforeWrite:
-                    return ExceptionFactory.Timeout(this, "The timeout was reached before the message could be written to the output buffer, and it was not sent", message, server, result);
-                case WriteResult.WriteFailure:
-                default:
-                    return ExceptionFactory.ConnectionFailure(IncludeDetailInExceptions, ConnectionFailureType.ProtocolFailure, "An unknown error occurred when writing the message", server);
-            }
-        }
+            WriteResult.Success => null,
+            WriteResult.NoConnectionAvailable => ExceptionFactory.NoConnectionAvailable(this, message, server),
+            WriteResult.TimeoutBeforeWrite => ExceptionFactory.Timeout(this, "The timeout was reached before the message could be written to the output buffer, and it was not sent", message, server, result),
+            _ => ExceptionFactory.ConnectionFailure(IncludeDetailInExceptions, ConnectionFailureType.ProtocolFailure, "An unknown error occurred when writing the message", server),
+        };
 
         internal static void ThrowFailed<T>(TaskCompletionSource<T> source, Exception unthrownException)
         {

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2011,6 +2011,8 @@ namespace StackExchange.Redis
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Used - it's a partial")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Partial - may use instance data")]
         partial void OnTraceLog(LogProxy log, [CallerMemberName] string caller = null);
 
         private static async Task<ServerEndPoint> NominatePreferredMaster(LogProxy log, ServerEndPoint[] servers, bool useTieBreakers, Task<string>[] tieBreakers, List<ServerEndPoint> masters, int timeoutMs)

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2011,9 +2011,7 @@ namespace StackExchange.Redis
             }
         }
 
-#pragma warning disable IDE0060
         partial void OnTraceLog(LogProxy log, [CallerMemberName] string caller = null);
-#pragma warning restore IDE0060
 
         private static async Task<ServerEndPoint> NominatePreferredMaster(LogProxy log, ServerEndPoint[] servers, bool useTieBreakers, Task<string>[] tieBreakers, List<ServerEndPoint> masters, int timeoutMs)
         {

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2244,10 +2244,8 @@ namespace StackExchange.Redis
             => PrepareToPushMessageToBridge(message, processor, resultBox, ref server) ? server.TryWriteAsync(message) : new ValueTask<WriteResult>(WriteResult.NoConnectionAvailable);
 
         [Obsolete("prefer async")]
-#pragma warning disable CS0618
         private WriteResult TryPushMessageToBridgeSync<T>(Message message, ResultProcessor<T> processor, IResultBox<T> resultBox, ref ServerEndPoint server)
             => PrepareToPushMessageToBridge(message, processor, resultBox, ref server) ? server.TryWriteSync(message) : WriteResult.NoConnectionAvailable;
-#pragma warning restore CS0618
 
         /// <summary>
         /// See Object.ToString()

--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -41,7 +41,7 @@ namespace StackExchange.Redis
         public void Add(string hostAndPort)
         {
             var endpoint = Format.TryParseEndPoint(hostAndPort);
-            if (endpoint == null) throw new ArgumentException();
+            if (endpoint == null) throw new ArgumentException($"Could not parse host and port from '{hostAndPort}'", nameof(hostAndPort));
             Add(endpoint);
         }
 

--- a/src/StackExchange.Redis/Enums/ClientFlags.cs
+++ b/src/StackExchange.Redis/Enums/ClientFlags.cs
@@ -18,6 +18,7 @@ namespace StackExchange.Redis
     /// N: no specific flag set
     /// </summary>
     [Flags]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ClientFlags : long
     {
         /// <summary>

--- a/src/StackExchange.Redis/Enums/ClientType.cs
+++ b/src/StackExchange.Redis/Enums/ClientType.cs
@@ -6,6 +6,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// The class of the connection
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ClientType
     {
         /// <summary>

--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -7,6 +7,7 @@ namespace StackExchange.Redis
     /// Behaviour markers associated with a given command
     /// </summary>
     [Flags]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum CommandFlags
     {
         /// <summary>

--- a/src/StackExchange.Redis/Enums/ReplicationChangeOptions.cs
+++ b/src/StackExchange.Redis/Enums/ReplicationChangeOptions.cs
@@ -7,6 +7,7 @@ namespace StackExchange.Redis
     /// Additional operations to perform when making a server a master
     /// </summary>
     [Flags]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ReplicationChangeOptions
     {
         /// <summary>

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -270,7 +270,7 @@ namespace StackExchange.Redis
 
             sb.Append(" (Please take a look at this article for some common client-side issues that can cause timeouts: ");
             sb.Append(timeoutHelpLink);
-            sb.Append(")");
+            sb.Append(')');
 
             var ex = new RedisTimeoutException(sb.ToString(), message?.Status ?? CommandStatus.Unknown)
             {
@@ -397,7 +397,7 @@ namespace StackExchange.Redis
                 if (muxer.AuthSuspect) sb.Append(" There was an authentication failure; check that passwords (or client certificates) are configured correctly.");
                 else if (muxer.RawConfig.AbortOnConnectFail) sb.Append(" Error connecting right now. To allow this multiplexer to continue retrying until it's able to connect, use abortConnect=false in your connection string or AbortOnConnectFail=false; in your code.");
             }
-            if (!string.IsNullOrWhiteSpace(failureMessage)) sb.Append(" ").Append(failureMessage.Trim());
+            if (!string.IsNullOrWhiteSpace(failureMessage)) sb.Append(' ').Append(failureMessage.Trim());
 
             return new RedisConnectionException(ConnectionFailureType.UnableToConnect, sb.ToString());
         }

--- a/src/StackExchange.Redis/ExponentialRetry.cs
+++ b/src/StackExchange.Redis/ExponentialRetry.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace StackExchange.Redis
 {
@@ -38,7 +38,7 @@ namespace StackExchange.Redis
         {
             var exponential = (int)Math.Min(maxDeltaBackOffMilliseconds, deltaBackOffMilliseconds * Math.Pow(1.1, currentRetryCount));
             int random;
-            r = r ?? new Random();
+            r ??= new Random();
             random = r.Next((int)deltaBackOffMilliseconds, exponential);
             return timeElapsedMillisecondsSinceLastRetry >= random;
             //exponential backoff with deltaBackOff of 5000ms

--- a/src/StackExchange.Redis/GeoEntry.cs
+++ b/src/StackExchange.Redis/GeoEntry.cs
@@ -82,18 +82,14 @@ namespace StackExchange.Redis
     /// </summary>
     public readonly struct GeoPosition : IEquatable<GeoPosition>
     {
-        internal static string GetRedisUnit(GeoUnit unit)
+        internal static string GetRedisUnit(GeoUnit unit) => unit switch
         {
-            switch (unit)
-            {
-                case GeoUnit.Meters: return "m";
-                case GeoUnit.Kilometers: return "km";
-                case GeoUnit.Miles: return "mi";
-                case GeoUnit.Feet: return "ft";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(unit));
-            }
-        }
+            GeoUnit.Meters => "m",
+            GeoUnit.Kilometers => "km",
+            GeoUnit.Miles => "mi",
+            GeoUnit.Feet => "ft",
+            _ => throw new ArgumentOutOfRangeException(nameof(unit)),
+        };
 
         /// <summary>
         /// The Latitude of the GeoPosition

--- a/src/StackExchange.Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/WrapperBase.cs
@@ -1042,7 +1042,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
         protected Func<RedisKey, RedisKey> GetMapFunction()
         {
             // create as a delegate when first required, then re-use
-            return mapFunction ?? (mapFunction = new Func<RedisKey, RedisKey>(ToInner));
+            return mapFunction ??= new Func<RedisKey, RedisKey>(ToInner);
         }
     }
 }

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -481,55 +481,46 @@ namespace StackExchange.Redis
             }
         }
 
-        internal static Message Create(int db, CommandFlags flags, RedisCommand command, in RedisKey key, RedisKey[] keys)
+        internal static Message Create(int db, CommandFlags flags, RedisCommand command, in RedisKey key, RedisKey[] keys) => keys.Length switch
         {
-            switch (keys.Length)
-            {
-                case 0: return new CommandKeyMessage(db, flags, command, key);
-                case 1: return new CommandKeyKeyMessage(db, flags, command, key, keys[0]);
-                case 2: return new CommandKeyKeyKeyMessage(db, flags, command, key, keys[0], keys[1]);
-                default: return new CommandKeyKeysMessage(db, flags, command, key, keys);
-            }
-        }
+            0 => new CommandKeyMessage(db, flags, command, key),
+            1 => new CommandKeyKeyMessage(db, flags, command, key, keys[0]),
+            2 => new CommandKeyKeyKeyMessage(db, flags, command, key, keys[0], keys[1]),
+            _ => new CommandKeyKeysMessage(db, flags, command, key, keys),
+        };
 
-        internal static Message Create(int db, CommandFlags flags, RedisCommand command, IList<RedisKey> keys)
+        internal static Message Create(int db, CommandFlags flags, RedisCommand command, IList<RedisKey> keys) => keys.Count switch
         {
-            switch (keys.Count)
-            {
-                case 0: return new CommandMessage(db, flags, command);
-                case 1: return new CommandKeyMessage(db, flags, command, keys[0]);
-                case 2: return new CommandKeyKeyMessage(db, flags, command, keys[0], keys[1]);
-                case 3: return new CommandKeyKeyKeyMessage(db, flags, command, keys[0], keys[1], keys[2]);
-                default: return new CommandKeysMessage(db, flags, command, (keys as RedisKey[]) ?? keys.ToArray());
-            }
-        }
+            0 => new CommandMessage(db, flags, command),
+            1 => new CommandKeyMessage(db, flags, command, keys[0]),
+            2 => new CommandKeyKeyMessage(db, flags, command, keys[0], keys[1]),
+            3 => new CommandKeyKeyKeyMessage(db, flags, command, keys[0], keys[1], keys[2]),
+            _ => new CommandKeysMessage(db, flags, command, (keys as RedisKey[]) ?? keys.ToArray()),
+        };
 
-        internal static Message Create(int db, CommandFlags flags, RedisCommand command, IList<RedisValue> values)
+        internal static Message Create(int db, CommandFlags flags, RedisCommand command, IList<RedisValue> values) => values.Count switch
         {
-            switch (values.Count)
-            {
-                case 0: return new CommandMessage(db, flags, command);
-                case 1: return new CommandValueMessage(db, flags, command, values[0]);
-                case 2: return new CommandValueValueMessage(db, flags, command, values[0], values[1]);
-                case 3: return new CommandValueValueValueMessage(db, flags, command, values[0], values[1], values[2]);
-                // no 4; not worth adding
-                case 5: return new CommandValueValueValueValueValueMessage(db, flags, command, values[0], values[1], values[2], values[3], values[4]);
-                default: return new CommandValuesMessage(db, flags, command, (values as RedisValue[]) ?? values.ToArray());
-            }
-        }
+            0 => new CommandMessage(db, flags, command),
+            1 => new CommandValueMessage(db, flags, command, values[0]),
+            2 => new CommandValueValueMessage(db, flags, command, values[0], values[1]),
+            3 => new CommandValueValueValueMessage(db, flags, command, values[0], values[1], values[2]),
+            // no 4; not worth adding
+            5 => new CommandValueValueValueValueValueMessage(db, flags, command, values[0], values[1], values[2], values[3], values[4]),
+            _ => new CommandValuesMessage(db, flags, command, (values as RedisValue[]) ?? values.ToArray()),
+        };
 
         internal static Message Create(int db, CommandFlags flags, RedisCommand command, in RedisKey key, RedisValue[] values)
         {
             if (values == null) throw new ArgumentNullException(nameof(values));
-            switch (values.Length)
+            return values.Length switch
             {
-                case 0: return new CommandKeyMessage(db, flags, command, key);
-                case 1: return new CommandKeyValueMessage(db, flags, command, key, values[0]);
-                case 2: return new CommandKeyValueValueMessage(db, flags, command, key, values[0], values[1]);
-                case 3: return new CommandKeyValueValueValueMessage(db, flags, command, key, values[0], values[1], values[2]);
-                case 4: return new CommandKeyValueValueValueValueMessage(db, flags, command, key, values[0], values[1], values[2], values[3]);
-                default: return new CommandKeyValuesMessage(db, flags, command, key, values);
-            }
+                0 => new CommandKeyMessage(db, flags, command, key),
+                1 => new CommandKeyValueMessage(db, flags, command, key, values[0]),
+                2 => new CommandKeyValueValueMessage(db, flags, command, key, values[0], values[1]),
+                3 => new CommandKeyValueValueValueMessage(db, flags, command, key, values[0], values[1], values[2]),
+                4 => new CommandKeyValueValueValueValueMessage(db, flags, command, key, values[0], values[1], values[2], values[3]),
+                _ => new CommandKeyValuesMessage(db, flags, command, key, values),
+            };
         }
 
         internal static Message Create(int db, CommandFlags flags, RedisCommand command, in RedisKey key0, RedisValue[] values, in RedisKey key1)

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -59,6 +59,7 @@ namespace StackExchange.Redis
         internal PhysicalConnection.WriteStatus ConnectionWriteState { get; private set; }
 #endif
         [Conditional("DEBUG")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "DEBUG uses instance data")]
         internal void SetBacklogState(int position, PhysicalConnection physical)
         {
 #if DEBUG

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -192,17 +192,17 @@ namespace StackExchange.Redis
             }
             clone[ProfileLogSamples] = Interlocked.Read(ref operationCount);
             Array.Sort(clone);
-            sb.Append(" ").Append(clone[0]);
+            sb.Append(' ').Append(clone[0]);
             for (int i = 1; i < clone.Length; i++)
             {
                 if (clone[i] != clone[i - 1])
                 {
-                    sb.Append("+").Append(clone[i] - clone[i - 1]);
+                    sb.Append('+').Append(clone[i] - clone[i - 1]);
                 }
             }
             if (clone[0] != clone[ProfileLogSamples])
             {
-                sb.Append("=").Append(clone[ProfileLogSamples]);
+                sb.Append('=').Append(clone[ProfileLogSamples]);
             }
             double rate = (clone[ProfileLogSamples] - clone[0]) / ProfileLogSeconds;
             sb.Append(" (").Append(rate.ToString("N2")).Append(" ops/s; spans ").Append(ProfileLogSeconds).Append("s)");

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -165,10 +165,7 @@ namespace StackExchange.Redis
 
             var physical = this.physical;
             if (physical == null) return FailDueToNoConnection(message);
-
-#pragma warning disable CS0618
             var result = WriteMessageTakingWriteLockSync(physical, message);
-#pragma warning restore CS0618
             LogNonPreferred(message.Flags, isReplica);
             return result;
         }
@@ -722,9 +719,7 @@ namespace StackExchange.Redis
 
                 if (result == WriteResult.Success)
                 {
-#pragma warning disable CS0618
                     result = physical.FlushSync(false, TimeoutMilliseconds);
-#pragma warning restore CS0618
                 }
 
                 physical.SetIdle();

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -581,9 +581,7 @@ namespace StackExchange.Redis
 
         internal void RemovePhysical(PhysicalConnection connection)
         {
-#pragma warning disable 0420
             Interlocked.CompareExchange(ref physical, null, connection);
-#pragma warning restore 0420
         }
 
         [Conditional("VERBOSE")]
@@ -1109,9 +1107,7 @@ namespace StackExchange.Redis
 
         private State ChangeState(State newState)
         {
-#pragma warning disable 0420
             var oldState = (State)Interlocked.Exchange(ref state, (int)newState);
-#pragma warning restore 0420
             if (oldState != newState)
             {
                 Multiplexer.Trace(ConnectionType + " state changed from " + oldState + " to " + newState);
@@ -1121,9 +1117,7 @@ namespace StackExchange.Redis
 
         private bool ChangeState(State oldState, State newState)
         {
-#pragma warning disable 0420
             bool result = Interlocked.CompareExchange(ref state, (int)newState, (int)oldState) == (int)oldState;
-#pragma warning restore 0420
             if (result)
             {
                 Multiplexer.Trace(ConnectionType + " state changed from " + oldState + " to " + newState);

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -846,6 +846,7 @@ namespace StackExchange.Redis
             return WriteCrlf(span, offset);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "DEBUG uses instance data")]
         private async ValueTask<WriteResult> FlushAsync_Awaited(PhysicalConnection connection, ValueTask<FlushResult> flush, bool throwOnFailure
 #if DEBUG
             , int startFlush, long flushBytes
@@ -871,6 +872,7 @@ namespace StackExchange.Redis
 
         CancellationTokenSource _reusableFlushSyncTokenSource;
         [Obsolete("this is an anti-pattern; work to reduce reliance on this is in progress")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0062:Make local function 'static'", Justification = "DEBUG uses instance data")]
         internal WriteResult FlushSync(bool throwOnFailure, int millisecondsTimeout)
         {
             var cts = _reusableFlushSyncTokenSource ??= new CancellationTokenSource();

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -340,11 +340,11 @@ namespace StackExchange.Redis
                         exMessage.Append(" (").Append(sc.ShutdownKind);
                         if (sc.SocketError != SocketError.Success)
                         {
-                            exMessage.Append("/").Append(sc.SocketError);
+                            exMessage.Append('/').Append(sc.SocketError);
                         }
                         if (sc.BytesRead == 0) exMessage.Append(", 0-read");
                         if (sc.BytesSent == 0) exMessage.Append(", 0-sent");
-                        exMessage.Append(", last-recv: ").Append(sc.LastReceived).Append(")");
+                        exMessage.Append(", last-recv: ").Append(sc.LastReceived).Append(')');
                     }
                     else if (pipe is IMeasuredDuplexPipe mdp)
                     {
@@ -365,8 +365,8 @@ namespace StackExchange.Redis
                     {
                         if (bridge != null)
                         {
-                            exMessage.Append(" on ").Append(Format.ToString(bridge.ServerEndPoint?.EndPoint)).Append("/").Append(connectionType)
-                                .Append(", ").Append(_writeStatus).Append("/").Append(_readStatus)
+                            exMessage.Append(" on ").Append(Format.ToString(bridge.ServerEndPoint?.EndPoint)).Append('/').Append(connectionType)
+                                .Append(", ").Append(_writeStatus).Append('/').Append(_readStatus)
                                 .Append(", last: ").Append(bridge.LastCommand);
 
                             data.Add(Tuple.Create("FailureType", failureType.ToString()));

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1250,7 +1250,7 @@ namespace StackExchange.Redis
             return VolatileSocket?.Available ?? -1;
         }
 
-        private RemoteCertificateValidationCallback GetAmbientIssuerCertificateCallback()
+        private static RemoteCertificateValidationCallback GetAmbientIssuerCertificateCallback()
         {
             try
             {

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1761,9 +1761,7 @@ namespace StackExchange.Redis
             if (!line.HasValue) return RawResult.Nil; // incomplete line
 
             int count = 0;
-#pragma warning disable IDE0059
             foreach (var _ in line.GetInlineTokenizer()) count++;
-#pragma warning restore IDE0059
             var block = arena.Allocate(count);
 
             var iter = block.GetEnumerator();

--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -255,12 +255,12 @@ namespace StackExchange.Redis
         internal bool GetBoolean()
         {
             if (Payload.Length != 1) throw new InvalidCastException();
-            switch (Payload.First.Span[0])
+            return Payload.First.Span[0] switch
             {
-                case (byte)'1': return true;
-                case (byte)'0': return false;
-                default: throw new InvalidCastException();
-            }
+                (byte)'1' => true,
+                (byte)'0' => false,
+                _ => throw new InvalidCastException(),
+            };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/StackExchange.Redis/RedisBase.cs
+++ b/src/StackExchange.Redis/RedisBase.cs
@@ -61,7 +61,7 @@ namespace StackExchange.Redis
             return new RedisFeatures(version);
         }
 
-        protected void WhenAlwaysOrExists(When when)
+        protected static void WhenAlwaysOrExists(When when)
         {
             switch (when)
             {
@@ -73,7 +73,7 @@ namespace StackExchange.Redis
             }
         }
 
-        protected void WhenAlwaysOrExistsOrNotExists(When when)
+        protected static void WhenAlwaysOrExistsOrNotExists(When when)
         {
             switch (when)
             {
@@ -86,7 +86,7 @@ namespace StackExchange.Redis
             }
         }
 
-        protected void WhenAlwaysOrNotExists(When when)
+        protected static void WhenAlwaysOrNotExists(When when)
         {
             switch (when)
             {

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -82,7 +82,7 @@ namespace StackExchange.Redis
             }
 
             // store it
-            (pending ?? (pending = new List<Message>())).Add(message);
+            (pending ??= new List<Message>()).Add(message);
             return task;
         }
 

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -91,7 +91,7 @@ namespace StackExchange.Redis
             throw new NotSupportedException("ExecuteSync cannot be used inside a batch");
         }
 
-        private void FailNoServer(List<Message> messages)
+        private static void FailNoServer(List<Message> messages)
         {
             if (messages == null) return;
             foreach(var msg in messages)

--- a/src/StackExchange.Redis/RedisChannel.cs
+++ b/src/StackExchange.Redis/RedisChannel.cs
@@ -38,16 +38,13 @@ namespace StackExchange.Redis
             IsPatternBased = isPatternBased;
         }
 
-        private static bool DeterminePatternBased(byte[] value, PatternMode mode)
+        private static bool DeterminePatternBased(byte[] value, PatternMode mode) => mode switch
         {
-            return mode switch
-            {
-                PatternMode.Auto => value != null && Array.IndexOf(value, (byte)'*') >= 0,
-                PatternMode.Literal => false,
-                PatternMode.Pattern => true,
-                _ => throw new ArgumentOutOfRangeException(nameof(mode)),
-            };
-        }
+            PatternMode.Auto => value != null && Array.IndexOf(value, (byte)'*') >= 0,
+            PatternMode.Literal => false,
+            PatternMode.Pattern => true,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode)),
+        };
 
         /// <summary>
         /// Indicate whether two channel names are not equal

--- a/src/StackExchange.Redis/RedisChannel.cs
+++ b/src/StackExchange.Redis/RedisChannel.cs
@@ -40,15 +40,13 @@ namespace StackExchange.Redis
 
         private static bool DeterminePatternBased(byte[] value, PatternMode mode)
         {
-            switch (mode)
+            return mode switch
             {
-                case PatternMode.Auto:
-                    return value != null && Array.IndexOf(value, (byte)'*') >= 0;
-                case PatternMode.Literal: return false;
-                case PatternMode.Pattern: return true;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mode));
-            }
+                PatternMode.Auto => value != null && Array.IndexOf(value, (byte)'*') >= 0,
+                PatternMode.Literal => false,
+                PatternMode.Pattern => true,
+                _ => throw new ArgumentOutOfRangeException(nameof(mode)),
+            };
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -2853,13 +2853,13 @@ namespace StackExchange.Redis
         private Message GetSortedSetAddMessage(RedisKey key, RedisValue member, double score, When when, CommandFlags flags)
         {
             WhenAlwaysOrExistsOrNotExists(when);
-            switch (when)
+            return when switch
             {
-                case When.Always: return Message.Create(Database, flags, RedisCommand.ZADD, key, score, member);
-                case When.NotExists: return Message.Create(Database, flags, RedisCommand.ZADD, key, RedisLiterals.NX, score, member);
-                case When.Exists: return Message.Create(Database, flags, RedisCommand.ZADD, key, RedisLiterals.XX, score, member);
-                default: throw new ArgumentOutOfRangeException(nameof(when));
-            }
+                When.Always => Message.Create(Database, flags, RedisCommand.ZADD, key, score, member),
+                When.NotExists => Message.Create(Database, flags, RedisCommand.ZADD, key, RedisLiterals.NX, score, member),
+                When.Exists => Message.Create(Database, flags, RedisCommand.ZADD, key, RedisLiterals.XX, score, member),
+                _ => throw new ArgumentOutOfRangeException(nameof(when)),
+            };
         }
 
         private Message GetSortedSetAddMessage(RedisKey key, SortedSetEntry[] values, When when, CommandFlags flags)
@@ -2977,13 +2977,12 @@ namespace StackExchange.Redis
 
         private Message GetSortedSetCombineAndStoreCommandMessage(SetOperation operation, RedisKey destination, RedisKey[] keys, double[] weights, Aggregate aggregate, CommandFlags flags)
         {
-            RedisCommand command;
-            switch (operation)
+            var command = operation switch
             {
-                case SetOperation.Intersect: command = RedisCommand.ZINTERSTORE; break;
-                case SetOperation.Union: command = RedisCommand.ZUNIONSTORE; break;
-                default: throw new ArgumentOutOfRangeException(nameof(operation));
-            }
+                SetOperation.Intersect => RedisCommand.ZINTERSTORE,
+                SetOperation.Union => RedisCommand.ZUNIONSTORE,
+                _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+            };
             if (keys == null) throw new ArgumentNullException(nameof(keys));
 
             List<RedisValue> values = null;
@@ -3484,13 +3483,13 @@ namespace StackExchange.Redis
                 }
             }
 
-            switch (when)
+            return when switch
             {
-                case When.Always: return Message.Create(Database, flags, RedisCommand.PSETEX, key, milliseconds, value);
-                case When.Exists: return Message.Create(Database, flags, RedisCommand.SET, key, value, RedisLiterals.PX, milliseconds, RedisLiterals.XX);
-                case When.NotExists: return Message.Create(Database, flags, RedisCommand.SET, key, value, RedisLiterals.PX, milliseconds, RedisLiterals.NX);
-            }
-            throw new NotSupportedException();
+                When.Always => Message.Create(Database, flags, RedisCommand.PSETEX, key, milliseconds, value),
+                When.Exists => Message.Create(Database, flags, RedisCommand.SET, key, value, RedisLiterals.PX, milliseconds, RedisLiterals.XX),
+                When.NotExists => Message.Create(Database, flags, RedisCommand.SET, key, value, RedisLiterals.PX, milliseconds, RedisLiterals.NX),
+                _ => throw new NotSupportedException(),
+            };
         }
 
         private Message IncrMessage(RedisKey key, long value, CommandFlags flags)
@@ -3511,16 +3510,13 @@ namespace StackExchange.Redis
             }
         }
 
-        private RedisCommand SetOperationCommand(SetOperation operation, bool store)
+        private RedisCommand SetOperationCommand(SetOperation operation, bool store) => operation switch
         {
-            switch (operation)
-            {
-                case SetOperation.Difference: return store ? RedisCommand.SDIFFSTORE : RedisCommand.SDIFF;
-                case SetOperation.Intersect: return store ? RedisCommand.SINTERSTORE : RedisCommand.SINTER;
-                case SetOperation.Union: return store ? RedisCommand.SUNIONSTORE : RedisCommand.SUNION;
-                default: throw new ArgumentOutOfRangeException(nameof(operation));
-            }
-        }
+            SetOperation.Difference => store ? RedisCommand.SDIFFSTORE : RedisCommand.SDIFF,
+            SetOperation.Intersect => store ? RedisCommand.SINTERSTORE : RedisCommand.SINTER,
+            SetOperation.Union => store ? RedisCommand.SUNIONSTORE : RedisCommand.SUNION,
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
 
         private CursorEnumerable<T> TryScan<T>(RedisKey key, RedisValue pattern, int pageSize, long cursor, int pageOffset, CommandFlags flags, RedisCommand command, ResultProcessor<ScanEnumerable<T>.ScanResult> processor, out ServerEndPoint server)
         {

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -746,7 +746,7 @@ namespace StackExchange.Redis
                 : base(db, flags, RedisCommand.MIGRATE, key)
             {
                 if (toServer == null) throw new ArgumentNullException(nameof(toServer));
-                if (!Format.TryGetHostPort(toServer, out string toHost, out int toPort)) throw new ArgumentException("toServer");
+                if (!Format.TryGetHostPort(toServer, out string toHost, out int toPort)) throw new ArgumentException($"Couldn't get host and port from {toServer}", nameof(toServer));
                 this.toHost = toHost;
                 this.toPort = toPort;
                 if (toDatabase < 0) throw new ArgumentOutOfRangeException(nameof(toDatabase));

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -351,7 +351,7 @@ namespace StackExchange.Redis
         public Task<RedisValue[]> HashGetAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
         {
             if (hashFields == null) throw new ArgumentNullException(nameof(hashFields));
-            if (hashFields.Length == 0) return CompletedTask<RedisValue[]>.FromResult(new RedisValue[0], asyncState);
+            if (hashFields.Length == 0) return CompletedTask<RedisValue[]>.FromResult(Array.Empty<RedisValue>(), asyncState);
             var msg = Message.Create(Database, flags, RedisCommand.HMGET, key, hashFields);
             return ExecuteAsync(msg, ResultProcessor.RedisValueArray);
         }
@@ -2711,7 +2711,7 @@ namespace StackExchange.Redis
             return tran;
         }
 
-        private RedisValue GetLexRange(RedisValue value, Exclude exclude, bool isStart)
+        private static RedisValue GetLexRange(RedisValue value, Exclude exclude, bool isStart)
         {
             if (value.IsNull)
             {
@@ -2831,7 +2831,7 @@ namespace StackExchange.Redis
             return Message.Create(Database, flags, RedisCommand.XREAD, values);
         }
 
-        private RedisValue GetRange(double value, Exclude exclude, bool isStart)
+        private static RedisValue GetRange(double value, Exclude exclude, bool isStart)
         {
             if (isStart)
             {
@@ -3510,7 +3510,7 @@ namespace StackExchange.Redis
             }
         }
 
-        private RedisCommand SetOperationCommand(SetOperation operation, bool store) => operation switch
+        private static RedisCommand SetOperationCommand(SetOperation operation, bool store) => operation switch
         {
             SetOperation.Difference => store ? RedisCommand.SDIFFSTORE : RedisCommand.SDIFF,
             SetOperation.Intersect => store ? RedisCommand.SINTERSTORE : RedisCommand.SINTER,

--- a/src/StackExchange.Redis/RedisKey.cs
+++ b/src/StackExchange.Redis/RedisKey.cs
@@ -231,7 +231,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="x">The first <see cref="RedisKey"/> to add.</param>
         /// <param name="y">The second <see cref="RedisKey"/> to add.</param>
-        [Obsolete]
+        [Obsolete("Prefer WithPrefix")]
         public static RedisKey operator +(RedisKey x, RedisKey y)
         {
             return new RedisKey(ConcatenateBytes(x.KeyPrefix, x.KeyValue, y.KeyPrefix), y.KeyValue);

--- a/src/StackExchange.Redis/RedisKey.cs
+++ b/src/StackExchange.Redis/RedisKey.cs
@@ -137,8 +137,8 @@ namespace StackExchange.Redis
                 if (keyValue0 == keyValue1) return true; // ref equal
                 if (keyValue0 == null || keyValue1 == null) return false; // null vs non-null
 
-                if (keyValue0 is string && keyValue1 is string) return ((string)keyValue0) == ((string)keyValue1);
-                if (keyValue0 is byte[] && keyValue1 is byte[]) return RedisValue.Equals((byte[])keyValue0, (byte[])keyValue1);
+                if (keyValue0 is string keyString1 && keyValue1 is string keyString2) return keyString1 == keyString2;
+                if (keyValue0 is byte[] keyBytes1 && keyValue1 is byte[] keyBytes2) return RedisValue.Equals(keyBytes1, keyBytes2);
             }
 
             return RedisValue.Equals(ConcatenateBytes(keyPrefix0, keyValue0, null), ConcatenateBytes(keyPrefix1, keyValue1, null));
@@ -162,7 +162,7 @@ namespace StackExchange.Redis
 
         internal RedisValue AsRedisValue()
         {
-            if (KeyPrefix == null && KeyValue is string) return (string)KeyValue;
+            if (KeyPrefix == null && KeyValue is string keyString) return keyString;
             return (byte[])this;
         }
 
@@ -207,7 +207,7 @@ namespace StackExchange.Redis
             {
                 if (key.KeyValue == null) return null;
 
-                if (key.KeyValue is string) return (string)key.KeyValue;
+                if (key.KeyValue is string keyString) return keyString;
 
                 arr = (byte[])key.KeyValue;
             }
@@ -260,8 +260,8 @@ namespace StackExchange.Redis
             }
 
             int aLen = a?.Length ?? 0,
-                bLen = b == null ? 0 : (b is string
-                ? Encoding.UTF8.GetByteCount((string)b)
+                bLen = b == null ? 0 : (b is string bString
+                ? Encoding.UTF8.GetByteCount(bString)
                 : ((byte[])b).Length),
                 cLen = c?.Length ?? 0;
 

--- a/src/StackExchange.Redis/RedisLiterals.cs
+++ b/src/StackExchange.Redis/RedisLiterals.cs
@@ -141,16 +141,13 @@ namespace StackExchange.Redis
             timeout = "timeout",
             yes = "yes";
 
-        internal static RedisValue Get(Bitwise operation)
+        internal static RedisValue Get(Bitwise operation) => operation switch
         {
-            switch (operation)
-            {
-                case Bitwise.And: return AND;
-                case Bitwise.Or: return OR;
-                case Bitwise.Xor: return XOR;
-                case Bitwise.Not: return NOT;
-                default: throw new ArgumentOutOfRangeException(nameof(operation));
-            }
-        }
+            Bitwise.And => AND,
+            Bitwise.Or => OR,
+            Bitwise.Xor => XOR,
+            Bitwise.Not => NOT,
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
     }
 }

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -656,7 +656,7 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.DemandOK);
         }
 
-        private void FixFlags(Message message, ServerEndPoint server)
+        private static void FixFlags(Message message, ServerEndPoint server)
         {
             // since the server is specified explicitly, we don't want defaults
             // to make the "non-preferred-endpoint" counters look artificially

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -98,10 +98,9 @@ namespace StackExchange.Redis
         {
             ICompletable completable = null;
             ChannelMessageQueue queues = null;
-            Subscription sub;
             lock (subscriptions)
             {
-                if (subscriptions.TryGetValue(subscription, out sub))
+                if (subscriptions.TryGetValue(subscription, out Subscription sub))
                 {
                     completable = sub.ForInvoke(channel, payload, out queues);
                 }

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -87,7 +87,7 @@ namespace StackExchange.Redis
             // (there is no task for the inner command)
             lock (SyncLock)
             {
-                (_pending ?? (_pending = new List<QueuedMessage>())).Add(queued);
+                (_pending ??= new List<QueuedMessage>()).Add(queued);
 
                 switch (message.Command)
                 {

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -456,7 +456,6 @@ namespace StackExchange.Redis
                 connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog($"got {result} for {message.CommandAndKey}");
                 if (message is TransactionMessage tran)
                 {
-                    var bridge = connection.BridgeCouldBeNull;
                     var wrapped = tran.InnerOperations;
                     switch (result.Type)
                     {

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -225,13 +225,13 @@ namespace StackExchange.Redis
                 for (int i = 0; i < conditions.Length; i++)
                 {
                     int newSlot = conditions[i].Condition.GetHashSlot(serverSelectionStrategy);
-                    slot = serverSelectionStrategy.CombineSlot(slot, newSlot);
+                    slot = ServerSelectionStrategy.CombineSlot(slot, newSlot);
                     if (slot == ServerSelectionStrategy.MultipleSlots) return slot;
                 }
                 for (int i = 0; i < InnerOperations.Length; i++)
                 {
                     int newSlot = InnerOperations[i].Wrapped.GetHashSlot(serverSelectionStrategy);
-                    slot = serverSelectionStrategy.CombineSlot(slot, newSlot);
+                    slot = ServerSelectionStrategy.CombineSlot(slot, newSlot);
                     if (slot == ServerSelectionStrategy.MultipleSlots) return slot;
                 }
                 return slot;

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -88,7 +88,7 @@ namespace StackExchange.Redis
         public static RedisValue Unbox(object value)
         {
             var val = TryParse(value, out var valid);
-            if (!valid) throw new ArgumentException(nameof(value));
+            if (!valid) throw new ArgumentException("Could not parse value", nameof(value));
             return val;
         }
 

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -340,16 +340,13 @@ namespace StackExchange.Redis
         /// <summary>
         /// Get the size of this value in bytes
         /// </summary>
-        public long Length()
+        public long Length() => Type switch
         {
-            switch (Type)
-            {
-                case StorageType.Null: return 0;
-                case StorageType.Raw: return _memory.Length;
-                case StorageType.String: return Encoding.UTF8.GetByteCount((string)_objectOrSentinel);
-                default: throw new InvalidOperationException("Unable to compute length of type: " + Type);
-            }
-        }
+            StorageType.Null => 0,
+            StorageType.Raw => _memory.Length,
+            StorageType.String => Encoding.UTF8.GetByteCount((string)_objectOrSentinel),
+            _ => throw new InvalidOperationException("Unable to compute length of type: " + Type),
+        };
 
         /// <summary>
         /// Compare against a RedisValue for relative order
@@ -579,15 +576,12 @@ namespace StackExchange.Redis
         /// Converts a <see cref="RedisValue"/> to a <see cref="bool"/>.
         /// </summary>
         /// <param name="value">The <see cref="RedisValue"/> to convert.</param>
-        public static explicit operator bool(RedisValue value)
+        public static explicit operator bool(RedisValue value) => (long)value switch
         {
-            switch ((long)value)
-            {
-                case 0: return false;
-                case 1: return true;
-                default: throw new InvalidCastException();
-            }
-        }
+            0 => false,
+            1 => true,
+            _ => throw new InvalidCastException(),
+        };
 
         /// <summary>
         /// Converts a <see cref="RedisValue"/> to a <see cref="int"/>.
@@ -603,16 +597,13 @@ namespace StackExchange.Redis
         public static explicit operator long(RedisValue value)
         {
             value = value.Simplify();
-            switch (value.Type)
+            return value.Type switch
             {
-                case StorageType.Null:
-                    return 0; // in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
-                case StorageType.Int64:
-                    return value.OverlappedValueInt64;
-                case StorageType.UInt64:
-                    return checked((long)value.OverlappedValueUInt64); // this will throw since unsigned is always 64-bit
-            }
-            throw new InvalidCastException($"Unable to cast from {value.Type} to long: '{value}'");
+                StorageType.Null => 0,// in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
+                StorageType.Int64 => value.OverlappedValueInt64,
+                StorageType.UInt64 => checked((long)value.OverlappedValueUInt64),// this will throw since unsigned is always 64-bit
+                _ => throw new InvalidCastException($"Unable to cast from {value.Type} to long: '{value}'"),
+            };
         }
 
         /// <summary>
@@ -623,16 +614,13 @@ namespace StackExchange.Redis
         public static explicit operator uint(RedisValue value)
         {
             value = value.Simplify();
-            switch (value.Type)
+            return value.Type switch
             {
-                case StorageType.Null:
-                    return 0; // in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
-                case StorageType.Int64:
-                    return checked((uint)value.OverlappedValueInt64);
-                case StorageType.UInt64:
-                    return checked((uint)value.OverlappedValueUInt64);
-            }
-            throw new InvalidCastException($"Unable to cast from {value.Type} to uint: '{value}'");
+                StorageType.Null => 0,// in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
+                StorageType.Int64 => checked((uint)value.OverlappedValueInt64),
+                StorageType.UInt64 => checked((uint)value.OverlappedValueUInt64),
+                _ => throw new InvalidCastException($"Unable to cast from {value.Type} to uint: '{value}'"),
+            };
         }
 
         /// <summary>
@@ -643,16 +631,13 @@ namespace StackExchange.Redis
         public static explicit operator ulong(RedisValue value)
         {
             value = value.Simplify();
-            switch (value.Type)
+            return value.Type switch
             {
-                case StorageType.Null:
-                    return 0; // in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
-                case StorageType.Int64:
-                    return checked((ulong)value.OverlappedValueInt64); // throw if negative
-                case StorageType.UInt64:
-                    return value.OverlappedValueUInt64;
-            }
-            throw new InvalidCastException($"Unable to cast from {value.Type} to ulong: '{value}'");
+                StorageType.Null => 0,// in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
+                StorageType.Int64 => checked((ulong)value.OverlappedValueInt64),// throw if negative
+                StorageType.UInt64 => value.OverlappedValueUInt64,
+                _ => throw new InvalidCastException($"Unable to cast from {value.Type} to ulong: '{value}'"),
+            };
         }
 
         /// <summary>
@@ -662,18 +647,14 @@ namespace StackExchange.Redis
         public static explicit operator double(RedisValue value)
         {
             value = value.Simplify();
-            switch (value.Type)
+            return value.Type switch
             {
-                case StorageType.Null:
-                    return 0; // in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
-                case StorageType.Int64:
-                    return value.OverlappedValueInt64;
-                case StorageType.UInt64:
-                    return value.OverlappedValueUInt64;
-                case StorageType.Double:
-                    return value.OverlappedValueDouble;
-            }
-            throw new InvalidCastException($"Unable to cast from {value.Type} to double: '{value}'");
+                StorageType.Null => 0,// in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
+                StorageType.Int64 => value.OverlappedValueInt64,
+                StorageType.UInt64 => value.OverlappedValueUInt64,
+                StorageType.Double => value.OverlappedValueDouble,
+                _ => throw new InvalidCastException($"Unable to cast from {value.Type} to double: '{value}'"),
+            };
         }
 
         /// <summary>
@@ -683,18 +664,14 @@ namespace StackExchange.Redis
         public static explicit operator decimal(RedisValue value)
         {
             value = value.Simplify();
-            switch (value.Type)
+            return value.Type switch
             {
-                case StorageType.Null:
-                    return 0; // in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
-                case StorageType.Int64:
-                    return value.OverlappedValueInt64;
-                case StorageType.UInt64:
-                    return value.OverlappedValueUInt64;
-                case StorageType.Double:
-                    return (decimal)value.OverlappedValueDouble;
-            }
-            throw new InvalidCastException($"Unable to cast from {value.Type} to decimal: '{value}'");
+                StorageType.Null => 0,// in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
+                StorageType.Int64 => value.OverlappedValueInt64,
+                StorageType.UInt64 => value.OverlappedValueUInt64,
+                StorageType.Double => (decimal)value.OverlappedValueDouble,
+                _ => throw new InvalidCastException($"Unable to cast from {value.Type} to decimal: '{value}'"),
+            };
         }
 
         /// <summary>
@@ -704,18 +681,14 @@ namespace StackExchange.Redis
         public static explicit operator float(RedisValue value)
         {
             value = value.Simplify();
-            switch (value.Type)
+            return value.Type switch
             {
-                case StorageType.Null:
-                    return 0; // in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
-                case StorageType.Int64:
-                    return value.OverlappedValueInt64;
-                case StorageType.UInt64:
-                    return value.OverlappedValueUInt64;
-                case StorageType.Double:
-                    return (float)value.OverlappedValueDouble;
-            }
-            throw new InvalidCastException($"Unable to cast from {value.Type} to double: '{value}'");
+                StorageType.Null => 0,// in redis, an arithmetic zero is kinda the same thing as not-exists (think "incr")
+                StorageType.Int64 => value.OverlappedValueInt64,
+                StorageType.UInt64 => value.OverlappedValueUInt64,
+                StorageType.Double => (float)value.OverlappedValueDouble,
+                _ => throw new InvalidCastException($"Unable to cast from {value.Type} to double: '{value}'"),
+            };
         }
 
         private static bool TryParseDouble(ReadOnlySpan<byte> blob, out double value)
@@ -909,27 +882,26 @@ namespace StackExchange.Redis
             if (conversionType == typeof(byte[])) return (byte[])this;
             if (conversionType == typeof(ReadOnlyMemory<byte>)) return (ReadOnlyMemory<byte>)this;
             if (conversionType == typeof(RedisValue)) return this;
-            switch (System.Type.GetTypeCode(conversionType))
+            return System.Type.GetTypeCode(conversionType) switch
             {
-                case TypeCode.Boolean: return (bool)this;
-                case TypeCode.Byte: return checked((byte)(uint)this);
-                case TypeCode.Char: return checked((char)(uint)this);
-                case TypeCode.DateTime: return DateTime.Parse((string)this, provider);
-                case TypeCode.Decimal: return (decimal)this;
-                case TypeCode.Double: return (double)this;
-                case TypeCode.Int16: return (short)this;
-                case TypeCode.Int32: return (int)this;
-                case TypeCode.Int64: return (long)this;
-                case TypeCode.SByte: return (sbyte)this;
-                case TypeCode.Single: return (float)this;
-                case TypeCode.String: return (string)this;
-                case TypeCode.UInt16: return checked((ushort)(uint)this);
-                case TypeCode.UInt32: return (uint)this;
-                case TypeCode.UInt64: return (ulong)this;
-                case TypeCode.Object: return this;
-                default:
-                    throw new NotSupportedException();
-            }
+                TypeCode.Boolean => (bool)this,
+                TypeCode.Byte => checked((byte)(uint)this),
+                TypeCode.Char => checked((char)(uint)this),
+                TypeCode.DateTime => DateTime.Parse((string)this, provider),
+                TypeCode.Decimal => (decimal)this,
+                TypeCode.Double => (double)this,
+                TypeCode.Int16 => (short)this,
+                TypeCode.Int32 => (int)this,
+                TypeCode.Int64 => (long)this,
+                TypeCode.SByte => (sbyte)this,
+                TypeCode.Single => (float)this,
+                TypeCode.String => (string)this,
+                TypeCode.UInt16 => checked((ushort)(uint)this),
+                TypeCode.UInt32 => (uint)this,
+                TypeCode.UInt64 => (ulong)this,
+                TypeCode.Object => this,
+                _ => throw new NotSupportedException(),
+            };
         }
 
         ushort IConvertible.ToUInt16(IFormatProvider provider) => checked((ushort)(uint)this);

--- a/src/StackExchange.Redis/ResultBox.cs
+++ b/src/StackExchange.Redis/ResultBox.cs
@@ -116,6 +116,8 @@ namespace StackExchange.Redis
             else
                 ActivateContinuationsImpl();
         }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Intentional observation")]
         private void ActivateContinuationsImpl()
         {
             var val = _value;

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -147,6 +147,7 @@ namespace StackExchange.Redis
         public static readonly HashEntryArrayProcessor
             HashEntryArray = new HashEntryArrayProcessor();
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Conditionally run on instance")]
         public void ConnectionFail(Message message, ConnectionFailureType fail, Exception innerException, string annotation)
         {
             PhysicalConnection.IdentifyFailureType(innerException, ref fail);

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1315,7 +1315,7 @@ namespace StackExchange.Redis
                 {
                     case ResultType.MultiBulk:
                         var typed = result.ToArray(
-                            (in RawResult item, in GeoRadiusOptions options) => Parse(item, options), this.options);
+                            (in RawResult item, in GeoRadiusOptions radiusOptions) => Parse(item, radiusOptions), options);
                         SetResult(message, typed);
                         return true;
                 }
@@ -2098,6 +2098,7 @@ The coordinates as a two items x,y array (longitude,latitude).
                 return final;
             }
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0071:Simplify interpolation", Justification = "Allocations (string.Concat vs. string.Format)")]
             protected override bool SetResultCore(PhysicalConnection connection, Message message, in RawResult result)
             {
                 bool happy;

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -160,17 +160,17 @@ namespace StackExchange.Redis
             SetException(message, ex);
         }
 
-        public void ConnectionFail(Message message, ConnectionFailureType fail, string errorMessage)
+        public static void ConnectionFail(Message message, ConnectionFailureType fail, string errorMessage)
         {
             SetException(message, new RedisConnectionException(fail, errorMessage));
         }
 
-        public void ServerFail(Message message, string errorMessage)
+        public static void ServerFail(Message message, string errorMessage)
         {
             SetException(message, new RedisServerException(errorMessage));
         }
 
-        public void SetException(Message message, Exception ex)
+        public static void SetException(Message message, Exception ex)
         {
             var box = message?.ResultBox;
             box?.SetException(ex);
@@ -512,7 +512,7 @@ namespace StackExchange.Redis
 
         internal sealed class SortedSetEntryProcessor : ResultProcessor<SortedSetEntry?>
         {
-            public bool TryParse(in RawResult result, out SortedSetEntry? entry)
+            public static bool TryParse(in RawResult result, out SortedSetEntry? entry)
             {
                 switch (result.Type)
                 {
@@ -1968,7 +1968,7 @@ The coordinates as a two items x,y array (longitude,latitude).
         {
             // For command response formats see https://redis.io/topics/streams-intro.
 
-            protected StreamEntry ParseRedisStreamEntry(in RawResult item)
+            protected static StreamEntry ParseRedisStreamEntry(in RawResult item)
             {
                 if (item.IsNull || item.Type != ResultType.MultiBulk)
                 {
@@ -1990,10 +1990,10 @@ The coordinates as a two items x,y array (longitude,latitude).
                 }
 
                 return result.GetItems().ToArray(
-                    (in RawResult item, in StreamProcessorBase<T> obj) => obj.ParseRedisStreamEntry(item), this);
+                    (in RawResult item, in StreamProcessorBase<T> obj) => ParseRedisStreamEntry(item), this);
             }
 
-            protected NameValueEntry[] ParseStreamEntryValues(in RawResult result)
+            protected static NameValueEntry[] ParseStreamEntryValues(in RawResult result)
             {
                 // The XRANGE, XREVRANGE, XREAD commands return stream entries
                 // in the following format.  The name/value pairs are interleaved
@@ -2294,7 +2294,7 @@ The coordinates as a two items x,y array (longitude,latitude).
 
     internal abstract class ResultProcessor<T> : ResultProcessor
     {
-        protected void SetResult(Message message, T value)
+        protected static void SetResult(Message message, T value)
         {
             if (message == null) return;
             var box = message.ResultBox as IResultBox<T>;

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -209,18 +209,12 @@ namespace StackExchange.Redis
         {
             if (!IsValidParameterHash(t, script, out _, out _)) throw new Exception("Shouldn't be possible");
 
-            Expression GetMember(Expression root, MemberInfo member)
+            static Expression GetMember(Expression root, MemberInfo member) => member.MemberType switch
             {
-                switch (member.MemberType)
-                {
-                    case MemberTypes.Property:
-                        return Expression.Property(root, (PropertyInfo)member);
-                    case MemberTypes.Field:
-                        return Expression.Field(root, (FieldInfo)member);
-                    default:
-                        throw new ArgumentException(nameof(member));
-                }
-            }
+                MemberTypes.Property => Expression.Property(root, (PropertyInfo)member),
+                MemberTypes.Field => Expression.Field(root, (FieldInfo)member),
+                _ => throw new ArgumentException(nameof(member)),
+            };
             var keys = new List<MemberInfo>();
             var args = new List<MemberInfo>();
 

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -213,7 +213,7 @@ namespace StackExchange.Redis
             {
                 MemberTypes.Property => Expression.Property(root, (PropertyInfo)member),
                 MemberTypes.Field => Expression.Field(root, (FieldInfo)member),
-                _ => throw new ArgumentException(nameof(member)),
+                _ => throw new ArgumentException($"Member type '{member.MemberType}' isn't recognized", nameof(member)),
             };
             var keys = new List<MemberInfo>();
             var args = new List<MemberInfo>();

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -175,7 +175,7 @@ namespace StackExchange.Redis
                     return false;
                 }
 
-                var memberType = member is FieldInfo ? ((FieldInfo)member).FieldType : ((PropertyInfo)member).PropertyType;
+                var memberType = member is FieldInfo memberFieldInfo ? memberFieldInfo.FieldType : ((PropertyInfo)member).PropertyType;
                 if (!ConvertableTypes.Contains(memberType))
                 {
                     missingMember = null;
@@ -229,7 +229,7 @@ namespace StackExchange.Redis
                 var argName = script.Arguments[i];
                 var member = t.GetMember(argName).SingleOrDefault(m => m is PropertyInfo || m is FieldInfo);
 
-                var memberType = member is FieldInfo ? ((FieldInfo)member).FieldType : ((PropertyInfo)member).PropertyType;
+                var memberType = member is FieldInfo memberFieldInfo ? memberFieldInfo.FieldType : ((PropertyInfo)member).PropertyType;
 
                 if (memberType == typeof(RedisKey))
                 {

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -75,7 +75,7 @@ namespace StackExchange.Redis
                 {
                     ret.Append("ARGV[");
                     ret.Append(argIx + 1);
-                    ret.Append("]");
+                    ret.Append(']');
                 }
                 else
                 {

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -202,14 +202,12 @@ namespace StackExchange.Redis
         public PhysicalBridge GetBridge(ConnectionType type, bool create = true, LogProxy log = null)
         {
             if (isDisposed) return null;
-            switch (type)
+            return type switch
             {
-                case ConnectionType.Interactive:
-                    return interactive ?? (create ? interactive = CreateBridge(ConnectionType.Interactive, log) : null);
-                case ConnectionType.Subscription:
-                    return subscription ?? (create ? subscription = CreateBridge(ConnectionType.Subscription, log) : null);
-            }
-            return null;
+                ConnectionType.Interactive => interactive ?? (create ? interactive = CreateBridge(ConnectionType.Interactive, log) : null),
+                ConnectionType.Subscription => subscription ?? (create ? subscription = CreateBridge(ConnectionType.Subscription, log) : null),
+                _ => null,
+            };
         }
 
         public PhysicalBridge GetBridge(RedisCommand command, bool create = true)

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -240,6 +240,7 @@ namespace StackExchange.Redis
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0071:Simplify interpolation", Justification = "Allocations (string.Concat vs. string.Format)")]
         public void UpdateNodeRelations(ClusterConfiguration configuration)
         {
             var thisNode = configuration.Nodes.FirstOrDefault(x => x.EndPoint.Equals(EndPoint));

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -257,7 +257,7 @@ namespace StackExchange.Redis
                     }
                     else if (node.ParentNodeId == thisNode.NodeId)
                     {
-                        (replicas ?? (replicas = new List<ServerEndPoint>())).Add(Multiplexer.GetServerEndPoint(node.EndPoint));
+                        (replicas ??= new List<ServerEndPoint>()).Add(Multiplexer.GetServerEndPoint(node.EndPoint));
                     }
                 }
                 Master = master;
@@ -647,7 +647,7 @@ namespace StackExchange.Redis
         {
             if (ConfigCheckSeconds < Multiplexer.RawConfig.ConfigCheckSeconds)
             {
-                r = r ?? new Random();
+                r ??= new Random();
                 var newExponentialConfigCheck = ConfigCheckSeconds * 2;
                 var jitter = r.Next(ConfigCheckSeconds + 1, newExponentialConfigCheck);
                 ConfigCheckSeconds = Math.Min(jitter, Multiplexer.RawConfig.ConfigCheckSeconds);

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -725,9 +725,7 @@ namespace StackExchange.Redis
             {
                 message.SetSource(processor, null);
                 Multiplexer.Trace("Enqueue: " + message);
-#pragma warning disable CS0618
                 (bridge ?? GetBridge(message.Command)).TryWriteSync(message, isReplica);
-#pragma warning restore CS0618
             }
         }
 

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -57,7 +57,7 @@ namespace StackExchange.Redis
         }
 
         public ServerType ServerType { get; set; } = ServerType.Standalone;
-        internal int TotalSlots => RedisClusterSlotCount;
+        internal static int TotalSlots => RedisClusterSlotCount;
 
         /// <summary>
         /// Computes the hash-slot that would be used by the given key
@@ -187,7 +187,7 @@ namespace StackExchange.Redis
             }
         }
 
-        internal int CombineSlot(int oldSlot, int newSlot)
+        internal static int CombineSlot(int oldSlot, int newSlot)
         {
             if (oldSlot == MultipleSlots || newSlot == NoSlot) return oldSlot;
             if (oldSlot == NoSlot) return newSlot;
@@ -234,7 +234,7 @@ namespace StackExchange.Redis
             return multiplexer.AnyConnected(ServerType, (uint)Interlocked.Increment(ref anyStartOffset), command, flags);
         }
 
-        private ServerEndPoint FindMaster(ServerEndPoint endpoint, RedisCommand command)
+        private static ServerEndPoint FindMaster(ServerEndPoint endpoint, RedisCommand command)
         {
             int max = 5;
             do
@@ -246,7 +246,7 @@ namespace StackExchange.Redis
             return null;
         }
 
-        private ServerEndPoint FindReplica(ServerEndPoint endpoint, RedisCommand command, bool allowDisconnected = false)
+        private static ServerEndPoint FindReplica(ServerEndPoint endpoint, RedisCommand command, bool allowDisconnected = false)
         {
             if (endpoint.IsReplica && endpoint.IsSelectable(command, allowDisconnected)) return endpoint;
 

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -8,7 +8,6 @@ namespace StackExchange.Redis
     {
         public const int NoSlot = -1, MultipleSlots = -2;
         private const int RedisClusterSlotCount = 16384;
-#pragma warning disable IDE1006 // Naming Styles
         private static readonly ushort[] s_crc16tab = new ushort[]
         {
             0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,
@@ -44,7 +43,6 @@ namespace StackExchange.Redis
             0xef1f,0xff3e,0xcf5d,0xdf7c,0xaf9b,0xbfba,0x8fd9,0x9ff8,
             0x6e17,0x7e36,0x4e55,0x5e74,0x2e93,0x3eb2,0x0ed1,0x1ef0
         };
-#pragma warning restore IDE1006 // Naming Styles
 
         private readonly ConnectionMultiplexer multiplexer;
         private int anyStartOffset;

--- a/src/StackExchange.Redis/StreamPosition.cs
+++ b/src/StackExchange.Redis/StreamPosition.cs
@@ -42,14 +42,14 @@ namespace StackExchange.Redis
         {
             if (value == NewMessages)
             {
-                switch (command)
+                return command switch
                 {
-                    case RedisCommand.XREAD: throw new InvalidOperationException("StreamPosition.NewMessages cannot be used with StreamRead.");
-                    case RedisCommand.XREADGROUP: return StreamConstants.UndeliveredMessages;
-                    case RedisCommand.XGROUP: return StreamConstants.NewMessages;
-                    default: // new is only valid for the above
-                        throw new ArgumentException($"Unsupported command in StreamPosition.Resolve: {command}.", nameof(command));
-                }
+                    RedisCommand.XREAD => throw new InvalidOperationException("StreamPosition.NewMessages cannot be used with StreamRead."),
+                    RedisCommand.XREADGROUP => StreamConstants.UndeliveredMessages,
+                    RedisCommand.XGROUP => StreamConstants.NewMessages,
+                    // new is only valid for the above
+                    _ => throw new ArgumentException($"Unsupported command in StreamPosition.Resolve: {command}.", nameof(command)),
+                };
             } else if (value == StreamPosition.Beginning)
             {
                 switch(command)

--- a/tests/BasicTest/Program.cs
+++ b/tests/BasicTest/Program.cs
@@ -212,7 +212,6 @@ namespace BasicTest
             }
         }
     }
-#pragma warning disable CS1591
 
     [Config(typeof(SlowConfig))]
     public class Issue898 : IDisposable

--- a/tests/NRediSearch.Test/ClientTests/AggregationBuilderTests.cs
+++ b/tests/NRediSearch.Test/ClientTests/AggregationBuilderTests.cs
@@ -168,7 +168,7 @@ namespace NRediSearch.Test.ClientTests
             }
             catch (RedisException) { }
 
-            AggregationBuilder r2 = new AggregationBuilder()
+            _ = new AggregationBuilder()
                 .GroupBy("@name", Reducers.Sum("@count").As("sum"))
                 .SortBy(10, SortedField.Descending("@sum"))
                 .Cursor(1, 1000);

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -371,9 +371,11 @@ namespace NRediSearch.Test.ClientTests
             Assert.True(cl.AlterIndex(new TagField("tags", ","), new TextField("name", 0.5)));
             for (int i = 0; i < 100; i++)
             {
-                var fields2 = new Dictionary<string, RedisValue>();
-                fields2.Add("name", $"name{i}");
-                fields2.Add("tags", $"tagA,tagB,tag{i}");
+                var fields2 = new Dictionary<string, RedisValue>
+                {
+                    { "name", $"name{i}" },
+                    { "tags", $"tagA,tagB,tag{i}" }
+                };
                 Assert.True(cl.UpdateDocument($"doc{i}", fields2, 1.0));
             }
             SearchResult res2 = cl.Search(new Query("@tags:{tagA}"));
@@ -739,22 +741,26 @@ namespace NRediSearch.Test.ClientTests
             Output.WriteLine("Initial search: " + search.TotalResults);
             Assert.Equal(0, search.TotalResults);
 
-            var fields1 = new Dictionary<string, RedisValue>();
-            fields1.Add("title", "hello world");
-            fields1.Add("category", "red");
-            Assert.True(cl.AddDocument("foo", fields1));
-            var fields2 = new Dictionary<string, RedisValue>();
-            fields2.Add("title", "hello world");
-            fields2.Add("category", "blue");
-            Assert.True(cl.AddDocument("bar", fields2));
-            var fields3 = new Dictionary<string, RedisValue>();
-            fields3.Add("title", "hello world");
-            fields3.Add("category", "green,yellow");
-            Assert.True(cl.AddDocument("baz", fields3));
-            var fields4 = new Dictionary<string, RedisValue>();
-            fields4.Add("title", "hello world");
-            fields4.Add("category", "orange;purple");
-            Assert.True(cl.AddDocument("qux", fields4));
+            Assert.True(cl.AddDocument("foo", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "red" }
+            }));
+            Assert.True(cl.AddDocument("bar", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "blue" }
+            }));
+            Assert.True(cl.AddDocument("baz", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "green,yellow" }
+            }));
+            Assert.True(cl.AddDocument("qux", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "orange;purple" }
+            }));
 
             Assert.Equal(1, cl.Search(new Query("@category:{red}")).TotalResults);
             Assert.Equal(1, cl.Search(new Query("@category:{blue}")).TotalResults);
@@ -781,22 +787,26 @@ namespace NRediSearch.Test.ClientTests
                     .AddTagField("category", ";");
 
             Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
-            var fields1 = new Dictionary<string, RedisValue>();
-            fields1.Add("title", "hello world");
-            fields1.Add("category", "red");
-            Assert.True(cl.AddDocument("foo", fields1));
-            var fields2 = new Dictionary<string, RedisValue>();
-            fields2.Add("title", "hello world");
-            fields2.Add("category", "blue");
-            Assert.True(cl.AddDocument("bar", fields2));
-            var fields3 = new Dictionary<string, RedisValue>();
-            fields3.Add("title", "hello world");
-            fields3.Add("category", "green;yellow");
-            Assert.True(cl.AddDocument("baz", fields3));
-            var fields4 = new Dictionary<string, RedisValue>();
-            fields4.Add("title", "hello world");
-            fields4.Add("category", "orange,purple");
-            Assert.True(cl.AddDocument("qux", fields4));
+            Assert.True(cl.AddDocument("foo", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "red" }
+            }));
+            Assert.True(cl.AddDocument("bar", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "blue" }
+            }));
+            Assert.True(cl.AddDocument("baz", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "green;yellow" }
+            }));
+            Assert.True(cl.AddDocument("qux", new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "category", "orange,purple" }
+            }));
 
             Assert.Equal(1, cl.Search(new Query("@category:{red}")).TotalResults);
             Assert.Equal(1, cl.Search(new Query("@category:{blue}")).TotalResults);
@@ -816,9 +826,11 @@ namespace NRediSearch.Test.ClientTests
 
             Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
 
-            var fields = new Dictionary<string, RedisValue>();
-            fields.Add("title", "hello world");
-            fields.Add("body", "lorem ipsum");
+            var fields = new Dictionary<string, RedisValue>
+            {
+                { "title", "hello world" },
+                { "body", "lorem ipsum" }
+            };
 
             var results = cl.AddDocuments(new Document("doc1", fields), new Document("doc2", fields), new Document("doc3", fields));
 
@@ -841,10 +853,11 @@ namespace NRediSearch.Test.ClientTests
             Schema sc = new Schema().AddTextField("field1", 1.0).AddTextField("field2", 1.0);
             Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
 
-
-            var doc = new Dictionary<string, RedisValue>();
-            doc.Add("field1", "value1");
-            doc.Add("field2", "value2");
+            var doc = new Dictionary<string, RedisValue>
+            {
+                { "field1", "value1" },
+                { "field2", "value2" }
+            };
             // Store it
             Assert.True(cl.AddDocument("doc", doc));
 
@@ -862,9 +875,11 @@ namespace NRediSearch.Test.ClientTests
             Schema sc = new Schema().AddTextField("field1", 1.0).AddTextField("field2", 1.0);
             Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
 
-            var doc = new Dictionary<string, RedisValue>();
-            doc.Add("field1", "value");
-            doc.Add("field2", "not");
+            var doc = new Dictionary<string, RedisValue>
+            {
+                { "field1", "value" },
+                { "field2", "not" }
+            };
 
             // Store it
             Assert.True(cl.AddDocument("doc1", doc));

--- a/tests/NRediSearch.Test/ExampleUsage.cs
+++ b/tests/NRediSearch.Test/ExampleUsage.cs
@@ -24,7 +24,7 @@ namespace NRediSearch.Test
                 .AddTextField("body", 1.0)
                 .AddNumericField("price");
 
-            bool result = false;
+            bool result;
             try
             {
                 result = client.CreateIndex(sc, new ConfiguredIndexOptions());

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -163,7 +163,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void IntentionalWrongServer()
         {
-            string StringGet(IServer server, RedisKey key, CommandFlags flags = CommandFlags.None)
+            static string StringGet(IServer server, RedisKey key, CommandFlags flags = CommandFlags.None)
                 => (string)server.Execute("GET", new object[] { key }, flags);
 
             using (var conn = Create())

--- a/tests/StackExchange.Redis.Tests/Failover.cs
+++ b/tests/StackExchange.Redis.Tests/Failover.cs
@@ -206,7 +206,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public async Task SubscriptionsSurviveMasterSwitchAsync()
         {
-            void TopologyFail() => Skip.Inconclusive("Replication tolopogy change failed...and that's both inconsistent and not what we're testing.");
+            static void TopologyFail() => Skip.Inconclusive("Replication tolopogy change failed...and that's both inconsistent and not what we're testing.");
 
             if (RunningInCI)
             {

--- a/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
+++ b/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,7 +19,7 @@ namespace StackExchange.Redis.Tests
             }
         }
 
-        [Fact(Skip = "needs investigation on netcoreapp3.1")]
+        [Fact]
         public async Task MuxerIsCollected()
         {
 #if DEBUG

--- a/tests/StackExchange.Redis.Tests/GlobalSuppressions.cs
+++ b/tests/StackExchange.Redis.Tests/GlobalSuppressions.cs
@@ -5,11 +5,7 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.ConnectionFailedErrors.SSLCertificateValidationError(System.Boolean)")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.PreserveOrder.Execute(System.Boolean)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.PubSub.ExplicitPublishMode")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.PubSub.TestBasicPubSubFireAndForget(System.Boolean)")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.PubSub.TestPatternPubSub(System.Boolean)")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.PubSub.TestBasicPubSub(System.Boolean,System.String,System.Boolean)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.SSL.ConnectToSSLServer(System.Boolean,System.Boolean)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Redundancy", "RCS1163:Unused parameter.", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.SSL.ShowCertFailures(StackExchange.Redis.Tests.Helpers.TextWriterOutputHelper)~System.Net.Security.RemoteCertificateValidationCallback")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "<Pending>", Scope = "member", Target = "~M:StackExchange.Redis.Tests.ConnectionShutdown.ShutdownRaisesConnectionFailedAndRestore")]

--- a/tests/StackExchange.Redis.Tests/Helpers/redis-sharp.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/redis-sharp.cs
@@ -501,18 +501,14 @@ namespace RedisSharp
         {
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
-            switch (SendExpectString("TYPE {0}\r\n", key))
+            return SendExpectString("TYPE {0}\r\n", key) switch
             {
-                case "none":
-                    return KeyType.None;
-                case "string":
-                    return KeyType.String;
-                case "set":
-                    return KeyType.Set;
-                case "list":
-                    return KeyType.List;
-            }
-            throw new ResponseException("Invalid value");
+                "none" => KeyType.None,
+                "string" => KeyType.String,
+                "set" => KeyType.Set,
+                "list" => KeyType.List,
+                _ => throw new ResponseException("Invalid value"),
+            };
         }
 
         public string RandomKey()

--- a/tests/StackExchange.Redis.Tests/Locking.cs
+++ b/tests/StackExchange.Redis.Tests/Locking.cs
@@ -103,20 +103,13 @@ namespace StackExchange.Redis.Tests
             // note we get a ping from GetCounters
         }
 
-        private IConnectionMultiplexer Create(TestMode mode)
+        private IConnectionMultiplexer Create(TestMode mode) => mode switch
         {
-            switch (mode)
-            {
-                case TestMode.MultiExec:
-                    return Create();
-                case TestMode.NoMultiExec:
-                    return Create(disabledCommands: new[] { "multi", "exec" });
-                case TestMode.Twemproxy:
-                    return Create(proxy: Proxy.Twemproxy);
-                default:
-                    throw new NotSupportedException(mode.ToString());
-            }
-        }
+            TestMode.MultiExec => Create(),
+            TestMode.NoMultiExec => Create(disabledCommands: new[] { "multi", "exec" }),
+            TestMode.Twemproxy => Create(proxy: Proxy.Twemproxy),
+            _ => throw new NotSupportedException(mode.ToString()),
+        };
 
         [Theory, MemberData(nameof(TestModes))]
         public async Task TakeLockAndExtend(TestMode mode)

--- a/tests/StackExchange.Redis.Tests/MassiveOps.cs
+++ b/tests/StackExchange.Redis.Tests/MassiveOps.cs
@@ -39,7 +39,7 @@ namespace StackExchange.Redis.Tests
                 RedisKey key = Me();
                 var conn = muxer.GetDatabase();
                 await conn.PingAsync().ForAwait();
-                void nonTrivial(Task _)
+                static void nonTrivial(Task _)
                 {
                     Thread.SpinWait(5);
                 }

--- a/tests/StackExchange.Redis.Tests/Migrate.cs
+++ b/tests/StackExchange.Redis.Tests/Migrate.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'.
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalency.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalency.cs
@@ -12,7 +12,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void Int32_Matrix()
         {
-            void Check(RedisValue known, RedisValue test)
+            static void Check(RedisValue known, RedisValue test)
             {
                 KeysAndValues.CheckSame(known, test);
                 if (known.IsNull)
@@ -51,7 +51,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void Int64_Matrix()
         {
-            void Check(RedisValue known, RedisValue test)
+            static void Check(RedisValue known, RedisValue test)
             {
                 KeysAndValues.CheckSame(known, test);
                 if (known.IsNull)
@@ -90,7 +90,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void Double_Matrix()
         {
-            void Check(RedisValue known, RedisValue test)
+            static void Check(RedisValue known, RedisValue test)
             {
                 KeysAndValues.CheckSame(known, test);
                 if (known.IsNull)

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalency.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalency.cs
@@ -213,9 +213,9 @@ namespace StackExchange.Redis.Tests
             Assert.True(((RedisValue)123.0).TryParse(out l));
             Assert.Equal(123, l);
 
-            Assert.False(((RedisValue)"abc").TryParse(out l));
-            Assert.False(((RedisValue)"123.1").TryParse(out l));
-            Assert.False(((RedisValue)123.1).TryParse(out l));
+            Assert.False(((RedisValue)"abc").TryParse(out long _));
+            Assert.False(((RedisValue)"123.1").TryParse(out long _));
+            Assert.False(((RedisValue)123.1).TryParse(out long _));
         }
 
         [Fact]
@@ -227,7 +227,7 @@ namespace StackExchange.Redis.Tests
             Assert.True(((RedisValue)123.0).TryParse(out i));
             Assert.Equal(123, i);
 
-            Assert.False(((RedisValue)(int.MaxValue + 123L)).TryParse(out i));
+            Assert.False(((RedisValue)(int.MaxValue + 123L)).TryParse(out int _));
 
             Assert.True(((RedisValue)"123").TryParse(out i));
             Assert.Equal(123, i);
@@ -241,9 +241,9 @@ namespace StackExchange.Redis.Tests
             Assert.True(((RedisValue)123.0).TryParse(out i));
             Assert.Equal(123, i);
 
-            Assert.False(((RedisValue)"abc").TryParse(out i));
-            Assert.False(((RedisValue)"123.1").TryParse(out i));
-            Assert.False(((RedisValue)123.1).TryParse(out i));
+            Assert.False(((RedisValue)"abc").TryParse(out int _));
+            Assert.False(((RedisValue)"123.1").TryParse(out int _));
+            Assert.False(((RedisValue)123.1).TryParse(out int _));
         }
 
         [Fact]
@@ -276,7 +276,7 @@ namespace StackExchange.Redis.Tests
             Assert.True(((RedisValue)"123.1").TryParse(out d));
             Assert.Equal(123.1, d);
 
-            Assert.False(((RedisValue)"abc").TryParse(out d));
+            Assert.False(((RedisValue)"abc").TryParse(out double _));
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -801,7 +801,7 @@ return timeTaken
             Assert.False(ReferenceEquals(first, shouldBeNew));
         }
 
-        private static void PurgeLuaScriptOnFinalize(string script)
+        private static void PurgeLuaScriptOnFinalizeImpl(string script)
         {
             var first = LuaScript.Prepare(script);
             var fromCache = LuaScript.Prepare(script);
@@ -818,7 +818,7 @@ return timeTaken
 
             // This has to be a separate method to guarantee that the created LuaScript objects go out of scope,
             //   and are thus available to be GC'd
-            PurgeLuaScriptOnFinalize(Script);
+            PurgeLuaScriptOnFinalizeImpl(Script);
             CollectGarbage();
 
             Assert.Equal(0, LuaScript.GetCachedScriptCount());

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -801,7 +801,7 @@ return timeTaken
             Assert.False(ReferenceEquals(first, shouldBeNew));
         }
 
-        private static void _PurgeLuaScriptOnFinalize(string script)
+        private static void PurgeLuaScriptOnFinalize(string script)
         {
             var first = LuaScript.Prepare(script);
             var fromCache = LuaScript.Prepare(script);
@@ -818,7 +818,7 @@ return timeTaken
 
             // This has to be a separate method to guarantee that the created LuaScript objects go out of scope,
             //   and are thus available to be GC'd
-            _PurgeLuaScriptOnFinalize(Script);
+            PurgeLuaScriptOnFinalize(Script);
             CollectGarbage();
 
             Assert.Equal(0, LuaScript.GetCachedScriptCount());

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -823,7 +823,7 @@ return timeTaken
 
             Assert.Equal(0, LuaScript.GetCachedScriptCount());
 
-            var shouldBeNew = LuaScript.Prepare(Script);
+            LuaScript.Prepare(Script);
             Assert.Equal(1, LuaScript.GetCachedScriptCount());
         }
 

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -417,9 +417,7 @@ namespace StackExchange.Redis.Tests
                 for (int i = 0; i < threads; i++)
                 {
                     var thd = threadArr[i];
-#pragma warning disable SYSLIB0006 // yes, we know
                     if (thd.IsAlive) thd.Abort();
-#pragma warning restore SYSLIB0006 // yes, we know
                 }
                 throw new TimeoutException();
             }

--- a/tests/StackExchange.Redis.Tests/TransactionWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/TransactionWrapperTests.cs
@@ -1,11 +1,11 @@
 ﻿using System.Text;
+using System.Threading.Tasks;
 using Moq;
 using StackExchange.Redis.KeyspaceIsolation;
 using Xunit;
 
 namespace StackExchange.Redis.Tests
 {
-#pragma warning disable RCS1047 // Non-asynchronous method name should not end with 'Async'. 
     [Collection(nameof(MoqDependentCollection))]
     public sealed class TransactionWrapperTests
     {
@@ -117,9 +117,9 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public void ExecuteAsync()
+        public async Task ExecuteAsync()
         {
-            wrapper.ExecuteAsync(CommandFlags.None);
+            await wrapper.ExecuteAsync(CommandFlags.None);
             mock.Verify(_ => _.ExecuteAsync(CommandFlags.None), Times.Once());
         }
 
@@ -130,5 +130,4 @@ namespace StackExchange.Redis.Tests
             mock.Verify(_ => _.Execute(CommandFlags.None), Times.Once());
         }
     }
-#pragma warning restore RCS1047 // Non-asynchronous method name should not end with 'Async'.
 }

--- a/toys/KestrelRedisServer/KestrelRedisServer.csproj
+++ b/toys/KestrelRedisServer/KestrelRedisServer.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <!--<PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.1.3" />-->
     <ProjectReference Include="..\StackExchange.Redis.Server\StackExchange.Redis.Server.csproj" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 
 </Project>

--- a/toys/StackExchange.Redis.Server/MemoryCacheRedisServer.cs
+++ b/toys/StackExchange.Redis.Server/MemoryCacheRedisServer.cs
@@ -42,7 +42,6 @@ namespace StackExchange.Redis.Server
 
         protected override IEnumerable<RedisKey> Keys(int database, RedisKey pattern)
         {
-            string s = pattern;
             foreach (var pair in _cache)
             {
                 if (IsMatch(pattern, pair.Key)) yield return pair.Key;

--- a/toys/StackExchange.Redis.Server/RespServer.cs
+++ b/toys/StackExchange.Redis.Server/RespServer.cs
@@ -32,7 +32,7 @@ namespace StackExchange.Redis.Server
 
         private static Dictionary<CommandBytes, RespCommand> BuildCommands(RespServer server)
         {
-            RedisCommandAttribute CheckSignatureAndGetAttribute(MethodInfo method)
+            static RedisCommandAttribute CheckSignatureAndGetAttribute(MethodInfo method)
             {
                 if (method.ReturnType != typeof(TypedRedisValue)) return null;
                 var p = method.GetParameters();
@@ -307,7 +307,7 @@ namespace StackExchange.Redis.Server
 
         public static async ValueTask WriteResponseAsync(RedisClient client, PipeWriter output, TypedRedisValue value)
         {
-            void WritePrefix(PipeWriter ooutput, char pprefix)
+            static void WritePrefix(PipeWriter ooutput, char pprefix)
             {
                 var span = ooutput.GetSpan(1);
                 span[0] = (byte)pprefix;
@@ -385,7 +385,7 @@ namespace StackExchange.Redis.Server
 
         public ValueTask<bool> TryProcessRequestAsync(ref ReadOnlySequence<byte> buffer, RedisClient client, PipeWriter output)
         {
-            async ValueTask<bool> Awaited(ValueTask wwrite, TypedRedisValue rresponse)
+            static async ValueTask<bool> Awaited(ValueTask wwrite, TypedRedisValue rresponse)
             {
                 await wwrite;
                 rresponse.Recycle();


### PR DESCRIPTION
Tidying up for newer C# versions and removing old cruft:
- Removing unneeded pragmas (e.g. transitive obsoletes)
- Switch expressions
- Expression body usages, where it's cleaner with new switch expressions
- Statics where useful to remove virtual calls
- A handful of pattern matching usages where we were repeat casting
- `StringBuilder` optimizations for .NET Core (single char appends)
- Suppression fixes for contention between frameworks
- Suppression additions for dupe enum values (that are there for compat)
- Fix messages/arguments for many argument exceptions
- Re-enables the GC test (was the only skipped one - no longer needed)
- Misc compiler warning fixes
- Fixes KestrelRedisServer's conflict with `System.Runtime.CompilerServices.Unsafe`

These are broken up by commit for an easier review, but didn't want to make 12 PRs for some maintenance catch-up.

Note: this does not fix all informational message, including a few suspects for actual issues and some that are the way we structure `Dispose() => Dispose(true)` in a few files. Given those may change functionality, will do a follow-up PR there. This is meant to get all the noise gone and general cleanup without any significant impact anywhere.