### PR TITLE
Add == & != operators for ChannelMessaege and RedisFeatures

### DIFF
--- a/src/StackExchange.Redis/ChannelMessageQueue.cs
+++ b/src/StackExchange.Redis/ChannelMessageQueue.cs
@@ -57,8 +57,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Checks if 2 messages are not .Equal()
         /// </summary>
-        public static bool operator !=(ChannelMessage left, ChannelMessage right) => !(left == right);
-    }
+        public static bool operator !=(ChannelMessage left, ChannelMessage right) => !left.Equals(right);
 
     /// <summary>
     /// Represents a message queue of ordered pub/sub notifications

--- a/src/StackExchange.Redis/ChannelMessageQueue.cs
+++ b/src/StackExchange.Redis/ChannelMessageQueue.cs
@@ -48,6 +48,16 @@ namespace StackExchange.Redis
         /// The value that was broadcast
         /// </summary>
         public RedisValue Message { get; }
+
+        /// <summary>
+        /// Checks if 2 messages are .Equal()
+        /// </summary>
+        public static bool operator ==(ChannelMessage left, ChannelMessage right) => left.Equals(right);
+
+        /// <summary>
+        /// Checks if 2 messages are not .Equal()
+        /// </summary>
+        public static bool operator !=(ChannelMessage left, ChannelMessage right) => !(left == right);
     }
 
     /// <summary>

--- a/src/StackExchange.Redis/ChannelMessageQueue.cs
+++ b/src/StackExchange.Redis/ChannelMessageQueue.cs
@@ -58,6 +58,7 @@ namespace StackExchange.Redis
         /// Checks if 2 messages are not .Equal()
         /// </summary>
         public static bool operator !=(ChannelMessage left, ChannelMessage right) => !left.Equals(right);
+    }
 
     /// <summary>
     /// Represents a message queue of ordered pub/sub notifications

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -259,9 +259,20 @@ namespace StackExchange.Redis
         /// <summary>Returns the hash code for this instance.</summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode() => Version.GetHashCode();
+
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <returns>true if <paramref name="obj" /> and this instance are the same type and represent the same value; otherwise, false. </returns>
         /// <param name="obj">The object to compare with the current instance. </param>
         public override bool Equals(object obj) => obj is RedisFeatures f && f.Version == Version;
+
+        /// <summary>
+        /// Checks if 2 RedisFeatures are .Equal()
+        /// </summary>
+        public static bool operator ==(RedisFeatures left, RedisFeatures right) => left.Equals(right);
+
+        /// <summary>
+        /// Checks if 2 RedisFeatures are not .Equal()
+        /// </summary>
+        public static bool operator !=(RedisFeatures left, RedisFeatures right) => !(left == right);
     }
 }

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -273,6 +273,6 @@ namespace StackExchange.Redis
         /// <summary>
         /// Checks if 2 RedisFeatures are not .Equal()
         /// </summary>
-        public static bool operator !=(RedisFeatures left, RedisFeatures right) => !(left == right);
+        public static bool operator !=(RedisFeatures left, RedisFeatures right) => !left.Equals(right);
     }
 }


### PR DESCRIPTION
Best practice cleanup, since we're overriding `.Equals()`