### PR TITLE
Tests: better logging

### DIFF
--- a/tests/StackExchange.Redis.Tests/SentinelFailover.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelFailover.cs
@@ -66,6 +66,15 @@ namespace StackExchange.Redis.Tests
             var sw = Stopwatch.StartNew();
             SentinelServerA.SentinelFailover(ServiceName);
 
+            // There's no point in doing much for 10 seconds - this is a built-in delay of how Sentinel works
+            // The actual completion invoking the replication of the former master is handled via
+            // https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L4799-L4808
+            // ...which is invoked by INFO polls every 10 seconds (https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L81)
+            // ...which is calling https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L2666
+            // However, the quicker iteration on INFO during an o_down does not appply here: https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L3089-L3104
+            // So...we're waiting 10 seconds, no matter what. Might as well just idle to be more stable.
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
             // wait until the replica becomes the master
             Log("Waiting for ready post-failover...");
             await WaitForReadyAsync(expectedMaster: replicas[0]);

--- a/tests/StackExchange.Redis.Tests/SentinelFailover.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelFailover.cs
@@ -66,12 +66,12 @@ namespace StackExchange.Redis.Tests
             var sw = Stopwatch.StartNew();
             SentinelServerA.SentinelFailover(ServiceName);
 
-            // There's no point in doing much for 10 seconds - this is a built-in delay of how Sentinel works
+            // There's no point in doing much for 10 seconds - this is a built-in delay of how Sentinel works.
             // The actual completion invoking the replication of the former master is handled via
             // https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L4799-L4808
             // ...which is invoked by INFO polls every 10 seconds (https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L81)
             // ...which is calling https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L2666
-            // However, the quicker iteration on INFO during an o_down does not appply here: https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L3089-L3104
+            // However, the quicker iteration on INFO during an o_down does not apply here: https://github.com/redis/redis/blob/f233c4c59d24828c77eb1118f837eaee14695f7f/src/sentinel.c#L3089-L3104
             // So...we're waiting 10 seconds, no matter what. Might as well just idle to be more stable.
             await Task.Delay(TimeSpan.FromSeconds(10));
 

--- a/tests/StackExchange.Redis.Tests/SentinelFailover.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelFailover.cs
@@ -20,6 +20,10 @@ namespace StackExchange.Redis.Tests
             conn.ConfigurationChanged += (s, e) => {
                 Log($"Configuration changed: {e.EndPoint}");
             };
+            var sub = conn.GetSubscriber();
+            sub.Subscribe("*", (channel, message) => {
+                Log($"Sub: {channel}, message:{message}");
+            });
 
             var db = conn.GetDatabase();
             await db.PingAsync();

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -326,7 +326,8 @@ namespace StackExchange.Redis.Tests
                 }
                 //Assert.True(false, $"There were {privateFailCount} private ambient exceptions.");
             }
-            TestBase.Log(output, $"Service Counts: (Scheduler) Queue: {SocketManager.Shared?.SchedulerPool?.TotalServicedByQueue.ToString()}, Pool: {SocketManager.Shared?.SchedulerPool?.TotalServicedByPool.ToString()}");
+            var pool = SocketManager.Shared?.SchedulerPool;
+            TestBase.Log(output, $"Service Counts: (Scheduler) By Queue: {pool?.TotalServicedByQueue.ToString()}, By Pool: {pool?.TotalServicedByPool.ToString()}, Workers: {pool?.WorkerCount.ToString()}, Available: {pool?.AvailableCount.ToString()}");
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -361,10 +361,10 @@ namespace StackExchange.Redis.Tests
         }
 
         public static string Me([CallerFilePath] string filePath = null, [CallerMemberName] string caller = null) =>
-#if NET462
-            "net462-"
-#elif NETCOREAPP2_1
-            "netcoreapp2.1-"
+#if NET472
+            "net472-"
+#elif NETCOREAPP3_1
+            "netcoreapp3.1-"
 #else
             "unknown-"
 #endif


### PR DESCRIPTION
The Sentinel issue appears to be server-side, it's waiting 10 seconds to issue the REPLICAOF after a failover. This seems to be a Redis issue I haven't narrowed down yet, but increasing logging here to help tests in general.