### PR TITLE
prevent GetOutstandingCount from throwing

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Sentinel potential memory leak fix in OnManagedConnectionFailed handler (#1710 via alexSatov)
-- fix issue where `GetOutstandingCount` could obscure underlying faults by faulting itself (#1792)
+- fix issue where `GetOutstandingCount` could obscure underlying faults by faulting itself (#1792 via mgravell)
 
 ## 2.2.50
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Sentinel potential memory leak fix in OnManagedConnectionFailed handler (#1710 via alexSatov)
+- fix issue where `GetOutstandingCount` could obscure underlying faults by faulting itself (#1792)
 
 ## 2.2.50
 

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -437,19 +437,20 @@ namespace StackExchange.Redis
         internal void GetOutstandingCount(RedisCommand command, out int inst, out int qs, out long @in, out int qu, out bool aw, out long toRead, out long toWrite,
             out BacklogStatus bs, out PhysicalConnection.ReadStatus rs, out PhysicalConnection.WriteStatus ws)
         {
-            var bridge = GetBridge(command, false);
-            if (bridge == null)
+            inst = qs = qu = 0;
+            @in = toRead = toWrite = 0;
+            aw = false;
+            bs = BacklogStatus.Inactive;
+            rs = PhysicalConnection.ReadStatus.NA;
+            ws = PhysicalConnection.WriteStatus.NA;
+            try
             {
-                inst = qs = qu = 0;
-                @in = toRead = toWrite = 0;
-                aw = false;
-                bs = BacklogStatus.Inactive;
-                rs = PhysicalConnection.ReadStatus.NA;
-                ws = PhysicalConnection.WriteStatus.NA;
+                var bridge = GetBridge(command, false);
+                bridge?.GetOutstandingCount(out inst, out qs, out @in, out qu, out aw, out toRead, out toWrite, out bs, out rs, out ws);
             }
-            else
-            {
-                bridge.GetOutstandingCount(out inst, out qs, out @in, out qu, out aw, out toRead, out toWrite, out bs, out rs, out ws);
+            catch (Exception ex)
+            {   // only needs to be best efforts
+                System.Diagnostics.Debug.WriteLine(ex.Message);
             }
         }
 


### PR DESCRIPTION
A few stack-traces have shown `GetOutstandingCount` participating in faults due to broken sockets etc; however, we use `GetOutstandingCount` from *within* those handlers, so: allowing it to blow up could be masking the original/underlying exception; fix that, by making `GetOutstandingCount` best-efforts only