### PR TITLE
Add .NET version and timestamp on default logger rows

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Unreleased
+- logging additions (.NET Version and timestamps) for better debugging (#1796 via philon-msft)
 
 ## 2.2.62
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -965,7 +965,7 @@ namespace StackExchange.Redis
                 {
                     lock (SyncLock)
                     {
-                        _log?.WriteLine(message);
+                        _log?.WriteLine($"{DateTime.UtcNow.ToString("o")}: {message}");
                     }
                 }
             }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using StackExchange.Redis.Profiling;
 using Pipelines.Sockets.Unofficial;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace StackExchange.Redis
 {
@@ -852,6 +853,8 @@ namespace StackExchange.Redis
             {
                 try
                 {
+                    log?.WriteLine($"Connecting (async) on {RuntimeInformation.FrameworkDescription}");
+
                     muxer = CreateMultiplexer(configuration, logProxy, out connectHandler);
                     killMe = muxer;
                     Interlocked.Increment(ref muxer._connectAttemptCount);
@@ -1141,6 +1144,8 @@ namespace StackExchange.Redis
             {
                 try
                 {
+                    log?.WriteLine($"Connecting (sync) on {RuntimeInformation.FrameworkDescription}");
+
                     muxer = CreateMultiplexer(configuration, logProxy, out connectHandler);
                     killMe = muxer;
                     Interlocked.Increment(ref muxer._connectAttemptCount);

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -965,7 +965,7 @@ namespace StackExchange.Redis
                 {
                     lock (SyncLock)
                     {
-                        _log?.WriteLine($"{DateTime.UtcNow.ToString("o")}: {message}");
+                        _log?.WriteLine($"{DateTime.UtcNow:HH:mm:ss.ffff}: {message}");
                     }
                 }
             }

--- a/tests/StackExchange.Redis.Tests/Helpers/TextWriterOutputHelper.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/TextWriterOutputHelper.cs
@@ -24,8 +24,12 @@ namespace StackExchange.Redis.Tests.Helpers
         {
             try
             {
-                base.Write(TestBase.Time());
-                base.Write(": ");
+                // Prevent double timestamps
+                if (value.Length < "HH:mm:ss.ffff:".Length || value["HH:mm:ss.ffff:".Length - 1] != ':')
+                {
+                    base.Write(TestBase.Time());
+                    base.Write(": ");
+                }
                 base.WriteLine(value);
             }
             catch (Exception ex)

--- a/tests/StackExchange.Redis.Tests/MultiMaster.cs
+++ b/tests/StackExchange.Redis.Tests/MultiMaster.cs
@@ -32,10 +32,10 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void TestMultiNoTieBreak()
         {
-            using (var log = new StringWriter())
-            using (Create(log: log, tieBreaker: ""))
+            var log = new StringBuilder();
+            Writer.EchoTo(log);
+            using (Create(log: Writer, tieBreaker: ""))
             {
-                Log(log.ToString());
                 Assert.Contains("Choosing master arbitrarily", log.ToString());
             }
         }

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -119,7 +119,7 @@ namespace StackExchange.Redis.Tests
             Console.WriteLine("  GC LOH Mode: " + GCSettings.LargeObjectHeapCompactionMode);
             Console.WriteLine("  GC Latency Mode: " + GCSettings.LatencyMode);
         }
-        internal static string Time() => DateTime.UtcNow.ToString("HH:mm:ss.fff");
+        internal static string Time() => DateTime.UtcNow.ToString("HH:mm:ss.ffff");
         protected void OnConnectionFailed(object sender, ConnectionFailedEventArgs e)
         {
             Interlocked.Increment(ref privateFailCount);


### PR DESCRIPTION
Prefix each entry with a timestamp that looks like:

```
18:18:47.9261: Connecting (async) on .NET Core 3.1.16
18:18:47.9263: cachename.redis.cache.windows.net:6380/Interactive: Connecting...
18:18:47.9463: cachename.redis.cache.windows.net:6380: BeginConnectAsync
18:18:47.9483: 1 unique nodes specified
```