### PR TITLE
Stream Length Transaction Conditions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - logging additions (.NET Version and timestamps) for better debugging (#1796 via philon-msft)
+- add: `Condition` API (transactions) now supports `StreamLengthEqual` and variants (#1807 via AlphaGremlin)
 
 ## 2.2.62
 

--- a/src/StackExchange.Redis/Condition.cs
+++ b/src/StackExchange.Redis/Condition.cs
@@ -332,6 +332,27 @@ namespace StackExchange.Redis
         /// <param name="count">The number of members which sorted set must not have.</param>
         public static Condition SortedSetScoreNotExists(RedisKey key, RedisValue score, RedisValue count) => new SortedSetScoreCondition(key, score, false, count);
 
+        /// <summary>
+        /// Enforces that the given stream length is a certain value
+        /// </summary>
+        /// <param name="key">The key of the stream to check.</param>
+        /// <param name="length">The length the stream must have.</param>
+        public static Condition StreamLengthEqual(RedisKey key, long length) => new LengthCondition(key, RedisType.Stream, 0, length);
+
+        /// <summary>
+        /// Enforces that the given stream length is less than a certain value
+        /// </summary>
+        /// <param name="key">The key of the stream to check.</param>
+        /// <param name="length">The length the stream must be less than.</param>
+        public static Condition StreamLengthLessThan(RedisKey key, long length) => new LengthCondition(key, RedisType.Stream, 1, length);
+
+        /// <summary>
+        /// Enforces that the given stream length is greater than a certain value
+        /// </summary>
+        /// <param name="key">The key of the stream to check.</param>
+        /// <param name="length">The length the stream must be greater than.</param>
+        public static Condition StreamLengthGreaterThan(RedisKey key, long length) => new LengthCondition(key, RedisType.Stream, -1, length);
+
 #pragma warning restore RCS1231
 
         internal abstract void CheckCommands(CommandMap commandMap);
@@ -675,6 +696,7 @@ namespace StackExchange.Redis
                     RedisType.Set => RedisCommand.SCARD,
                     RedisType.List => RedisCommand.LLEN,
                     RedisType.SortedSet => RedisCommand.ZCARD,
+                    RedisType.Stream => RedisCommand.XLEN,
                     RedisType.String => RedisCommand.STRLEN,
                     _ => throw new ArgumentException($"Type {type} isn't recognized", nameof(type)),
                 };

--- a/tests/StackExchange.Redis.Tests/Transactions.cs
+++ b/tests/StackExchange.Redis.Tests/Transactions.cs
@@ -1100,6 +1100,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
+                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.Streams), r => r.Streams);
+
                 RedisKey key = Me(), key2 = Me() + "2";
                 var db = muxer.GetDatabase();
                 db.KeyDelete(key, CommandFlags.FireAndForget);


### PR DESCRIPTION
Adding some new condition overloads for XLEN, useful for deleting empty streams in a safe method. It's a very simple change, one line to the length condition implementation plus the overloads.

Tests have been added and pass, though I don't have the infrastructure to run the failover/cluster/etc tests. I can include the .trx file if that's important.

I would have liked to add more conditions, like one that calls XPENDING to examine the number of pending messages, but that would need a new condition implementation with different messages and more complicated code to examine the results. Maybe I'll do it in another pull request, if I find the time.