### PR TITLE
Socket available bytes check: add a disposal guard

### DIFF
--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1249,7 +1249,15 @@ namespace StackExchange.Redis
                 return counters.BytesAvailableOnSocket;
             }
             readCount = writeCount = -1;
-            return VolatileSocket?.Available ?? -1;
+            try
+            {
+                return VolatileSocket?.Available ?? -1;
+            }
+            catch
+            {
+                // If this fails, we're likely in a race disposal situation and do not want to blow sky high here.
+                return -1;
+            }
         }
 
         private static RemoteCertificateValidationCallback GetAmbientIssuerCertificateCallback()


### PR DESCRIPTION
This prevents a disposal race from killing us in connection phases and such, protected against in the counters above in Unofficial (see https://github.com/mgravell/Pipelines.Sockets.Unofficial/blob/19b141f30fe2485dd79993be0ac87a9fc6b34b74/src/Pipelines.Sockets.Unofficial/SocketConnection.cs#L235) but not here - adding the same protection guard.

Stack trace of such an error:
```
----- Inner Stack Trace -----
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success)
   at Interop.Winsock.ioctlsocket(SafeSocketHandle socketHandle, Int32 cmd, Int32& argp)
   at System.Net.Sockets.SocketPal.GetAvailable(SafeSocketHandle handle, Int32& available)
   at System.Net.Sockets.Socket.get_Available()
   at StackExchange.Redis.PhysicalConnection.GetSocketBytes(Int64& readCount, Int64& writeCount) in /_/src/StackExchange.Redis/PhysicalConnection.cs:line 1250
   at StackExchange.Redis.PhysicalBridge.GetOutstandingCount(Int32& inst, Int32& qs, Int64& in, Int32& qu, Boolean& aw, Int64& toRead, Int64& toWrite, BacklogStatus& bs, ReadStatus& rs, WriteStatus& ws) in /_/src/StackExchange.Redis/PhysicalBridge.cs:line 304
   at StackExchange.Redis.ConnectionMultiplexer.ReconfigureAsync(Boolean first, Boolean reconfigureAll, LogProxy log, EndPoint blame, String cause, Boolean publishReconfigure, CommandFlags publishReconfigureFlags) in /_/src/StackExchange.Redis/ConnectionMultiplexer.cs:line 1748
```