### PR TITLE
Add support for count argument to ListLeftPop, ListLeftPopAsync, ListRightPop, and ListRightPopAsync

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -5,6 +5,7 @@
 - fix potential errors getting socket bytes (#1836 via NickCraver)
 - logging additions (.NET Version and timestamps) for better debugging (#1796 via philon-msft)
 - add: `Condition` API (transactions) now supports `StreamLengthEqual` and variants (#1807 via AlphaGremlin)
+- Add support for count argument to `ListLeftPop`, `ListLeftPopAsync`, `ListRightPop`, and `ListRightPopAsync` (#1850 via jjfmarket)
 
 ## 2.2.62
 

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -641,12 +641,12 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Removes and returns count elements from the tail of the list stored at key.
-        /// If there are less elements in the list than count, removes and returns all the elements in the list
+        /// If there are less elements in the list than count, removes and returns all the elements in the list.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="count">The number of items to remove</param>
+        /// <param name="count">The number of items to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
         /// <remarks>https://redis.io/commands/lpop</remarks>
         RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
@@ -732,12 +732,12 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Removes and returns count elements from the head of the list stored at key.
-        /// If there are less elements in the list than count, removes and returns all the elements in the list
+        /// If there are less elements in the list than count, removes and returns all the elements in the list.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="count">tThe number of items to remove</param>
+        /// <param name="count">tThe number of items to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
         /// <remarks>https://redis.io/commands/rpop</remarks>
         RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -640,6 +640,17 @@ namespace StackExchange.Redis
         RedisValue ListLeftPop(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Removes and returns count elements from the tail of the list stored at key.
+        /// If there are less elements in the list than count, removes and returns all the elements in the list
+        /// </summary>
+        /// <param name="key">The key of the list.</param>
+        /// <param name="count">The number of items to remove</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <remarks>https://redis.io/commands/lpop</remarks>
+        RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <param name="key">The key of the list.</param>
@@ -718,6 +729,17 @@ namespace StackExchange.Redis
         /// <returns>The element being popped.</returns>
         /// <remarks>https://redis.io/commands/rpop</remarks>
         RedisValue ListRightPop(RedisKey key, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Removes and returns count elements from the head of the list stored at key.
+        /// If there are less elements in the list than count, removes and returns all the elements in the list
+        /// </summary>
+        /// <param name="key">The key of the list.</param>
+        /// <param name="count">tThe number of items to remove</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <remarks>https://redis.io/commands/rpop</remarks>
+        RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Atomically returns and removes the last element (tail) of the list stored at source, and pushes the element at the first element (head) of the list stored at destination.

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -617,6 +617,17 @@ namespace StackExchange.Redis
         Task<RedisValue> ListLeftPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Removes and returns count elements from the head of the list stored at key.
+        /// If the list contains less than count elements, removes and returns the number of elements in the list
+        /// </summary>
+        /// <param name="key">The key of the list.</param>
+        /// <param name="count">The number of elements to remove</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <remarks>https://redis.io/commands/lpop</remarks>
+        Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <param name="key">The key of the list.</param>
@@ -695,6 +706,17 @@ namespace StackExchange.Redis
         /// <returns>The element being popped.</returns>
         /// <remarks>https://redis.io/commands/rpop</remarks>
         Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Removes and returns count elements from the end the list stored at key.
+        /// If the list contains less than count elements, removes and returns the number of elements in the list
+        /// </summary>
+        /// <param name="key">The key of the list.</param>
+        /// <param name="count">The number of elements to pop</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <remarks>https://redis.io/commands/rpop</remarks>
+        Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Atomically returns and removes the last element (tail) of the list stored at source, and pushes the element at the first element (head) of the list stored at destination.

--- a/src/StackExchange.Redis/KeyspaceIsolation/DatabaseWrapper.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/DatabaseWrapper.cs
@@ -301,6 +301,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.ListLeftPop(ToInner(key), flags);
         }
 
+        public RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.ListLeftPop(ToInner(key), count, flags);
+        }
+
         public long ListLeftPush(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
         {
             return Inner.ListLeftPush(ToInner(key), values, flags);
@@ -334,6 +339,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public RedisValue ListRightPop(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return Inner.ListRightPop(ToInner(key), flags);
+        }
+
+        public RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.ListRightPop(ToInner(key), count, flags);
         }
 
         public RedisValue ListRightPopLeftPush(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/KeyspaceIsolation/WrapperBase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/WrapperBase.cs
@@ -286,6 +286,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
             return Inner.ListLeftPopAsync(ToInner(key), flags);
         }
 
+        public Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.ListLeftPopAsync(ToInner(key), count, flags);
+        }
+
         public Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
         {
             return Inner.ListLeftPushAsync(ToInner(key), values, flags);
@@ -319,6 +324,11 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             return Inner.ListRightPopAsync(ToInner(key), flags);
+        }
+
+        public Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return Inner.ListRightPopAsync(ToInner(key), count, flags);
         }
 
         public Task<RedisValue> ListRightPopLeftPushAsync(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -922,10 +922,22 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.RedisValue);
         }
 
+        public RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.LPOP, key, count);
+            return ExecuteSync(msg, ResultProcessor.RedisValueArray);
+        }
+
         public Task<RedisValue> ListLeftPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(Database, flags, RedisCommand.LPOP, key);
             return ExecuteAsync(msg, ResultProcessor.RedisValue);
+        }
+
+        public Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.LPOP, key, count);
+            return ExecuteAsync(msg, ResultProcessor.RedisValueArray);
         }
 
         public long ListLeftPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
@@ -1016,10 +1028,22 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.RedisValue);
         }
 
+        public RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.RPOP, key, count);
+            return ExecuteSync(msg, ResultProcessor.RedisValueArray);
+        }
+
         public Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(Database, flags, RedisCommand.RPOP, key);
             return ExecuteAsync(msg, ResultProcessor.RedisValue);
+        }
+
+        public Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(Database, flags, RedisCommand.RPOP, key, count);
+            return ExecuteAsync(msg, ResultProcessor.RedisValueArray);
         }
 
         public RedisValue ListRightPopLeftPush(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None)
@@ -1933,7 +1957,7 @@ namespace StackExchange.Redis
                 key,
                 groupName,
                 position,
-                true, 
+                true,
                 flags);
         }
 
@@ -2251,7 +2275,7 @@ namespace StackExchange.Redis
                 false,
                 flags);
         }
-        
+
         public Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None)
         {
             var actualPosition = position ?? StreamPosition.NewMessages;
@@ -2815,7 +2839,7 @@ namespace StackExchange.Redis
              * [7] = id1
              * [8] = id2
              * [9] = id3
-             * 
+             *
              * */
 
             var pairCount = streamPositions.Length;

--- a/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -370,6 +370,13 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public void ListLeftPop_1()
+        {
+            wrapper.ListLeftPop("key", 123, CommandFlags.None);
+            mock.Verify(_ => _.ListLeftPop("prefix:key", 123, CommandFlags.None));
+        }
+
+        [Fact]
         public void ListLeftPush_1()
         {
             wrapper.ListLeftPush("key", "value", When.Exists, CommandFlags.None);
@@ -418,6 +425,13 @@ namespace StackExchange.Redis.Tests
         {
             wrapper.ListRightPop("key", CommandFlags.None);
             mock.Verify(_ => _.ListRightPop("prefix:key", CommandFlags.None));
+        }
+
+        [Fact]
+        public void ListRightPop_1()
+        {
+            wrapper.ListRightPop("key", 123, CommandFlags.None);
+            mock.Verify(_ => _.ListRightPop("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]

--- a/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -331,6 +331,13 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public void ListLeftPopAsync_1()
+        {
+            wrapper.ListLeftPopAsync("key", 123, CommandFlags.None);
+            mock.Verify(_ => _.ListLeftPopAsync("prefix:key", 123, CommandFlags.None));
+        }
+
+        [Fact]
         public void ListLeftPushAsync_1()
         {
             wrapper.ListLeftPushAsync("key", "value", When.Exists, CommandFlags.None);
@@ -379,6 +386,13 @@ namespace StackExchange.Redis.Tests
         {
             wrapper.ListRightPopAsync("key", CommandFlags.None);
             mock.Verify(_ => _.ListRightPopAsync("prefix:key", CommandFlags.None));
+        }
+
+        [Fact]
+        public void ListRightPopAsync_1()
+        {
+            wrapper.ListRightPopAsync("key", 123, CommandFlags.None);
+            mock.Verify(_ => _.ListRightPopAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]


### PR DESCRIPTION
Add support for count argument to ListLeftPop, ListLeftPopAsync, ListRightPop, and ListRightPopAsync

Optional Count argument was added in Redis 6.2