### PR TITLE
Use a dedicated thread, rather than the thread-pool, for the backlog processor

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -5,6 +5,7 @@
 - fix potential errors getting socket bytes (#1836 via NickCraver)
 - logging additions (.NET Version and timestamps) for better debugging (#1796 via philon-msft)
 - add: `Condition` API (transactions) now supports `StreamLengthEqual` and variants (#1807 via AlphaGremlin)
+- fix potential task/thread exhaustion from the backlog processor (#1854 via mgravell)
 
 ## 2.2.62
 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -777,7 +777,10 @@ namespace StackExchange.Redis
                 // to unblock the thread-pool when there could be sync-over-async callers. Note that in reality,
                 // the initial "enough" of the back-log processor is typically sync, which means that the thread
                 // we start is actually useful, despite thinking "but that will just go async and back to the pool"
-                new Thread(s => ((PhysicalBridge)s).ProcessBacklogAsync().RedisFireAndForget()).Start(this);
+                var thread = new Thread(s => ((PhysicalBridge)s).ProcessBacklogAsync().RedisFireAndForget());
+                thread.IsBackground = true; // don't keep process alive (also: act like the thread-pool used to)
+                thread.Name = "redisbacklog"; // help anyone looking at thread-dumps
+                thread.Start(this);
             }
         }
 #if DEBUG


### PR DESCRIPTION
Pain point in the last release was a spiral of death triggered (or at least: exacerbated) by the backlog processor