### PR TITLE
Adding sortable tag field support & UNF support

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - NRediSearch: Support on json index (#1808 via AvitalFineRedis)
+- NRediSearch: Support sortable TagFields and unNormalizedForm for Tag & Text Fields (#1862 via slorello89 & AvitalFineRedis)
 - fix potential errors getting socket bytes (#1836 via NickCraver)
 - logging additions (.NET Version and timestamps) for better debugging (#1796 via philon-msft)
 - add: `Condition` API (transactions) now supports `StreamLengthEqual` and variants (#1807 via AlphaGremlin)

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -220,12 +220,12 @@ namespace NRediSearch
         {
             public string Separator { get; }
 
-            internal TagField(string name, string separator = ",") : base(name, FieldType.Tag, false)
+            internal TagField(string name, string separator = ",", bool sortable = false) : base(name, FieldType.Tag, sortable)
             {
                 Separator = separator;
             }
 
-            internal TagField(FieldName name, string separator = ",") : base(name, FieldType.Tag, false)
+            internal TagField(FieldName name, string separator = ",", bool sortable = false) : base(name, FieldType.Tag, sortable)
             {
                 Separator = separator;
             }
@@ -235,8 +235,10 @@ namespace NRediSearch
                 base.SerializeRedisArgs(args);
                 if (Separator != ",")
                 {
+                    if (Sortable) args.Remove("SORTABLE");
                     args.Add("SEPARATOR".Literal());
                     args.Add(Separator);
+                    if (Sortable) args.Add("SORTABLE".Literal());
                 }
             }
         }
@@ -262,6 +264,30 @@ namespace NRediSearch
         public Schema AddTagField(FieldName name, string separator = ",")
         {
             Fields.Add(new TagField(name, separator));
+            return this;
+        }
+
+        /// <summary>
+        /// Add a sortable TAG field.
+        /// </summary>
+        /// <param name="name">The field's name.</param>
+        /// <param name="separator">The tag separator.</param>
+        /// <returns>The <see cref="Schema"/> object.</returns>
+        public Schema AddSortableTagField(string name, string separator = ",")
+        {
+            Fields.Add(new TagField(name, separator, sortable: true));
+            return this;
+        }
+
+        /// <summary>
+        /// Add a sortable TAG field.
+        /// </summary>
+        /// <param name="name">The field's name.</param>
+        /// <param name="separator">The tag separator.</param>
+        /// <returns>The <see cref="Schema"/> object.</returns>
+        public Schema AddSortableTagField(FieldName name, string separator = ",")
+        {
+            Fields.Add(new TagField(name, separator, sortable: true));
             return this;
         }
     }

--- a/src/NRediSearch/Schema.cs
+++ b/src/NRediSearch/Schema.cs
@@ -69,15 +69,21 @@ namespace NRediSearch
             public double Weight { get; }
             public bool NoStem { get; }
 
-            public TextField(string name, double weight = 1.0, bool sortable = false, bool noStem = false, bool noIndex = false, bool unf = false)
-            : base(name, FieldType.FullText, sortable, noIndex, unf)
+            public TextField(string name, double weight, bool sortable, bool noStem, bool noIndex)
+            : this(name, weight, sortable, noStem, noIndex, false) { }
+
+            public TextField(string name, double weight = 1.0, bool sortable = false, bool noStem = false, bool noIndex = false, bool unNormalizedForm = false)
+            : base(name, FieldType.FullText, sortable, noIndex, unNormalizedForm)
             {
                 Weight = weight;
                 NoStem = noStem;
             }
 
-            public TextField(FieldName name, double weight = 1.0, bool sortable = false, bool noStem = false, bool noIndex = false, bool unf = false)
-            : base(name, FieldType.FullText, sortable, noIndex, unf)
+            public TextField(FieldName name, double weight, bool sortable, bool noStem, bool noIndex)
+            : this(name, weight, sortable, noStem, noIndex, false) { }
+
+            public TextField(FieldName name, double weight = 1.0, bool sortable = false, bool noStem = false, bool noIndex = false, bool unNormalizedForm = false)
+            : base(name, FieldType.FullText, sortable, noIndex, unNormalizedForm)
             {
                 Weight = weight;
                 NoStem = noStem;
@@ -137,10 +143,12 @@ namespace NRediSearch
         /// </summary>
         /// <param name="name">The field's name.</param>
         /// <param name="weight">Its weight, a positive floating point number.</param>
+        /// <param name="unNormalizedForm">Set this to true to prevent the indexer from sorting on the normalized form.
+        /// Normalied form is the field sent to lower case with all diaretics removed</param>
         /// <returns>The <see cref="Schema"/> object.</returns>
         public Schema AddSortableTextField(string name, double weight = 1.0, bool unf = false)
         {
-            Fields.Add(new TextField(name, weight, true, unf: unf));
+            Fields.Add(new TextField(name, weight, true, unNormalizedForm: unf));
             return this;
         }
 
@@ -150,11 +158,29 @@ namespace NRediSearch
         /// <param name="name">The field's name.</param>
         /// <param name="weight">Its weight, a positive floating point number.</param>
         /// <returns>The <see cref="Schema"/> object.</returns>
-        public Schema AddSortableTextField(FieldName name, double weight = 1.0, bool unf = false)
+        public Schema AddSortableTextField(string name, double weight) => AddSortableTextField(name, weight, false);
+
+        /// <summary>
+        /// Add a text field that can be sorted on.
+        /// </summary>
+        /// <param name="name">The field's name.</param>
+        /// <param name="weight">Its weight, a positive floating point number.</param>
+        /// <param name="unNormalizedForm">Set this to true to prevent the indexer from sorting on the normalized form.
+        /// Normalied form is the field sent to lower case with all diaretics removed</param>
+        /// <returns>The <see cref="Schema"/> object.</returns>
+        public Schema AddSortableTextField(FieldName name, double weight = 1.0, bool unNormalizedForm = false)
         {
-            Fields.Add(new TextField(name, weight, true, unf: unf));
+            Fields.Add(new TextField(name, weight, true, unNormalizedForm: unNormalizedForm));
             return this;
         }
+
+        /// <summary>
+        /// Add a text field that can be sorted on.
+        /// </summary>
+        /// <param name="name">The field's name.</param>
+        /// <param name="weight">Its weight, a positive floating point number.</param>
+        /// <returns>The <see cref="Schema"/> object.</returns>
+        public Schema AddSortableTextField(FieldName name, double weight) => AddSortableTextField(name, weight, false);
 
         /// <summary>
         /// Add a numeric field to the schema.
@@ -226,14 +252,14 @@ namespace NRediSearch
         {
             public string Separator { get; }
 
-            internal TagField(string name, string separator = ",", bool sortable = false, bool unf = false)
-            : base(name, FieldType.Tag, sortable, unf: unf)
+            internal TagField(string name, string separator = ",", bool sortable = false, bool unNormalizedForm = false)
+            : base(name, FieldType.Tag, sortable, unf: unNormalizedForm)
             {
                 Separator = separator;
             }
 
-            internal TagField(FieldName name, string separator = ",", bool sortable = false, bool unf = false)
-            : base(name, FieldType.Tag, sortable, unf: unf)
+            internal TagField(FieldName name, string separator = ",", bool sortable = false, bool unNormalizedForm = false)
+            : base(name, FieldType.Tag, sortable, unf: unNormalizedForm)
             {
                 Separator = separator;
             }
@@ -282,10 +308,12 @@ namespace NRediSearch
         /// </summary>
         /// <param name="name">The field's name.</param>
         /// <param name="separator">The tag separator.</param>
+        /// <param name="unNormalizedForm">Set this to true to prevent the indexer from sorting on the normalized form.
+        /// Normalied form is the field sent to lower case with all diaretics removed</param>
         /// <returns>The <see cref="Schema"/> object.</returns>
-        public Schema AddSortableTagField(string name, string separator = ",", bool unf = false)
+        public Schema AddSortableTagField(string name, string separator = ",", bool unNormalizedForm = false)
         {
-            Fields.Add(new TagField(name, separator, sortable: true, unf: unf));
+            Fields.Add(new TagField(name, separator, sortable: true, unNormalizedForm: unNormalizedForm));
             return this;
         }
 
@@ -294,10 +322,12 @@ namespace NRediSearch
         /// </summary>
         /// <param name="name">The field's name.</param>
         /// <param name="separator">The tag separator.</param>
+        /// <param name="unNormalizedForm">Set this to true to prevent the indexer from sorting on the normalized form.
+        /// Normalied form is the field sent to lower case with all diaretics removed</param>
         /// <returns>The <see cref="Schema"/> object.</returns>
-        public Schema AddSortableTagField(FieldName name, string separator = ",", bool unf = false)
+        public Schema AddSortableTagField(FieldName name, string separator = ",", bool unNormalizedForm = false)
         {
-            Fields.Add(new TagField(name, separator, sortable: true, unf: unf));
+            Fields.Add(new TagField(name, separator, sortable: true, unNormalizedForm: unNormalizedForm));
             return this;
         }
     }

--- a/tests/NRediSearch.Test/ClientTests/ClientTest.cs
+++ b/tests/NRediSearch.Test/ClientTests/ClientTest.cs
@@ -875,14 +875,14 @@ namespace NRediSearch.Test.ClientTests
 
             // Check that UNF can't be given to non-sortable filed
             try {
-                var temp = new Schema().AddField(new TextField("non-sortable-unf", 1.0, sortable: false, unf: true));
+                var temp = new Schema().AddField(new TextField("non-sortable-unf", 1.0, sortable: false, unNormalizedForm: true));
                 Assert.True(false);
             } catch (ArgumentException) {
                 Assert.True(true);
             }
 
             Schema sc = new Schema().AddSortableTextField("txt").AddSortableTextField("txt_unf", unf: true).
-                              AddSortableTagField("tag").AddSortableTagField("tag_unf", unf: true);
+                              AddSortableTagField("tag").AddSortableTagField("tag_unf", unNormalizedForm: true);
             Assert.True(cl.CreateIndex(sc, new ConfiguredIndexOptions()));
             Db.Execute("HSET", "doc1", "txt", "FOO", "txt_unf", "FOO", "tag", "FOO", "tag_unf", "FOO");
 


### PR DESCRIPTION
Adding the ability to add sorted tag fields in indices per #1838

Note: When serializing the arguments RediSearch cares about the order of the separator and sortable arguments, hence after calling `base.SerializeRedisArgs`, if the index is sortable and removes the sortable flag, and then adds it back after the separator flag is added.