### PR TITLE
Add support for listening to Azure Maintenance Events

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,6 +7,7 @@
 - logging additions (.NET Version and timestamps) for better debugging (#1796 via philon-msft)
 - add: `Condition` API (transactions) now supports `StreamLengthEqual` and variants (#1807 via AlphaGremlin)
 - fix potential task/thread exhaustion from the backlog processor (#1854 via mgravell)
+- add support for listening to Azure Maintenance Events (#1865 via amsoedal)
 
 ## 2.2.62
 

--- a/src/StackExchange.Redis/AzureMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/AzureMaintenanceEvent.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using System.Buffers.Text;
+using static StackExchange.Redis.ConnectionMultiplexer;
+using System.Globalization;
+
+namespace StackExchange.Redis
+{
+    /// <summary>
+    /// Azure node maintenance event. For more information, please see: https://github.com/Azure/AzureCacheForRedis/blob/main/AzureRedisEvents.md
+    /// </summary>
+    public class AzureMaintenanceEvent
+    {
+        private const string PubSubChannelName = "AzureRedisEvents";
+
+        internal AzureMaintenanceEvent(string azureEvent)
+        {
+            if (azureEvent == null)
+            {
+                return;
+            }
+
+            // The message consists of key-value pairs delimted by pipes. For example, a message might look like:
+            // NotificationType|NodeMaintenanceStarting|StartTimeUtc|2021-09-23T12:34:19|IsReplica|False|IpAddress|13.67.42.199|SSLPort|15001|NonSSLPort|13001
+            var message = azureEvent.AsSpan();
+            try
+            {
+                while (message.Length > 0)
+                {
+                    if (message[0] == '|')
+                    {
+                        message = message.Slice(1);
+                        continue;
+                    }
+
+                    // Grab the next pair
+                    var nextDelimiter = message.IndexOf('|');
+                    if (nextDelimiter < 0)
+                    {
+                        // The rest of the message is not a key-value pair and is therefore malformed. Stop processing it.
+                        break;
+                    }
+
+                    if (nextDelimiter == message.Length - 1)
+                    {
+                        // The message is missing the value for this key-value pair. It is malformed so we stop processing it.
+                        break;
+                    }
+
+                    var key = message.Slice(0, nextDelimiter);
+                    message = message.Slice(key.Length + 1);
+
+                    var valueEnd = message.IndexOf('|');
+                    var value = valueEnd > -1 ? message.Slice(0, valueEnd) : message;
+                    message = message.Slice(value.Length);
+
+                    if (key.Length > 0 && value.Length > 0)
+                    {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+                        switch (key)
+                        {
+                            case var _ when key.SequenceEqual(nameof(NotificationType).AsSpan()):
+                                NotificationType = value.ToString();
+                                break;
+                            case var _ when key.SequenceEqual("StartTimeInUTC".AsSpan()) && DateTime.TryParseExact(value, "s", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime startTime):
+                                StartTimeUtc = DateTime.SpecifyKind(startTime, DateTimeKind.Utc);
+                                break;
+                            case var _ when key.SequenceEqual(nameof(IsReplica).AsSpan()) && bool.TryParse(value, out var isReplica):
+                                IsReplica = isReplica;
+                                break;
+                            case var _ when key.SequenceEqual(nameof(IPAddress).AsSpan()) && IPAddress.TryParse(value, out var ipAddress):
+                                IPAddress = ipAddress;
+                                break;
+                            case var _ when key.SequenceEqual(nameof(SSLPort).AsSpan()) && Int32.TryParse(value, out var port):
+                                SSLPort = port;
+                                break;
+                            case var _ when key.SequenceEqual(nameof(NonSSLPort).AsSpan()) && Int32.TryParse(value, out var nonsslport):
+                                NonSSLPort = nonsslport;
+                                break;
+                            default:
+                                break;
+                        }
+#else
+                        switch (key)
+                        {
+                            case var _ when key.SequenceEqual(nameof(NotificationType).AsSpan()):
+                                NotificationType = value.ToString();
+                                break;
+                            case var _ when key.SequenceEqual("StartTimeInUTC".AsSpan()) && DateTime.TryParseExact(value.ToString(), "s", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime startTime):
+                                StartTimeUtc = DateTime.SpecifyKind(startTime, DateTimeKind.Utc);
+                                break;
+                            case var _ when key.SequenceEqual(nameof(IsReplica).AsSpan()) && bool.TryParse(value.ToString(), out var isReplica):
+                                IsReplica = isReplica;
+                                break;
+                            case var _ when key.SequenceEqual(nameof(IPAddress).AsSpan()) && IPAddress.TryParse(value.ToString(), out var ipAddress):
+                                IPAddress = ipAddress;
+                                break;
+                            case var _ when key.SequenceEqual(nameof(SSLPort).AsSpan()) && Int32.TryParse(value.ToString(), out var port):
+                                SSLPort = port;
+                                break;
+                            case var _ when key.SequenceEqual(nameof(NonSSLPort).AsSpan()) && Int32.TryParse(value.ToString(), out var nonsslport):
+                                NonSSLPort = nonsslport;
+                                break;
+                            default:
+                                break;
+                        }
+#endif
+                    }
+                }
+            }
+            catch
+            {
+                // TODO: Append to rolling debug log when it's present
+            }
+        }
+
+        internal async static Task AddListenerAsync(ConnectionMultiplexer multiplexer, LogProxy logProxy)
+        {
+            try
+            {
+                var sub = multiplexer.GetSubscriber();
+                if (sub == null)
+                {
+                    logProxy?.WriteLine("Failed to GetSubscriber for AzureRedisEvents");
+                    return;
+                }
+
+                await sub.SubscribeAsync(PubSubChannelName, (channel, message) =>
+                {
+                    var newMessage = new AzureMaintenanceEvent(message);
+                    multiplexer.InvokeServerMaintenanceEvent(newMessage);
+
+                    if (newMessage.NotificationType.Equals("NodeMaintenanceEnded") || newMessage.NotificationType.Equals("NodeMaintenanceFailover"))
+                    {
+                        multiplexer.ReconfigureAsync(first: false, reconfigureAll: true, log: logProxy, blame: null, cause: $"Azure Event: {newMessage.NotificationType}").Wait();
+                    }
+                }).ForAwait();
+            }
+            catch (Exception e)
+            {
+                logProxy?.WriteLine($"Encountered exception: {e}");
+            }
+        }
+
+        /// <summary>
+        /// Raw message received from the server
+        /// </summary>
+        public string RawMessage { get; }
+
+        /// <summary>
+        /// indicates the event type
+        /// </summary>
+        public string NotificationType { get; }
+
+        /// <summary>
+        /// indicates the start time of the event
+        /// </summary>
+        public DateTime? StartTimeUtc { get; }
+
+        /// <summary>
+        /// indicates if the event is for a replica node
+        /// </summary>
+        public bool IsReplica { get; }
+
+        /// <summary>
+        /// IPAddress of the node event is intended for
+        /// </summary>
+        public IPAddress IPAddress { get; }
+
+        /// <summary>
+        /// ssl port
+        /// </summary>
+        public int SSLPort { get; }
+
+        /// <summary>
+        /// non-ssl port
+        /// </summary>
+        public int NonSSLPort { get; }
+
+        /// <summary>
+        /// Returns a string representing the maintenance event with all of its properties
+        /// </summary>
+        public override string ToString()
+            => RawMessage;
+    }
+}

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -790,22 +790,25 @@ namespace StackExchange.Redis
         // Microsoft Azure team wants abortConnect=false by default
         private bool GetDefaultAbortOnConnectFailSetting() => !IsAzureEndpoint();
 
-        private bool IsAzureEndpoint()
+        internal bool IsAzureEndpoint()
         {
+            List<string> azureRedisHosts = new List<string> {
+                ".redis.cache.windows.net",
+                ".redis.cache.chinacloudapi.cn",
+                ".redis.cache.usgovcloudapi.net",
+                ".redis.cache.cloudapi.de",
+                ".redisenterprise.cache.azure.net"
+            };
+
             foreach (var ep in EndPoints)
             {
                 if (ep is DnsEndPoint dnsEp)
                 {
-                    int firstDot = dnsEp.Host.IndexOf('.');
-                    if (firstDot >= 0)
+                    foreach (var host in azureRedisHosts)
                     {
-                        switch (dnsEp.Host.Substring(firstDot).ToLowerInvariant())
+                        if (dnsEp.Host.EndsWith(host, StringComparison.InvariantCultureIgnoreCase))
                         {
-                            case ".redis.cache.windows.net":
-                            case ".redis.cache.chinacloudapi.cn":
-                            case ".redis.cache.usgovcloudapi.net":
-                            case ".redis.cache.cloudapi.de":
-                                return true;
+                            return true;
                         }
                     }
                 }

--- a/tests/StackExchange.Redis.Tests/AzureMaintenanceEventTests.cs
+++ b/tests/StackExchange.Redis.Tests/AzureMaintenanceEventTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StackExchange.Redis.Tests
+{
+    public class AzureMaintenanceEventTests : TestBase
+    {
+        public AzureMaintenanceEventTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData("NotificationType|NodeMaintenanceStarting|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress||SSLPort|15001|NonSSLPort|13001", "NodeMaintenanceStarting", "2021-03-02T23:26:57", false, null, 15001, 13001)]
+        [InlineData("NotificationType|NodeMaintenanceFailover|StartTimeInUTC||IsReplica|False|IPAddress||SSLPort|15001|NonSSLPort|13001", "NodeMaintenanceFailover", null, false, null, 15001, 13001)]
+        [InlineData("NotificationType|NodeMaintenanceFailover|StartTimeInUTC||IsReplica|True|IPAddress||SSLPort|15001|NonSSLPort|13001", "NodeMaintenanceFailover", null, true, null, 15001, 13001)]
+        [InlineData("NotificationType|NodeMaintenanceStarting|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|j|IPAddress||SSLPort|char|NonSSLPort|char", "NodeMaintenanceStarting", "2021-03-02T23:26:57", false, null, 0, 0)]
+        [InlineData("NotificationType|NodeMaintenanceStarting|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress||SSLPort|15999|NonSSLPort|139991", "NodeMaintenanceStarting", "2021-03-02T23:26:57", false, null, 15999, 139991)]
+        [InlineData("NotificationType|NodeMaintenanceStarting|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress|127.0.0.1|SSLPort|15999|NonSSLPort|139991", "NodeMaintenanceStarting", "2021-03-02T23:26:57", false, "127.0.0.1", 15999, 139991)]
+        [InlineData("NotificationType|", null, null, false, null, 0, 0)]
+        [InlineData("NotificationType|NodeMaintenanceStarting1", "NodeMaintenanceStarting1", null, false, null, 0, 0)]
+        [InlineData("1|2|3", null, null, false, null, 0, 0)]
+        [InlineData("StartTimeInUTC|", null, null, false, null, 0, 0)]
+        [InlineData("IsReplica|", null, null, false, null, 0, 0)]
+        [InlineData("SSLPort|", null, null, false, null, 0, 0)]
+        [InlineData("NonSSLPort |", null, null, false, null, 0, 0)]
+        [InlineData("StartTimeInUTC|thisisthestart", null, null, false, null, 0, 0)]
+        [InlineData(null, null, null, false, null, 0, 0)]
+        public void TestAzureMaintenanceEventStrings(string message, string expectedEventType, string expectedStart, bool expectedIsReplica, string expectedIP, int expectedSSLPort, int expectedNonSSLPort)
+        {
+            DateTime? expectedStartTimeUtc = null;
+            if (expectedStart != null && DateTime.TryParse(expectedStart, out DateTime startTimeUtc))
+            {
+                expectedStartTimeUtc = DateTime.SpecifyKind(startTimeUtc, DateTimeKind.Utc);
+            }
+            IPAddress.TryParse(expectedIP, out IPAddress expectedIPAddress);
+
+            var azureMaintenance = new AzureMaintenanceEvent(message);
+
+            Assert.Equal(expectedEventType, azureMaintenance.NotificationType);
+            Assert.Equal(expectedStartTimeUtc, azureMaintenance.StartTimeUtc);
+            Assert.Equal(expectedIsReplica, azureMaintenance.IsReplica);
+            Assert.Equal(expectedIPAddress, azureMaintenance.IPAddress);
+            Assert.Equal(expectedSSLPort, azureMaintenance.SSLPort);
+            Assert.Equal(expectedNonSSLPort, azureMaintenance.NonSSLPort);
+        }
+    }
+}


### PR DESCRIPTION
Adding an automatic subscription to the AzureRedisEvents pubsub channel for Azure caches. This channel notifies clients of upcoming maintenance and failover events.

By exposing these events, users will be able to know about maintenance ahead of time, and can implement their own logic (e.g. diverting traffic from the cache to another database for the duration of the maintenance event) in response, with the goal of minimizing downtime and disrupted connections. We also automatically refresh our view of the topology of the cluster in response to certain events.

Here are some of the possible notifications:

```
// This event gets fired ~20s before maintenance begins
NodeMaintenanceStarting,

// This event gets fired when maintenance is imminent (<5s)
NodeMaintenanceStart,

// Indicates that the node maintenance operation is over
NodeMaintenanceEnded,

// Indicates that a replica has been promoted to primary
NodeMaintenanceFailover
```