### PR TITLE
Updated the Configuration.md to verbalize ECHO permission require

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,7 +1,7 @@
 ﻿Configuration
 ===
 
-When connecting to Redis using StackExchange.Redis, your ACL user needs to at least have permissions to run the ECHO command. We run this command to verify that we have a valid connection to the Redis service.
+When connecting to Redis version 6 or above with an ACL configured, your ACL user needs to at least have permissions to run the ECHO command. We run this command to verify that we have a valid connection to the Redis service.
 Because there are lots of different ways to configure redis, StackExchange.Redis offers a rich configuration model, which is invoked when calling `Connect` (or `ConnectAsync`):
 
 ```csharp


### PR DESCRIPTION
My ACL user was never granted the ECHO permission since my logic never had a use case for it. When I first configured StackExchange.Redis, I kept getting a connection exception, but I have a nodejs implementation that uses the node-redis npm package to connect to my server just fine. I looked through your logs and source code and found what I was missing.

"...Error: NOPERM this user has no permissions to run the 'echo' command or its subcommand [serverName]:6379: OnConnectedAsync completed (Disconnected)..."