### PR TITLE
Ensure valid timeout settings in ExponentialRetry

### DIFF
--- a/src/StackExchange.Redis/ExponentialRetry.cs
+++ b/src/StackExchange.Redis/ExponentialRetry.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Redis
         /// Initializes a new instance using the specified back off interval with default maxDeltaBackOffMilliseconds of 10 seconds
         /// </summary>
         /// <param name="deltaBackOffMilliseconds">time in milliseconds for the back-off interval between retries</param>
-        public ExponentialRetry(int deltaBackOffMilliseconds) : this(deltaBackOffMilliseconds, (int)TimeSpan.FromSeconds(10).TotalMilliseconds) {}
+        public ExponentialRetry(int deltaBackOffMilliseconds) : this(deltaBackOffMilliseconds, Math.Max(deltaBackOffMilliseconds, (int)TimeSpan.FromSeconds(10).TotalMilliseconds)) { }
 
         /// <summary>
         /// Initializes a new instance using the specified back off interval.
@@ -25,6 +25,21 @@ namespace StackExchange.Redis
         /// <param name="maxDeltaBackOffMilliseconds">time in milliseconds for the maximum value that the back-off interval can exponentially grow up to</param>
         public ExponentialRetry(int deltaBackOffMilliseconds, int maxDeltaBackOffMilliseconds)
         {
+            if (deltaBackOffMilliseconds < 0)
+            {
+                throw new ArgumentException("must be greater than or equal to zero", nameof(deltaBackOffMilliseconds));
+            }
+
+            if (maxDeltaBackOffMilliseconds < 0)
+            {
+                throw new ArgumentException("must be greater than or equal to zero", nameof(maxDeltaBackOffMilliseconds));
+            }
+
+            if (maxDeltaBackOffMilliseconds < deltaBackOffMilliseconds)
+            {
+                throw new ArgumentException($"must be greater than or equal to {nameof(deltaBackOffMilliseconds)}", nameof(maxDeltaBackOffMilliseconds));
+            }
+
             this.deltaBackOffMilliseconds = deltaBackOffMilliseconds;
             this.maxDeltaBackOffMilliseconds = maxDeltaBackOffMilliseconds;
         }

--- a/tests/StackExchange.Redis.Tests/ConnectionReconnectRetryPolicyTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionReconnectRetryPolicyTests.cs
@@ -26,6 +26,22 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public void TestExponentialRetryArgs()
+        {
+            new ExponentialRetry(5000);
+            new ExponentialRetry(5000, 10000);
+
+            var ex = Assert.Throws<ArgumentException>(() => new ExponentialRetry(-1));
+            Assert.Equal("deltaBackOffMilliseconds", ex.ParamName);
+
+            ex = Assert.Throws<ArgumentException>(() => new ExponentialRetry(5000, -1));
+            Assert.Equal("maxDeltaBackOffMilliseconds", ex.ParamName);
+
+            ex = Assert.Throws<ArgumentException>(() => new ExponentialRetry(10000, 5000));
+            Assert.Equal("maxDeltaBackOffMilliseconds", ex.ParamName);
+        }
+
+        [Fact]
         public void TestLinearRetry()
         {
             IReconnectRetryPolicy linearRetry = new LinearRetry(5000);


### PR DESCRIPTION
Setting a timeout from the connectionstring can cause `deltaBackOffMilliseconds `to be lower than `maxDeltaBackOffMilliseconds`, which will cause an `ArgumentOutOfRangeException `('minValue' cannot be greater than maxValue.) in `ShouldRetry`.