### PR TITLE
Makes StreamEntry constructor public

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Makes `StreamEntry` constructor public for better unit test experience (#1923 via WeihanLi)
+
 ## 2.2.88
 
 - Connection backoff default is now exponential instead of linear (#1896 via lolodi)

--- a/src/StackExchange.Redis/StreamEntry.cs
+++ b/src/StackExchange.Redis/StreamEntry.cs
@@ -7,7 +7,10 @@ namespace StackExchange.Redis
     /// </summary>
     public readonly struct StreamEntry
     {
-        internal StreamEntry(RedisValue id, NameValueEntry[] values)
+        /// <summary>
+        /// Creates an stream entry
+        /// </summary>
+        public StreamEntry(RedisValue id, NameValueEntry[] values)
         {
             Id = id;
             Values = values;


### PR DESCRIPTION
Makes `StreamEntry` constructor public to fixes #1922 
