### PR TITLE
fix #1926 integer overflow in BufferReader (make total consumed 64-bit)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Makes `StreamEntry` constructor public for better unit test experience (#1923 via WeihanLi)
+- Fix integer overflow error (issue #1926) with 2GiB+ result payloads
 
 ## 2.2.88
 

--- a/src/StackExchange.Redis/BufferReader.cs
+++ b/src/StackExchange.Redis/BufferReader.cs
@@ -114,32 +114,11 @@ namespace StackExchange.Redis
             var delta = _totalConsumed - _lastSnapshotBytes;
             if (delta == 0) return _lastSnapshotPosition;
 
-            SequencePosition pos;
-            try
-            {
-                pos = _buffer.GetPosition(delta, _lastSnapshotPosition);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                ThrowSnapshotFailure(delta, ex);
-                throw; // should never be reached
-            }
+            var pos = _buffer.GetPosition(delta, _lastSnapshotPosition);
             _lastSnapshotBytes = _totalConsumed;
             return _lastSnapshotPosition = pos;
         }
-        private void ThrowSnapshotFailure(long delta, Exception innerException)
-        {
-            long length;
-            try
-            {
-                length = _buffer.Length;
-            }
-            catch
-            {
-                length = -1;
-            }
-            throw new ArgumentOutOfRangeException($"Error calculating {nameof(SnapshotPosition)}: {_totalConsumed} of {length}, {_lastSnapshotBytes}+{delta}", innerException);
-        }
+
         public ReadOnlySequence<byte> ConsumeAsBuffer(int count)
         {
             if (!TryConsumeAsBuffer(count, out var buffer)) throw new EndOfStreamException();


### PR DESCRIPTION
total consumed was `int`, which was causing integer overflow issues with 2GiB+ payloads, manifesting in an `ArgumentOutOfRangeException` in `SnapshotPosition()`