### PR TITLE
Default versions: assume v2.8 as a minimum (SCAN over KEYS) and 4.0+ in Azure

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Makes `StreamEntry` constructor public for better unit test experience (#1923 via WeihanLi)
-- Fix integer overflow error (issue #1926) with 2GiB+ result payloads
+- Fix integer overflow error (issue #1926) with 2GiB+ result payloads (#1928 via mgravell)
+- Update assumed redis versions to v2.8 or v4.0 in the Azure case (#1929 via NickCraver)
 
 ## 2.2.88
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -288,7 +288,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The server version to assume
         /// </summary>
-        public Version DefaultVersion { get { return defaultVersion ?? (IsAzureEndpoint() ? RedisFeatures.v3_0_0 : RedisFeatures.v2_0_0); } set { defaultVersion = value; } }
+        public Version DefaultVersion { get { return defaultVersion ?? (IsAzureEndpoint() ? RedisFeatures.v4_0_0 : RedisFeatures.v2_8_0); } set { defaultVersion = value; } }
 
         /// <summary>
         /// The endpoints defined for this configuration

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -14,6 +14,9 @@ namespace StackExchange.Redis.Tests
 {
     public class Config : TestBase
     {
+        public Version DefaultVersion = new (2, 8, 0);
+        public Version DefaultAzureVersion = new (4, 0, 0);
+
         public Config(ITestOutputHelper output) : base(output) { }
 
         [Fact]
@@ -63,7 +66,7 @@ namespace StackExchange.Redis.Tests
         public void ConfigurationOptionsDefaultForAzure()
         {
             var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net");
-            Assert.True(options.DefaultVersion.Equals(new Version(3, 0, 0)));
+            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
             Assert.False(options.AbortOnConnectFail);
         }
 
@@ -80,7 +83,7 @@ namespace StackExchange.Redis.Tests
         {
             // added a few upper case chars to validate comparison
             var options = ConfigurationOptions.Parse("contoso.REDIS.CACHE.chinacloudapi.cn");
-            Assert.True(options.DefaultVersion.Equals(new Version(3, 0, 0)));
+            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
             Assert.False(options.AbortOnConnectFail);
         }
 
@@ -88,7 +91,7 @@ namespace StackExchange.Redis.Tests
         public void ConfigurationOptionsDefaultForAzureGermany()
         {
             var options = ConfigurationOptions.Parse("contoso.redis.cache.cloudapi.de");
-            Assert.True(options.DefaultVersion.Equals(new Version(3, 0, 0)));
+            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
             Assert.False(options.AbortOnConnectFail);
         }
 
@@ -96,7 +99,7 @@ namespace StackExchange.Redis.Tests
         public void ConfigurationOptionsDefaultForAzureUSGov()
         {
             var options = ConfigurationOptions.Parse("contoso.redis.cache.usgovcloudapi.net");
-            Assert.True(options.DefaultVersion.Equals(new Version(3, 0, 0)));
+            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
             Assert.False(options.AbortOnConnectFail);
         }
 
@@ -104,7 +107,7 @@ namespace StackExchange.Redis.Tests
         public void ConfigurationOptionsDefaultForNonAzure()
         {
             var options = ConfigurationOptions.Parse("redis.contoso.com");
-            Assert.True(options.DefaultVersion.Equals(new Version(2, 0, 0)));
+            Assert.True(options.DefaultVersion.Equals(DefaultVersion));
             Assert.True(options.AbortOnConnectFail);
         }
 
@@ -112,7 +115,7 @@ namespace StackExchange.Redis.Tests
         public void ConfigurationOptionsDefaultWhenNoEndpointsSpecifiedYet()
         {
             var options = new ConfigurationOptions();
-            Assert.True(options.DefaultVersion.Equals(new Version(2, 0, 0)));
+            Assert.True(options.DefaultVersion.Equals(DefaultVersion));
             Assert.True(options.AbortOnConnectFail);
         }
 


### PR DESCRIPTION
This more reflects reality today and if we cannot detect a server version (e.g. config has INFO disabled as in #1926) then we'll do smarter things like use SCAN over KEYS.