### PR TITLE
Initialize ScriptEvalMessage with the correct command

### DIFF
--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3807,7 +3807,7 @@ namespace StackExchange.Redis
             }
 
             public ScriptEvalMessage(int db, CommandFlags flags, byte[] hash, RedisKey[] keys, RedisValue[] values)
-                : this(db, flags, RedisCommand.EVAL, null, hash, keys, values)
+                : this(db, flags, RedisCommand.EVALSHA, null, hash, keys, values)
             {
                 if (hash == null) throw new ArgumentNullException(nameof(hash));
                 if (hash.Length != ResultProcessor.ScriptLoadProcessor.Sha1HashLength) throw new ArgumentOutOfRangeException(nameof(hash), "Invalid hash length");

--- a/tests/StackExchange.Redis.Tests/Profiling.cs
+++ b/tests/StackExchange.Redis.Tests/Profiling.cs
@@ -20,6 +20,9 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
+                var server = conn.GetServer(TestConfig.Current.MasterServerAndPort);
+                var script = LuaScript.Prepare("return redis.call('get', @key)");
+                var loaded = script.Load(server);
                 var key = Me();
 
                 var session = new ProfilingSession();
@@ -29,8 +32,10 @@ namespace StackExchange.Redis.Tests
                 var dbId = TestConfig.GetDedicatedDB();
                 var db = conn.GetDatabase(dbId);
                 db.StringSet(key, "world");
-                var result = db.ScriptEvaluate(LuaScript.Prepare("return redis.call('get', @key)"), new { key = (RedisKey)key });
+                var result = db.ScriptEvaluate(script, new { key = (RedisKey)key });
                 Assert.Equal("world", result.AsString());
+                var loadedResult = db.ScriptEvaluate(loaded, new { key = (RedisKey)key });
+                Assert.Equal("world", loadedResult.AsString());
                 var val = db.StringGet(key);
                 Assert.Equal("world", val);
                 var s = (string)db.Execute("ECHO", "fii");
@@ -44,7 +49,7 @@ namespace StackExchange.Redis.Tests
                 }
 
                 var all = string.Join(",", cmds.Select(x => x.Command));
-                Assert.Equal("SET,EVAL,GET,ECHO", all);
+                Assert.Equal("SET,EVAL,EVALSHA,GET,ECHO", all);
                 Log("Checking for SET");
                 var set = cmds.SingleOrDefault(cmd => cmd.Command == "SET");
                 Assert.NotNull(set);
@@ -54,20 +59,26 @@ namespace StackExchange.Redis.Tests
                 Log("Checking for EVAL");
                 var eval = cmds.SingleOrDefault(cmd => cmd.Command == "EVAL");
                 Assert.NotNull(eval);
+                Log("Checking for EVALSHA");
+                var evalSha = cmds.SingleOrDefault(cmd => cmd.Command == "EVALSHA");
+                Assert.NotNull(evalSha);
                 Log("Checking for ECHO");
                 var echo = cmds.SingleOrDefault(cmd => cmd.Command == "ECHO");
                 Assert.NotNull(echo);
 
-                Assert.Equal(4, cmds.Count());
+                Assert.Equal(5, cmds.Count());
 
                 Assert.True(set.CommandCreated <= eval.CommandCreated);
-                Assert.True(eval.CommandCreated <= get.CommandCreated);
+                Assert.True(eval.CommandCreated <= evalSha.CommandCreated);
+                Assert.True(evalSha.CommandCreated <= get.CommandCreated);
 
                 AssertProfiledCommandValues(set, conn, dbId);
 
                 AssertProfiledCommandValues(get, conn, dbId);
 
                 AssertProfiledCommandValues(eval, conn, dbId);
+
+                AssertProfiledCommandValues(evalSha, conn, dbId);
 
                 AssertProfiledCommandValues(echo, conn, dbId);
             }


### PR DESCRIPTION
Currently the constructor for ScriptEvalMessage that takes a SHA1 hash, and sends the `EVALSHA` command, initializes the base Message class's command to `RedisCommand.EVAL` instead of `RedisCommand.EVALSHA`.