### PR TITLE
Tests: ensure we're not referencing ValueTuple

### DIFF
--- a/tests/StackExchange.Redis.Tests/SanityChecks.cs
+++ b/tests/StackExchange.Redis.Tests/SanityChecks.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
+using Xunit;
+
+namespace StackExchange.Redis.Tests
+{
+    public sealed class SanityChecks
+    {
+        /// <summary>
+        /// Ensure we don't reference System.ValueTuple as it causes issues with .NET Full Framework
+        /// </summary>
+        /// <remarks>
+        /// Modified from https://github.com/ltrzesniewski/InlineIL.Fody/blob/137e8b57f78b08cdc3abdaaf50ac01af50c58759/src/InlineIL.Tests/AssemblyTests.cs#L14
+        /// Thanks Lucas Trzesniewski!
+        /// </remarks>
+        [Fact]
+        public void ValueTupleRefernces()
+        {
+            using var fileStream = File.OpenRead(typeof(RedisValue).Assembly.Location);
+            using var peReader = new PEReader(fileStream);
+            var metadataReader = peReader.GetMetadataReader();
+
+            foreach (var typeRefHandle in metadataReader.TypeReferences)
+            {
+                var typeRef = metadataReader.GetTypeReference(typeRefHandle);
+                if (metadataReader.GetString(typeRef.Namespace) == typeof(ValueTuple).Namespace)
+                {
+                    var typeName = metadataReader.GetString(typeRef.Name);
+                    Assert.DoesNotContain(nameof(ValueTuple), typeName);
+                }
+            }
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/SanityChecks.cs
+++ b/tests/StackExchange.Redis.Tests/SanityChecks.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Redis.Tests
         /// Thanks Lucas Trzesniewski!
         /// </remarks>
         [Fact]
-        public void ValueTupleRefernces()
+        public void ValueTupleNotReferenced()
         {
             using var fileStream = File.OpenRead(typeof(RedisValue).Assembly.Location);
             using var peReader = new PEReader(fileStream);


### PR DESCRIPTION
Adding a sanity check to ensure this doesn't regress as long as we support .NET Full Framework.

Thanks @ltrzesniewski!