### PR TITLE
Tests: handle clock skew vs. test containers

### DIFF
--- a/tests/StackExchange.Redis.Tests/Expiry.cs
+++ b/tests/StackExchange.Redis.Tests/Expiry.cs
@@ -63,6 +63,9 @@ namespace StackExchange.Redis.Tests
                 conn.KeyDelete(key, CommandFlags.FireAndForget);
 
                 var now = utc ? DateTime.UtcNow : DateTime.Now;
+                var serverTime = GetServer(muxer).Time();
+                var offset = DateTime.UtcNow - serverTime;
+
                 Log("Now: {0}", now);
                 conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
                 var a = conn.KeyTimeToLiveAsync(key);
@@ -79,6 +82,10 @@ namespace StackExchange.Redis.Tests
 
                 Assert.Null(await a);
                 var time = await b;
+
+                // Adjust for server time offset, if any when checking expectations
+                time += offset;
+
                 Assert.NotNull(time);
                 Log("Time: {0}, Expected: {1}-{2}", time, TimeSpan.FromMinutes(59), TimeSpan.FromMinutes(60));
                 Assert.True(time >= TimeSpan.FromMinutes(59));

--- a/tests/StackExchange.Redis.Tests/Issues/SO25113323.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO25113323.cs
@@ -23,7 +23,8 @@ namespace StackExchange.Redis.Tests.Issues
                 await Task.Delay(2000).ForAwait();
 
                 // When
-                var expiresOn = DateTime.UtcNow.AddSeconds(-2);
+                var serverTime = GetServer(conn).Time();
+                var expiresOn = serverTime.AddSeconds(-2);
 
                 var firstResult = cache.KeyExpire(key, expiresOn, CommandFlags.PreferMaster);
                 var secondResult = cache.KeyExpire(key, expiresOn, CommandFlags.PreferMaster);


### PR DESCRIPTION
I hit an oddity in the Docker setup locally today where the clock drifted ~10 seconds and these tests were failing because they make an inherent assumption of local clock == server clock. This aims to remove that assumption from the test suite and treat server time as accurate or account for the skew when checking TTLs.