### PR TITLE
v2.5 work: .NET 6.0: add build defaulting to the thread pool

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,14 +16,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Setup .NET Core 3.x
+    - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+        dotnet-version: | 
+          3.1.x
+          5.0.x
+          6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (docker-compose)
@@ -50,11 +49,10 @@ jobs:
     - name: Setup .NET Core 3.x
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+        dotnet-version: | 
+          3.1.x
+          5.0.x
+          6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (v3.0.503)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,15 @@
 image:
-- Visual Studio 2022
+- Visual Studio 2019
 
 init:
   - git config --global core.autocrlf input
 
 install:
 - cmd: >-
+    choco install dotnet-sdk --version 5.0.404
+
+    choco install dotnet-sdk --version 6.0.101
+
     cd tests\RedisConfigs\3.0.503
 
     redis-server.exe --service-install --service-name "redis-6379" "..\Basic\master-6379.conf"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,11 @@
 image:
-- Visual Studio 2019
+- Visual Studio 2022
 
 init:
   - git config --global core.autocrlf input
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 5.0.100
-
     cd tests\RedisConfigs\3.0.503
 
     redis-server.exe --service-install --service-name "redis-6379" "..\Basic\master-6379.conf"

--- a/src/StackExchange.Redis/CommandTrace.cs
+++ b/src/StackExchange.Redis/CommandTrace.cs
@@ -50,7 +50,7 @@ namespace StackExchange.Redis
 
             const string BaseUrl = "https://redis.io/commands/";
 
-            string encoded0 = Uri.EscapeUriString(((string)Arguments[0]).ToLowerInvariant());
+            string encoded0 = Uri.EscapeDataString(((string)Arguments[0]).ToLowerInvariant());
 
             if (Arguments.Length > 1)
             {
@@ -62,7 +62,7 @@ namespace StackExchange.Redis
                     case "config":
                     case "debug":
                     case "pubsub":
-                        string encoded1 = Uri.EscapeUriString(((string)Arguments[1]).ToLowerInvariant());
+                        string encoded1 = Uri.EscapeDataString(((string)Arguments[1]).ToLowerInvariant());
                         return BaseUrl + encoded0 + "-" + encoded1;
                 }
             }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.ReaderWriter.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.ReaderWriter.cs
@@ -1,4 +1,6 @@
-﻿namespace StackExchange.Redis
+﻿using System;
+
+namespace StackExchange.Redis
 {
     public partial class ConnectionMultiplexer
     {
@@ -6,7 +8,7 @@
 
         partial void OnCreateReaderWriter(ConfigurationOptions configuration)
         {
-            SocketManager = configuration.SocketManager ?? SocketManager.Shared;
+            SocketManager = configuration.SocketManager ?? GetDefaultSocketManager();
         }
 
         partial void OnCloseReaderWriter()
@@ -14,5 +16,23 @@
             SocketManager = null;
         }
         partial void OnWriterCreated();
+
+        private static readonly Version SharedThreadpoolMinVersion = new(6, 0, 0);
+
+        /// <summary>
+        /// .NET 6.0+ has changes to sync-over-async stalls in the .NET primary thread pool
+        /// If we're in that environment, by default remove the overhead of our own threadpool
+        /// This will eliminate some context-switching overhead and better-size threads on both large
+        /// and small environments, from 16 core machines to single core VMs where the default 10 threads
+        /// isn't an ideal situation.
+        /// </summary>
+        internal static SocketManager GetDefaultSocketManager()
+        {
+#if NET6_0_OR_GREATER
+            return SocketManager.ThreadPool;
+#else
+            return SocketManager.Shared;
+#endif
+        }
     }
 }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.ReaderWriter.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.ReaderWriter.cs
@@ -17,8 +17,6 @@ namespace StackExchange.Redis
         }
         partial void OnWriterCreated();
 
-        private static readonly Version SharedThreadpoolMinVersion = new(6, 0, 0);
-
         /// <summary>
         /// .NET 6.0+ has changes to sync-over-async stalls in the .NET primary thread pool
         /// If we're in that environment, by default remove the overhead of our own threadpool

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- extend the default lib targets for the main lib; mostly because of "vectors" -->
-    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -457,7 +457,7 @@ namespace StackExchange.Redis.Tests
                 EndPoints = { { IPAddress.Loopback, 6379 } },
             };
             using var muxer = ConnectionMultiplexer.Connect(config);
-            Assert.Same(SocketManager.Shared.Scheduler, muxer.SocketManager.Scheduler);
+            Assert.Same(ConnectionMultiplexer.GetDefaultSocketManager().Scheduler, muxer.SocketManager.Scheduler);
         }
 
         [Theory]

--- a/tests/StackExchange.Redis.Tests/Migrate.cs
+++ b/tests/StackExchange.Redis.Tests/Migrate.cs
@@ -10,7 +10,7 @@ namespace StackExchange.Redis.Tests
     {
         public Migrate(ITestOutputHelper output) : base (output) { }
 
-        [Fact]
+        [FactLongRunning]
         public async Task Basic()
         {
             var fromConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.SecureServer, TestConfig.Current.SecurePort } }, Password = TestConfig.Current.SecurePassword, AllowAdmin = true };

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -643,7 +643,7 @@ namespace StackExchange.Redis.Tests
             }
         }
 
-        internal static Task AllowReasonableTimeToPublishAndProcess() => Task.Delay(100);
+        internal static Task AllowReasonableTimeToPublishAndProcess() => Task.Delay(500);
 
         [Fact]
         public async Task TestPartialSubscriberGetMessage()

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -361,14 +361,7 @@ namespace StackExchange.Redis.Tests
         }
 
         public static string Me([CallerFilePath] string filePath = null, [CallerMemberName] string caller = null) =>
-#if NET472
-            "net472-"
-#elif NETCOREAPP3_1
-            "netcoreapp3.1-"
-#else
-            "unknown-"
-#endif
-         + Path.GetFileNameWithoutExtension(filePath) + "-" + caller;
+            Environment.Version.ToString() + Path.GetFileNameWithoutExtension(filePath) + "-" + caller;
 
         protected static TimeSpan RunConcurrent(Action work, int threads, int timeout = 10000, [CallerMemberName] string caller = null)
         {
@@ -417,7 +410,9 @@ namespace StackExchange.Redis.Tests
                 for (int i = 0; i < threads; i++)
                 {
                     var thd = threadArr[i];
+#if !NET6_0_OR_GREATER
                     if (thd.IsAlive) thd.Abort();
+#endif
                 }
                 throw new TimeoutException();
             }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2",
+  "version": "2.5-prerelease",
   "versionHeightOffset": -1,
   "assemblyVersion": "2.0",
   "publicReleaseRefSpec": [


### PR DESCRIPTION
This adds a `net6.0` build (and test run) that uses the default thread pool for pipe scheduling rather than our scheduler. Namely due to 2 major changes since this was introduced:
1. Thread theft has long since been resolved (never an issue in .NET Core+)
2. Sync-over-async is an app problem, but should be much better in .NET 6.0+ which has changes specifically for this in thread pool growth (see https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#threading)

Due to this combo of changes, we want to see if this behaves much better in the next alpha. The advantages are we move from 10 threads by default shared between connections to no dedicated threads for the scheduler. It has the following benefits:
1. While these threads were mostly idle (waiting for data), people saw them in profiler traces and attribute them as working/CPU-consuming though that's not what a profiler is really saying.
2. The default of 10 threads is a best guess, but the world varies widely. Some users are deploying many connections on 20-100 core VMs and it's a bad default limiting them (by default - not if configured). On the other end of the spectrum, a _lot_ of people run small 1-4 core VMs or containers and the default size is bigger than needed.

Instead of the above tradeoffs meant to unblock users, want to simplify, let the main thread pool scale, and hope the default is a net win for most or all users. If a consumer application has a _ton_ of sync-over-async (e.g. 100,000 tasks queued suddenly), this may be a net negative change for them - that's why we want to alpha and see how this behaves with workloads we may not have predicted.