### PR TITLE
Tests: failure simulation and time fixes

### DIFF
--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -292,15 +292,18 @@ namespace StackExchange.Redis
 
         internal void SimulateConnectionFailure(SimulatedFailureType failureType)
         {
+            var raiseFailed = false;
             if (connectionType == ConnectionType.Interactive)
             {
                 if (failureType.HasFlag(SimulatedFailureType.InteractiveInbound))
                 {
                     _ioPipe?.Input.Complete(new Exception("Simulating interactive input failure"));
+                    raiseFailed = true;
                 }
                 if (failureType.HasFlag(SimulatedFailureType.InteractiveOutbound))
                 {
                     _ioPipe?.Output.Complete(new Exception("Simulating interactive output failure"));
+                    raiseFailed = true;
                 }
             }
             else if (connectionType == ConnectionType.Subscription)
@@ -308,13 +311,18 @@ namespace StackExchange.Redis
                 if (failureType.HasFlag(SimulatedFailureType.SubscriptionInbound))
                 {
                     _ioPipe?.Input.Complete(new Exception("Simulating subscription input failure"));
+                    raiseFailed = true;
                 }
                 if (failureType.HasFlag(SimulatedFailureType.SubscriptionOutbound))
                 {
                     _ioPipe?.Output.Complete(new Exception("Simulating subscription output failure"));
+                    raiseFailed = true;
                 }
             }
-            RecordConnectionFailed(ConnectionFailureType.SocketFailure);
+            if (raiseFailed)
+            {
+                RecordConnectionFailed(ConnectionFailureType.SocketFailure);
+            }
         }
 
         public void RecordConnectionFailed(ConnectionFailureType failureType, Exception innerException = null, [CallerMemberName] string origin = null,

--- a/tests/StackExchange.Redis.Tests/Expiry.cs
+++ b/tests/StackExchange.Redis.Tests/Expiry.cs
@@ -64,9 +64,10 @@ namespace StackExchange.Redis.Tests
 
                 var now = utc ? DateTime.UtcNow : DateTime.Now;
                 var serverTime = GetServer(muxer).Time();
+                Log("Server time: {0}", serverTime);
                 var offset = DateTime.UtcNow - serverTime;
 
-                Log("Now: {0}", now);
+                Log("Now (local time): {0}", now);
                 conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
                 var a = conn.KeyTimeToLiveAsync(key);
                 conn.KeyExpire(key, now.AddHours(1), CommandFlags.FireAndForget);
@@ -84,7 +85,7 @@ namespace StackExchange.Redis.Tests
                 var time = await b;
 
                 // Adjust for server time offset, if any when checking expectations
-                time += offset;
+                time -= offset;
 
                 Assert.NotNull(time);
                 Log("Time: {0}, Expected: {1}-{2}", time, TimeSpan.FromMinutes(59), TimeSpan.FromMinutes(60));


### PR DESCRIPTION
I got time backwards and the simulation was raising events in a race for a connection it _wasn't_, e.g. both interactive directions would still raise an event on the subscriber because I'm a dummy.