### PR TITLE
AppVeyor: only build main branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,10 @@ install:
       Start-Service redis-*
     }
 
+branches:
+  only:
+    - main
+    
 skip_branch_with_pr: true
 skip_tags: true
 skip_commits:


### PR DESCRIPTION
Eliminate the double builds on branches before a PR is open