### PR TITLE
Pub/Sub: default to 3.0, fix PING, fix server selection in cluster, and cleanup

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -306,7 +306,7 @@ namespace StackExchange.Redis
         /// </summary>
         public Version DefaultVersion
         {
-            get => defaultVersion ?? (IsAzureEndpoint() ? RedisFeatures.v4_0_0 : RedisFeatures.v2_8_0);
+            get => defaultVersion ?? (IsAzureEndpoint() ? RedisFeatures.v4_0_0 : RedisFeatures.v3_0_0);
             set => defaultVersion = value;
         }
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Threading.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Threading.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading;
+using Pipelines.Sockets.Unofficial;
+
+namespace StackExchange.Redis
+{
+    public partial class ConnectionMultiplexer
+    {
+        private static readonly WaitCallback s_CompleteAsWorker = s => ((ICompletable)s).TryComplete(true);
+        internal static void CompleteAsWorker(ICompletable completable)
+        {
+            if (completable != null)
+            {
+                ThreadPool.QueueUserWorkItem(s_CompleteAsWorker, completable);
+            }
+        }
+
+        internal static bool TryCompleteHandler<T>(EventHandler<T> handler, object sender, T args, bool isAsync) where T : EventArgs, ICompletable
+        {
+            if (handler == null) return true;
+            if (isAsync)
+            {
+                if (handler.IsSingle())
+                {
+                    try
+                    {
+                        handler(sender, args);
+                    }
+                    catch { }
+                }
+                else
+                {
+                    foreach (EventHandler<T> sub in handler.AsEnumerable())
+                    {
+                        try
+                        {
+                            sub(sender, args);
+                        }
+                        catch { }
+                    }
+                }
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Verbose.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Verbose.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Runtime.CompilerServices;
+
+namespace StackExchange.Redis
+{
+    public partial class ConnectionMultiplexer
+    {
+        internal event Action<string, Exception, string> MessageFaulted;
+        internal event Action<bool> Closing;
+        internal event Action<string> PreTransactionExec, TransactionLog, InfoMessage;
+        internal event Action<EndPoint, ConnectionType> Connecting;
+        internal event Action<EndPoint, ConnectionType> Resurrecting;
+
+        partial void OnTrace(string message, string category);
+        static partial void OnTraceWithoutContext(string message, string category);
+
+        [Conditional("VERBOSE")]
+        internal void Trace(string message, [CallerMemberName] string category = null) => OnTrace(message, category);
+
+        [Conditional("VERBOSE")]
+        internal void Trace(bool condition, string message, [CallerMemberName] string category = null)
+        {
+            if (condition) OnTrace(message, category);
+        }
+
+        [Conditional("VERBOSE")]
+        internal static void TraceWithoutContext(string message, [CallerMemberName] string category = null) => OnTraceWithoutContext(message, category);
+
+        [Conditional("VERBOSE")]
+        internal static void TraceWithoutContext(bool condition, string message, [CallerMemberName] string category = null)
+        {
+            if (condition) OnTraceWithoutContext(message, category);
+        }
+
+        [Conditional("VERBOSE")]
+        internal void OnMessageFaulted(Message msg, Exception fault, [CallerMemberName] string origin = default, [CallerFilePath] string path = default, [CallerLineNumber] int lineNumber = default) =>
+            MessageFaulted?.Invoke(msg?.CommandAndKey, fault, $"{origin} ({path}#{lineNumber})");
+
+        [Conditional("VERBOSE")]
+        internal void OnInfoMessage(string message) => InfoMessage?.Invoke(message);
+
+        [Conditional("VERBOSE")]
+        internal void OnClosing(bool complete) => Closing?.Invoke(complete);
+
+        [Conditional("VERBOSE")]
+        internal void OnConnecting(EndPoint endpoint, ConnectionType connectionType) => Connecting?.Invoke(endpoint, connectionType);
+
+        [Conditional("VERBOSE")]
+        internal void OnResurrecting(EndPoint endpoint, ConnectionType connectionType) => Resurrecting.Invoke(endpoint, connectionType);
+
+        [Conditional("VERBOSE")]
+        internal void OnPreTransactionExec(Message message) => PreTransactionExec?.Invoke(message.CommandAndKey);
+
+        [Conditional("VERBOSE")]
+        internal void OnTransactionLog(string message) => TransactionLog?.Invoke(message);
+    }
+}

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1504,33 +1504,6 @@ namespace StackExchange.Redis
             return new RedisServer(this, server, asyncState);
         }
 
-        [Conditional("VERBOSE")]
-        internal void Trace(string message, [CallerMemberName] string category = null)
-        {
-            OnTrace(message, category);
-        }
-
-        [Conditional("VERBOSE")]
-        internal void Trace(bool condition, string message, [CallerMemberName] string category = null)
-        {
-            if (condition) OnTrace(message, category);
-        }
-
-        partial void OnTrace(string message, string category);
-        static partial void OnTraceWithoutContext(string message, string category);
-
-        [Conditional("VERBOSE")]
-        internal static void TraceWithoutContext(string message, [CallerMemberName] string category = null)
-        {
-            OnTraceWithoutContext(message, category);
-        }
-
-        [Conditional("VERBOSE")]
-        internal static void TraceWithoutContext(bool condition, string message, [CallerMemberName] string category = null)
-        {
-            if (condition) OnTraceWithoutContext(message, category);
-        }
-
         /// <summary>
         /// The number of operations that have been performed on all connections
         /// </summary>
@@ -1773,7 +1746,7 @@ namespace StackExchange.Redis
                             {
                                 var server = servers[i];
                                 var task = available[i];
-                                var bs = server.GetBridgeStatus(RedisCommand.PING);
+                                var bs = server.GetBridgeStatus(ConnectionType.Interactive);
 
                                 log?.WriteLine($"  Server[{i}] ({Format.ToString(server)}) Status: {task.Status} (inst: {bs.MessagesSinceLastHeartbeat}, qs: {bs.Connection.MessagesSentAwaitingResponse}, in: {bs.Connection.BytesAvailableOnSocket}, qu: {bs.MessagesSinceLastHeartbeat}, aw: {bs.IsWriterActive}, in-pipe: {bs.Connection.BytesInReadPipe}, out-pipe: {bs.Connection.BytesInWritePipe}, bw: {bs.BacklogStatus}, rs: {bs.Connection.ReadStatus}. ws: {bs.Connection.WriteStatus})");
                             }
@@ -2174,16 +2147,14 @@ namespace StackExchange.Redis
 
         private IDisposable pulse;
 
-        internal ServerEndPoint SelectServer(Message message)
-        {
-            if (message == null) return null;
-            return ServerSelectionStrategy.Select(message);
-        }
+        internal ServerEndPoint SelectServer(Message message) =>
+            message == null ? null : ServerSelectionStrategy.Select(message);
 
-        internal ServerEndPoint SelectServer(RedisCommand command, CommandFlags flags, in RedisKey key)
-        {
-            return ServerSelectionStrategy.Select(command, key, flags);
-        }
+        internal ServerEndPoint SelectServer(RedisCommand command, CommandFlags flags, in RedisKey key) =>
+            ServerSelectionStrategy.Select(command, key, flags);
+
+        internal ServerEndPoint SelectServer(RedisCommand command, CommandFlags flags, in RedisChannel channel) =>
+            ServerSelectionStrategy.Select(command, channel, flags);
 
         private bool PrepareToPushMessageToBridge<T>(Message message, ResultProcessor<T> processor, IResultBox<T> resultBox, ref ServerEndPoint server)
         {

--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -82,5 +82,7 @@ namespace StackExchange.Redis
         NoScriptCache = 512,
 
         // 1024: used for timed-out; never user-specified, so not visible on the public API
+
+        // 2048: Use subscription connection type; never user-specified, so not visible on the public API
     }
 }

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -312,7 +312,7 @@ namespace StackExchange.Redis
             // Add server data, if we have it
             if (server != null && message != null)
             {
-                var bs = server.GetBridgeStatus(message.Command);
+                var bs = server.GetBridgeStatus(message.IsForSubscriptionBridge ? ConnectionType.Subscription: ConnectionType.Interactive);
 
                 switch (bs.Connection.ReadStatus)
                 {
@@ -338,7 +338,7 @@ namespace StackExchange.Redis
 
                 if (multiplexer.StormLogThreshold >= 0 && bs.Connection.MessagesSentAwaitingResponse >= multiplexer.StormLogThreshold && Interlocked.CompareExchange(ref multiplexer.haveStormLog, 1, 0) == 0)
                 {
-                    var log = server.GetStormLog(message.Command);
+                    var log = server.GetStormLog(message);
                     if (string.IsNullOrWhiteSpace(log)) Interlocked.Exchange(ref multiplexer.haveStormLog, 0);
                     else Interlocked.Exchange(ref multiplexer.stormLogSnapshot, log);
                 }

--- a/src/StackExchange.Redis/Interfaces/ISubscriber.cs
+++ b/src/StackExchange.Redis/Interfaces/ISubscriber.cs
@@ -100,8 +100,8 @@ namespace StackExchange.Redis
         EndPoint SubscribedEndpoint(RedisChannel channel);
 
         /// <summary>
-        /// Unsubscribe from a specified message channel; note; if no handler is specified, the subscription is cancelled regardless
-        /// of the subscribers; if a handler is specified, the subscription is only cancelled if this handler is the
+        /// Unsubscribe from a specified message channel; note; if no handler is specified, the subscription is canceled regardless
+        /// of the subscribers; if a handler is specified, the subscription is only canceled if this handler is the
         /// last handler remaining against the channel
         /// </summary>
         /// <param name="channel">The channel that was subscribed to.</param>
@@ -128,8 +128,8 @@ namespace StackExchange.Redis
         Task UnsubscribeAllAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Unsubscribe from a specified message channel; note; if no handler is specified, the subscription is cancelled regardless
-        /// of the subscribers; if a handler is specified, the subscription is only cancelled if this handler is the
+        /// Unsubscribe from a specified message channel; note; if no handler is specified, the subscription is canceled regardless
+        /// of the subscribers; if a handler is specified, the subscription is only canceled if this handler is the
         /// last handler remaining against the channel
         /// </summary>
         /// <param name="channel">The channel that was subscribed to.</param>

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -74,7 +74,8 @@ namespace StackExchange.Redis
 
         private const CommandFlags AskingFlag = (CommandFlags)32,
                                    ScriptUnavailableFlag = (CommandFlags)256,
-                                   NeedsAsyncTimeoutCheckFlag = (CommandFlags)1024;
+                                   NeedsAsyncTimeoutCheckFlag = (CommandFlags)1024,
+                                   DemandSubscriptionConnection = (CommandFlags)2048;
 
         private const CommandFlags MaskMasterServerPreference = CommandFlags.DemandMaster
                                                               | CommandFlags.DemandReplica
@@ -669,6 +670,15 @@ namespace StackExchange.Redis
         }
         private int _writeTickCount;
         public int GetWriteTime() => Volatile.Read(ref _writeTickCount);
+
+        /// <summary>
+        /// Gets if this command should be sent over the subscription bridge.
+        /// </summary>
+        internal bool IsForSubscriptionBridge => (Flags & DemandSubscriptionConnection) != 0;
+        /// <summary>
+        /// Sends this command to the subscription connection rather than the interactive.
+        /// </summary>
+        internal void SetForSubscriptionBridge() => Flags |= DemandSubscriptionConnection;
 
         private void SetNeedsTimeoutCheck() => Flags |= NeedsAsyncTimeoutCheckFlag;
         internal bool HasAsyncTimedOut(int now, int timeoutMilliseconds, out int millisecondsTaken)

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -364,6 +364,7 @@ namespace StackExchange.Redis
                     if (commandMap.IsAvailable(RedisCommand.PING) && features.PingOnSubscriber)
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.PING);
+                        msg.SetForSubscriptionBridge();
                         msg.SetSource(ResultProcessor.Tracer, null);
                     }
                     else if (commandMap.IsAvailable(RedisCommand.UNSUBSCRIBE))

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -30,7 +30,7 @@ namespace StackExchange.Redis
                     FailNoServer(snapshot);
                     throw ExceptionFactory.NoConnectionAvailable(multiplexer, message, server);
                 }
-                var bridge = server.GetBridge(message.Command);
+                var bridge = server.GetBridge(message);
                 if (bridge == null)
                 {
                     FailNoServer(snapshot);

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -372,16 +372,20 @@ namespace StackExchange.Redis
                 catch { }
             }
 
+            Message msg;
             if (usePing)
             {
-                return ResultProcessor.TimingProcessor.CreateMessage(-1, flags, RedisCommand.PING);
+                msg = ResultProcessor.TimingProcessor.CreateMessage(-1, flags, RedisCommand.PING);
             }
             else
             {
                 // can't use regular PING, but we can unsubscribe from something random that we weren't even subscribed to...
                 RedisValue channel = multiplexer.UniqueId;
-                return ResultProcessor.TimingProcessor.CreateMessage(-1, flags, RedisCommand.UNSUBSCRIBE, channel);
+                msg = ResultProcessor.TimingProcessor.CreateMessage(-1, flags, RedisCommand.UNSUBSCRIBE, channel);
             }
+            // Ensure the ping is sent over the intended subscriver connection, which wouldn't happen in GetBridge() by default with PING;
+            msg.SetForSubscriptionBridge();
+            return msg;
         }
 
         public long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None)

--- a/tests/StackExchange.Redis.Tests/AsyncTests.cs
+++ b/tests/StackExchange.Redis.Tests/AsyncTests.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis.Tests
         {
             SetExpectedAmbientFailureCount(-1); // this will get messy
 
-            using (var conn = Create(allowAdmin: true))
+            using (var conn = Create(allowAdmin: true, shared: false))
             {
                 var server = conn.GetServer(TestConfig.Current.MasterServer, TestConfig.Current.MasterPort);
 

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -14,7 +14,7 @@ namespace StackExchange.Redis.Tests
 {
     public class Config : TestBase
     {
-        public Version DefaultVersion = new (2, 8, 0);
+        public Version DefaultVersion = new (3, 0, 0);
         public Version DefaultAzureVersion = new (4, 0, 0);
 
         public Config(ITestOutputHelper output) : base(output) { }

--- a/tests/StackExchange.Redis.Tests/ConnectFailTimeout.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectFailTimeout.cs
@@ -13,7 +13,7 @@ namespace StackExchange.Redis.Tests
         public async Task NoticesConnectFail()
         {
             SetExpectedAmbientFailureCount(-1);
-            using (var conn = Create(allowAdmin: true))
+            using (var conn = Create(allowAdmin: true, shared: false))
             {
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
 

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -105,17 +105,17 @@ namespace StackExchange.Redis.Tests
 
             int failCount = 0, restoreCount = 0;
 
-            using (var muxer = ConnectionMultiplexer.Connect(config, log: Writer))
+            using (var muxer = ConnectionMultiplexer.Connect(config))
             {
                 muxer.ConnectionFailed += (s, e) =>
                 {
                     Interlocked.Increment(ref failCount);
-                    Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+                    Log($"Connection Failed ({e.ConnectionType}, {e.FailureType}): {e.Exception}");
                 };
                 muxer.ConnectionRestored += (s, e) =>
                 {
                     Interlocked.Increment(ref restoreCount);
-                    Log($"Connection Restored ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+                    Log($"Connection Restored ({e.ConnectionType}, {e.FailureType})");
                 };
 
                 muxer.GetDatabase();

--- a/tests/StackExchange.Redis.Tests/ConnectionShutdown.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionShutdown.cs
@@ -14,7 +14,7 @@ namespace StackExchange.Redis.Tests
         [Fact(Skip = "Unfriendly")]
         public async Task ShutdownRaisesConnectionFailedAndRestore()
         {
-            using (var conn = Create(allowAdmin: true))
+            using (var conn = Create(allowAdmin: true, shared: false))
             {
                 int failed = 0, restored = 0;
                 Stopwatch watch = Stopwatch.StartNew();

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -523,9 +523,6 @@ namespace StackExchange.Redis.Tests
                 });
                 await sub.PingAsync().ForAwait();
 
-                // Give a delay between subscriptions and when we try to publish to be safe
-                await Task.Delay(1000).ForAwait();
-
                 lock (syncLock)
                 {
                     for (int i = 0; i < count; i++)

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using StackExchange.Redis.Maintenance;
+using StackExchange.Redis.Profiling;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable AccessToModifiedClosure
@@ -55,7 +57,7 @@ namespace StackExchange.Redis.Tests
         [InlineData("Foo:", true, "f")]
         public async Task TestBasicPubSub(string channelPrefix, bool wildCard, string breaker)
         {
-            using (var muxer = Create(channelPrefix: channelPrefix))
+            using (var muxer = Create(channelPrefix: channelPrefix, log: Writer))
             {
                 var pub = GetAnyMaster(muxer);
                 var sub = muxer.GetSubscriber();
@@ -91,6 +93,7 @@ namespace StackExchange.Redis.Tests
 
                 await PingAsync(muxer, pub, sub, 3).ForAwait();
 
+                await UntilCondition(TimeSpan.FromSeconds(5), () => received.Count == 1);
                 lock (received)
                 {
                     Assert.Single(received);
@@ -124,7 +127,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public async Task TestBasicPubSubFireAndForget()
         {
-            using (var muxer = Create())
+            using (var muxer = Create(log: Writer))
             {
                 var pub = GetAnyMaster(muxer);
                 var sub = muxer.GetSubscriber();
@@ -155,6 +158,7 @@ namespace StackExchange.Redis.Tests
                 var count = sub.Publish(key, "def", CommandFlags.FireAndForget);
                 await PingAsync(muxer, pub, sub).ForAwait();
 
+                await UntilCondition(TimeSpan.FromSeconds(5), () => received.Count == 1);
                 lock (received)
                 {
                     Assert.Single(received);
@@ -182,9 +186,7 @@ namespace StackExchange.Redis.Tests
                 // way to prove that is to use TPL objects
                 var t1 = sub.PingAsync();
                 var t2 = pub.PingAsync();
-                await Task.Delay(100).ForAwait(); // especially useful when testing any-order mode
-
-                if (!Task.WaitAll(new[] { t1, t2 }, muxer.TimeoutMilliseconds * 2)) throw new TimeoutException();
+                await Task.WhenAll(t1, t2).ForAwait();
             }
         }
 
@@ -220,6 +222,7 @@ namespace StackExchange.Redis.Tests
                 var count = sub.Publish("abc", "def");
                 await PingAsync(muxer, pub, sub).ForAwait();
 
+                await UntilCondition(TimeSpan.FromSeconds(5), () => received.Count == 1);
                 lock (received)
                 {
                     Assert.Single(received);
@@ -348,7 +351,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public async Task PubSubGetAllCorrectOrder()
         {
-            using (var muxer = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000))
+            using (var muxer = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
             {
                 var sub = muxer.GetSubscriber();
                 RedisChannel channel = Me();
@@ -519,6 +522,9 @@ namespace StackExchange.Redis.Tests
                     return i % 2 == 0 ? null : Task.CompletedTask;
                 });
                 await sub.PingAsync().ForAwait();
+
+                // Give a delay between subscriptions and when we try to publish to be safe
+                await Task.Delay(1000).ForAwait();
 
                 lock (syncLock)
                 {
@@ -743,8 +749,10 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public async Task SubscriptionsSurviveConnectionFailureAsync()
         {
-            using (var muxer = Create(allowAdmin: true, shared: false))
+            var session = new ProfilingSession();
+            using (var muxer = Create(allowAdmin: true, shared: false, syncTimeout: 1000) as ConnectionMultiplexer)
             {
+                muxer.RegisterProfiler(() => session);
                 RedisChannel channel = Me();
                 var sub = muxer.GetSubscriber();
                 int counter = 0;
@@ -752,23 +760,89 @@ namespace StackExchange.Redis.Tests
                 {
                     Interlocked.Increment(ref counter);
                 }).ConfigureAwait(false);
-                await Task.Delay(200).ConfigureAwait(false);
-                await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
-                sub.Ping();
-                await Task.Delay(200).ConfigureAwait(false);
-                Assert.Equal(1, Thread.VolatileRead(ref counter));
-                var server = GetServer(muxer);
-                Assert.Equal(1, server.GetCounters().Subscription.SocketCount);
 
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                SetExpectedAmbientFailureCount(2);
+                var profile1 = session.FinishProfiling();
+                foreach (var command in profile1)
+                {
+                    Log($"{command.EndPoint}: {command}");
+                }
+                // We shouldn't see the initial connection here
+                Assert.Equal(0, profile1.Count(p => p.Command == nameof(RedisCommand.SUBSCRIBE)));
+
+                Assert.Equal(1, muxer.GetSubscriptionsCount());
+
                 await Task.Delay(200).ConfigureAwait(false);
-                sub.Ping();
-                Assert.Equal(2, server.GetCounters().Subscription.SocketCount);
+
                 await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
-                await Task.Delay(200).ConfigureAwait(false);
                 sub.Ping();
-                Assert.Equal(2, Thread.VolatileRead(ref counter));
+                await Task.Delay(200).ConfigureAwait(false);
+
+                var counter1 = Thread.VolatileRead(ref counter);
+                Log($"Expecting 1 messsage, got {counter1}");
+                Assert.Equal(1, counter1);
+
+                var server = GetServer(muxer);
+                var socketCount = server.GetCounters().Subscription.SocketCount;
+                Log($"Expecting 1 socket, got {socketCount}");
+                Assert.Equal(1, socketCount);
+
+                // We might fail both connections or just the primary in the time period
+                SetExpectedAmbientFailureCount(-1);
+
+                // Make sure we fail all the way
+                muxer.AllowConnect = false;
+                Log("Failing connection");
+                // Fail all connections
+                server.SimulateConnectionFailure(SimulatedFailureType.All);
+                // Trigger failure
+                Assert.Throws<RedisConnectionException>(() => sub.Ping());
+                Assert.False(sub.IsConnected(channel));
+
+                // Now reconnect...
+                muxer.AllowConnect = true;
+                Log("Waiting on reconnect");
+                // Wait until we're reconnected
+                await UntilCondition(TimeSpan.FromSeconds(10), () => sub.IsConnected(channel));
+                Log("Reconnected");
+                // Ensure we're reconnected
+                Assert.True(sub.IsConnected(channel));
+
+                // And time to resubscribe...
+                await Task.Delay(1000).ConfigureAwait(false);
+
+                // Ensure we've sent the subscribe command after reconnecting
+                var profile2 = session.FinishProfiling();
+                foreach (var command in profile2)
+                {
+                    Log($"{command.EndPoint}: {command}");
+                }
+                //Assert.Equal(1, profile2.Count(p => p.Command == nameof(RedisCommand.SUBSCRIBE)));
+
+                Log($"Issuing ping after reconnected");
+                sub.Ping();
+                Assert.Equal(1, muxer.GetSubscriptionsCount());
+
+                Log("Publishing");
+                var published = await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
+
+                Log($"Published to {published} subscriber(s).");
+                Assert.Equal(1, published);
+
+                // Give it a few seconds to get our messages
+                Log("Waiting for 2 messages");
+                await UntilCondition(TimeSpan.FromSeconds(5), () => Thread.VolatileRead(ref counter) == 2);
+
+                var counter2 = Thread.VolatileRead(ref counter);
+                Log($"Expecting 2 messsages, got {counter2}");
+                Assert.Equal(2, counter2);
+
+                // Log all commands at the end
+                Log("All commands since connecting:");
+                var profile3 = session.FinishProfiling();
+                foreach (var command in profile3)
+                {
+                    Log($"{command.EndPoint}: {command}");
+                }
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -128,6 +128,7 @@ namespace StackExchange.Redis.Tests
             {
                 privateExceptions.Add($"{Time()}: Connection failed ({e.FailureType}): {EndPointCollection.ToString(e.EndPoint)}/{e.ConnectionType}: {e.Exception}");
             }
+            Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
         }
 
         protected void OnInternalError(object sender, InternalErrorEventArgs e)
@@ -285,6 +286,10 @@ namespace StackExchange.Redis.Tests
                 caller);
             muxer.InternalError += OnInternalError;
             muxer.ConnectionFailed += OnConnectionFailed;
+            muxer.ConnectionRestored += (s, e) =>
+            {
+                Log($"Connection Restored ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+            };
             return muxer;
         }
 


### PR DESCRIPTION
In prep for changes to how we handle subscriptions internally, this does several things:
- Upgrades default Redis server assumption to 3.x
- Routes PING on Subscription keepalives over the subscription bridge appropriately
- Fixes cluster sharding from default(RedisKey) to shared logic for RedisChannel as well (both in byte[] form)
- General code cleanup in the area (getting a lot of DEBUG/VERBOSE noise into isolated files)