### PR TITLE
Pub/Sub subscription processor: actually set the result

### DIFF
--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -400,6 +400,7 @@ namespace StackExchange.Redis
                     if (items.Length >= 3 && items[2].TryGetInt64(out long count))
                     {
                         connection.SubscriptionCount = count;
+                        SetResult(message, true);
                         return true;
                     }
                 }


### PR DESCRIPTION
This hasn't worked in over 8 years, but due to other things upstream ignoring the result and pretending success, it didn't matter.

I imagine only @mgravell will understand why this was confusing to debug for hours or find it hilarious, but yep: that was broken.