### PR TITLE
Builds: remove .NET 5.0 installer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         dotnet-version: | 
           3.1.x
-          5.0.x
           6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true


### PR DESCRIPTION
We're testing netcoreapp3.1 and net6 now, so no need for the 5.x runtime.