### PR TITLE
Exceptions: Add threadpool stats in .NET Core+

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,7 @@
 - Fix profiler showing `EVAL` instead `EVALSHA` (#1930 via martinpotter)
 - Moved tiebreaker fetching in connections into the handshake phase (streamline + simplification) (#1931 via NickCraver)
 - Fixed potential disposed object usage around Arenas (pulling in [Piplines.Sockets.Unofficial#63](https://github.com/mgravell/Pipelines.Sockets.Unofficial/pull/63) by MarcGravell)
+- Adds thread pool work item stats to exception messages to help diagnose contention (#1964 via NickCraver)
 
 ## 2.2.88
 

--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -94,7 +94,7 @@ By default Redis Timeout exception(s) includes useful information, which can hel
 |mgr | 8 of 10 available|Redis Internal Dedicated Thread Pool State| 
 |IOCP | IOCP: (Busy=0,Free=500,Min=248,Max=500)| Runtime Global Thread Pool IO Threads. |
 |WORKER | WORKER: (Busy=170,Free=330,Min=248,Max=500)| Runtime Global Thread Pool Worker Threads.| 
-|POOL | POOL: (Threads=8,Queued=0,Completed=42)| Thread Pool Work Item Stats.| 
+|POOL | POOL: (Threads=8,QueuedItems=0,CompletedItems=42)| Thread Pool Work Item Stats.| 
 |v | Redis Version: version |Current redis version you are currently using in your application.|
 |active | Message-Current: {string} |Included in exception message when `IncludeDetailInExceptions=True` on multiplexer|
 |next | Message-Next: {string} |When `IncludeDetailInExceptions=True` on multiplexer, it might include command and key, otherwise only command.|

--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -94,6 +94,7 @@ By default Redis Timeout exception(s) includes useful information, which can hel
 |mgr | 8 of 10 available|Redis Internal Dedicated Thread Pool State| 
 |IOCP | IOCP: (Busy=0,Free=500,Min=248,Max=500)| Runtime Global Thread Pool IO Threads. |
 |WORKER | WORKER: (Busy=170,Free=330,Min=248,Max=500)| Runtime Global Thread Pool Worker Threads.| 
+|POOL | POOL: (Threads=8,Queued=0,Completed=42)| Thread Pool Work Item Stats.| 
 |v | Redis Version: version |Current redis version you are currently using in your application.|
 |active | Message-Current: {string} |Included in exception message when `IncludeDetailInExceptions=True` on multiplexer|
 |next | Message-Next: {string} |When `IncludeDetailInExceptions=True` on multiplexer, it might include command and key, otherwise only command.|

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -702,8 +702,12 @@ namespace StackExchange.Redis
             {
                 var sb = new StringBuilder();
                 sb.Append(message);
-                busyWorkerCount = PerfCounterHelper.GetThreadPoolStats(out string iocp, out string worker);
+                busyWorkerCount = PerfCounterHelper.GetThreadPoolStats(out string iocp, out string worker, out string workItems);
                 sb.Append(", IOCP: ").Append(iocp).Append(", WORKER: ").Append(worker);
+                if (workItems != null)
+                {
+                    sb.Append(", POOL: ").Append(workItems);
+                }
                 log?.WriteLine(sb.ToString());
             }
         }

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -356,7 +356,10 @@ namespace StackExchange.Redis
             int busyWorkerCount = PerfCounterHelper.GetThreadPoolStats(out string iocp, out string worker, out string workItems);
             Add(data, sb, "ThreadPool-IO-Completion", "IOCP", iocp);
             Add(data, sb, "ThreadPool-Workers", "WORKER", worker);
-            Add(data, sb, "ThreadPool-Items", "POOL", workItems);
+            if (workItems != null)
+            {
+                Add(data, sb, "ThreadPool-Items", "POOL", workItems);
+            }
             data.Add(Tuple.Create("Busy-Workers", busyWorkerCount.ToString()));
 
             if (multiplexer.IncludePerformanceCountersInExceptions)

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -353,9 +353,10 @@ namespace StackExchange.Redis
                     Add(data, sb, "Key-HashSlot", "PerfCounterHelperkeyHashSlot", message.GetHashSlot(multiplexer.ServerSelectionStrategy).ToString());
                 }
             }
-            int busyWorkerCount = PerfCounterHelper.GetThreadPoolStats(out string iocp, out string worker);
+            int busyWorkerCount = PerfCounterHelper.GetThreadPoolStats(out string iocp, out string worker, out string workItems);
             Add(data, sb, "ThreadPool-IO-Completion", "IOCP", iocp);
             Add(data, sb, "ThreadPool-Workers", "WORKER", worker);
+            Add(data, sb, "ThreadPool-Items", "POOL", workItems);
             data.Add(Tuple.Create("Busy-Workers", busyWorkerCount.ToString()));
 
             if (multiplexer.IncludePerformanceCountersInExceptions)

--- a/src/StackExchange.Redis/PerfCounterHelper.cs
+++ b/src/StackExchange.Redis/PerfCounterHelper.cs
@@ -58,7 +58,7 @@ namespace StackExchange.Redis
         {
             GetThreadPoolStats(out string iocp, out string worker, out string workItems);
             var cpu = includePerformanceCounters ? GetSystemCpuPercent() : "n/a";
-            return $"IOCP: {iocp}, WORKER: {worker}, POOL: {workItems}, Local-CPU: {cpu}";
+            return $"IOCP: {iocp}, WORKER: {worker}, POOL: {workItems ?? "n/a"}, Local-CPU: {cpu}";
         }
 
         internal static string GetSystemCpuPercent() =>

--- a/src/StackExchange.Redis/PerfCounterHelper.cs
+++ b/src/StackExchange.Redis/PerfCounterHelper.cs
@@ -56,9 +56,9 @@ namespace StackExchange.Redis
 
         internal static string GetThreadPoolAndCPUSummary(bool includePerformanceCounters)
         {
-            GetThreadPoolStats(out string iocp, out string worker);
+            GetThreadPoolStats(out string iocp, out string worker, out string workItems);
             var cpu = includePerformanceCounters ? GetSystemCpuPercent() : "n/a";
-            return $"IOCP: {iocp}, WORKER: {worker}, Local-CPU: {cpu}";
+            return $"IOCP: {iocp}, WORKER: {worker}, POOL: {workItems}, Local-CPU: {cpu}";
         }
 
         internal static string GetSystemCpuPercent() =>
@@ -66,7 +66,7 @@ namespace StackExchange.Redis
                 ? Math.Round(systemCPU, 2) + "%"
                 : "unavailable";
 
-        internal static int GetThreadPoolStats(out string iocp, out string worker)
+        internal static int GetThreadPoolStats(out string iocp, out string worker, out string workItems)
         {
             ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxIoThreads);
             ThreadPool.GetAvailableThreads(out int freeWorkerThreads, out int freeIoThreads);
@@ -77,6 +77,13 @@ namespace StackExchange.Redis
 
             iocp = $"(Busy={busyIoThreads},Free={freeIoThreads},Min={minIoThreads},Max={maxIoThreads})";
             worker = $"(Busy={busyWorkerThreads},Free={freeWorkerThreads},Min={minWorkerThreads},Max={maxWorkerThreads})";
+
+#if NETCOREAPP
+            workItems = $"(Threads={ThreadPool.ThreadCount},Queued={ThreadPool.PendingWorkItemCount},Completed={ThreadPool.CompletedWorkItemCount})";
+#else
+            workItems = null;
+#endif
+
             return busyWorkerThreads;
         }
     }

--- a/src/StackExchange.Redis/PerfCounterHelper.cs
+++ b/src/StackExchange.Redis/PerfCounterHelper.cs
@@ -79,7 +79,7 @@ namespace StackExchange.Redis
             worker = $"(Busy={busyWorkerThreads},Free={freeWorkerThreads},Min={minWorkerThreads},Max={maxWorkerThreads})";
 
 #if NETCOREAPP
-            workItems = $"(Threads={ThreadPool.ThreadCount},Queued={ThreadPool.PendingWorkItemCount},Completed={ThreadPool.CompletedWorkItemCount})";
+            workItems = $"(Threads={ThreadPool.ThreadCount},QueuedItems={ThreadPool.PendingWorkItemCount},CompletedItems={ThreadPool.CompletedWorkItemCount})";
 #else
             workItems = null;
 #endif

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -123,6 +123,11 @@ namespace StackExchange.Redis.Tests
                     Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
                     Assert.Contains("mc: 1/1/0", ex.Message);
                     Assert.Contains("serverEndpoint: " + server.EndPoint, ex.Message);
+                    Assert.Contains("IOCP: ", ex.Message);
+                    Assert.Contains("WORKER: ", ex.Message);
+#if NETCOREAPP
+                    Assert.Contains("POOL: ", ex.Message);
+#endif
                     Assert.DoesNotContain("Unspecified/", ex.Message);
                     Assert.EndsWith(" (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)", ex.Message);
                     Assert.Null(ex.InnerException);


### PR DESCRIPTION
I swear I already did this somewhere but it got lost, this adds additional thread pool stats exposed in .NET Core 3.1+. We'll get for example `ThreadPool.PendingWorkItemCount` on exception messages to better indicate app contention.