### PR TITLE
API Additions/Deprecations: MakePrimaryAsync/ReplicaOfAsync

### DIFF
--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -18,7 +18,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// From 2.0, this flag is not used
         /// </summary>
-        [Obsolete("From 2.0, this flag is not used", false)]
+        [Obsolete("From 2.0, this flag is not used, this will be removed in 3.0.", false)]
         HighPriority = 1,
         /// <summary>
         /// The caller is not interested in the result; the caller will immediately receive a default-value

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -418,11 +418,19 @@ namespace StackExchange.Redis
         Task<DateTime> LastSaveAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Promote the selected node to be master
+        /// Promote the selected node to be primary.
         /// </summary>
         /// <param name="options">The options to use for this topology change.</param>
         /// <param name="log">The log to write output to.</param>
+        [Obsolete("Please use " + nameof(MakePrimaryAsync) + ", this will be removed in 3.0.")]
         void MakeMaster(ReplicationChangeOptions options, TextWriter log = null);
+
+        /// <summary>
+        /// Promote the selected node to be primary.
+        /// </summary>
+        /// <param name="options">The options to use for this topology change.</param>
+        /// <param name="log">The log to write output to.</param>
+        Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter log = null);
 
         /// <summary>
         /// Returns the role info for the current server.
@@ -540,7 +548,7 @@ namespace StackExchange.Redis
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/replicaof</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOf) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         void SlaveOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
@@ -550,6 +558,7 @@ namespace StackExchange.Redis
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/replicaof</remarks>
+        [Obsolete("Please use " + nameof(ReplicaOfAsync) + ", this will be removed in 3.0.")]
         void ReplicaOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -558,7 +567,7 @@ namespace StackExchange.Redis
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/replicaof</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Task SlaveOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -336,7 +336,16 @@ namespace StackExchange.Redis
         {
             using (var proxy = LogProxy.TryCreate(log))
             {
-                multiplexer.MakeMaster(server, options, proxy);
+                // Do you believe in magic?
+                multiplexer.MakePrimaryAsync(server, options, proxy).Wait(60000);
+            }
+        }
+
+        public async Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter log = null)
+        {
+            using (var proxy = LogProxy.TryCreate(log))
+            {
+                await multiplexer.MakePrimaryAsync(server, options, proxy);
             }
         }
 
@@ -571,6 +580,32 @@ namespace StackExchange.Redis
             return Message.Create(-1, flags, sendMessageTo.GetFeatures().ReplicaCommands ? RedisCommand.REPLICAOF : RedisCommand.SLAVEOF, host, port);
         }
 
+        private Message GetTiebreakerRemovalMessage()
+        {
+            var configuration = multiplexer.RawConfig;
+
+            if (!string.IsNullOrWhiteSpace(configuration.TieBreaker) && multiplexer.CommandMap.IsAvailable(RedisCommand.DEL))
+            {
+                var msg = Message.Create(0, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.DEL, (RedisKey)configuration.TieBreaker);
+                msg.SetInternalCall();
+                return msg;
+            }
+            return null;
+        }
+
+        private Message GetConfigChangeMessage()
+        {
+            // attempt to broadcast a reconfigure message to anybody listening to this server
+            var channel = multiplexer.ConfigurationChangedChannel;
+            if (channel != null && multiplexer.CommandMap.IsAvailable(RedisCommand.PUBLISH))
+            {
+                var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.PUBLISH, (RedisValue)channel, RedisLiterals.Wildcard);
+                msg.SetInternalCall();
+                return msg;
+            }
+            return null;
+        }
+
         internal override Task<T> ExecuteAsync<T>(Message message, ResultProcessor<T> processor, ServerEndPoint server = null)
         {   // inject our expected server automatically
             if (server == null) server = this.server;
@@ -614,46 +649,56 @@ namespace StackExchange.Redis
             {
                 throw new ArgumentException("Cannot replicate to self");
             }
-            // prepare the actual replicaof message (not sent yet)
-            var replicaOfMsg = CreateReplicaOfMessage(server, master, flags);
 
-            var configuration = multiplexer.RawConfig;
-
+#pragma warning disable CS0618
             // attempt to cease having an opinion on the master; will resume that when replication completes
             // (note that this may fail; we aren't depending on it)
-            if (!string.IsNullOrWhiteSpace(configuration.TieBreaker)
-                && multiplexer.CommandMap.IsAvailable(RedisCommand.DEL))
+            if (GetTiebreakerRemovalMessage() is Message tieBreakerRemoval)
             {
-                var del = Message.Create(0, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.DEL, (RedisKey)configuration.TieBreaker);
-                del.SetInternalCall();
-#pragma warning disable CS0618
-                server.WriteDirectFireAndForgetSync(del, ResultProcessor.Boolean);
-#pragma warning restore CS0618
+                tieBreakerRemoval.SetSource(ResultProcessor.Boolean, null);
+                server.GetBridge(tieBreakerRemoval).TryWriteSync(tieBreakerRemoval, server.IsReplica);
             }
+
+            var replicaOfMsg = CreateReplicaOfMessage(server, master, flags);
             ExecuteSync(replicaOfMsg, ResultProcessor.DemandOK);
 
             // attempt to broadcast a reconfigure message to anybody listening to this server
-            var channel = multiplexer.ConfigurationChangedChannel;
-            if (channel != null && multiplexer.CommandMap.IsAvailable(RedisCommand.PUBLISH))
+            if (GetConfigChangeMessage() is Message configChangeMessage)
             {
-                var pub = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.PUBLISH, (RedisValue)channel, RedisLiterals.Wildcard);
-                pub.SetInternalCall();
-#pragma warning disable CS0618
-                server.WriteDirectFireAndForgetSync(pub, ResultProcessor.Int64);
-#pragma warning restore CS0618
+                configChangeMessage.SetSource(ResultProcessor.Int64, null);
+                server.GetBridge(configChangeMessage).TryWriteSync(configChangeMessage, server.IsReplica);
             }
+#pragma warning restore CS0618
         }
 
         Task IServer.SlaveOfAsync(EndPoint master, CommandFlags flags) => ReplicaOfAsync(master, flags);
 
-        public Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None)
+        public async Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None)
         {
-            var msg = CreateReplicaOfMessage(server, master, flags);
             if (master == server.EndPoint)
             {
                 throw new ArgumentException("Cannot replicate to self");
             }
-            return ExecuteAsync(msg, ResultProcessor.DemandOK);
+
+            // attempt to cease having an opinion on the master; will resume that when replication completes
+            // (note that this may fail; we aren't depending on it)
+            if (GetTiebreakerRemovalMessage() is Message tieBreakerRemoval && !server.IsReplica)
+            {
+                try
+                {
+                    await server.WriteDirectAsync(tieBreakerRemoval, ResultProcessor.Boolean);
+                }
+                catch { }
+            }
+
+            var msg = CreateReplicaOfMessage(server, master, flags);
+            await ExecuteAsync(msg, ResultProcessor.DemandOK);
+
+            // attempt to broadcast a reconfigure message to anybody listening to this server
+            if (GetConfigChangeMessage() is Message configChangeMessage)
+            {
+                await server.WriteDirectAsync(configChangeMessage, ResultProcessor.Int64);
+            }
         }
 
         private static void FixFlags(Message message, ServerEndPoint server)

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -333,9 +333,7 @@ namespace StackExchange.Redis
             log?.WriteLine($"{Format.ToString(this)}: Auto-configuring...");
 
             var commandMap = Multiplexer.CommandMap;
-#pragma warning disable CS0618
-            const CommandFlags flags = CommandFlags.FireAndForget | CommandFlags.HighPriority | CommandFlags.NoRedirect;
-#pragma warning restore CS0618
+            const CommandFlags flags = CommandFlags.FireAndForget | CommandFlags.NoRedirect;
             var features = GetFeatures();
             Message msg;
 
@@ -670,10 +668,11 @@ namespace StackExchange.Redis
             if (version >= RedisFeatures.v2_8_0 && Multiplexer.CommandMap.IsAvailable(RedisCommand.INFO)
                 && (bridge = GetBridge(ConnectionType.Interactive, false)) != null)
             {
-#pragma warning disable CS0618
-                var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.HighPriority | CommandFlags.NoRedirect, RedisCommand.INFO, RedisLiterals.replication);
+                var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.INFO, RedisLiterals.replication);
                 msg.SetInternalCall();
-                WriteDirectFireAndForgetSync(msg, ResultProcessor.AutoConfigure, bridge);
+                msg.SetSource(ResultProcessor.AutoConfigure, null);
+#pragma warning disable CS0618
+                bridge.TryWriteSync(msg, isReplica);
 #pragma warning restore CS0618
                 return true;
             }
@@ -762,17 +761,6 @@ namespace StackExchange.Redis
                 ConnectionMultiplexer.ThrowFailed(tcs, ex);
             }
             return tcs.Task;
-        }
-
-        [Obsolete("prefer async")]
-        internal void WriteDirectFireAndForgetSync<T>(Message message, ResultProcessor<T> processor, PhysicalBridge bridge = null)
-        {
-            if (message != null)
-            {
-                message.SetSource(processor, null);
-                Multiplexer.Trace("Enqueue: " + message);
-                (bridge ?? GetBridge(message)).TryWriteSync(message, isReplica);
-            }
         }
 
         internal void ReportNextFailure()


### PR DESCRIPTION
Note: this is based on #1912, so let's wait until that's in.

Changeset overall:
- Add `MakePrimaryAsync` (deprecate `MakeMaster`)
  - This yanks the code and does an evil .Wait() - better ideas?
- Add `ReplicaOfAsync` (deprecate `ReplicaOf`)
- Remove the last usages of `CommandFlags.HighPriority`
- Remove `ServerEndPoint.WriteDirectFireAndForgetSync<T>` path