### PR TITLE
CI Tweaks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Install .NET SDK
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
@@ -39,16 +39,18 @@ jobs:
       run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
 
   windows:
-    name: StackExchange.Redis (Windows Server 2019)
-    runs-on: windows-2019
+    name: StackExchange.Redis (Windows Server 2022)
+    runs-on: windows-2022
+    env:
+      NUGET_CERT_REVOCATION_MODE: offline # Disabling signing because of massive perf hit, see https://github.com/NuGet/Home/issues/11548
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: Setup .NET Core 3.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: | 
-          6.0.x
+    # - name: Install .NET SDK
+    #   uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: | 
+    #       6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (v3.0.503)
@@ -77,6 +79,6 @@ jobs:
       continue-on-error: true
       if: success() || failure()
       with:
-        name: Tests Results - Windows Server 2019
+        name: Tests Results - Windows Server 2022
         path: 'test-results/*.trx'
         reporter: dotnet-trx

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,7 @@ jobs:
         name: StackExchange.Redis.Tests (Ubuntu) - Results
         path: 'test-results/*.trx'
         reporter: dotnet-trx
+        list-tests: 'failed'
     - name: .NET Lib Pack
       run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
 
@@ -82,4 +83,5 @@ jobs:
       with:
         name: StackExchange.Redis.Tests (Windows Server 2019) - Results
         path: 'test-results/*.trx'
-        reporter: dotnet-trx      
+        reporter: dotnet-trx
+        list-tests: 'failed'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,6 @@ jobs:
         name: StackExchange.Redis.Tests (Ubuntu) - Results
         path: 'test-results/*.trx'
         reporter: dotnet-trx
-        list-tests: failed
     - name: .NET Lib Pack
       run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
 
@@ -83,4 +82,3 @@ jobs:
         name: StackExchange.Redis.Tests (Windows Server 2019) - Results
         path: 'test-results/*.trx'
         reporter: dotnet-trx
-        list-tests: failed

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: CI Builds
+name: CI
 
 on:
   pull_request:
@@ -32,7 +32,7 @@ jobs:
       continue-on-error: true
       if: success() || failure()
       with:
-        name: StackExchange.Redis.Tests (Ubuntu) - Results
+        name: Test Results - Ubuntu
         path: 'test-results/*.trx'
         reporter: dotnet-trx
     - name: .NET Lib Pack
@@ -77,6 +77,6 @@ jobs:
       continue-on-error: true
       if: success() || failure()
       with:
-        name: StackExchange.Redis.Tests (Windows Server 2019) - Results
+        name: Tests Results - Windows Server 2019
         path: 'test-results/*.trx'
         reporter: dotnet-trx

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          3.1.x
           6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
@@ -49,7 +48,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          3.1.x
           6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         name: StackExchange.Redis.Tests (Ubuntu) - Results
         path: 'test-results/*.trx'
         reporter: dotnet-trx
-        list-tests: 'failed'
+        list-tests: failed
     - name: .NET Lib Pack
       run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
 
@@ -51,7 +51,6 @@ jobs:
       with:
         dotnet-version: | 
           3.1.x
-          5.0.x
           6.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
@@ -84,4 +83,4 @@ jobs:
         name: StackExchange.Redis.Tests (Windows Server 2019) - Results
         path: 'test-results/*.trx'
         reporter: dotnet-trx
-        list-tests: 'failed'
+        list-tests: failed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 5.0.404
-
     choco install dotnet-sdk --version 6.0.101
 
     cd tests\RedisConfigs\3.0.503

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Based on #1912 (otherwise tests fail those PRs are working on, but this is good against `main` too)
- Shortens the names in the check list
- Removes .NET 5.0 SDK we don't need the runtime for anymore
- Removes `netcoreapp3.1` from StackExchange.Redis.Tests (running `net472` and `net6.0` now) 