### PR TITLE
Migrates links to https:// everywhere possible and misc doc tweaks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,11 +24,11 @@ SOFTWARE.
 
 Third Party Licenses:
 
-The Redis project (http://redis.io/) is independent of this client library, and
+The Redis project (https://redis.io/) is independent of this client library, and
 is licensed separately under the three clause BSD license. The full license
-information can be viewed here: http://redis.io/topics/license
+information can be viewed here: https://redis.io/topics/license
 
-This tool makes use of the "redis-doc" library from http://redis.io/documentation
+This tool makes use of the "redis-doc" library from https://redis.io/documentation
 in the intellisense comments, which is licensed under the
 Creative Commons Attribution-ShareAlike 4.0 International license; full
 details are available here:
@@ -43,5 +43,5 @@ This tool is not used in the release binaries.
 The development solution uses the BookSleeve package from nuget
 (https://code.google.com/p/booksleeve/) by Marc Gravell. This is licensed
 under the Apache 2.0 license; full details are available here:
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 This tool is not used in the release binaries.

--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -23,7 +23,7 @@ If it finds both nodes are masters, a tie-breaker key can optionally be specifie
 Once you have a `ConnectionMultiplexer`, there are 3 main things you might want to do:
 
 - access a redis database (note that in the case of a cluster, a single logical database may be spread over multiple nodes)
-- make use of the [pub/sub](http://redis.io/topics/pubsub) features of redis
+- make use of the [pub/sub](https://redis.io/topics/pubsub) features of redis
 - access an individual server for maintenance / monitoring purposes
 
 Using a redis database
@@ -43,7 +43,7 @@ object asyncState = ...
 IDatabase db = redis.GetDatabase(databaseNumber, asyncState);
 ```
 
-Once you have the `IDatabase`, it is simply a case of using the [redis API](http://redis.io/commands). Note that all methods have both synchronous and asynchronous implementations. In line with Microsoft's naming guidance, the asynchronous methods all end `...Async(...)`, and are fully `await`-able etc.
+Once you have the `IDatabase`, it is simply a case of using the [redis API](https://redis.io/commands). Note that all methods have both synchronous and asynchronous implementations. In line with Microsoft's naming guidance, the asynchronous methods all end `...Async(...)`, and are fully `await`-able etc.
 
 The simplest operation would be to store and retrieve a value:
 
@@ -55,7 +55,7 @@ string value = db.StringGet("mykey");
 Console.WriteLine(value); // writes: "abcdefg"
 ```
 
-Note that the `String...` prefix here denotes the [String redis type](http://redis.io/topics/data-types), and is largely separate to the [.NET String type][3], although both can store text data. However, redis allows raw binary data for both keys and values - the usage is identical:
+Note that the `String...` prefix here denotes the [String redis type](https://redis.io/topics/data-types), and is largely separate to the [.NET String type][3], although both can store text data. However, redis allows raw binary data for both keys and values - the usage is identical:
 
 ```csharp
 byte[] key = ..., value = ...;
@@ -64,18 +64,18 @@ db.StringSet(key, value);
 byte[] value = db.StringGet(key);
 ```
 
-The entire range of [redis database commands](http://redis.io/commands) covering all redis data types is available for use.
+The entire range of [redis database commands](https://redis.io/commands) covering all redis data types is available for use.
 
 Using redis pub/sub
 ----
 
-Another common use of redis is as a [pub/sub message](http://redis.io/topics/pubsub) distribution tool; this is also simple, and in the event of connection failure, the `ConnectionMultiplexer` will handle all the details of re-subscribing to the requested channels.
+Another common use of redis is as a [pub/sub message](https://redis.io/topics/pubsub) distribution tool; this is also simple, and in the event of connection failure, the `ConnectionMultiplexer` will handle all the details of re-subscribing to the requested channels.
 
 ```csharp
 ISubscriber sub = redis.GetSubscriber();
 ```
 
-Again, the object returned from `GetSubscriber` is a cheap pass-thru object that does not need to be stored. The pub/sub API has no concept of databases, but as before we can optionally provide an async-state. Note that all subscriptions are global: they are not scoped to the lifetime of the `ISubscriber` instance. The pub/sub features in redis use named "channels"; channels do not need to be defined in advance on the server (an interesting use here is things like per-user notification channels, which is what drives parts of the realtime updates on [Stack Overflow](http://stackoverflow.com)). As is common in .NET, subscriptions take the form of callback delegates which accept the channel-name and the message:
+Again, the object returned from `GetSubscriber` is a cheap pass-thru object that does not need to be stored. The pub/sub API has no concept of databases, but as before we can optionally provide an async-state. Note that all subscriptions are global: they are not scoped to the lifetime of the `ISubscriber` instance. The pub/sub features in redis use named "channels"; channels do not need to be defined in advance on the server (an interesting use here is things like per-user notification channels, which is what drives parts of the realtime updates on [Stack Overflow](https://stackoverflow.com)). As is common in .NET, subscriptions take the form of callback delegates which accept the channel-name and the message:
 
 ```csharp
 sub.Subscribe("messages", (channel, message) => {
@@ -118,13 +118,13 @@ For maintenance purposes, it is sometimes necessary to issue server-specific com
 IServer server = redis.GetServer("localhost", 6379);
 ```
 
-The `GetServer` method will accept an [`EndPoint`](http://msdn.microsoft.com/en-us/library/system.net.endpoint(v=vs.110).aspx) or the name/value pair that uniquely identify the server. As before, the object returned from `GetServer` is a cheap pass-thru object that does not need to be stored, and async-state can be optionally specified. Note that the set of available endpoints is also available:
+The `GetServer` method will accept an [`EndPoint`](https://docs.microsoft.com/en-us/dotnet/api/system.net.endpoint) or the name/value pair that uniquely identify the server. As before, the object returned from `GetServer` is a cheap pass-thru object that does not need to be stored, and async-state can be optionally specified. Note that the set of available endpoints is also available:
 
 ```csharp
 EndPoint[] endpoints = redis.GetEndPoints();
 ```
 
-From the `IServer` instance, the [Server commands](http://redis.io/commands#server) are available; for example:
+From the `IServer` instance, the [Server commands](https://redis.io/commands#server) are available; for example:
 
 ```csharp
 DateTime lastSave = server.LastSave();
@@ -139,7 +139,7 @@ There are 3 primary usage mechanisms with StackExchange.Redis:
 - Synchronous - where the operation completes before the methods returns to the caller (note that while this may block the caller, it absolutely **does not** block other threads: the key idea in StackExchange.Redis is that it aggressively shares the connection between concurrent callers)
 - Asynchronous - where the operation completes some time in the future, and a `Task` or `Task<T>` is returned immediately, which can later:
     - be `.Wait()`ed (blocking the current thread until the response is available)
-    - have a continuation callback added ([`ContinueWith`](http://msdn.microsoft.com/en-us/library/system.threading.tasks.task.continuewith(v=vs.110).aspx) in the TPL)
+    - have a continuation callback added ([`ContinueWith`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.continuewith) in the TPL)
     - be *awaited* (which is a language-level feature that simplifies the latter, while also continuing immediately if the reply is already known)
 - Fire-and-Forget - where you really aren't interested in the reply, and are happy to continue irrespective of the response
 
@@ -161,9 +161,6 @@ The fire-and-forget usage is accessed by the optional `CommandFlags flags` param
 db.StringIncrement(pageKey, flags: CommandFlags.FireAndForget);
 ```
 
-
-
-
-  [1]: http://msdn.microsoft.com/en-us/library/dd460717%28v=vs.110%29.aspx
-  [2]: http://msdn.microsoft.com/en-us/library/system.threading.tasks.task.asyncstate(v=vs.110).aspx
-  [3]: http://msdn.microsoft.com/en-us/library/system.string(v=vs.110).aspx
+  [1]: https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-parallel-library-tpl
+  [2]: https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.asyncstate
+  [3]: https://docs.microsoft.com/en-us/dotnet/api/system.string

--- a/docs/ExecSync.md
+++ b/docs/ExecSync.md
@@ -1,5 +1,5 @@
 ﻿The Dangers of Synchronous Continuations
 ===
 
-Once, there was more content here; then [a suitably evil workaround was found](http://stackoverflow.com/a/22588431/23354). This page is not
+Once, there was more content here; then [a suitably evil workaround was found](https://stackoverflow.com/a/22588431/23354). This page is not
 listed in the index, but remains for your curiosity.

--- a/docs/KeysValues.md
+++ b/docs/KeysValues.md
@@ -1,9 +1,9 @@
 ﻿Keys, Values and Channels
 ===
 
-In dealing with redis, there is quite an important distinction between *keys* and *everything else*. A key is the unique name of a piece of data (which could be a String, a List, Hash, or any of the other [redis data types](http://redis.io/topics/data-types)) within a database. Keys are never interpreted as... well, anything: they are simply inert names. Further - when dealing with clustered or sharded systems, it is the key that defines the node (or nodes if there are replicas) that contain this data - so keys are crucial for routing commands.
+In dealing with redis, there is quite an important distinction between *keys* and *everything else*. A key is the unique name of a piece of data (which could be a String, a List, Hash, or any of the other [redis data types](https://redis.io/topics/data-types)) within a database. Keys are never interpreted as... well, anything: they are simply inert names. Further - when dealing with clustered or sharded systems, it is the key that defines the node (or nodes if there are replicas) that contain this data - so keys are crucial for routing commands.
 
-This contrasts with *values*; values are the *things that you store* against keys - either individually (for String data) or as groups. Values do not affect command routing <small>(caveat: except for [the `SORT` command](http://redis.io/commands/sort) when `BY` or `GET` is specified, but that is *really* complicated to explain)</small>. Likewise, values are often *interpreted* by redis for the purposes of an operation:
+This contrasts with *values*; values are the *things that you store* against keys - either individually (for String data) or as groups. Values do not affect command routing <small>(caveat: except for [the `SORT` command](https://redis.io/commands/sort) when `BY` or `GET` is specified, but that is *really* complicated to explain)</small>. Likewise, values are often *interpreted* by redis for the purposes of an operation:
 
 - `incr` (and the various similar commands) interpret String values as numeric data
 - sorting can interpret values using either numeric or unicode rules
@@ -90,7 +90,7 @@ Channel names for pub/sub are represented by the `RedisChannel` type; this is la
 Scripting
 ---
 
-[Lua scripting in redis](http://redis.io/commands/EVAL) has two notable features:
+[Lua scripting in redis](https://redis.io/commands/EVAL) has two notable features:
 
 - the inputs must keep keys and values separate (which inside the script become `KEYS` and `ARGV`, respectively)
 - the return format is not defined in advance: it is specific to your script

--- a/docs/PipelinesMultiplexers.md
+++ b/docs/PipelinesMultiplexers.md
@@ -69,7 +69,7 @@ Multiplexing
 
 Pipelining is all well and good, but often any single block of code only wants a single value (or maybe wants to perform a few operations, but which depend on each-other). This means that we still have the problem that we spend most of our time waiting for data to transfer between client and server.  Now consider a busy application, perhaps a web-server. Such applications are generally inherently concurrent, so if you have 20 parallel application requests all requiring data, you might think of spinning up 20 connections, or you could synchronize access to a single connection (which would mean the last caller would need to wait for the latency of all the other 19 before it even got started). Or as a compromise, perhaps a pool of 5 connections which are leased - no matter how you are doing it, there is going to be a lot of waiting. **StackExchange.Redis does not do this**; instead, it does a *lot* of work for you to make effective use of all this idle time by *multiplexing* a single connection. When used concurrently by different callers, it **automatically pipelines the separate requests**, so regardless of whether the requests use blocking or asynchronous access, the work is all pipelined. So we could have 10 or 20 of our "get a and b" scenario from earlier (from different application requests), and they would all get onto the connection as soon as possible. Essentially, it fills the `waiting` time with work from other callers.
 
-For this reason, the only redis features that StackExchange.Redis does not offer (and *will not ever offer*) are the "blocking pops" ([BLPOP](http://redis.io/commands/blpop), [BRPOP](http://redis.io/commands/brpop) and [BRPOPLPUSH](http://redis.io/commands/brpoplpush)) - because this would allow a single caller to stall the entire multiplexer, blocking all other callers. The only other time that StackExchange.Redis needs to hold work is when verifying pre-conditions for a transaction, which is why StackExchange.Redis encapsulates such conditions into internally managed `Condition` instances. [Read more about transactions here](Transactions). If you feel you want "blocking pops", then I strongly suggest you consider pub/sub instead:
+For this reason, the only redis features that StackExchange.Redis does not offer (and *will not ever offer*) are the "blocking pops" ([BLPOP](https://redis.io/commands/blpop), [BRPOP](https://redis.io/commands/brpop) and [BRPOPLPUSH](https://redis.io/commands/brpoplpush)) - because this would allow a single caller to stall the entire multiplexer, blocking all other callers. The only other time that StackExchange.Redis needs to hold work is when verifying pre-conditions for a transaction, which is why StackExchange.Redis encapsulates such conditions into internally managed `Condition` instances. [Read more about transactions here](Transactions). If you feel you want "blocking pops", then I strongly suggest you consider pub/sub instead:
 
 ```csharp
 sub.Subscribe(channel, delegate {
@@ -105,6 +105,6 @@ if (value == null) {
 return value;
 ```
 
-  [1]: http://msdn.microsoft.com/en-us/library/dd460717(v=vs.110).aspx
-  [2]: http://msdn.microsoft.com/en-us/library/system.threading.tasks.task(v=vs.110).aspx
-  [3]: http://msdn.microsoft.com/en-us/library/dd321424(v=vs.110).aspx
+  [1]: https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-parallel-library-tpl
+  [2]: https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task
+  [3]: https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task-1

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -241,7 +241,7 @@ plans to release `1.2.7`.
 - add: track message status in exceptions (#576)
 - add: `GetDatabase()` optimization for DB 0 and low numbered databases: `IDatabase` instance is retained and recycled (as long as no `asyncState` is provided)
 - improved connection retry policy (#510, #572)
-- add `Execute`/`ExecuteAsync` API to support "modules"; [more info](http://blog.marcgravell.com/2017/04/stackexchangeredis-and-redis-40-modules.html)
+- add `Execute`/`ExecuteAsync` API to support "modules"; [more info](https://blog.marcgravell.com/2017/04/stackexchangeredis-and-redis-40-modules.html)
 - fix: timeout link fixed re /docs change (below)
 - [`NRediSearch`](https://www.nuget.org/packages/NRediSearch/) added as exploration into "modules"
 

--- a/docs/Scripting.md
+++ b/docs/Scripting.md
@@ -1,24 +1,23 @@
 ﻿Scripting
 ===
 
-Basic [Lua scripting](http://redis.io/commands/EVAL) is supported by the `IServer.ScriptLoad(Async)`, `IServer.ScriptExists(Async)`, `IServer.ScriptFlush(Async)`, `IDatabase.ScriptEvaluate`, and `IDatabaseAsync.ScriptEvaluateAsync` methods.
+Basic [Lua scripting](https://redis.io/commands/EVAL) is supported by the `IServer.ScriptLoad(Async)`, `IServer.ScriptExists(Async)`, `IServer.ScriptFlush(Async)`, `IDatabase.ScriptEvaluate`, and `IDatabaseAsync.ScriptEvaluateAsync` methods.
 These methods expose the basic commands necessary to submit and execute Lua scripts to redis.
 
-More sophisticated scripting is available through the `LuaScript` class.  The `LuaScript` class makes it simpler to prepare and submit parameters along with a script, as well as allowing you to use 
-cleaner variables names.
+More sophisticated scripting is available through the `LuaScript` class.  The `LuaScript` class makes it simpler to prepare and submit parameters along with a script, as well as allowing you to use cleaner variables names.
 
 An example use of the `LuaScript`:
 
-```
-	const string Script = "redis.call('set', @key, @value)";
+```csharp
+const string Script = "redis.call('set', @key, @value)";
 
-	using (ConnectionMultiplexer conn = /* init code */)
-	{
-		var db = conn.GetDatabase(0);
+using (ConnectionMultiplexer conn = /* init code */)
+{
+	var db = conn.GetDatabase(0);
 
-		var prepared = LuaScript.Prepare(Script);
-		db.ScriptEvaluate(prepared, new { key = (RedisKey)"mykey", value = 123 });
-	}
+	var prepared = LuaScript.Prepare(Script);
+	db.ScriptEvaluate(prepared, new { key = (RedisKey)"mykey", value = 123 });
+}
 ```
 
 The `LuaScript` class rewrites variables in scripts of the form `@myVar` into the appropriate `ARGV[someIndex]` required by redis.  If the 
@@ -36,25 +35,25 @@ Any object that exposes field or property members with the same name as @-prefix
  - RedisKey
  - RedisValue
 
-StackExchange.Redis handles Lua script caching internally. It automatically transmits the Lua script to redis on the first call to 'ScriptEvaluate'. For further calls of the same script only the hash with [`EVALSHA`](http://redis.io/commands/evalsha) is used.
+StackExchange.Redis handles Lua script caching internally. It automatically transmits the Lua script to redis on the first call to 'ScriptEvaluate'. For further calls of the same script only the hash with [`EVALSHA`](https://redis.io/commands/evalsha) is used.
 
 For more control of the Lua script transmission to redis, `LuaScript` objects can be converted into `LoadedLuaScript`s via `LuaScript.Load(IServer)`.
-`LoadedLuaScripts` are evaluated with the [`EVALSHA`](http://redis.io/commands/evalsha), and referred to by hash.
+`LoadedLuaScripts` are evaluated with the [`EVALSHA`](https://redis.io/commands/evalsha), and referred to by hash.
 
 An example use of `LoadedLuaScript`:
 
-```
-	const string Script = "redis.call('set', @key, @value)";
+```csharp
+const string Script = "redis.call('set', @key, @value)";
 
-	using (ConnectionMultiplexer conn = /* init code */)
-	{
-		var db = conn.GetDatabase(0);
-		var server = conn.GetServer(/* appropriate parameters*/);
+using (ConnectionMultiplexer conn = /* init code */)
+{
+	var db = conn.GetDatabase(0);
+	var server = conn.GetServer(/* appropriate parameters*/);
 
-		var prepared = LuaScript.Prepare(Script);
-		var loaded = prepared.Load(server);
-		loaded.Evaluate(db, new { key = (RedisKey)"mykey", value = 123 });
-	}
+	var prepared = LuaScript.Prepare(Script);
+	var loaded = prepared.Load(server);
+	loaded.Evaluate(db, new { key = (RedisKey)"mykey", value = 123 });
+}
 ```
 
 All methods on both `LuaScript` and `LoadedLuaScript` have Async alternatives, and expose the actual script submitted to redis as the `ExecutableScript` property.

--- a/docs/ServerMaintenanceEvent.md
+++ b/docs/ServerMaintenanceEvent.md
@@ -17,7 +17,7 @@ Azure Cache for Redis currently sends the following notifications:
 
 The library will automatically subscribe to the pub/sub channel to receive notifications from the server, if one exists. For Azure Redis caches, this is the 'AzureRedisEvents' channel. To plug in your maintenance handling logic, you can pass in an event handler via the `ServerMaintenanceEvent` event on your `ConnectionMultiplexer`. For example:
 
-```
+```csharp
 multiplexer.ServerMaintenanceEvent += (object sender, ServerMaintenanceEvent e) =>
 {
     if (e is AzureMaintenanceEvent azureEvent && azureEvent.NotificationType == AzureNotificationType.NodeMaintenanceStart)

--- a/docs/ThreadTheft.md
+++ b/docs/ThreadTheft.md
@@ -3,7 +3,7 @@
 If you're here because you followed a link in an exception and you just want your code to work,
 the short version is: try adding the following *early on* in your application startup:
 
-``` c#
+```csharp
 ConnectionMultiplexer.SetFeatureFlag("preventthreadtheft", true);
 ```
 
@@ -40,14 +40,13 @@ be an asynchronous dispatch API. But... not all implementations are equal. Some
 in particular of `LegacyAspNetSynchronizationContext`, which is what you get if you
 configure ASP.NET with:
 
-
 ``` xml
 <add key="aspnet:UseTaskFriendlySynchronizationContext" value="false" />
 ```
 
 or
 
-```
+```xml
 <httpRuntime targetFramework="4.5" />
 ```
 

--- a/docs/Transactions.md
+++ b/docs/Transactions.md
@@ -1,7 +1,7 @@
 ﻿Transactions in Redis
 =====================
 
-Transactions in Redis are not like transactions in, say a SQL database. The [full documentation is here](http://redis.io/topics/transactions),
+Transactions in Redis are not like transactions in, say a SQL database. The [full documentation is here](https://redis.io/topics/transactions),
 but to paraphrase:
 
 A transaction in redis consists of a block of commands placed between `MULTI` and `EXEC` (or `DISCARD` for rollback). Once a `MULTI`
@@ -41,14 +41,14 @@ you *can* do is: `WATCH` a key, check data from that key in the normal way, then
 If, when you check the data, you discover that you don't actually need the transaction, you can use `UNWATCH` to
 forget all the watched keys. Note that watched keys are also reset during `EXEC` and `DISCARD`. So *at the Redis layer*, this is conceptually:
 
-```
+```lua
 WATCH {custKey}
 HEXISTS {custKey} "UniqueId"
-(check the reply, then either:)
+-- (check the reply, then either:)
 MULTI
 HSET {custKey} "UniqueId" {newId}
 EXEC
-(or, if we find there was already an unique-id:)
+-- (or, if we find there was already an unique-id:)
 UNWATCH
 ```
 
@@ -98,13 +98,13 @@ bool wasSet = db.HashSet(custKey, "UniqueID", newId, When.NotExists);
 Lua
 ---
 
-You should also keep in mind that Redis 2.6 and above [support Lua scripting](http://redis.io/commands/EVAL), a versatile tool for performing multiple operations as a single atomic unit at the server.
+You should also keep in mind that Redis 2.6 and above [support Lua scripting](https://redis.io/commands/EVAL), a versatile tool for performing multiple operations as a single atomic unit at the server.
 Since no other connections are serviced during a Lua script it behaves much like a transaction, but without the complexity of `MULTI` / `EXEC` etc.  This also avoids issues such as bandwidth and latency
 between the caller and the server, but the trade-off is that it monopolises the server for the duration of the script.
 
 At the Redis layer (and assuming `HSETNX` did not exist) this could be implemented as:
 
-```
+```lua
 EVAL "if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end" 1 {custKey} {newId}
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ StackExchange.Redis
 ## Overview
 
 StackExchange.Redis is a high performance general purpose redis client for .NET languages (C#, etc.). It is the logical successor to [BookSleeve](https://code.google.com/archive/p/booksleeve/),
-and is the client developed-by (and used-by) [Stack Exchange](http://stackexchange.com/) for busy sites like [Stack Overflow](http://stackoverflow.com/). For the full reasons
-why this library was created (i.e. "What about BookSleeve?") [please see here](http://marcgravell.blogspot.com/2014/03/so-i-went-and-wrote-another-redis-client.html).
+and is the client developed-by (and used-by) [Stack Exchange](https://stackexchange.com/) for busy sites like [Stack Overflow](https://stackoverflow.com/). For the full reasons
+why this library was created (i.e. "What about BookSleeve?") [please see here](https://marcgravell.blogspot.com/2014/03/so-i-went-and-wrote-another-redis-client.html).
 
 Features
 --
@@ -44,6 +44,7 @@ Documentation
 - [Profiling](Profiling) - profiling interfaces, as well as how to profile in an `async` world
 - [Scripting](Scripting) - running Lua scripts with convenient named parameter replacement
 - [Testing](Testing) - running the `StackExchange.Redis.Tests` suite to validate changes
+- [Timeouts](Timeouts) - guidance on dealing with timeout problems
 - [Thread Theft](ThreadTheft) - guidance on avoiding TPL threading problems
 
 Questions and Contributions
@@ -51,5 +52,5 @@ Questions and Contributions
 
 If you think you have found a bug or have a feature request, please [report an issue][2], or if appropriate: submit a pull request. If you have a question, feel free to [contact me](https://github.com/mgravell).
 
-  [1]: http://msdn.microsoft.com/en-us/library/dd460717%28v=vs.110%29.aspx
+  [1]: https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-parallel-library-tpl
   [2]: https://github.com/StackExchange/StackExchange.Redis/issues?state=open

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -54,11 +54,10 @@ namespace StackExchange.Redis
         });
 
         /// <summary>
-        /// The commands available to <a href="ssdb">http://www.ideawu.com/ssdb/</a>
+        /// The commands available to <a href="https://ssdb.io/">https://ssdb.io/</a>
         /// </summary>
-        /// <remarks>http://www.ideawu.com/ssdb/docs/redis-to-ssdb.html</remarks>
+        /// <remarks>https://ssdb.io/docs/redis-to-ssdb.html</remarks>
         public static CommandMap SSDB { get; } = Create(new HashSet<string> {
-            // see http://www.ideawu.com/ssdb/docs/redis-to-ssdb.html
             "ping",
             "get", "set", "del", "incr", "incrby", "mget", "mset", "keys", "getset", "setnx",
             "hget", "hset", "hdel", "hincrby", "hkeys", "hvals", "hmget", "hmset", "hlen",

--- a/tests/RedisConfigs/3.0.503/redis.windows-service.conf
+++ b/tests/RedisConfigs/3.0.503/redis.windows-service.conf
@@ -516,7 +516,7 @@ slave-priority 100
 # If the AOF is enabled on startup Redis will load the AOF, that is the file
 # with the better durability guarantees.
 #
-# Please check http://redis.io/topics/persistence for more information.
+# Please check https://redis.io/topics/persistence for more information.
 
 appendonly no
 
@@ -738,7 +738,7 @@ lua-time-limit 5000
 # cluster-require-full-coverage yes
 
 # In order to setup your cluster make sure to read the documentation
-# available at http://redis.io web site.
+# available at https://redis.io web site.
 
 ################################## SLOW LOG ###################################
 
@@ -788,7 +788,7 @@ latency-monitor-threshold 0
 ############################# Event notification ##############################
 
 # Redis can notify Pub/Sub clients about events happening in the key space.
-# This feature is documented at http://redis.io/topics/notifications
+# This feature is documented at https://redis.io/topics/notifications
 #
 # For instance if keyspace events notification is enabled, and a client
 # performs a DEL operation on key "foo" stored in the Database 0, two

--- a/tests/RedisConfigs/3.0.503/redis.windows.conf
+++ b/tests/RedisConfigs/3.0.503/redis.windows.conf
@@ -516,7 +516,7 @@ slave-priority 100
 # If the AOF is enabled on startup Redis will load the AOF, that is the file
 # with the better durability guarantees.
 #
-# Please check http://redis.io/topics/persistence for more information.
+# Please check https://redis.io/topics/persistence for more information.
 
 appendonly no
 
@@ -738,7 +738,7 @@ lua-time-limit 5000
 # cluster-require-full-coverage yes
 
 # In order to setup your cluster make sure to read the documentation
-# available at http://redis.io web site.
+# available at https://redis.io web site.
 
 ################################## SLOW LOG ###################################
 
@@ -788,7 +788,7 @@ latency-monitor-threshold 0
 ############################# Event notification ##############################
 
 # Redis can notify Pub/Sub clients about events happening in the key space.
-# This feature is documented at http://redis.io/topics/notifications
+# This feature is documented at https://redis.io/topics/notifications
 #
 # For instance if keyspace events notification is enabled, and a client
 # performs a DEL operation on key "foo" stored in the Database 0, two


### PR DESCRIPTION
- Code formatting
- http:// -> https://
- Generally updating MDSN links that moved
- Updates moved SSDB site
- Adding Timeouts link (resolves #1942)

Note: touches the license file but only to update to https:// URLs.