### PR TITLE
Docs: Global cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -89,5 +89,8 @@ csharp_space_after_keywords_in_control_flow_statements = true:suggestion
 # Language settings
 csharp_prefer_simple_default_expression = false:none
 
+# RCS1194: Implement exception constructors.
+dotnet_diagnostic.RCS1194.severity = none
+
 # RCS1229: Use async/await when necessary.
 dotnet_diagnostic.RCS1229.severity = none

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,7 +13,7 @@
       <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0" />
       <PackageReference Update="Moq" Version="4.15.1" />
       <PackageReference Update="NSubstitute" Version="4.2.2" />
-      <PackageReference Update="Pipelines.Sockets.Unofficial" Version="2.2.0" />
+      <PackageReference Update="Pipelines.Sockets.Unofficial" Version="2.2.2" />
       <PackageReference Update="System.Diagnostics.PerformanceCounter" Version="5.0.0" />
       <PackageReference Update="System.IO.Compression" Version="4.3.0" />
       <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
@@ -25,6 +25,6 @@
       <!-- note that it is only the tests that have a dependency on this; the main lib takes the
       transitive dependency from Pipelines.Sockets.Unofficial; this is for testing some binding
       redirect problems (something new and different for us!) -->
-      <PackageReference Update="System.IO.Pipelines" Version="5.0.0" />
+      <PackageReference Update="System.IO.Pipelines" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -165,10 +165,10 @@ The above is equivalent to (in the connection string):
 $INFO=,$SELECT=use
 ```
 
-Twemproxy
+twemproxy
 ---
 
-[Twemproxy](https://github.com/twitter/twemproxy) is a tool that allows multiple redis instances to be used as though it were a single server, with inbuilt sharding and fault tolerance (much like redis cluster, but implemented separately). The feature-set available to Twemproxy is reduced. To avoid having to configure this manually, the `Proxy` option can be used:
+[twemproxy](https://github.com/twitter/twemproxy) is a tool that allows multiple redis instances to be used as though it were a single server, with inbuilt sharding and fault tolerance (much like redis cluster, but implemented separately). The feature-set available to Twemproxy is reduced. To avoid having to configure this manually, the `Proxy` option can be used:
 
 ```csharp
 var options = new ConfigurationOptions

--- a/docs/Timeouts.md
+++ b/docs/Timeouts.md
@@ -71,13 +71,15 @@ How to configure this setting:
 
 > **Important Note:** the value specified in this configuration element is a *per-core* setting.  For example, if you have a 4 core machine and want your minIOThreads setting to be 200 at runtime, you would use `<processModel minIoThreads="50"/>`.
 
- - Outside of ASP.NET, use the [ThreadPool.SetMinThreads(…)](https://docs.microsoft.com/en-us/dotnet/api/system.threading.threadpool.setminthreads?view=netcore-2.0#System_Threading_ThreadPool_SetMinThreads_System_Int32_System_Int32_) API.
-
-- In .Net Core, add Environment Variable COMPlus_ThreadPool_ForceMinWorkerThreads to overwrite default MinThreads setting, according to [Environment/Registry Configuration Knobs](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/clr-configuration-knobs.md) - You can also use the same ThreadPool.SetMinThreads() Method as described above.
+ - Outside of ASP.NET, use one of the methods described in [Run-time configuration options for threading
+](https://docs.microsoft.com/dotnet/core/run-time-config/threading#minimum-threads):
+   - [ThreadPool.SetMinThreads(…)](https://docs.microsoft.com/dotnet/api/system.threading.threadpool.setminthreads)
+   - The `ThreadPoolMinThreads` MSBuild property
+   - The `System.Threading.ThreadPool.MinThreads` setting in your `runtimeconfig.json`
 
 Explanation for abbreviations appearing in exception messages
 ---
-By default Redis Timeout exception(s) includes useful information, which can help in uderstanding & diagnosing the timeouts. Some of the abbrivations are as follows:
+By default Redis Timeout exception(s) includes useful information, which can help in understanding & diagnosing the timeouts. Some of the abbreviations are as follows:
 
 | Abbreviation   | Long Name | Meaning |
 | ------------- | ---------------------- | ---------------------------- | 

--- a/src/StackExchange.Redis/AssemblyInfoHack.cs
+++ b/src/StackExchange.Redis/AssemblyInfoHack.cs
@@ -1,4 +1,4 @@
-﻿// Yes, this is embarassing. However, in .NET Core the including AssemblyInfo (ifdef'd or not) will screw with
+﻿// Yes, this is embarrassing. However, in .NET Core the including AssemblyInfo (ifdef'd or not) will screw with
 // your version numbers. Therefore, we need to move the attribute out into another file...this file.
 // When .csproj merges in, this should be able to return to Properties/AssemblyInfo.cs
 using System;

--- a/src/StackExchange.Redis/BacklogPolicy.cs
+++ b/src/StackExchange.Redis/BacklogPolicy.cs
@@ -31,7 +31,7 @@
         /// <summary>
         /// Whether to queue commands while disconnected.
         /// True means queue for attempts up until their timeout.
-        /// False means to fail ASAP and queue nothing.
+        /// <see langword="false"/> means to fail ASAP and queue nothing.
         /// </summary>
         public bool QueueWhileDisconnected { get; init; }
 

--- a/src/StackExchange.Redis/BacklogPolicy.cs
+++ b/src/StackExchange.Redis/BacklogPolicy.cs
@@ -12,7 +12,7 @@
         /// Backlog behavior matching StackExchange.Redis's 2.x line, failing fast and not attempting to queue
         /// and retry when a connection is available again.
         /// </summary>
-        public static BacklogPolicy FailFast = new()
+        public static BacklogPolicy FailFast { get; } = new()
         {
             QueueWhileDisconnected = false,
             AbortPendingOnConnectionFailure = true,
@@ -22,7 +22,7 @@
         /// Default backlog policy which will allow commands to be issues against an endpoint and queue up.
         /// Commands are still subject to their async timeout (which serves as a queue size check).
         /// </summary>
-        public static BacklogPolicy Default = new()
+        public static BacklogPolicy Default { get; } = new()
         {
             QueueWhileDisconnected = true,
             AbortPendingOnConnectionFailure = false,

--- a/src/StackExchange.Redis/BufferReader.cs
+++ b/src/StackExchange.Redis/BufferReader.cs
@@ -10,6 +10,7 @@ namespace StackExchange.Redis
         Success,
         NeedMoreData,
     }
+
     internal ref struct BufferReader
     {
         private long _totalConsumed;
@@ -209,6 +210,7 @@ namespace StackExchange.Redis
             Consume(1);
             return value;
         }
+
         public int PeekByte() => IsEmpty ? -1 : _current[OffsetThisSpan];
 
         public ReadOnlySequence<byte> SliceFromCurrent()

--- a/src/StackExchange.Redis/ChannelMessageQueue.cs
+++ b/src/StackExchange.Redis/ChannelMessageQueue.cs
@@ -7,25 +7,22 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents a message that is broadcast via pub/sub
+    /// Represents a message that is broadcast via publish/subscribe.
     /// </summary>
     public readonly struct ChannelMessage
     {
-        private readonly ChannelMessageQueue _queue; // this is *smaller* than storing a RedisChannel for the subscribed channel
+        // this is *smaller* than storing a RedisChannel for the subscribed channel
+        private readonly ChannelMessageQueue _queue;
+
         /// <summary>
-        /// See Object.ToString
+        /// The Channel:Message string representation.
         /// </summary>
         public override string ToString() => ((string)Channel) + ":" + ((string)Message);
 
-        /// <summary>
-        /// See Object.GetHashCode
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => Channel.GetHashCode() ^ Message.GetHashCode();
 
-        /// <summary>
-        /// See Object.Equals
-        /// </summary>
-        /// <param name="obj">The <see cref="object"/> to compare.</param>
+        /// <inheritdoc/>
         public override bool Equals(object obj) => obj is ChannelMessage cm
             && cm.Channel == Channel && cm.Message == Message;
         internal ChannelMessage(ChannelMessageQueue queue, in RedisChannel channel, in RedisValue value)
@@ -36,16 +33,17 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The channel that the subscription was created from
+        /// The channel that the subscription was created from.
         /// </summary>
         public RedisChannel SubscriptionChannel => _queue.Channel;
 
         /// <summary>
-        /// The channel that the message was broadcast to
+        /// The channel that the message was broadcast to.
         /// </summary>
         public RedisChannel Channel { get; }
+
         /// <summary>
-        /// The value that was broadcast
+        /// The value that was broadcast.
         /// </summary>
         public RedisValue Message { get; }
 
@@ -61,25 +59,28 @@ namespace StackExchange.Redis
     }
 
     /// <summary>
-    /// Represents a message queue of ordered pub/sub notifications
+    /// Represents a message queue of ordered pub/sub notifications.
     /// </summary>
-    /// <remarks>To create a ChannelMessageQueue, use ISubscriber.Subscribe[Async](RedisKey)</remarks>
+    /// <remarks>
+    /// To create a ChannelMessageQueue, use <see cref="ISubscriber.Subscribe(RedisChannel, CommandFlags)"/>
+    /// or <see cref="ISubscriber.SubscribeAsync(RedisChannel, CommandFlags)"/>.
+    /// </remarks>
     public sealed class ChannelMessageQueue
     {
         private readonly Channel<ChannelMessage> _queue;
         /// <summary>
-        /// The Channel that was subscribed for this queue
+        /// The Channel that was subscribed for this queue.
         /// </summary>
         public RedisChannel Channel { get; }
         private RedisSubscriber _parent;
 
         /// <summary>
-        /// See Object.ToString
+        /// The string representation of this channel.
         /// </summary>
         public override string ToString() => (string)Channel;
 
         /// <summary>
-        /// An awaitable task the indicates completion of the queue (including drain of data)
+        /// An awaitable task the indicates completion of the queue (including drain of data).
         /// </summary>
         public Task Completion => _queue.Reader.Completion;
 
@@ -97,9 +98,7 @@ namespace StackExchange.Redis
             AllowSynchronousContinuations = false,
         };
 
-#pragma warning disable RCS1231 // Make parameter ref read-only. - uses as a delegate for Action<RedisChannel, RedisValue>
         private void Write(in RedisChannel channel, in RedisValue value)
-#pragma warning restore RCS1231 // Make parameter ref read-only.
         {
             var writer = _queue.Writer;
             writer.TryWrite(new ChannelMessage(this, channel, value));

--- a/src/StackExchange.Redis/ClientInfo.cs
+++ b/src/StackExchange.Redis/ClientInfo.cs
@@ -47,6 +47,9 @@ namespace StackExchange.Redis
         /// S: the client is a normal replica server
         /// U: the client is connected via a Unix domain socket
         /// x: the client is in a MULTI/EXEC context
+        /// t: the client enabled keys tracking in order to perform client side caching
+        /// R: the client tracking target client is invalid
+        /// B: the client enabled broadcast tracking mode
         /// </summary>
         public string FlagsRaw { get; private set; }
 
@@ -172,7 +175,11 @@ namespace StackExchange.Redis
                                 AddFlag(ref flags, value, ClientFlags.Unblocked, 'u');
                                 AddFlag(ref flags, value, ClientFlags.UnixDomainSocket, 'U');
                                 AddFlag(ref flags, value, ClientFlags.Transaction, 'x');
-                                
+
+                                AddFlag(ref flags, value, ClientFlags.KeysTracking, 't');
+                                AddFlag(ref flags, value, ClientFlags.TrackingTargetInvalid, 'R');
+                                AddFlag(ref flags, value, ClientFlags.BroadcastTracking, 'B');
+
                                 client.Flags = flags;
                                 break;
                             case "id": client.Id = Format.ParseInt64(value); break;

--- a/src/StackExchange.Redis/ClientInfo.cs
+++ b/src/StackExchange.Redis/ClientInfo.cs
@@ -5,106 +5,160 @@ using System.Net;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents the state of an individual client connection to redis
+    /// Represents the state of an individual client connection to redis.
     /// </summary>
     public sealed class ClientInfo
     {
         internal static readonly ResultProcessor<ClientInfo[]> Processor = new ClientInfoProcessor();
 
         /// <summary>
-        /// Address (host and port) of the client
+        /// Address (host and port) of the client.
         /// </summary>
         public EndPoint Address { get; private set; }
 
         /// <summary>
-        /// total duration of the connection in seconds
+        /// Total duration of the connection in seconds.
         /// </summary>
         public int AgeSeconds { get; private set; }
 
         /// <summary>
-        /// current database ID
+        /// Current database ID.
         /// </summary>
         public int Database { get; private set; }
 
         /// <summary>
-        /// The flags associated with this connection
+        /// The flags associated with this connection.
         /// </summary>
         public ClientFlags Flags { get; private set; }
 
         /// <summary>
         /// The client flags can be a combination of:
-        ///
-        /// A: connection to be closed ASAP
-        /// b: the client is waiting in a blocking operation
-        /// c: connection to be closed after writing entire reply
-        /// d: a watched keys has been modified - EXEC will fail
-        /// i: the client is waiting for a VM I/O (deprecated)
-        /// M: the client is a master
-        /// N: no specific flag set
-        /// O: the client is a replica in MONITOR mode
-        /// P: the client is a Pub/Sub subscriber
-        /// r: the client is in readonly mode against a cluster node
-        /// S: the client is a normal replica server
-        /// U: the client is connected via a Unix domain socket
-        /// x: the client is in a MULTI/EXEC context
-        /// t: the client enabled keys tracking in order to perform client side caching
-        /// R: the client tracking target client is invalid
-        /// B: the client enabled broadcast tracking mode
+        /// <list type="table">
+        ///     <item>
+        ///         <term>A</term>
+        ///         <description>Connection to be closed ASAP.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>b</term>
+        ///         <description>The client is waiting in a blocking operation.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>c</term>
+        ///         <description>Connection to be closed after writing entire reply.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>d</term>
+        ///         <description>A watched keys has been modified - EXEC will fail.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>i</term>
+        ///         <description>The client is waiting for a VM I/O (deprecated).</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>M</term>
+        ///         <description>The client is a primary.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>N</term>
+        ///         <description>No specific flag set.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>O</term>
+        ///         <description>The client is a replica in MONITOR mode.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>P</term>
+        ///         <description>The client is a Pub/Sub subscriber.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>r</term>
+        ///         <description>The client is in readonly mode against a cluster node.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>S</term>
+        ///         <description>The client is a normal replica server.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>u</term>
+        ///         <description>The client is unblocked.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>U</term>
+        ///         <description>The client is unblocked.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>x</term>
+        ///         <description>The client is in a MULTI/EXEC context.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>t</term>
+        ///         <description>The client enabled keys tracking in order to perform client side caching.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>R</term>
+        ///         <description>The client tracking target client is invalid.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>B</term>
+        ///         <description>The client enabled broadcast tracking mode.</description>
+        ///     </item>
+        /// </list>
         /// </summary>
+        /// <remarks>https://redis.io/commands/client-list</remarks>
         public string FlagsRaw { get; private set; }
 
         /// <summary>
-        /// The host of the client (typically an IP address)
+        /// The host of the client (typically an IP address).
         /// </summary>
         public string Host => Format.TryGetHostPort(Address, out string host, out _) ? host : null;
 
         /// <summary>
-        /// idle time of the connection in seconds
+        /// Idle time of the connection in seconds.
         /// </summary>
         public int IdleSeconds { get; private set; }
 
         /// <summary>
-        ///  last command played
+        /// Last command played.
         /// </summary>
         public string LastCommand { get; private set; }
 
         /// <summary>
-        /// The name allocated to this connection, if any
+        /// The name allocated to this connection, if any.
         /// </summary>
         public string Name { get; private set; }
 
         /// <summary>
-        /// number of pattern matching subscriptions
+        /// Number of pattern matching subscriptions.
         /// </summary>
         public int PatternSubscriptionCount { get; private set; }
 
         /// <summary>
-        /// The port of the client
+        /// The port of the client.
         /// </summary>
         public int Port => Format.TryGetHostPort(Address, out _, out int port) ? port : 0;
 
         /// <summary>
-        /// The raw content from redis
+        /// The raw content from redis.
         /// </summary>
         public string Raw { get; private set; }
 
         /// <summary>
-        /// number of channel subscriptions
+        /// Number of channel subscriptions.
         /// </summary>
         public int SubscriptionCount { get; private set; }
 
         /// <summary>
-        /// number of commands in a MULTI/EXEC context
+        /// Number of commands in a MULTI/EXEC context.
         /// </summary>
         public int TransactionCommandLength { get; private set; }
 
         /// <summary>
-        /// an unique 64-bit client ID (introduced in Redis 2.8.12).
+        /// A unique 64-bit client ID (introduced in Redis 2.8.12).
         /// </summary>
         public long Id { get;private set; }
 
         /// <summary>
-        /// Format the object as a string
+        /// Format the object as a string.
         /// </summary>
         public override string ToString()
         {
@@ -113,7 +167,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The class of the connection
+        /// The class of the connection.
         /// </summary>
         public ClientType ClientType
         {

--- a/src/StackExchange.Redis/ClusterConfiguration.cs
+++ b/src/StackExchange.Redis/ClusterConfiguration.cs
@@ -9,14 +9,14 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Indicates a range of slots served by a cluster node
+    /// Indicates a range of slots served by a cluster node.
     /// </summary>
     public readonly struct SlotRange : IEquatable<SlotRange>, IComparable<SlotRange>, IComparable
     {
         private readonly short from, to;
 
         /// <summary>
-        /// Create a new SlotRange value
+        /// Create a new SlotRange value.
         /// </summary>
         /// <param name="from">The slot ID to start at.</param>
         /// <param name="to">The slot ID to end at.</param>
@@ -34,18 +34,19 @@ namespace StackExchange.Redis
             this.from = from;
             this.to = to;
         }
+
         /// <summary>
-        /// The start of the range (inclusive)
+        /// The start of the range (inclusive).
         /// </summary>
         public int From => from;
 
         /// <summary>
-        /// The end of the range (inclusive)
+        /// The end of the range (inclusive).
         /// </summary>
         public int To => to;
 
         /// <summary>
-        /// Indicates whether two ranges are not equal
+        /// Indicates whether two ranges are not equal.
         /// </summary>
         /// <param name="x">The first slot range.</param>
         /// <param name="y">The second slot range.</param>
@@ -93,7 +94,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
+        /// Compares the current instance with another object of the same type and returns an integer that indicates
+        /// whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
         /// </summary>
         /// <param name="other">The other slot range to compare to.</param>
         public int CompareTo(SlotRange other)
@@ -103,20 +105,18 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See Object.Equals
+        /// See <see cref="object.Equals(object)"/>.
         /// </summary>
         /// <param name="obj">The other slot range to compare to.</param>
         public override bool Equals(object obj) => obj is SlotRange sRange && Equals(sRange);
 
         /// <summary>
-        /// Indicates whether two ranges are equal
+        /// Indicates whether two ranges are equal.
         /// </summary>
         /// <param name="other">The other slot range to compare to.</param>
         public bool Equals(SlotRange other) => other.from == from && other.to == to;
 
-        /// <summary>
-        /// See Object.GetHashCode()
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             int x = from, y = to; // makes CS0675 a little happier
@@ -124,7 +124,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See Object.ToString()
+        /// String representation ("{from}-{to}") of the range.
         /// </summary>
         public override string ToString() => from == to ? from.ToString() : (from + "-" + to);
 
@@ -151,7 +151,7 @@ namespace StackExchange.Redis
     }
 
     /// <summary>
-    /// Describes the state of the cluster as reported by a single node
+    /// Describes the state of the cluster as reported by a single node.
     /// </summary>
     public sealed class ClusterConfiguration
     {
@@ -212,18 +212,17 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Gets all nodes contained in the configuration
+        /// Gets all nodes contained in the configuration.
         /// </summary>
-        /// <returns></returns>
         public ICollection<ClusterNode> Nodes => nodeLookup.Values;
 
         /// <summary>
-        /// The node that was asked for the configuration
+        /// The node that was asked for the configuration.
         /// </summary>
         public EndPoint Origin { get; }
 
         /// <summary>
-        /// Obtain the node relating to a specified endpoint
+        /// Obtain the node relating to a specified endpoint.
         /// </summary>
         /// <param name="endpoint">The endpoint to get a cluster node from.</param>
         public ClusterNode this[EndPoint endpoint] => endpoint == null
@@ -322,8 +321,9 @@ namespace StackExchange.Redis
             Slots = slots?.AsReadOnly() ?? (IList<SlotRange>)Array.Empty<SlotRange>();
             IsConnected = parts[7] == "connected"; // Can be "connected" or "disconnected"
         }
+
         /// <summary>
-        /// Gets all child nodes of the current node
+        /// Gets all child nodes of the current node.
         /// </summary>
         public IList<ClusterNode> Children
         {
@@ -345,43 +345,44 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Gets the endpoint of the current node
+        /// Gets the endpoint of the current node.
         /// </summary>
         public EndPoint EndPoint { get; }
 
         /// <summary>
-        /// Gets whether this is the node which responded to the CLUSTER NODES request
+        /// Gets whether this is the node which responded to the CLUSTER NODES request.
         /// </summary>
         public bool IsMyself { get; }
 
         /// <summary>
-        /// Gets whether this node is a replica
+        /// Gets whether this node is a replica.
         /// </summary>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(IsReplica) + " instead.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsSlave => IsReplica;
+
         /// <summary>
-        /// Gets whether this node is a replica
+        /// Gets whether this node is a replica.
         /// </summary>
         public bool IsReplica { get; }
 
         /// <summary>
-        /// Gets whether this node is flagged as noaddr
+        /// Gets whether this node is flagged as noaddr.
         /// </summary>
         public bool IsNoAddr { get; }
 
         /// <summary>
-        /// Gets the node's connection status
+        /// Gets the node's connection status.
         /// </summary>
         public bool IsConnected { get; }
 
         /// <summary>
-        /// Gets the unique node-id of the current node
+        /// Gets the unique node-id of the current node.
         /// </summary>
         public string NodeId { get; }
 
         /// <summary>
-        /// Gets the parent node of the current node
+        /// Gets the parent node of the current node.
         /// </summary>
         public ClusterNode Parent
         {
@@ -395,22 +396,23 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Gets the unique node-id of the parent of the current node
+        /// Gets the unique node-id of the parent of the current node.
         /// </summary>
         public string ParentNodeId { get; }
 
         /// <summary>
-        /// The configuration as reported by the server
+        /// The configuration as reported by the server.
         /// </summary>
         public string Raw { get; }
 
         /// <summary>
-        /// The slots owned by this server
+        /// The slots owned by this server.
         /// </summary>
         public IList<SlotRange> Slots { get; }
 
         /// <summary>
-        /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
+        /// Compares the current instance with another object of the same type and returns an integer that indicates
+        /// whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
         /// </summary>
         /// <param name="other">The <see cref="ClusterNode"/> to compare to.</param>
         public int CompareTo(ClusterNode other)
@@ -428,13 +430,13 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See Object.Equals
+        /// See <see cref="object.Equals(object)"/>.
         /// </summary>
         /// <param name="obj">The <see cref="ClusterNode"/> to compare to.</param>
         public override bool Equals(object obj) => Equals(obj as ClusterNode);
 
         /// <summary>
-        /// Indicates whether two ClusterNode instances are equivalent
+        /// Indicates whether two <see cref="ClusterNode"/> instances are equivalent.
         /// </summary>
         /// <param name="other">The <see cref="ClusterNode"/> to compare to.</param>
         public bool Equals(ClusterNode other)
@@ -444,13 +446,11 @@ namespace StackExchange.Redis
             return ToString() == other.ToString(); // lazy, but effective - plus only computes once
         }
 
-        /// <summary>
-        /// See object.GetHashCode()
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => ToString().GetHashCode();
 
         /// <summary>
-        /// See Object.ToString()
+        /// A string summary of this cluster configuration.
         /// </summary>
         public override string ToString()
         {
@@ -490,9 +490,6 @@ namespace StackExchange.Redis
             return false;
         }
 
-        int IComparable.CompareTo(object obj)
-        {
-            return CompareTo(obj as ClusterNode);
-        }
+        int IComparable.CompareTo(object obj) => CompareTo(obj as ClusterNode);
     }
 }

--- a/src/StackExchange.Redis/ClusterConfiguration.cs
+++ b/src/StackExchange.Redis/ClusterConfiguration.cs
@@ -357,7 +357,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets whether this node is a replica.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(IsReplica) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(IsReplica) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsSlave => IsReplica;
 

--- a/src/StackExchange.Redis/CommandBytes.cs
+++ b/src/StackExchange.Redis/CommandBytes.cs
@@ -46,6 +46,7 @@ namespace StackExchange.Redis
             hashCode = (hashCode * -1521134295) + _3.GetHashCode();
             return hashCode;
         }
+
         public override bool Equals(object obj) => obj is CommandBytes cb && Equals(cb);
 
         bool IEquatable<CommandBytes>.Equals(CommandBytes other) => _0 == other._0 && _1 == other._1 && _2 == other._2 && _3 == other._3;
@@ -78,9 +79,7 @@ namespace StackExchange.Redis
 
         public bool IsEmpty => _0 == 0L; // cheap way of checking zero length
 
-#pragma warning disable RCS1231 // Make parameter ref read-only. - spans are tiny!
         public unsafe void CopyTo(Span<byte> target)
-#pragma warning restore RCS1231 // Make parameter ref read-only.
         {
             fixed (ulong* uPtr = &_0)
             {
@@ -121,9 +120,7 @@ namespace StackExchange.Redis
             }
         }
 
-#pragma warning disable RCS1231 // Make parameter ref read-only. - spans are tiny!
         public unsafe CommandBytes(ReadOnlySpan<byte> value)
-#pragma warning restore RCS1231 // Make parameter ref read-only.
         {
             if (value.Length > MaxLength) throw new ArgumentOutOfRangeException("Maximum command length exceeded: " + value.Length + " bytes");
             _0 = _1 = _2 = _3 = 0L;

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis
         public static CommandMap Default { get; } = CreateImpl(null, null);
 
         /// <summary>
-        /// The commands available to <a href="https://github.com/twitter/twemproxy">https://github.com/twitter/twemproxy</a>.
+        /// The commands available to <a href="https://github.com/twitter/twemproxy">twemproxy</a>.
         /// </summary>
         /// <remarks>https://github.com/twitter/twemproxy/blob/master/notes/redis.md</remarks>
         public static CommandMap Twemproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
@@ -52,7 +52,7 @@ namespace StackExchange.Redis
         });
 
         /// <summary>
-        /// The commands available to <a href="https://ssdb.io/">https://ssdb.io/</a>.
+        /// The commands available to <a href="https://ssdb.io/">SSDB</a>.
         /// </summary>
         /// <remarks>https://ssdb.io/docs/redis-to-ssdb.html</remarks>
         public static CommandMap SSDB { get; } = Create(new HashSet<string> {
@@ -64,7 +64,7 @@ namespace StackExchange.Redis
         }, true);
 
         /// <summary>
-        /// The commands available to <a href="Sentinel">https://redis.io/topics/sentinel</a>.
+        /// The commands available to <a href="https://redis.io/topics/sentinel">Sentinel</a>.
         /// </summary>
         /// <remarks>https://redis.io/topics/sentinel</remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -5,23 +5,21 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents the commands mapped on a particular configuration
+    /// Represents the commands mapped on a particular configuration.
     /// </summary>
     public sealed class CommandMap
     {
         private readonly CommandBytes[] map;
 
-        internal CommandMap(CommandBytes[] map)
-        {
-            this.map = map;
-        }
+        internal CommandMap(CommandBytes[] map) => this.map = map;
+
         /// <summary>
-        /// The default commands specified by redis
+        /// The default commands specified by redis.
         /// </summary>
         public static CommandMap Default { get; } = CreateImpl(null, null);
 
         /// <summary>
-        /// The commands available to <a href="twemproxy">https://github.com/twitter/twemproxy</a>
+        /// The commands available to <a href="twemproxy">https://github.com/twitter/twemproxy</a>.
         /// </summary>
         /// <remarks>https://github.com/twitter/twemproxy/blob/master/notes/redis.md</remarks>
         public static CommandMap Twemproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
@@ -54,7 +52,7 @@ namespace StackExchange.Redis
         });
 
         /// <summary>
-        /// The commands available to <a href="ssdb">http://www.ideawu.com/ssdb/</a>
+        /// The commands available to <a href="ssdb">http://www.ideawu.com/ssdb/</a>.
         /// </summary>
         /// <remarks>http://www.ideawu.com/ssdb/docs/redis-to-ssdb.html</remarks>
         public static CommandMap SSDB { get; } = Create(new HashSet<string> {
@@ -67,7 +65,7 @@ namespace StackExchange.Redis
         }, true);
 
         /// <summary>
-        /// The commands available to <a href="Sentinel">https://redis.io/topics/sentinel</a>
+        /// The commands available to <a href="Sentinel">https://redis.io/topics/sentinel</a>.
         /// </summary>
         /// <remarks>https://redis.io/topics/sentinel</remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {
@@ -75,7 +73,7 @@ namespace StackExchange.Redis
             "auth", "ping", "info", "role", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);
 
         /// <summary>
-        /// Create a new CommandMap, customizing some commands
+        /// Create a new <see cref="CommandMap"/>, customizing some commands.
         /// </summary>
         /// <param name="overrides">The commands to override.</param>
         public static CommandMap Create(Dictionary<string, string> overrides)
@@ -96,7 +94,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Creates a CommandMap by specifying which commands are available or unavailable
+        /// Creates a CommandMap by specifying which commands are available or unavailable.
         /// </summary>
         /// <param name="commands">The commands to specify.</param>
         /// <param name="available">Whether the commands are available or excluded.</param>
@@ -140,7 +138,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See Object.ToString()
+        /// See <see cref="object.ToString"/>.
         /// </summary>
         public override string ToString()
         {

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis
         public static CommandMap Default { get; } = CreateImpl(null, null);
 
         /// <summary>
-        /// The commands available to <a href="twemproxy">https://github.com/twitter/twemproxy</a>.
+        /// The commands available to <a href="https://github.com/twitter/twemproxy">https://github.com/twitter/twemproxy</a>.
         /// </summary>
         /// <remarks>https://github.com/twitter/twemproxy/blob/master/notes/redis.md</remarks>
         public static CommandMap Twemproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
@@ -93,7 +93,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Creates a CommandMap by specifying which commands are available or unavailable.
+        /// Creates a <see cref="CommandMap"/> by specifying which commands are available or unavailable.
         /// </summary>
         /// <param name="commands">The commands to specify.</param>
         /// <param name="available">Whether the commands are available or excluded.</param>

--- a/src/StackExchange.Redis/CommandTrace.cs
+++ b/src/StackExchange.Redis/CommandTrace.cs
@@ -3,7 +3,7 @@
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents the information known about long-running commands
+    /// Represents the information known about long-running commands.
     /// </summary>
     public sealed class CommandTrace
     {
@@ -26,7 +26,7 @@ namespace StackExchange.Redis
         public RedisValue[] Arguments { get; }
 
         /// <summary>
-        /// The amount of time needed for its execution
+        /// The amount of time needed for its execution.
         /// </summary>
         public TimeSpan Duration { get; }
 

--- a/src/StackExchange.Redis/Condition.cs
+++ b/src/StackExchange.Redis/Condition.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Describes a pre-condition used in a redis transaction.
+    /// Describes a precondition used in a redis transaction.
     /// </summary>
     public abstract class Condition
     {
@@ -241,7 +241,7 @@ namespace StackExchange.Redis
         public static Condition SortedSetLengthEqual(RedisKey key, long length, double min = double.NegativeInfinity, double max = double.PositiveInfinity) => new SortedSetRangeLengthCondition(key, min, max, 0, length);
 
         /// <summary>
-        /// Enforces that the given sorted set cardinality is less than a certain value
+        /// Enforces that the given sorted set cardinality is less than a certain value.
         /// </summary>
         /// <param name="key">The key of the sorted set to check.</param>
         /// <param name="length">The length the sorted set must be less than.</param>
@@ -366,10 +366,8 @@ namespace StackExchange.Redis
         {
             public static readonly ConditionProcessor Default = new();
 
-#pragma warning disable RCS1231 // Make parameter ref read-only.
             public static Message CreateMessage(Condition condition, int db, CommandFlags flags, RedisCommand command, in RedisKey key, RedisValue value = default(RedisValue)) =>
                 new ConditionMessage(condition, db, flags, command, key, value);
-#pragma warning restore RCS1231 // Make parameter ref read-only.
 
             public static Message CreateMessage(Condition condition, int db, CommandFlags flags, RedisCommand command, in RedisKey key, in RedisValue value, in RedisValue value1) =>
                 new ConditionMessage(condition, db, flags, command, key, value, value1);
@@ -556,12 +554,9 @@ namespace StackExchange.Redis
                 {
                     case RedisType.SortedSet:
                         var parsedValue = RedisValue.Null;
-                        if (!result.IsNull)
+                        if (!result.IsNull && result.TryGetDouble(out var val))
                         {
-                            if (result.TryGetDouble(out var val))
-                            {
-                                parsedValue = val;
-                            }
+                            parsedValue = val;
                         }
 
                         value = (parsedValue == expectedValue) == expectedEqual;
@@ -596,6 +591,8 @@ namespace StackExchange.Redis
             private readonly long index;
             private readonly RedisValue? expectedValue;
             private readonly RedisKey key;
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1242:Do not pass non-read-only struct by read-only reference.", Justification = "Attribute")]
             public ListCondition(in RedisKey key, long index, bool expectedResult, in RedisValue? expectedValue)
             {
                 if (key.IsNull) throw new ArgumentNullException(nameof(key));
@@ -827,7 +824,7 @@ namespace StackExchange.Redis
     }
 
     /// <summary>
-    /// Indicates the status of a condition as part of a transaction
+    /// Indicates the status of a condition as part of a transaction.
     /// </summary>
     public sealed class ConditionResult
     {
@@ -844,7 +841,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Indicates whether the condition was satisfied
+        /// Indicates whether the condition was satisfied.
         /// </summary>
         public bool WasSatisfied => wasSatisfied;
 

--- a/src/StackExchange.Redis/Condition.cs
+++ b/src/StackExchange.Redis/Condition.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 
-#pragma warning disable RCS1231
-
 namespace StackExchange.Redis
 {
     /// <summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using static StackExchange.Redis.ConnectionMultiplexer;
 
@@ -202,7 +202,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Automatically encodes and decodes channels
+        /// Automatically encodes and decodes channels.
         /// </summary>
         public RedisChannel ChannelPrefix { get; set; }
 
@@ -216,13 +216,13 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a certificate validation check that checks against the supplied issuer even if not known by the machine
+        /// Create a certificate validation check that checks against the supplied issuer even if not known by the machine.
         /// </summary>
         /// <param name="issuerCertificatePath">The file system path to find the certificate at.</param>
         public void TrustIssuer(string issuerCertificatePath) => CertificateValidationCallback = TrustIssuerCallback(issuerCertificatePath);
 
         /// <summary>
-        /// Create a certificate validation check that checks against the supplied issuer even if not known by the machine
+        /// Create a certificate validation check that checks against the supplied issuer even if not known by the machine.
         /// </summary>
         /// <param name="issuer">The issuer to trust.</param>
         public void TrustIssuer(X509Certificate2 issuer) => CertificateValidationCallback = TrustIssuerCallback(issuer);
@@ -254,12 +254,12 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The client name to use for all connections
+        /// The client name to use for all connections.
         /// </summary>
         public string ClientName { get; set; }
 
         /// <summary>
-        /// The number of times to repeat the initial connect cycle if no servers respond promptly
+        /// The number of times to repeat the initial connect cycle if no servers respond promptly.
         /// </summary>
         public int ConnectRetry
         {
@@ -268,7 +268,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The command-map associated with this configuration
+        /// The command-map associated with this configuration.
         /// </summary>
         public CommandMap CommandMap
         {
@@ -281,7 +281,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Channel to use for broadcasting and listening for configuration change notification
+        /// Channel to use for broadcasting and listening for configuration change notification.
         /// </summary>
         public string ConfigurationChannel
         {
@@ -290,7 +290,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher)
+        /// Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher).
         /// </summary>
         public int ConnectTimeout
         {
@@ -299,12 +299,12 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Specifies the default database to be used when calling ConnectionMultiplexer.GetDatabase() without any parameters
+        /// Specifies the default database to be used when calling ConnectionMultiplexer.GetDatabase() without any parameters.
         /// </summary>
         public int? DefaultDatabase { get; set; }
 
         /// <summary>
-        /// The server version to assume
+        /// The server version to assume.
         /// </summary>
         public Version DefaultVersion
         {
@@ -313,12 +313,13 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The endpoints defined for this configuration
+        /// The endpoints defined for this configuration.
         /// </summary>
         public EndPointCollection EndPoints { get; } = new EndPointCollection();
 
         /// <summary>
-        /// Use ThreadPriority.AboveNormal for SocketManager reader and writer threads (true by default). If false, ThreadPriority.Normal will be used.
+        /// Use ThreadPriority.AboveNormal for SocketManager reader and writer threads (true by default).
+        /// If <see langword="false"/>, <see cref="ThreadPriority.Normal"/> will be used.
         /// </summary>
         public bool HighPrioritySocketThreads
         {
@@ -326,9 +327,8 @@ namespace StackExchange.Redis
             set => highPrioritySocketThreads = value;
         }
 
-        // Use coalesce expression.
         /// <summary>
-        /// Specifies the time in seconds at which connections should be pinged to ensure validity
+        /// Specifies the time in seconds at which connections should be pinged to ensure validity.
         /// </summary>
         public int KeepAlive
         {
@@ -347,7 +347,7 @@ namespace StackExchange.Redis
         public string Password { get; set; }
 
         /// <summary>
-        /// Specifies whether asynchronous operations should be invoked in a way that guarantees their original delivery order
+        /// Specifies whether asynchronous operations should be invoked in a way that guarantees their original delivery order.
         /// </summary>
         [Obsolete("Not supported; if you require ordered pub/sub, please see " + nameof(ChannelMessageQueue), false)]
         public bool PreserveAsyncOrder
@@ -357,7 +357,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Type of proxy to use (if any); for example Proxy.Twemproxy.
+        /// Type of proxy to use (if any); for example <see cref="Proxy.Twemproxy"/>.
         /// </summary>
         public Proxy Proxy
         {
@@ -395,8 +395,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Specifies the time in milliseconds that the system should allow for responses before concluding that the socket is unhealthy
-        /// (defaults to SyncTimeout)
+        /// Specifies the time in milliseconds that the system should allow for responses before concluding that the socket is unhealthy.
         /// </summary>
         [Obsolete("This setting no longer has any effect, and should not be used")]
         public int ResponseTimeout
@@ -411,13 +410,13 @@ namespace StackExchange.Redis
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// Gets or sets the SocketManager instance to be used with these options; if this is null a shared cross-multiplexer SocketManager
-        /// is used
+        /// Gets or sets the SocketManager instance to be used with these options.
+        /// If this is null a shared cross-multiplexer <see cref="SocketManager"/> is used.
         /// </summary>
         public SocketManager SocketManager { get; set; }
 
         /// <summary>
-        /// Indicates whether the connection should be encrypted
+        /// Indicates whether the connection should be encrypted.
         /// </summary>
         public bool Ssl
         {
@@ -426,7 +425,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The target-host to use when validating SSL certificate; setting a value here enables SSL mode
+        /// The target-host to use when validating SSL certificate; setting a value here enables SSL mode.
         /// </summary>
         public string SslHost
         {
@@ -440,7 +439,7 @@ namespace StackExchange.Redis
         public SslProtocols? SslProtocols { get; set; }
 
         /// <summary>
-        /// Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)
+        /// Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds).
         /// </summary>
         public int SyncTimeout
         {
@@ -449,7 +448,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Tie-breaker used to choose between masters (must match the endpoint exactly)
+        /// Tie-breaker used to choose between masters (must match the endpoint exactly).
         /// </summary>
         public string TieBreaker
         {
@@ -458,7 +457,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The size of the output buffer to use
+        /// The size of the output buffer to use.
         /// </summary>
         [Obsolete("This setting no longer has any effect, and should not be used")]
         public int WriteBuffer
@@ -481,7 +480,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Check configuration every n seconds (every minute by default)
+        /// Check configuration every n seconds (every minute by default).
         /// </summary>
         public int ConfigCheckSeconds
         {
@@ -490,10 +489,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Parse the configuration from a comma-delimited configuration string
+        /// Parse the configuration from a comma-delimited configuration string.
         /// </summary>
         /// <param name="configuration">The configuration string to parse.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="configuration"/> is empty.</exception>
         public static ConfigurationOptions Parse(string configuration)
         {
@@ -503,11 +502,11 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Parse the configuration from a comma-delimited configuration string
+        /// Parse the configuration from a comma-delimited configuration string.
         /// </summary>
         /// <param name="configuration">The configuration string to parse.</param>
         /// <param name="ignoreUnknown">Whether to ignore unknown elements in <paramref name="configuration"/>.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="configuration"/> is empty.</exception>
         public static ConfigurationOptions Parse(string configuration, bool ignoreUnknown)
         {
@@ -517,7 +516,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a copy of the configuration
+        /// Create a copy of the configuration.
         /// </summary>
         public ConfigurationOptions Clone()
         {
@@ -575,12 +574,12 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Resolve the default port for any endpoints that did not have a port explicitly specified
+        /// Resolve the default port for any endpoints that did not have a port explicitly specified.
         /// </summary>
         public void SetDefaultPorts() => EndPoints.SetDefaultPorts(Ssl ? 6380 : 6379);
 
         /// <summary>
-        /// Sets default config settings required for sentinel usage
+        /// Sets default config settings required for sentinel usage.
         /// </summary>
         internal void SetSentinelDefaults()
         {
@@ -881,7 +880,7 @@ namespace StackExchange.Redis
             }
         }
 
-        // Microsoft Azure team wants abortConnect=false by default
+        ///<summary>Microsoft Azure team wants abortConnect=false by default</summary>
         private bool GetDefaultAbortOnConnectFailSetting() => !IsAzureEndpoint();
 
         /// <summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -880,7 +880,7 @@ namespace StackExchange.Redis
             }
         }
 
-        ///<summary>Microsoft Azure team wants abortConnect=false by default</summary>
+        ///<summary>Microsoft Azure team wants abortConnect=false by default.</summary>
         private bool GetDefaultAbortOnConnectFailSetting() => !IsAzureEndpoint();
 
         /// <summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -299,7 +299,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Specifies the default database to be used when calling ConnectionMultiplexer.GetDatabase() without any parameters.
+        /// Specifies the default database to be used when calling <see cref="ConnectionMultiplexer.GetDatabase(int, object)"/> without any parameters.
         /// </summary>
         public int? DefaultDatabase { get; set; }
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -833,7 +833,7 @@ namespace StackExchange.Redis
                         case OptionKeys.WriteBuffer:
 #pragma warning disable CS0618 // Type or member is obsolete
                             WriteBuffer = OptionKeys.ParseInt32(key, value);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618
                             break;
                         case OptionKeys.Proxy:
                             Proxy = OptionKeys.ParseProxy(key, value);
@@ -841,7 +841,7 @@ namespace StackExchange.Redis
                         case OptionKeys.ResponseTimeout:
 #pragma warning disable CS0618 // Type or member is obsolete
                             ResponseTimeout = OptionKeys.ParseInt32(key, value, minValue: 1);
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618
                             break;
                         case OptionKeys.DefaultDatabase:
                             DefaultDatabase = OptionKeys.ParseInt32(key, value);

--- a/src/StackExchange.Redis/ConnectionCounters.cs
+++ b/src/StackExchange.Redis/ConnectionCounters.cs
@@ -3,7 +3,7 @@
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Illustrates the counters associated with an individual connection
+    /// Illustrates the counters associated with an individual connection.
     /// </summary>
     public class ConnectionCounters
     {
@@ -13,78 +13,78 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The number of operations that have been completed asynchronously
+        /// The number of operations that have been completed asynchronously.
         /// </summary>
         public long CompletedAsynchronously { get; internal set; }
 
         /// <summary>
-        /// The number of operations that have been completed synchronously
+        /// The number of operations that have been completed synchronously.
         /// </summary>
         public long CompletedSynchronously { get; internal set; }
 
         /// <summary>
-        /// The type of this connection
+        /// The type of this connection.
         /// </summary>
         public ConnectionType ConnectionType { get; }
 
         /// <summary>
-        /// The number of operations that failed to complete asynchronously
+        /// The number of operations that failed to complete asynchronously.
         /// </summary>
         public long FailedAsynchronously { get; internal set; }
 
         /// <summary>
-        /// Indicates if there are any pending items or failures on this connection
+        /// Indicates if there are any pending items or failures on this connection.
         /// </summary>
         public bool IsEmpty => PendingUnsentItems == 0 && SentItemsAwaitingResponse == 0 && ResponsesAwaitingAsyncCompletion == 0 && FailedAsynchronously == 0;
 
         /// <summary>
-        /// Indicates the total number of messages despatched to a non-preferred endpoint, for example sent to a master
-        /// when the caller stated a preference of replica
+        /// Indicates the total number of messages dispatched to a non-preferred endpoint, for example sent
+        /// to a primary when the caller stated a preference of replica.
         /// </summary>
         public long NonPreferredEndpointCount { get; internal set; }
 
         /// <summary>
-        /// The number of operations performed on this connection
+        /// The number of operations performed on this connection.
         /// </summary>
         public long OperationCount { get; internal set; }
 
         /// <summary>
-        /// Operations that have been requested, but which have not yet been sent to the server
+        /// Operations that have been requested, but which have not yet been sent to the server.
         /// </summary>
         public int PendingUnsentItems { get; internal set; }
 
         /// <summary>
-        /// Operations for which the response has been processed, but which are awaiting asynchronous completion
+        /// Operations for which the response has been processed, but which are awaiting asynchronous completion.
         /// </summary>
         public int ResponsesAwaitingAsyncCompletion { get; internal set; }
 
         /// <summary>
-        /// Operations that have been sent to the server, but which are awaiting a response
+        /// Operations that have been sent to the server, but which are awaiting a response.
         /// </summary>
         public int SentItemsAwaitingResponse { get; internal set; }
 
         /// <summary>
-        /// The number of sockets used by this logical connection (total, including reconnects)
+        /// The number of sockets used by this logical connection (total, including reconnects).
         /// </summary>
         public long SocketCount { get; internal set; }
 
         /// <summary>
-        /// The number of subscriptions (with and without patterns) currently held against this connection
+        /// The number of subscriptions (with and without patterns) currently held against this connection.
         /// </summary>
         public long Subscriptions { get;internal set; }
 
         /// <summary>
-        /// Indicates the total number of outstanding items against this connection
+        /// Indicates the total number of outstanding items against this connection.
         /// </summary>
         public int TotalOutstanding => PendingUnsentItems + SentItemsAwaitingResponse + ResponsesAwaitingAsyncCompletion;
 
         /// <summary>
-        /// Indicates the total number of writers items against this connection
+        /// Indicates the total number of writers items against this connection.
         /// </summary>
         public int WriterCount { get; internal set; }
 
         /// <summary>
-        /// See Object.ToString()
+        /// See <see cref="object.ToString"/>.
         /// </summary>
         public override string ToString()
         {
@@ -109,20 +109,18 @@ namespace StackExchange.Redis
             WriterCount += other.WriterCount;
         }
 
-        internal bool Any()
-        {
-            return CompletedAsynchronously != 0
-                || CompletedSynchronously != 0
-                || FailedAsynchronously != 0
-                || NonPreferredEndpointCount != 0
-                || OperationCount != 0
-                || PendingUnsentItems != 0
-                || ResponsesAwaitingAsyncCompletion != 0
-                || SentItemsAwaitingResponse != 0
-                || SocketCount != 0
-                || Subscriptions != 0
-                || WriterCount != 0;
-        }
+        internal bool Any() =>
+            CompletedAsynchronously != 0
+            || CompletedSynchronously != 0
+            || FailedAsynchronously != 0
+            || NonPreferredEndpointCount != 0
+            || OperationCount != 0
+            || PendingUnsentItems != 0
+            || ResponsesAwaitingAsyncCompletion != 0
+            || SentItemsAwaitingResponse != 0
+            || SocketCount != 0
+            || Subscriptions != 0
+            || WriterCount != 0;
 
         internal void Append(StringBuilder sb)
         {

--- a/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
+++ b/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
@@ -29,7 +29,7 @@ namespace StackExchange.Redis
         /// <param name="endPoint">Redis endpoint.</param>
         /// <param name="connectionType">Redis connection type.</param>
         /// <param name="failureType">Redis connection failure type.</param>
-        /// <param name="exception">The exception occured.</param>
+        /// <param name="exception">The exception occurred.</param>
         /// <param name="physicalName">Connection physical name.</param>
         public ConnectionFailedEventArgs(object sender, EndPoint endPoint, ConnectionType connectionType, ConnectionFailureType failureType, Exception exception, string physicalName)
             : this (null, sender, endPoint, connectionType, failureType, exception, physicalName)
@@ -58,12 +58,8 @@ namespace StackExchange.Redis
         /// </summary>
         public ConnectionFailureType FailureType { get; }
 
-        void ICompletable.AppendStormLog(StringBuilder sb)
-        {
-            sb.Append("event, connection-failed: ");
-            if (EndPoint == null) sb.Append("n/a");
-            else sb.Append(Format.ToString(EndPoint));
-        }
+        void ICompletable.AppendStormLog(StringBuilder sb) =>
+            sb.Append("event, connection-failed: ").Append(EndPoint != null ? Format.ToString(EndPoint) : "n/a");
 
         bool ICompletable.TryComplete(bool isAsync) => ConnectionMultiplexer.TryCompleteHandler(handler, sender, this, isAsync);
 

--- a/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
+++ b/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Contains information about a server connection failure
+    /// Contains information about a server connection failure.
     /// </summary>
     public class ConnectionFailedEventArgs : EventArgs, ICompletable
     {
@@ -39,22 +39,22 @@ namespace StackExchange.Redis
         private readonly string _physicalName;
 
         /// <summary>
-        /// Gets the connection-type of the failing connection
+        /// Gets the connection-type of the failing connection.
         /// </summary>
         public ConnectionType ConnectionType { get; }
 
         /// <summary>
-        /// Gets the failing server-endpoint
+        /// Gets the failing server-endpoint.
         /// </summary>
         public EndPoint EndPoint { get; }
 
         /// <summary>
-        /// Gets the exception if available (this can be null)
+        /// Gets the exception if available (this can be null).
         /// </summary>
         public Exception Exception { get; }
 
         /// <summary>
-        /// The type of failure
+        /// The type of failure.
         /// </summary>
         public ConnectionFailureType FailureType { get; }
 

--- a/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
+++ b/src/StackExchange.Redis/ConnectionFailedEventArgs.cs
@@ -29,7 +29,7 @@ namespace StackExchange.Redis
         /// <param name="endPoint">Redis endpoint.</param>
         /// <param name="connectionType">Redis connection type.</param>
         /// <param name="failureType">Redis connection failure type.</param>
-        /// <param name="exception">The exception occurred.</param>
+        /// <param name="exception">The exception that occurred.</param>
         /// <param name="physicalName">Connection physical name.</param>
         public ConnectionFailedEventArgs(object sender, EndPoint endPoint, ConnectionType connectionType, ConnectionFailureType failureType, Exception exception, string physicalName)
             : this (null, sender, endPoint, connectionType, failureType, exception, physicalName)

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -951,7 +951,7 @@ namespace StackExchange.Redis
             return config;
         }
 
-        internal class LogProxy : IDisposable
+        internal sealed class LogProxy : IDisposable
         {
             public static LogProxy TryCreate(TextWriter writer)
                 => writer == null ? null : new LogProxy(writer);
@@ -2450,6 +2450,7 @@ namespace StackExchange.Redis
             return connection;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1075:Avoid empty catch clause that catches System.Exception.", Justification = "We don't care.")]
         internal void OnManagedConnectionRestored(object sender, ConnectionFailedEventArgs e)
         {
             ConnectionMultiplexer connection = (ConnectionMultiplexer)sender;
@@ -2490,6 +2491,7 @@ namespace StackExchange.Redis
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1075:Avoid empty catch clause that catches System.Exception.", Justification = "We don't care.")]
         internal void OnManagedConnectionFailed(object sender, ConnectionFailedEventArgs e)
         {
             ConnectionMultiplexer connection = (ConnectionMultiplexer)sender;

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -20,8 +20,10 @@ using StackExchange.Redis.Profiling;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents an inter-related group of connections to redis servers
+    /// Represents an inter-related group of connections to redis servers.
+    /// A reference to this should be held and re-used.
     /// </summary>
+    /// <remarks>https://stackexchange.github.io/StackExchange.Redis/PipelinesMultiplexers</remarks>
     public sealed partial class ConnectionMultiplexer : IInternalConnectionMultiplexer // implies : IConnectionMultiplexer and : IDisposable
     {
         [Flags]
@@ -34,7 +36,8 @@ namespace StackExchange.Redis
         private static FeatureFlags s_featureFlags;
 
         /// <summary>
-        /// Enables or disables a feature flag; this should only be used under support guidance, and should not be rapidly toggled
+        /// Enables or disables a feature flag.
+        /// This should only be used under support guidance, and should not be rapidly toggled.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Browsable(false)]
@@ -60,7 +63,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Returns the state of a feature flag; this should only be used under support guidance
+        /// Returns the state of a feature flag.
+        /// This should only be used under support guidance.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Browsable(false)]
@@ -76,7 +80,7 @@ namespace StackExchange.Redis
         private static int _collectedWithoutDispose;
         internal static int CollectedWithoutDispose => Thread.VolatileRead(ref _collectedWithoutDispose);
         /// <summary>
-        /// Invoked by the garbage collector
+        /// Invoked by the garbage collector.
         /// </summary>
         ~ConnectionMultiplexer()
         {
@@ -97,24 +101,26 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// For debugging: when not enabled, servers cannot connect
+        /// For debugging: when not enabled, servers cannot connect.
         /// </summary>
         internal volatile bool AllowConnect = true;
 
         /// <summary>
-        /// For debugging: when not enabled, end-connect is silently ignored (to simulate a long-running connect)
+        /// For debugging: when not enabled, end-connect is silently ignored (to simulate a long-running connect).
         /// </summary>
         internal volatile bool IgnoreConnect;
 
         /// <summary>
-        /// Tracks overall connection multiplexer counts
+        /// Tracks overall connection multiplexer counts.
         /// </summary>
         internal int _connectAttemptCount = 0, _connectCompletedCount = 0, _connectionCloseCount = 0;
 
         /// <summary>
-        /// Provides a way of overriding the default Task Factory. If not set, it will use the default Task.Factory.
+        /// Provides a way of overriding the default Task Factory.
+        /// If not set, it will use the default <see cref="Task.Factory"/>.
         /// Useful when top level code sets it's own factory which may interfere with Redis queries.
         /// </summary>
+        [Obsolete("No longer used, will be removed in 3.0.")]
         public static TaskFactory Factory
         {
             get => _factory ?? Task.Factory;
@@ -122,7 +128,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Get summary statistics associates with this server
+        /// Get summary statistics associated with all servers in this multiplexer.
         /// </summary>
         public ServerCounters GetCounters()
         {
@@ -137,7 +143,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Gets the client-name that will be used on all new connections
+        /// Gets the client-name that will be used on all new connections.
         /// </summary>
         public string ClientName => RawConfig.ClientName ?? GetDefaultClientName();
 
@@ -153,7 +159,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Tries to get the RoleInstance Id if Microsoft.WindowsAzure.ServiceRuntime is loaded.
-        /// In case of any failure, swallows the exception and returns null
+        /// In case of any failure, swallows the exception and returns null.
         /// </summary>
         internal static string TryGetAzureRoleInstanceIdNoThrow()
         {
@@ -197,7 +203,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Gets the configuration of the connection
+        /// Gets the configuration of the connection.
         /// </summary>
         public string Configuration => RawConfig.ToString();
 
@@ -207,8 +213,7 @@ namespace StackExchange.Redis
             var handler = ConnectionFailed;
             if (handler != null)
             {
-                ConnectionMultiplexer.CompleteAsWorker(
-                    new ConnectionFailedEventArgs(handler, this, endpoint, connectionType, failureType, exception, physicalName));
+                CompleteAsWorker(new ConnectionFailedEventArgs(handler, this, endpoint, connectionType, failureType, exception, physicalName));
             }
             if (reconfigure)
             {
@@ -225,12 +230,12 @@ namespace StackExchange.Redis
                 var handler = InternalError;
                 if (handler != null)
                 {
-                    ConnectionMultiplexer.CompleteAsWorker(
-                        new InternalErrorEventArgs(handler, this, endpoint, connectionType, exception, origin));
+                    CompleteAsWorker(new InternalErrorEventArgs(handler, this, endpoint, connectionType, exception, origin));
                 }
             }
             catch
-            { // our internal error event failed; whatcha gonna do, exactly?
+            {
+                // our internal error event failed...whatcha gonna do, exactly?
             }
         }
 
@@ -240,8 +245,7 @@ namespace StackExchange.Redis
             var handler = ConnectionRestored;
             if (handler != null)
             {
-                ConnectionMultiplexer.CompleteAsWorker(
-                    new ConnectionFailedEventArgs(handler, this, endpoint, connectionType, ConnectionFailureType.None, null, physicalName));
+                CompleteAsWorker(new ConnectionFailedEventArgs(handler, this, endpoint, connectionType, ConnectionFailureType.None, null, physicalName));
             }
             ReconfigureIfNeeded(endpoint, false, "connection restored");
         }
@@ -251,7 +255,7 @@ namespace StackExchange.Redis
             if (_isDisposed) return;
             if (handler != null)
             {
-                ConnectionMultiplexer.CompleteAsWorker(new EndPointEventArgs(handler, this, endpoint));
+                CompleteAsWorker(new EndPointEventArgs(handler, this, endpoint));
             }
         }
 
@@ -259,7 +263,7 @@ namespace StackExchange.Redis
         internal void OnConfigurationChangedBroadcast(EndPoint endpoint) => OnEndpointChanged(endpoint, ConfigurationChangedBroadcast);
 
         /// <summary>
-        /// A server replied with an error message;
+        /// Raised when a server replied with an error message.
         /// </summary>
         public event EventHandler<RedisErrorEventArgs> ErrorMessage;
         internal void OnErrorMessage(EndPoint endpoint, string message)
@@ -268,9 +272,7 @@ namespace StackExchange.Redis
             var handler = ErrorMessage;
             if (handler != null)
             {
-                ConnectionMultiplexer.CompleteAsWorker(
-                    new RedisErrorEventArgs(handler, this, endpoint, message)
-                );
+                CompleteAsWorker(new RedisErrorEventArgs(handler, this, endpoint, message));
             }
         }
 
@@ -298,7 +300,7 @@ namespace StackExchange.Redis
             }
         }
         /// <summary>
-        /// Write the configuration of all servers to an output stream
+        /// Write the configuration of all servers to an output stream.
         /// </summary>
         /// <param name="destination">The destination stream to write the export to.</param>
         /// <param name="options">The options to use for this export.</param>
@@ -306,7 +308,7 @@ namespace StackExchange.Redis
         {
             if (destination == null) throw new ArgumentNullException(nameof(destination));
 
-            // what is possible, given the command map?
+            // What is possible, given the command map?
             ExportOptions mask = 0;
             if (CommandMap.IsAvailable(RedisCommand.INFO)) mask |= ExportOptions.Info;
             if (CommandMap.IsAvailable(RedisCommand.CONFIG)) mask |= ExportOptions.Config;
@@ -458,7 +460,8 @@ namespace StackExchange.Redis
 
             // There's an inherent race here in zero-latency environments (e.g. when Redis is on localhost) when a broadcast is specified
             // The broadcast can get back from redis and trigger a reconfigure before we get a chance to get to ReconfigureAsync() below
-            // This results in running an outdated reconfig and the .CompareExchange() (due to already running a reconfig) failing...making our needed reconfig a no-op.
+            // This results in running an outdated reconfiguration and the .CompareExchange() (due to already running a reconfiguration)
+            // failing...making our needed reconfiguration a no-op.
             // If we don't block *that* run, then *our* run (at low latency) gets blocked. Then we're waiting on the
             // ConfigurationOptions.ConfigCheckSeconds interval to identify the current (created by this method call) topology correctly.
             var blockingReconfig = Interlocked.CompareExchange(ref activeConfigCause, "Block: Pending Master Reconfig", null) == null;
@@ -523,7 +526,7 @@ namespace StackExchange.Redis
                 throw ExceptionFactory.AdminModeNotEnabled(IncludeDetailInExceptions, message.Command, message, null);
             if (message.Command != RedisCommand.UNKNOWN) CommandMap.AssertAvailable(message.Command);
 
-            // using >= here because we will be adding 1 for the command itself (which is an arg for the purposes of the multi-bulk protocol)
+            // using >= here because we will be adding 1 for the command itself (which is an argument for the purposes of the multi-bulk protocol)
             if (message.ArgCount >= PhysicalConnection.REDIS_MAX_ARGS) throw ExceptionFactory.TooManyArgs(message.CommandAndKey, message.ArgCount);
         }
         private const string NoContent = "(no content)";
@@ -545,28 +548,28 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Raised whenever a physical connection fails
+        /// Raised whenever a physical connection fails.
         /// </summary>
         public event EventHandler<ConnectionFailedEventArgs> ConnectionFailed;
 
         /// <summary>
-        /// Raised whenever an internal error occurs (this is primarily for debugging)
+        /// Raised whenever an internal error occurs (this is primarily for debugging).
         /// </summary>
         public event EventHandler<InternalErrorEventArgs> InternalError;
 
         /// <summary>
-        /// Raised whenever a physical connection is established
+        /// Raised whenever a physical connection is established.
         /// </summary>
         public event EventHandler<ConnectionFailedEventArgs> ConnectionRestored;
 
         /// <summary>
-        /// Raised when configuration changes are detected
+        /// Raised when configuration changes are detected.
         /// </summary>
         public event EventHandler<EndPointEventArgs> ConfigurationChanged;
 
         /// <summary>
-        /// Raised when nodes are explicitly requested to reconfigure via broadcast;
-        /// this usually means master/replica changes
+        /// Raised when nodes are explicitly requested to reconfigure via broadcast.
+        /// This usually means primary/replica changes.
         /// </summary>
         public event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast;
 
@@ -576,16 +579,17 @@ namespace StackExchange.Redis
         public event EventHandler<ServerMaintenanceEvent> ServerMaintenanceEvent;
 
         /// <summary>
-        /// Gets the synchronous timeout associated with the connections
+        /// Gets the synchronous timeout associated with the connections.
         /// </summary>
         public int TimeoutMilliseconds { get; }
+
         /// <summary>
-        /// Gets the asynchronous timeout associated with the connections
+        /// Gets the asynchronous timeout associated with the connections.
         /// </summary>
         internal int AsyncTimeoutMilliseconds { get; }
 
         /// <summary>
-        /// Gets all endpoints defined on the server
+        /// Gets all endpoints defined on the server.
         /// </summary>
         /// <param name="configuredOnly">Whether to get only the endpoints specified explicitly in the config.</param>
         public EndPoint[] GetEndPoints(bool configuredOnly = false)
@@ -604,7 +608,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout)
+        /// Wait for a given asynchronous operation to complete (or timeout).
         /// </summary>
         /// <param name="task">The task to wait on.</param>
         public void Wait(Task task)
@@ -621,7 +625,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout)
+        /// Wait for a given asynchronous operation to complete (or timeout).
         /// </summary>
         /// <typeparam name="T">The type contains in the task to wait on.</typeparam>
         /// <param name="task">The task to wait on.</param>
@@ -646,7 +650,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Wait for the given asynchronous operations to complete (or timeout)
+        /// Wait for the given asynchronous operations to complete (or timeout).
         /// </summary>
         /// <param name="tasks">The tasks to wait on.</param>
         public void WaitAll(params Task[] tasks)
@@ -665,13 +669,12 @@ namespace StackExchange.Redis
             var watch = Stopwatch.StartNew();
             try
             {
-                // if none error, great
+                // If no error, great
                 if (Task.WaitAll(tasks, timeout)) return true;
             }
             catch
             { }
-            // if we get problems, need to give the non-failing ones time to finish
-            // to be fair and reasonable
+            // If we get problems, need to give the non-failing ones time to be fair and reasonable
             for (int i = 0; i < tasks.Length; i++)
             {
                 var task = tasks[i];
@@ -782,7 +785,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Raised when a hash-slot has been relocated
+        /// Raised when a hash-slot has been relocated.
         /// </summary>
         public event EventHandler<HashSlotMovedEventArgs> HashSlotMoved;
 
@@ -791,13 +794,12 @@ namespace StackExchange.Redis
             var handler = HashSlotMoved;
             if (handler != null)
             {
-                ConnectionMultiplexer.CompleteAsWorker(
-                  new HashSlotMovedEventArgs(handler, this, hashSlot, old, @new));
+                CompleteAsWorker(new HashSlotMovedEventArgs(handler, this, hashSlot, old, @new));
             }
         }
 
         /// <summary>
-        /// Compute the hash-slot of a specified key
+        /// Compute the hash-slot of a specified key.
         /// </summary>
         /// <param name="key">The key to get a hash slot ID for.</param>
         public int HashSlot(RedisKey key) => ServerSelectionStrategy.HashSlot(key);
@@ -845,7 +847,7 @@ namespace StackExchange.Redis
         internal bool IsDisposed => _isDisposed;
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance.
+        /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -853,7 +855,7 @@ namespace StackExchange.Redis
             ConnectAsync(ConfigurationOptions.Parse(configuration), log);
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance.
+        /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="configure">Action to further modify the parsed configuration options.</param>
@@ -862,10 +864,11 @@ namespace StackExchange.Redis
             ConnectAsync(ConfigurationOptions.Parse(configuration).Apply(configure), log);
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance.
+        /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
         /// </summary>
         /// <param name="configuration">The configuration options to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+        /// <remarks>Note: For Sentinel, do <b>not</b> specify a <see cref="ConfigurationOptions.CommandMap"/> - this is handled automatically.</remarks>
         public static Task<ConnectionMultiplexer> ConnectAsync(ConfigurationOptions configuration, TextWriter log = null)
         {
             SocketConnection.AssertDependencies();
@@ -1006,12 +1009,12 @@ namespace StackExchange.Redis
             connectHandler = null;
             if (log != null)
             {
-                // create a detachable event-handler to log detailed errors if something happens during connect/handshake
+                // Create a detachable event-handler to log detailed errors if something happens during connect/handshake
                 connectHandler = (_, a) =>
                 {
                     try
                     {
-                        lock (log.SyncLock) // keep the outer and any inner errors contiguous
+                        lock (log.SyncLock) // Keep the outer and any inner errors contiguous
                         {
                             var ex = a.Exception;
                             log?.WriteLine($"connection failed: {Format.ToString(a.EndPoint)} ({a.ConnectionType}, {a.FailureType}): {ex?.Message ?? "(unknown)"}");
@@ -1029,7 +1032,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance.
+        /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1037,7 +1040,7 @@ namespace StackExchange.Redis
             Connect(ConfigurationOptions.Parse(configuration), log);
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance.
+        /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="configure">Action to further modify the parsed configuration options.</param>
@@ -1046,10 +1049,11 @@ namespace StackExchange.Redis
             Connect(ConfigurationOptions.Parse(configuration).Apply(configure), log);
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance.
+        /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
         /// </summary>
         /// <param name="configuration">The configuration options to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+        /// <remarks>Note: For Sentinel, do <b>not</b> specify a <see cref="ConfigurationOptions.CommandMap"/> - this is handled automatically.</remarks>
         public static ConnectionMultiplexer Connect(ConfigurationOptions configuration, TextWriter log = null)
         {
             SocketConnection.AssertDependencies();
@@ -1063,7 +1067,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a Sentinel server.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1074,7 +1078,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a Sentinel server.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1085,7 +1089,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a Sentinel server.
         /// </summary>
         /// <param name="configuration">The configuration options to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1096,7 +1100,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a Sentinel server.
         /// </summary>
         /// <param name="configuration">The configuration options to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1107,8 +1111,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server, discovers the current master server
-        /// for the specified ServiceName in the config and returns a managed connection to the current master server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a sentinel server, discovers the current primary server
+        /// for the specified <see cref="ConfigurationOptions.ServiceName"/> in the config and returns a managed connection to the current primary server.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1118,8 +1122,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server, discovers the current master server
-        /// for the specified ServiceName in the config and returns a managed connection to the current master server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a sentinel server, discovers the current primary server
+        /// for the specified <see cref="ConfigurationOptions.ServiceName"/> in the config and returns a managed connection to the current primary server.
         /// </summary>
         /// <param name="configuration">The configuration options to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1128,15 +1132,15 @@ namespace StackExchange.Redis
             var sentinelConnection = SentinelConnect(configuration, log);
 
             var muxer = sentinelConnection.GetSentinelMasterConnection(configuration, log);
-            // set reference to sentinel connection so that we can dispose it
+            // Set reference to sentinel connection so that we can dispose it
             muxer.sentinelConnection = sentinelConnection;
 
             return muxer;
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server, discovers the current master server
-        /// for the specified ServiceName in the config and returns a managed connection to the current master server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a sentinel server, discovers the current primary server
+        /// for the specified <see cref="ConfigurationOptions.ServiceName"/> in the config and returns a managed connection to the current primary server.
         /// </summary>
         /// <param name="configuration">The string configuration to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1146,8 +1150,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a new ConnectionMultiplexer instance that connects to a sentinel server, discovers the current master server
-        /// for the specified ServiceName in the config and returns a managed connection to the current master server
+        /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a sentinel server, discovers the current primary server
+        /// for the specified <see cref="ConfigurationOptions.ServiceName"/> in the config and returns a managed connection to the current primary server.
         /// </summary>
         /// <param name="configuration">The configuration options to use for this multiplexer.</param>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
@@ -1156,7 +1160,7 @@ namespace StackExchange.Redis
             var sentinelConnection = await SentinelConnectAsync(configuration, log).ForAwait();
 
             var muxer = sentinelConnection.GetSentinelMasterConnection(configuration, log);
-            // set reference to sentinel connection so that we can dispose it
+            // Set reference to sentinel connection so that we can dispose it
             muxer.sentinelConnection = sentinelConnection;
 
             return muxer;
@@ -1409,7 +1413,7 @@ namespace StackExchange.Redis
         internal static long LastGlobalHeartbeatSecondsAgo => unchecked(Environment.TickCount - Thread.VolatileRead(ref lastGlobalHeartbeatTicks)) / 1000;
 
         /// <summary>
-        /// Obtain a pub/sub subscriber connection to the specified server
+        /// Obtain a pub/sub subscriber connection to the specified server.
         /// </summary>
         /// <param name="asyncState">The async state object to pass to the created <see cref="RedisSubscriber"/>.</param>
         public ISubscriber GetSubscriber(object asyncState = null)
@@ -1418,7 +1422,9 @@ namespace StackExchange.Redis
             return new RedisSubscriber(this, asyncState);
         }
 
-        // applies common db number defaults and rules
+        /// <summary>
+        /// Applies common db number defaults and rules.
+        /// </summary>
         internal int ApplyDefaultDatabase(int db)
         {
             if (db == -1)
@@ -1439,7 +1445,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Obtain an interactive connection to a database inside redis
+        /// Obtain an interactive connection to a database inside redis.
         /// </summary>
         /// <param name="db">The ID to get a database for.</param>
         /// <param name="asyncState">The async state to pass into the resulting <see cref="RedisDatabase"/>.</param>
@@ -1454,14 +1460,14 @@ namespace StackExchange.Redis
 
         // DB zero is stored separately, since 0-only is a massively common use-case
         private const int MaxCachedDatabaseInstance = 16; // 17 items - [0,16]
-        // side note: "databases 16" is the default in redis.conf; happy to store one extra to get nice alignment etc
+        // Side note: "databases 16" is the default in redis.conf; happy to store one extra to get nice alignment etc
         private IDatabase dbCacheZero;
         private IDatabase[] dbCacheLow;
         private IDatabase GetCachedDatabaseInstance(int db) // note that we already trust db here; only caller checks range
         {
-            // note we don't need to worry about *always* returning the same instance
-            // - if two threads ask for db 3 at the same time, it is OK for them to get
-            // different instances, one of which (arbitrarily) ends up cached for later use
+            // Note: we don't need to worry about *always* returning the same instance.
+            // If two threads ask for db 3 at the same time, it is OK for them to get
+            // different instances, one of which (arbitrarily) ends up cached for later use.
             if (db == 0)
             {
                 return dbCacheZero ??= new RedisDatabase(this, 0, null);
@@ -1471,7 +1477,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="host">The host to get a server for.</param>
         /// <param name="port">The port for <paramref name="host"/> to get a server for.</param>
@@ -1479,21 +1485,21 @@ namespace StackExchange.Redis
         public IServer GetServer(string host, int port, object asyncState = null) => GetServer(Format.ParseEndPoint(host, port), asyncState);
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="hostAndPort">The "host:port" string to get a server for.</param>
         /// <param name="asyncState">The async state to pass into the resulting <see cref="RedisServer"/>.</param>
         public IServer GetServer(string hostAndPort, object asyncState = null) => GetServer(Format.TryParseEndPoint(hostAndPort), asyncState);
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="host">The host to get a server for.</param>
         /// <param name="port">The port for <paramref name="host"/> to get a server for.</param>
         public IServer GetServer(IPAddress host, int port) => GetServer(new IPEndPoint(host, port));
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="endpoint">The endpoint to get a server for.</param>
         /// <param name="asyncState">The async state to pass into the resulting <see cref="RedisServer"/>.</param>
@@ -1507,7 +1513,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The number of operations that have been performed on all connections
+        /// The number of operations that have been performed on all connections.
         /// </summary>
         public long OperationCount
         {
@@ -1544,7 +1550,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Reconfigure the current connections based on the existing configuration
+        /// Reconfigure the current connections based on the existing configuration.
         /// </summary>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
         public async Task<bool> ConfigureAsync(TextWriter log = null)
@@ -1556,13 +1562,13 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Reconfigure the current connections based on the existing configuration
+        /// Reconfigure the current connections based on the existing configuration.
         /// </summary>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
         public bool Configure(TextWriter log = null)
         {
-            // note we expect ReconfigureAsync to internally allow [n] duration,
-            // so to avoid near misses, here we wait 2*[n]
+            // Note we expect ReconfigureAsync to internally allow [n] duration,
+            // so to avoid near misses, here we wait 2*[n].
             using (var logProxy = LogProxy.TryCreate(log))
             {
                 var task = ReconfigureAsync(first: false, reconfigureAll: true, logProxy, null, "configure");
@@ -1597,7 +1603,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Provides a text overview of the status of all connections
+        /// Provides a text overview of the status of all connections.
         /// </summary>
         public string GetStatus()
         {
@@ -1609,7 +1615,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Provides a text overview of the status of all connections
+        /// Provides a text overview of the status of all connections.
         /// </summary>
         /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
         public void GetStatus(TextWriter log)
@@ -1619,6 +1625,7 @@ namespace StackExchange.Redis
                 GetStatus(proxy);
             }
         }
+
         internal void GetStatus(LogProxy log)
         {
             if (log == null) return;
@@ -1640,10 +1647,12 @@ namespace StackExchange.Redis
                 server.Activate(ConnectionType.Interactive, log);
                 if (CommandMap.IsAvailable(RedisCommand.SUBSCRIBE))
                 {
-                    server.Activate(ConnectionType.Subscription, null); // no need to log the SUB stuff
+                    // Intentionally not logging the sub connection
+                    server.Activate(ConnectionType.Subscription, null);
                 }
             }
         }
+
         internal async Task<bool> ReconfigureAsync(bool first, bool reconfigureAll, LogProxy log, EndPoint blame, string cause, bool publishReconfigure = false, CommandFlags publishReconfigureFlags = CommandFlags.None)
         {
             if (_isDisposed) throw new ObjectDisposedException(ToString());
@@ -1707,12 +1716,12 @@ namespace StackExchange.Redis
                     Stopwatch watch = null;
 
                     int iterCount = first ? 2 : 1;
-                    // this is fix for https://github.com/StackExchange/StackExchange.Redis/issues/300
+                    // This is fix for https://github.com/StackExchange/StackExchange.Redis/issues/300
                     // auto discoverability of cluster nodes is made synchronous.
-                    // we try to connect to endpoints specified inside the user provided configuration
-                    // and when we encounter one such endpoint to which we are able to successfully connect,
-                    // we get the list of cluster nodes from this endpoint and try to proactively connect
-                    // to these nodes instead of relying on auto configure
+                    // We try to connect to endpoints specified inside the user provided configuration
+                    // and when we encounter an endpoint to which we are able to successfully connect,
+                    // we get the list of cluster nodes from that endpoint and try to proactively connect
+                    // to listed nodes instead of relying on auto configure.
                     for (int iter = 0; iter < iterCount; ++iter)
                     {
                         if (endpoints == null) break;
@@ -1788,7 +1797,7 @@ namespace StackExchange.Redis
                                     server.ClearUnselectable(UnselectableFlags.DidNotRespond);
                                     log?.WriteLine($"{Format.ToString(server)}: Returned with success as {server.ServerType} {(server.IsReplica ? "replica" : "primary")} (Source: {task.Result})");
 
-                                    // count the server types
+                                    // Count the server types
                                     switch (server.ServerType)
                                     {
                                         case ServerType.Twemproxy:
@@ -1805,14 +1814,14 @@ namespace StackExchange.Redis
 
                                     if (clusterCount > 0 && !encounteredConnectedClusterServer)
                                     {
-                                        // we have encountered a connected server with clustertype for the first time.
+                                        // We have encountered a connected server with a cluster type for the first time.
                                         // so we will get list of other nodes from this server using "CLUSTER NODES" command
                                         // and try to connect to these other nodes in the next iteration
                                         encounteredConnectedClusterServer = true;
                                         updatedClusterEndpointCollection = await GetEndpointsFromClusterNodes(server, log).ForAwait();
                                     }
 
-                                    // set the server UnselectableFlags and update masters list
+                                    // Set the server UnselectableFlags and update masters list
                                     switch (server.ServerType)
                                     {
                                         case ServerType.Twemproxy:
@@ -1853,13 +1862,13 @@ namespace StackExchange.Redis
                         }
                         else
                         {
-                            break; // we do not want to repeat the second iteration
+                            break; // We do not want to repeat the second iteration
                         }
                     }
 
                     if (clusterCount == 0)
                     {
-                        // set the serverSelectionStrategy
+                        // Set the serverSelectionStrategy
                         if (RawConfig.Proxy == Proxy.Twemproxy)
                         {
                             ServerSelectionStrategy.ServerType = ServerType.Twemproxy;
@@ -2007,7 +2016,8 @@ namespace StackExchange.Redis
         {
             Dictionary<string, int> uniques = null;
             if (useTieBreakers)
-            {   // count the votes
+            {
+                // Count the votes
                 uniques = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                 for (int i = 0; i < servers.Length; i++)
                 {
@@ -2118,14 +2128,15 @@ namespace StackExchange.Redis
         {
             if (string.IsNullOrWhiteSpace(input)) return input; // GIGO
 
-            if (!char.IsLetter(input[0])) return input; // need first char to be alpha for this to work
+            if (!char.IsLetter(input[0])) return input; // Need first char to be alpha for this to work
 
             int periodPosition = input.IndexOf('.');
-            if (periodPosition <= 0) return input; // no period or starts with a period? nothing useful to split
+            if (periodPosition <= 0) return input; // No period or starts with a period? Then nothing useful to split
 
             int colonPosition = input.IndexOf(':');
             if (colonPosition > 0)
-            { // has a port specifier
+            {
+                // Has a port specifier
                 return input.Substring(0, periodPosition) + input.Substring(colonPosition);
             }
             else
@@ -2174,7 +2185,7 @@ namespace StackExchange.Redis
                     server = ServerSelectionStrategy.Select(message, allowDisconnected: true);
                 }
             }
-            else // a server was specified; do we trust their choice, though?
+            else // A server was specified - do we trust their choice, though?
             {
                 if (message.IsMasterOnly() && server.IsReplica)
                 {
@@ -2194,7 +2205,7 @@ namespace StackExchange.Redis
                 // If we're not allowed to queue while disconnected, we'll bomb out below.
                 if (!server.IsConnected && !RawConfig.BacklogPolicy.QueueWhileDisconnected)
                 {
-                    // well, that's no use!
+                    // Well, that's no use!
                     server = null;
                 }
             }
@@ -2230,7 +2241,7 @@ namespace StackExchange.Redis
             => PrepareToPushMessageToBridge(message, processor, resultBox, ref server) ? server.TryWriteSync(message) : WriteResult.NoConnectionAvailable;
 
         /// <summary>
-        /// See Object.ToString()
+        /// Gets the client name for this multiplexer.
         /// </summary>
         public override string ToString()
         {
@@ -2239,13 +2250,13 @@ namespace StackExchange.Redis
             return s;
         }
 
-        internal readonly byte[] ConfigurationChangedChannel; // this gets accessed for every received event; let's make sure we can process it "raw"
-        internal readonly byte[] UniqueId = Guid.NewGuid().ToByteArray(); // unique identifier used when tracing
+        internal readonly byte[] ConfigurationChangedChannel; // This gets accessed for every received event; let's make sure we can process it "raw"
+        internal readonly byte[] UniqueId = Guid.NewGuid().ToByteArray(); // Unique identifier used when tracing
 
         /// <summary>
-        /// Gets or sets whether asynchronous operations should be invoked in a way that guarantees their original delivery order
+        /// Gets or sets whether asynchronous operations should be invoked in a way that guarantees their original delivery order.
         /// </summary>
-        [Obsolete("Not supported; if you require ordered pub/sub, please see " + nameof(ChannelMessageQueue), false)]
+        [Obsolete("Not supported; if you require ordered pub/sub, please see " + nameof(ChannelMessageQueue) + ", will be removed in 3.0", false)]
         public bool PreserveAsyncOrder
         {
             get => false;
@@ -2253,7 +2264,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Indicates whether any servers are connected
+        /// Indicates whether any servers are connected.
         /// </summary>
         public bool IsConnected
         {
@@ -2267,7 +2278,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Indicates whether any servers are currently trying to connect
+        /// Indicates whether any servers are currently trying to connect.
         /// </summary>
         public bool IsConnecting
         {
@@ -2290,11 +2301,9 @@ namespace StackExchange.Redis
         internal ConnectionMultiplexer sentinelConnection = null;
 
         /// <summary>
-        /// Initializes the connection as a Sentinel connection and adds
-        /// the necessary event handlers to track changes to the managed
-        /// masters.
+        /// Initializes the connection as a Sentinel connection and adds the necessary event handlers to track changes to the managed primaries.
         /// </summary>
-        /// <param name="logProxy"></param>
+        /// <param name="logProxy">The writer to log to, if any.</param>
         internal void InitializeSentinel(LogProxy logProxy)
         {
             if (ServerSelectionStrategy.ServerType != ServerType.Sentinel)
@@ -2336,8 +2345,7 @@ namespace StackExchange.Redis
             }
 
             // If we lose connection to a sentinel server,
-            // We need to reconfigure to make sure we still have
-            // a subscription to the +switch-master channel.
+            // we need to reconfigure to make sure we still have a subscription to the +switch-master channel
             ConnectionFailed += (sender, e) =>
             {
                 // Reconfigure to get subscriptions back online
@@ -2356,11 +2364,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Returns a managed connection to the master server indicated by
-        /// the ServiceName in the config.
+        /// Returns a managed connection to the primary server indicated by the <see cref="ConfigurationOptions.ServiceName"/> in the config.
         /// </summary>
-        /// <param name="config">the configuration to be used when connecting to the master</param>
-        /// <param name="log"></param>
+        /// <param name="config">The configuration to be used when connecting to the primary.</param>
+        /// <param name="log">The writer to log to, if any.</param>
         public ConnectionMultiplexer GetSentinelMasterConnection(ConfigurationOptions config, TextWriter log = null)
         {
             if (ServerSelectionStrategy.ServerType != ServerType.Sentinel)
@@ -2397,7 +2404,7 @@ namespace StackExchange.Redis
                 EndPoint[] replicaEndPoints = GetReplicasForService(config.ServiceName)
                                            ?? GetReplicasForService(config.ServiceName);
 
-                // Replace the master endpoint, if we found another one
+                // Replace the primary endpoint, if we found another one
                 // If not, assume the last state is the best we have and minimize the race
                 if (config.EndPoints.Count == 1)
                 {
@@ -2547,9 +2554,9 @@ namespace StackExchange.Redis
         /// <summary>
         /// Switches the SentinelMasterConnection over to a new master.
         /// </summary>
-        /// <param name="switchBlame">The endpoint responsible for the switch</param>
-        /// <param name="connection">The connection that should be switched over to a new master endpoint</param>
-        /// <param name="log">Log to write to, if any</param>
+        /// <param name="switchBlame">The endpoint responsible for the switch.</param>
+        /// <param name="connection">The connection that should be switched over to a new master endpoint.</param>
+        /// <param name="log">The writer to log to, if any.</param>
         internal void SwitchMaster(EndPoint switchBlame, ConnectionMultiplexer connection, TextWriter log = null)
         {
             if (log == null) log = TextWriter.Null;
@@ -2601,8 +2608,7 @@ namespace StackExchange.Redis
                                         })
                                         .FirstOrDefault(r => r != null);
 
-            // Ignore errors, as having an updated sentinel list is
-            // not essential
+            // Ignore errors, as having an updated sentinel list is not essential
             if (firstCompleteRequest == null)
                 return;
 
@@ -2621,7 +2627,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Close all connections and release all resources associated with this object
+        /// Close all connections and release all resources associated with this object.
         /// </summary>
         /// <param name="allowCommandsToComplete">Whether to allow all in-queue commands to complete first.</param>
         public void Close(bool allowCommandsToComplete = true)
@@ -2681,7 +2687,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Close all connections and release all resources associated with this object
+        /// Close all connections and release all resources associated with this object.
         /// </summary>
         /// <param name="allowCommandsToComplete">Whether to allow all in-queue commands to complete first.</param>
         public async Task CloseAsync(bool allowCommandsToComplete = true)
@@ -2702,7 +2708,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Release all resources associated with this object
+        /// Release all resources associated with this object.
         /// </summary>
         public void Dispose()
         {
@@ -2785,7 +2791,7 @@ namespace StackExchange.Redis
         {
             if (_isDisposed) throw new ObjectDisposedException(ToString());
 
-            if (message == null) // fire-and forget could involve a no-op, represented by null - for example Increment by 0
+            if (message == null) // Fire-and forget could involve a no-op, represented by null - for example Increment by 0
             {
                 return default(T);
             }
@@ -2821,10 +2827,10 @@ namespace StackExchange.Redis
                         Trace("Timeout performing " + message);
                         Interlocked.Increment(ref syncTimeouts);
                         throw ExceptionFactory.Timeout(this, null, message, server);
-                        // very important not to return "source" to the pool here
+                        // Very important not to return "source" to the pool here
                     }
                 }
-                // snapshot these so that we can recycle the box
+                // Snapshot these so that we can recycle the box
                 var val = source.GetResult(out var ex, canRecycle: true); // now that we aren't locking it...
                 if (ex != null) throw ex;
                 Trace(message + " received " + val);
@@ -2845,18 +2851,18 @@ namespace StackExchange.Redis
         internal int haveStormLog = 0;
         internal string stormLogSnapshot;
         /// <summary>
-        /// Limit at which to start recording unusual busy patterns (only one log will be retained at a time;
-        /// set to a negative value to disable this feature)
+        /// Limit at which to start recording unusual busy patterns (only one log will be retained at a time).
+        /// Set to a negative value to disable this feature.
         /// </summary>
         public int StormLogThreshold { get; set; } = 15;
 
         /// <summary>
-        /// Obtains the log of unusual busy patterns
+        /// Obtains the log of unusual busy patterns.
         /// </summary>
         public string GetStormLog() => Volatile.Read(ref stormLogSnapshot);
 
         /// <summary>
-        /// Resets the log of unusual busy patterns
+        /// Resets the log of unusual busy patterns.
         /// </summary>
         public void ResetStormLog()
         {
@@ -2869,10 +2875,10 @@ namespace StackExchange.Redis
         internal void OnAsyncTimeout() => Interlocked.Increment(ref asyncTimeouts);
 
         /// <summary>
-        /// Request all compatible clients to reconfigure or reconnect
+        /// Sends request to all compatible clients to reconfigure or reconnect.
         /// </summary>
-        /// <param name="flags">The command flags to use.</param>2
-        /// <returns>The number of instances known to have received the message (however, the actual number can be higher; returns -1 if the operation is pending)</returns>
+        /// <param name="flags">The command flags to use.</param>
+        /// <returns>The number of instances known to have received the message (however, the actual number can be higher; returns -1 if the operation is pending).</returns>
         public long PublishReconfigure(CommandFlags flags = CommandFlags.None)
         {
             byte[] channel = ConfigurationChangedChannel;
@@ -2895,10 +2901,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Request all compatible clients to reconfigure or reconnect
+        /// Sends request to all compatible clients to reconfigure or reconnect.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <returns>The number of instances known to have received the message (however, the actual number can be higher)</returns>
+        /// <returns>The number of instances known to have received the message (however, the actual number can be higher).</returns>
         public Task<long> PublishReconfigureAsync(CommandFlags flags = CommandFlags.None)
         {
             byte[] channel = ConfigurationChangedChannel;
@@ -2908,7 +2914,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Get the hash-slot associated with a given key, if applicable; this can be useful for grouping operations
+        /// Get the hash-slot associated with a given key, if applicable.
+        /// This can be useful for grouping operations.
         /// </summary>
         /// <param name="key">The <see cref="RedisKey"/> to determine the hash slot for.</param>
         public int GetHashSlot(RedisKey key) => ServerSelectionStrategy.HashSlot(key);

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1803,7 +1803,7 @@ namespace StackExchange.Redis
                                 Message msg = Message.Create(0, flags, RedisCommand.GET, tieBreakerKey);
                                 msg.SetInternalCall();
                                 msg = LoggingMessage.Create(log, msg);
-                                tieBreakers[i] = server.WriteDirectAsync(msg, ResultProcessor.String);
+                                tieBreakers[i] = server.WriteDirectAsync(msg, ResultProcessor.String, isHandshake: true);
                             }
                         }
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -152,7 +152,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Tries to get the Roleinstance Id if Microsoft.WindowsAzure.ServiceRuntime is loaded.
+        /// Tries to get the RoleInstance Id if Microsoft.WindowsAzure.ServiceRuntime is loaded.
         /// In case of any failure, swallows the exception and returns null
         /// </summary>
         internal static string TryGetAzureRoleInstanceIdNoThrow()
@@ -464,7 +464,7 @@ namespace StackExchange.Redis
             // Try and broadcast the fact a change happened to all members
             // We want everyone possible to pick it up.
             // We broadcast before *and after* the change to remote members, so that they don't go without detecting a change happened.
-            // This eliminates the race of pub/sub *then* re-slaving happening, since a method both preceeds and follows.
+            // This eliminates the race of pub/sub *then* re-slaving happening, since a method both precedes and follows.
             void Broadcast(ReadOnlySpan<ServerEndPoint> serverNodes)
             {
                 if ((options & ReplicationChangeOptions.Broadcast) != 0 && ConfigurationChangedChannel != null
@@ -1672,7 +1672,7 @@ namespace StackExchange.Redis
         internal async Task<bool> ReconfigureAsync(bool first, bool reconfigureAll, LogProxy log, EndPoint blame, string cause, bool publishReconfigure = false, CommandFlags publishReconfigureFlags = CommandFlags.None)
         {
             if (_isDisposed) throw new ObjectDisposedException(ToString());
-            bool showStats = log is object;
+            bool showStats = log is not null;
 
             bool ranThisCall = false;
             try
@@ -2242,7 +2242,7 @@ namespace StackExchange.Redis
                     }
                 }
 
-                Trace("Queueing on server: " + message);
+                Trace("Queuing on server: " + message);
                 return true;
             }
             Trace("No server or server unavailable - aborting: " + message);
@@ -2836,7 +2836,7 @@ namespace StackExchange.Redis
 
                     if (Monitor.Wait(source, TimeoutMilliseconds))
                     {
-                        Trace("Timeley response to " + message);
+                        Trace("Timely response to " + message);
                     }
                     else
                     {
@@ -2875,10 +2875,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// Obtains the log of unusual busy patterns
         /// </summary>
-        public string GetStormLog()
-        {
-            return Volatile.Read(ref stormLogSnapshot);
-        }
+        public string GetStormLog() => Volatile.Read(ref stormLogSnapshot);
+
         /// <summary>
         /// Resets the log of unusual busy patterns
         /// </summary>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -569,7 +569,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Raised when nodes are explicitly requested to reconfigure via broadcast.
-        /// This usually means primary/replica changes.
+        /// This usually means primary/replica role changes.
         /// </summary>
         public event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast;
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2363,8 +2363,10 @@ namespace StackExchange.Redis
         public ConnectionMultiplexer GetSentinelMasterConnection(ConfigurationOptions config, TextWriter log = null)
         {
             if (ServerSelectionStrategy.ServerType != ServerType.Sentinel)
+            {
                 throw new RedisConnectionException(ConnectionFailureType.UnableToConnect,
                     "Sentinel: The ConnectionMultiplexer is not a Sentinel connection. Detected as: " + ServerSelectionStrategy.ServerType);
+            }
 
             if (string.IsNullOrEmpty(config.ServiceName))
                 throw new ArgumentException("A ServiceName must be specified.");

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -235,7 +235,7 @@ namespace StackExchange.Redis
             }
             catch
             {
-                // our internal error event failed...whatcha gonna do, exactly?
+                // Our internal error event failed...whatcha gonna do, exactly?
             }
         }
 
@@ -589,7 +589,7 @@ namespace StackExchange.Redis
         internal int AsyncTimeoutMilliseconds { get; }
 
         /// <summary>
-        /// Gets all endpoints defined on the server.
+        /// Gets all endpoints defined on the multiplexer.
         /// </summary>
         /// <param name="configuredOnly">Whether to get only the endpoints specified explicitly in the config.</param>
         public EndPoint[] GetEndPoints(bool configuredOnly = false)
@@ -1423,7 +1423,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Applies common db number defaults and rules.
+        /// Applies common DB number defaults and rules.
         /// </summary>
         internal int ApplyDefaultDatabase(int db)
         {

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2792,7 +2792,7 @@ namespace StackExchange.Redis
 
             if (message.IsFireAndForget)
             {
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                 TryPushMessageToBridgeSync(message, processor, null, ref server);
 #pragma warning restore CS0618
                 Interlocked.Increment(ref fireAndForgets);
@@ -2804,7 +2804,7 @@ namespace StackExchange.Redis
 
                 lock (source)
                 {
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                     var result = TryPushMessageToBridgeSync(message, processor, source, ref server);
 #pragma warning restore CS0618
                     if (result != WriteResult.Success)

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1432,7 +1432,7 @@ namespace StackExchange.Redis
 
             if (db != 0 && RawConfig.Proxy == Proxy.Twemproxy)
             {
-                throw new NotSupportedException("Twemproxy only supports database 0");
+                throw new NotSupportedException("twemproxy only supports database 0");
             }
 
             return db;

--- a/src/StackExchange.Redis/CursorEnumerable.cs
+++ b/src/StackExchange.Redis/CursorEnumerable.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Provides the ability to iterate over a cursor-based sequence of redis data, synchronously or asynchronously
+    /// Provides the ability to iterate over a cursor-based sequence of redis data, synchronously or asynchronously.
     /// </summary>
     internal abstract class CursorEnumerable<T> : IEnumerable<T>, IScanningCursor, IAsyncEnumerable<T>
     {
@@ -35,11 +35,12 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Gets an enumerator for the sequence
+        /// Gets an enumerator for the sequence.
         /// </summary>
         public Enumerator GetEnumerator() => new Enumerator(this, default);
+
         /// <summary>
-        /// Gets an enumerator for the sequence
+        /// Gets an enumerator for the sequence.
         /// </summary>
         public Enumerator GetAsyncEnumerator(CancellationToken cancellationToken) => new Enumerator(this, cancellationToken);
 
@@ -74,7 +75,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Provides the ability to iterate over a cursor-based sequence of redis data, synchronously or asynchronously
+        /// Provides the ability to iterate over a cursor-based sequence of redis data, synchronously or asynchronously.
         /// </summary>
         public class Enumerator : IEnumerator<T>, IScanningCursor, IAsyncEnumerator<T>
         {
@@ -88,7 +89,7 @@ namespace StackExchange.Redis
             }
 
             /// <summary>
-            /// Gets the current value of the enumerator
+            /// Gets the current value of the enumerator.
             /// </summary>
             public T Current {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -100,7 +101,7 @@ namespace StackExchange.Redis
             }
 
             /// <summary>
-            /// Release all resources associated with this enumerator
+            /// Release all resources associated with this enumerator.
             /// </summary>
             public void Dispose()
             {
@@ -122,7 +123,7 @@ namespace StackExchange.Redis
             }
 
             /// <summary>
-            /// Release all resources associated with this enumerator
+            /// Release all resources associated with this enumerator.
             /// </summary>
             public ValueTask DisposeAsync()
             {
@@ -181,7 +182,7 @@ namespace StackExchange.Redis
             }
 
             /// <summary>
-            /// Try to move to the next item in the sequence
+            /// Try to move to the next item in the sequence.
             /// </summary>
             public bool MoveNext() => SimpleNext() || SlowNextSync();
 
@@ -199,7 +200,7 @@ namespace StackExchange.Redis
             }
 
             /// <summary>
-            /// Try to move to the next item in the sequence
+            /// Try to move to the next item in the sequence.
             /// </summary>
             public ValueTask<bool> MoveNextAsync()
             {
@@ -297,7 +298,7 @@ namespace StackExchange.Redis
             }
 
             /// <summary>
-            /// Reset the enumerator
+            /// Reset the enumerator.
             /// </summary>
             public void Reset()
             {
@@ -323,8 +324,11 @@ namespace StackExchange.Redis
             int IScanningCursor.PageOffset => _pageOffset;
         }
 
+        /// <summary>
+        /// The cursor position.
+        /// </summary>
         /// <remarks>
-        /// This may fail on cluster-proxy; I'm OK with this for now
+        /// This may fail on cluster-proxy - I'm OK with this for now.
         /// </remarks>
         long IScanningCursor.Cursor => activeCursor?.Cursor ?? (long)initialCursor;
 

--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -7,7 +7,7 @@ using System.Net;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// A list of endpoints
+    /// A list of endpoints.
     /// </summary>
     public sealed class EndPointCollection : Collection<EndPoint>, IEnumerable<EndPoint>
     {
@@ -103,6 +103,7 @@ namespace StackExchange.Redis
 
             base.InsertItem(index, item);
         }
+
         /// <summary>
         /// See <see cref="Collection{T}.SetItem(int, T)"/>.
         /// </summary>

--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -12,30 +12,30 @@ namespace StackExchange.Redis
     public sealed class EndPointCollection : Collection<EndPoint>, IEnumerable<EndPoint>
     {
         /// <summary>
-        /// Create a new EndPointCollection
+        /// Create a new <see cref="EndPointCollection"/>.
         /// </summary>
         public EndPointCollection() {}
 
         /// <summary>
-        /// Create a new EndPointCollection
+        /// Create a new <see cref="EndPointCollection"/>.
         /// </summary>
         /// <param name="endpoints">The endpoints to add to the collection.</param>
         public EndPointCollection(IList<EndPoint> endpoints) : base(endpoints) {}
 
         /// <summary>
-        /// Format an endpoint
+        /// Format an <see cref="EndPoint"/>.
         /// </summary>
         /// <param name="endpoint">The endpoint to get a string representation for.</param>
         public static string ToString(EndPoint endpoint) => Format.ToString(endpoint);
 
         /// <summary>
-        /// Attempt to parse a string into an EndPoint
+        /// Attempt to parse a string into an <see cref="EndPoint"/>.
         /// </summary>
         /// <param name="endpoint">The endpoint string to parse.</param>
         public static EndPoint TryParse(string endpoint) => Format.TryParseEndPoint(endpoint);
 
         /// <summary>
-        /// Adds a new endpoint to the list
+        /// Adds a new endpoint to the list.
         /// </summary>
         /// <param name="hostAndPort">The host:port string to add an endpoint for to the collection.</param>
         public void Add(string hostAndPort)
@@ -66,7 +66,7 @@ namespace StackExchange.Redis
         /// Try adding a new endpoint to the list.
         /// </summary>
         /// <param name="endpoint">The endpoint to add.</param>
-        /// <returns>True if the endpoint was added or false if not.</returns>
+        /// <returns><see langword="true"/> if the endpoint was added, <see langword="false"/> if not.</returns>
         public bool TryAdd(EndPoint endpoint)
         {
             if (endpoint == null)
@@ -86,7 +86,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See Collection&lt;T&gt;.InsertItem()
+        /// See <see cref="Collection{T}.InsertItem(int, T)"/>.
         /// </summary>
         /// <param name="index">The index to add <paramref name="item"/> into the collection at.</param>
         /// <param name="item">The item to insert at <paramref name="index"/>.</param>
@@ -104,7 +104,7 @@ namespace StackExchange.Redis
             base.InsertItem(index, item);
         }
         /// <summary>
-        /// See Collection&lt;T&gt;.SetItem()
+        /// See <see cref="Collection{T}.SetItem(int, T)"/>.
         /// </summary>
         /// <param name="index">The index to replace an endpoint at.</param>
         /// <param name="item">The item to replace the existing endpoint at <paramref name="index"/>.</param>

--- a/src/StackExchange.Redis/EndPointEventArgs.cs
+++ b/src/StackExchange.Redis/EndPointEventArgs.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Event information related to redis endpoints
+    /// Event information related to redis endpoints.
     /// </summary>
     public class EndPointEventArgs : EventArgs, ICompletable
     {
@@ -29,7 +29,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// The endpoint involved in this event (this can be null)
+        /// The endpoint involved in this event (this can be null).
         /// </summary>
         public EndPoint EndPoint { get; }
 

--- a/src/StackExchange.Redis/EndPointEventArgs.cs
+++ b/src/StackExchange.Redis/EndPointEventArgs.cs
@@ -33,12 +33,8 @@ namespace StackExchange.Redis
         /// </summary>
         public EndPoint EndPoint { get; }
 
-        void ICompletable.AppendStormLog(StringBuilder sb)
-        {
-            sb.Append("event, endpoint: ");
-            if (EndPoint == null) sb.Append("n/a");
-            else sb.Append(Format.ToString(EndPoint));
-        }
+        void ICompletable.AppendStormLog(StringBuilder sb) =>
+            sb.Append("event, endpoint: ").Append(EndPoint != null ? Format.ToString(EndPoint) : "n/a");
 
         bool ICompletable.TryComplete(bool isAsync) => ConnectionMultiplexer.TryCompleteHandler(handler, sender, this, isAsync);
     }

--- a/src/StackExchange.Redis/Enums/Aggregate.cs
+++ b/src/StackExchange.Redis/Enums/Aggregate.cs
@@ -1,20 +1,20 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Specifies how elements should be aggregated when combining sorted sets
+    /// Specifies how elements should be aggregated when combining sorted sets.
     /// </summary>
     public enum Aggregate
     {
         /// <summary>
-        /// The values of the combined elements are added
+        /// The values of the combined elements are added.
         /// </summary>
         Sum,
         /// <summary>
-        /// The least value of the combined elements is used
+        /// The least value of the combined elements is used.
         /// </summary>
         Min,
         /// <summary>
-        /// The greatest value of the combined elements is used
+        /// The greatest value of the combined elements is used.
         /// </summary>
         Max
     }

--- a/src/StackExchange.Redis/Enums/Bitwise.cs
+++ b/src/StackExchange.Redis/Enums/Bitwise.cs
@@ -20,6 +20,6 @@
         /// <summary>
         /// <a href="https://en.wikipedia.org/wiki/Bitwise_operation#NOT">Not</a>
         /// </summary>
-        Not
+        Not,
     }
 }

--- a/src/StackExchange.Redis/Enums/ClientFlags.cs
+++ b/src/StackExchange.Redis/Enums/ClientFlags.cs
@@ -88,7 +88,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The client is a replica in MONITOR mode.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaMonitor) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaMonitor) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         SlaveMonitor = 1,
         /// <summary>
@@ -98,7 +98,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The client is a normal replica server.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(Replica) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(Replica) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Slave = 2,
         /// <summary>

--- a/src/StackExchange.Redis/Enums/ClientFlags.cs
+++ b/src/StackExchange.Redis/Enums/ClientFlags.cs
@@ -5,96 +5,131 @@ namespace StackExchange.Redis
 {
     /// <summary>
     /// The client flags can be a combination of:
-    /// O: the client is a replica in MONITOR mode
-    /// S: the client is a normal replica server
-    /// M: the client is a master
-    /// x: the client is in a MULTI/EXEC context
-    /// b: the client is waiting in a blocking operation
-    /// i: the client is waiting for a VM I/O (deprecated)
-    /// d: a watched keys has been modified - EXEC will fail
-    /// c: connection to be closed after writing entire reply
-    /// u: the client is unblocked
-    /// A: connection to be closed ASAP
-    /// N: no specific flag set
+    /// <list type="table">
+    ///     <item>
+    ///         <term>O</term>
+    ///         <description>The client is a replica in MONITOR mode.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>S</term>
+    ///         <description>The client is a normal replica server.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>M</term>
+    ///         <description>The client is a primary.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>x</term>
+    ///         <description>The client is in a MULTI/EXEC context.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>b</term>
+    ///         <description>The client is waiting in a blocking operation.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>i</term>
+    ///         <description>The client is waiting for a VM I/O (deprecated).</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>d</term>
+    ///         <description>A watched keys has been modified - EXEC will fail.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>c</term>
+    ///         <description>Connection to be closed after writing entire reply.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>u</term>
+    ///         <description>The client is unblocked.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>A</term>
+    ///         <description>Connection to be closed ASAP.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>N</term>
+    ///         <description>No specific flag set.</description>
+    ///     </item>
+    /// </list>
     /// </summary>
     [Flags]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ClientFlags : long
     {
         /// <summary>
-        /// no specific flag set
+        /// No specific flag set.
         /// </summary>
         None = 0,
         /// <summary>
-        /// the client is a replica in MONITOR mode
+        /// The client is a replica in MONITOR mode.
         /// </summary>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaMonitor) + " instead.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         SlaveMonitor = 1,
         /// <summary>
-        /// the client is a replica in MONITOR mode
+        /// The client is a replica in MONITOR mode.
         /// </summary>
         ReplicaMonitor = 1, // as an implementation detail, note that enum.ToString on [Flags] prefers *later* options when naming Flags
         /// <summary>
-        /// the client is a normal replica server
+        /// The client is a normal replica server.
         /// </summary>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(Replica) + " instead.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Slave = 2,
         /// <summary>
-        /// the client is a normal replica server
+        /// The client is a normal replica server.
         /// </summary>
         Replica = 2, // as an implementation detail, note that enum.ToString on [Flags] prefers *later* options when naming Flags
         /// <summary>
-        /// the client is a master
+        /// The client is a master.
         /// </summary>
         Master = 4,
         /// <summary>
-        /// the client is in a MULTI/EXEC context
+        /// The client is in a MULTI/EXEC context.
         /// </summary>
         Transaction = 8,
         /// <summary>
-        /// the client is waiting in a blocking operation
+        /// The client is waiting in a blocking operation.
         /// </summary>
         Blocked = 16,
         /// <summary>
-        /// a watched keys has been modified - EXEC will fail
+        /// A watched keys has been modified - EXEC will fail.
         /// </summary>
         TransactionDoomed = 32,
         /// <summary>
-        /// connection to be closed after writing entire reply
+        /// Connection to be closed after writing entire reply.
         /// </summary>
         Closing = 64,
         /// <summary>
-        /// the client is unblocked
+        /// The client is unblocked.
         /// </summary>
         Unblocked = 128,
         /// <summary>
-        /// connection to be closed ASAP
+        /// Connection to be closed ASAP.
         /// </summary>
         CloseASAP = 256,
         /// <summary>
-        /// the client is a Pub/Sub subscriber
+        /// The client is a Pub/Sub subscriber.
         /// </summary>
         PubSubSubscriber = 512,
         /// <summary>
-        /// the client is in readonly mode against a cluster node
+        /// The client is in readonly mode against a cluster node.
         /// </summary>
         ReadOnlyCluster = 1024,
         /// <summary>
-        /// the client is connected via a Unix domain socket
+        /// The client is connected via a Unix domain socket.
         /// </summary>
         UnixDomainSocket = 2048,
         /// <summary>
-        /// the client enabled keys tracking in order to perform client side caching
+        /// The client enabled keys tracking in order to perform client side caching.
         /// </summary>
         KeysTracking = 4096,
         /// <summary>
-        /// the client tracking target client is invalid
+        /// The client tracking target client is invalid.
         /// </summary>
         TrackingTargetInvalid = 8192,
         /// <summary>
-        /// the client enabled broadcast tracking mode
+        /// The client enabled broadcast tracking mode.
         /// </summary>
         BroadcastTracking = 16384,
     }

--- a/src/StackExchange.Redis/Enums/ClientFlags.cs
+++ b/src/StackExchange.Redis/Enums/ClientFlags.cs
@@ -7,51 +7,76 @@ namespace StackExchange.Redis
     /// The client flags can be a combination of:
     /// <list type="table">
     ///     <item>
-    ///         <term>O</term>
-    ///         <description>The client is a replica in MONITOR mode.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>S</term>
-    ///         <description>The client is a normal replica server.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>M</term>
-    ///         <description>The client is a primary.</description>
-    ///     </item>
-    ///     <item>
-    ///         <term>x</term>
-    ///         <description>The client is in a MULTI/EXEC context.</description>
+    ///         <term>A</term>
+    ///         <description>Connection to be closed ASAP.</description>
     ///     </item>
     ///     <item>
     ///         <term>b</term>
     ///         <description>The client is waiting in a blocking operation.</description>
     ///     </item>
     ///     <item>
-    ///         <term>i</term>
-    ///         <description>The client is waiting for a VM I/O (deprecated).</description>
+    ///         <term>c</term>
+    ///         <description>Connection to be closed after writing entire reply.</description>
     ///     </item>
     ///     <item>
     ///         <term>d</term>
     ///         <description>A watched keys has been modified - EXEC will fail.</description>
     ///     </item>
     ///     <item>
-    ///         <term>c</term>
-    ///         <description>Connection to be closed after writing entire reply.</description>
+    ///         <term>i</term>
+    ///         <description>The client is waiting for a VM I/O (deprecated).</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>M</term>
+    ///         <description>The client is a primary.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>N</term>
+    ///         <description>No specific flag set.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>O</term>
+    ///         <description>The client is a replica in MONITOR mode.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>P</term>
+    ///         <description>The client is a Pub/Sub subscriber.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>r</term>
+    ///         <description>The client is in readonly mode against a cluster node.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>S</term>
+    ///         <description>The client is a normal replica server.</description>
     ///     </item>
     ///     <item>
     ///         <term>u</term>
     ///         <description>The client is unblocked.</description>
     ///     </item>
     ///     <item>
-    ///         <term>A</term>
-    ///         <description>Connection to be closed ASAP.</description>
+    ///         <term>U</term>
+    ///         <description>The client is unblocked.</description>
     ///     </item>
     ///     <item>
-    ///         <term>N</term>
-    ///         <description>No specific flag set.</description>
+    ///         <term>x</term>
+    ///         <description>The client is in a MULTI/EXEC context.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>t</term>
+    ///         <description>The client enabled keys tracking in order to perform client side caching.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>R</term>
+    ///         <description>The client tracking target client is invalid.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>B</term>
+    ///         <description>The client enabled broadcast tracking mode.</description>
     ///     </item>
     /// </list>
     /// </summary>
+    /// <remarks>https://redis.io/commands/client-list</remarks>
     [Flags]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ClientFlags : long

--- a/src/StackExchange.Redis/Enums/ClientFlags.cs
+++ b/src/StackExchange.Redis/Enums/ClientFlags.cs
@@ -85,5 +85,17 @@ namespace StackExchange.Redis
         /// the client is connected via a Unix domain socket
         /// </summary>
         UnixDomainSocket = 2048,
+        /// <summary>
+        /// the client enabled keys tracking in order to perform client side caching
+        /// </summary>
+        KeysTracking = 4096,
+        /// <summary>
+        /// the client tracking target client is invalid
+        /// </summary>
+        TrackingTargetInvalid = 8192,
+        /// <summary>
+        /// the client enabled broadcast tracking mode
+        /// </summary>
+        BroadcastTracking = 16384,
     }
 }

--- a/src/StackExchange.Redis/Enums/ClientType.cs
+++ b/src/StackExchange.Redis/Enums/ClientType.cs
@@ -20,7 +20,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Replication connections
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(Replica) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(Replica) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Slave = 1,
         /// <summary>

--- a/src/StackExchange.Redis/Enums/ClientType.cs
+++ b/src/StackExchange.Redis/Enums/ClientType.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Replication connections
         /// </summary>
-        Replica = 1, // / as an implementation detail, note that enum.ToString without [Flags] preferes *earlier* values
+        Replica = 1, // / as an implementation detail, note that enum.ToString without [Flags] prefers *earlier* values
         /// <summary>
         /// Replication connections
         /// </summary>

--- a/src/StackExchange.Redis/Enums/ClientType.cs
+++ b/src/StackExchange.Redis/Enums/ClientType.cs
@@ -16,7 +16,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Replication connections
         /// </summary>
-        Replica = 1, // / as an implementation detail, note that enum.ToString without [Flags] prefers *earlier* values
+        Replica = 1, // as an implementation detail, note that enum.ToString without [Flags] prefers *earlier* values
         /// <summary>
         /// Replication connections
         /// </summary>

--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -82,7 +82,5 @@ namespace StackExchange.Redis
         /// Indicates that script-related operations should use EVAL, not SCRIPT LOAD + EVALSHA
         /// </summary>
         NoScriptCache = 512,
-
-        // 1024: used for timed-out; never user-specified, so not visible on the public API
     }
 }

--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -18,7 +18,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// From 2.0, this flag is not used
         /// </summary>
-        [Obsolete("From 2.0, this flag is not used", false)]
+        [Obsolete("From 2.0, this flag is not used, this will be removed in 3.0.", false)]
         HighPriority = 1,
         /// <summary>
         /// The caller is not interested in the result; the caller will immediately receive a default-value

--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -41,7 +41,7 @@ namespace StackExchange.Redis
         /// This operation should be performed on the replica if it is available, but will be performed on
         /// a master if no replicas are available. Suitable for read operations only.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(PreferReplica) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(PreferReplica) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         PreferSlave = 8,
 
@@ -59,7 +59,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// This operation should only be performed on a replica. Suitable for read operations only.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(DemandReplica) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(DemandReplica) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         DemandSlave = 12,
 

--- a/src/StackExchange.Redis/Enums/CommandFlags.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace StackExchange.Redis
 {
-  /// <summary>
+    /// <summary>
     /// Behaviour markers associated with a given command
     /// </summary>
     [Flags]

--- a/src/StackExchange.Redis/Enums/CommandStatus.cs
+++ b/src/StackExchange.Redis/Enums/CommandStatus.cs
@@ -1,12 +1,12 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// track status of a command while communicating with Redis
+    /// Track status of a command while communicating with Redis.
     /// </summary>
     public enum CommandStatus
     {
         /// <summary>
-        /// command status unknown.
+        /// Command status unknown.
         /// </summary>
         Unknown,
         /// <summary>
@@ -14,7 +14,7 @@
         /// </summary>
         WaitingToBeSent,
         /// <summary>
-        /// command has been sent to Redis.
+        /// Command has been sent to Redis.
         /// </summary>
         Sent,
     }

--- a/src/StackExchange.Redis/Enums/ConnectionFailureType.cs
+++ b/src/StackExchange.Redis/Enums/ConnectionFailureType.cs
@@ -1,48 +1,48 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// The known types of connection failure
+    /// The known types of connection failure.
     /// </summary>
     public enum ConnectionFailureType
     {
         /// <summary>
-        /// This event is not a failure
+        /// This event is not a failure.
         /// </summary>
         None,
         /// <summary>
-        /// No viable connections were available for this operation
+        /// No viable connections were available for this operation.
         /// </summary>
         UnableToResolvePhysicalConnection,
         /// <summary>
-        /// The socket for this connection failed
+        /// The socket for this connection failed.
         /// </summary>
         SocketFailure,
         /// <summary>
-        /// Either SSL Stream or Redis authentication failed
+        /// Either SSL Stream or Redis authentication failed.
         /// </summary>
         AuthenticationFailure,
         /// <summary>
-        /// An unexpected response was received from the server
+        /// An unexpected response was received from the server.
         /// </summary>
         ProtocolFailure,
         /// <summary>
-        /// An unknown internal error occurred
+        /// An unknown internal error occurred.
         /// </summary>
         InternalFailure,
         /// <summary>
-        /// The socket was closed
+        /// The socket was closed.
         /// </summary>
         SocketClosed,
         /// <summary>
-        /// The socket was closed
+        /// The socket was closed.
         /// </summary>
         ConnectionDisposed,
         /// <summary>
-        /// The database is loading and is not available for use
+        /// The database is loading and is not available for use.
         /// </summary>
         Loading,
         /// <summary>
-        /// It has not been possible to create an intial connection to the redis server(s)
+        /// It has not been possible to create an initial connection to the redis server(s).
         /// </summary>
         UnableToConnect
     }

--- a/src/StackExchange.Redis/Enums/ConnectionType.cs
+++ b/src/StackExchange.Redis/Enums/ConnectionType.cs
@@ -1,20 +1,20 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// The type of a connection
+    /// The type of a connection.
     /// </summary>
     public enum ConnectionType
     {
         /// <summary>
-        /// Not connection-type related
+        /// Not connection-type related.
         /// </summary>
         None = 0,
         /// <summary>
-        /// An interactive connection handles request/response commands for accessing data on demand
+        /// An interactive connection handles request/response commands for accessing data on demand.
         /// </summary>
         Interactive,
         /// <summary>
-        /// A subscriber connection recieves unsolicted messages from the server as pub/sub events occur
+        /// A subscriber connection receives unsolicited messages from the server as pub/sub events occur.
         /// </summary>
         Subscription
     }

--- a/src/StackExchange.Redis/Enums/Exclude.cs
+++ b/src/StackExchange.Redis/Enums/Exclude.cs
@@ -4,25 +4,25 @@ namespace StackExchange.Redis
 {
     /// <summary>
     /// When performing a range query, by default the start / stop limits are inclusive;
-    /// however, both can also be specified separately as exclusive
+    /// however, both can also be specified separately as exclusive.
     /// </summary>
     [Flags]
     public enum Exclude
     {
         /// <summary>
-        /// Both start and stop are inclusive
+        /// Both start and stop are inclusive.
         /// </summary>
         None = 0,
         /// <summary>
-        /// Start is exclusive, stop is inclusive
+        /// Start is exclusive, stop is inclusive.
         /// </summary>
         Start = 1,
         /// <summary>
-        /// Start is inclusive, stop is exclusive
+        /// Start is inclusive, stop is exclusive.
         /// </summary>
         Stop = 2,
         /// <summary>
-        /// Both start and stop are exclusive
+        /// Both start and stop are exclusive.
         /// </summary>
         Both = Start | Stop
     }

--- a/src/StackExchange.Redis/Enums/ExportOptions.cs
+++ b/src/StackExchange.Redis/Enums/ExportOptions.cs
@@ -3,33 +3,33 @@
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Which settings to export
+    /// Which settings to export.
     /// </summary>
     [Flags]
     public enum ExportOptions
     {
         /// <summary>
-        /// No options
+        /// No options.
         /// </summary>
         None = 0,
         /// <summary>
-        /// The output of INFO
+        /// The output of INFO.
         /// </summary>
         Info = 1,
         /// <summary>
-        /// The output of CONFIG GET *
+        /// The output of CONFIG GET *.
         /// </summary>
         Config = 2,
         /// <summary>
-        /// The output of CLIENT LIST
+        /// The output of CLIENT LIST.
         /// </summary>
         Client = 4,
         /// <summary>
-        /// The output of CLUSTER NODES
+        /// The output of CLUSTER NODES.
         /// </summary>
         Cluster = 8,
         /// <summary>
-        /// Everything available
+        /// Everything available.
         /// </summary>
         All = -1
     }

--- a/src/StackExchange.Redis/Enums/GeoUnit.cs
+++ b/src/StackExchange.Redis/Enums/GeoUnit.cs
@@ -20,6 +20,6 @@
         /// <summary>
         /// Feet
         /// </summary>
-        Feet
+        Feet,
     }
 }

--- a/src/StackExchange.Redis/Enums/GeoUnit.cs
+++ b/src/StackExchange.Redis/Enums/GeoUnit.cs
@@ -1,10 +1,7 @@
-using System;
-using System.ComponentModel;
-
-namespace StackExchange.Redis
+﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Units associated with Geo Commands
+    /// Units associated with Geo Commands.
     /// </summary>
     public enum GeoUnit
     {

--- a/src/StackExchange.Redis/Enums/MigrateOptions.cs
+++ b/src/StackExchange.Redis/Enums/MigrateOptions.cs
@@ -3,13 +3,13 @@
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Additional options for the MIGRATE command
+    /// Additional options for the MIGRATE command.
     /// </summary>
     [Flags]
     public enum MigrateOptions
     {
         /// <summary>
-        /// No options specified
+        /// No options specified.
         /// </summary>
         None = 0,
         /// <summary>

--- a/src/StackExchange.Redis/Enums/MigrateOptions.cs
+++ b/src/StackExchange.Redis/Enums/MigrateOptions.cs
@@ -19,6 +19,6 @@ namespace StackExchange.Redis
         /// <summary>
         /// Replace existing key on the remote instance.
         /// </summary>
-        Replace = 2
+        Replace = 2,
     }
 }

--- a/src/StackExchange.Redis/Enums/Order.cs
+++ b/src/StackExchange.Redis/Enums/Order.cs
@@ -1,16 +1,16 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// The direction in which to sequence elements
+    /// The direction in which to sequence elements.
     /// </summary>
     public enum Order
     {
         /// <summary>
-        /// Ordered from low values to high values
+        /// Ordered from low values to high values.
         /// </summary>
         Ascending,
         /// <summary>
-        /// Ordered from high values to low values
+        /// Ordered from high values to low values.
         /// </summary>
         Descending
     }

--- a/src/StackExchange.Redis/Enums/Order.cs
+++ b/src/StackExchange.Redis/Enums/Order.cs
@@ -12,6 +12,6 @@
         /// <summary>
         /// Ordered from high values to low values.
         /// </summary>
-        Descending
+        Descending,
     }
 }

--- a/src/StackExchange.Redis/Enums/PositionKind.cs
+++ b/src/StackExchange.Redis/Enums/PositionKind.cs
@@ -4,6 +4,6 @@
     {
         Beginning = 0,
         Explicit = 1,
-        New = 2
+        New = 2,
     }
 }

--- a/src/StackExchange.Redis/Enums/Proxy.cs
+++ b/src/StackExchange.Redis/Enums/Proxy.cs
@@ -1,17 +1,17 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Specifies the proxy that is being used to communicate to redis
+    /// Specifies the proxy that is being used to communicate to redis.
     /// </summary>
     public enum Proxy
     {
         /// <summary>
-        /// Direct communication to the redis server(s)
+        /// Direct communication to the redis server(s).
         /// </summary>
         None,
         /// <summary>
-        /// Communication via <a href="https://github.com/twitter/twemproxy">twemproxy</a>
+        /// Communication via <a href="https://github.com/twitter/twemproxy">twemproxy</a>.
         /// </summary>
-        Twemproxy
+        Twemproxy,
     }
 }

--- a/src/StackExchange.Redis/Enums/RedisType.cs
+++ b/src/StackExchange.Redis/Enums/RedisType.cs
@@ -1,39 +1,49 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// The intrinsinc data-types supported by redis
+    /// The intrinsic data-types supported by redis.
     /// </summary>
     /// <remarks>https://redis.io/topics/data-types</remarks>
     public enum RedisType
     {
         /// <summary>
-        /// The specified key does not exist
+        /// The specified key does not exist.
         /// </summary>
         None,
         /// <summary>
-        /// Strings are the most basic kind of Redis value. Redis Strings are binary safe, this means that a Redis string can contain any kind of data, for instance a JPEG image or a serialized Ruby object.
+        /// Strings are the most basic kind of Redis value. Redis Strings are binary safe, this means that
+        /// a Redis string can contain any kind of data, for instance a JPEG image or a serialized Ruby object.
         /// A String value can be at max 512 Megabytes in length.
         /// </summary>
         /// <remarks>https://redis.io/commands#string</remarks>
         String,
         /// <summary>
-        /// Redis Lists are simply lists of strings, sorted by insertion order. It is possible to add elements to a Redis List pushing new elements on the head (on the left) or on the tail (on the right) of the list.
+        /// Redis Lists are simply lists of strings, sorted by insertion order.
+        /// It is possible to add elements to a Redis List pushing new elements on the head (on the left) or
+        /// on the tail (on the right) of the list.
         /// </summary>
         /// <remarks>https://redis.io/commands#list</remarks>
         List,
         /// <summary>
-        /// Redis Sets are an unordered collection of Strings. It is possible to add, remove, and test for existence of members in O(1) (constant time regardless of the number of elements contained inside the Set).
-        /// Redis Sets have the desirable property of not allowing repeated members. Adding the same element multiple times will result in a set having a single copy of this element. Practically speaking this means that adding a member does not require a check if exists then add operation.
+        /// Redis Sets are an unordered collection of Strings. It is possible to add, remove, and test for
+        /// existence of members in O(1) (constant time regardless of the number of elements contained inside the Set).
+        /// Redis Sets have the desirable property of not allowing repeated members.
+        /// Adding the same element multiple times will result in a set having a single copy of this element.
+        /// Practically speaking this means that adding a member does not require a check if exists then add operation.
         /// </summary>
         /// <remarks>https://redis.io/commands#set</remarks>
         Set,
         /// <summary>
-        /// Redis Sorted Sets are, similarly to Redis Sets, non repeating collections of Strings. The difference is that every member of a Sorted Set is associated with score, that is used in order to take the sorted set ordered, from the smallest to the greatest score. While members are unique, scores may be repeated.
+        /// Redis Sorted Sets are, similarly to Redis Sets, non repeating collections of Strings.
+        /// The difference is that every member of a Sorted Set is associated with score, that is used
+        /// in order to take the sorted set ordered, from the smallest to the greatest score.
+        /// While members are unique, scores may be repeated.
         /// </summary>
         /// <remarks>https://redis.io/commands#sorted_set</remarks>
         SortedSet,
         /// <summary>
-        /// Redis Hashes are maps between string fields and string values, so they are the perfect data type to represent objects (eg: A User with a number of fields like name, surname, age, and so forth)
+        /// Redis Hashes are maps between string fields and string values, so they are the perfect data type
+        /// to represent objects (e.g. A User with a number of fields like name, surname, age, and so forth).
         /// </summary>
         /// <remarks>https://redis.io/commands#hash</remarks>
         Hash,
@@ -45,7 +55,7 @@
         /// <remarks>https://redis.io/commands#stream</remarks>
         Stream,
         /// <summary>
-        /// The data-type was not recognised by the client library
+        /// The data-type was not recognised by the client library.
         /// </summary>
         Unknown,
     }

--- a/src/StackExchange.Redis/Enums/ReplicationChangeOptions.cs
+++ b/src/StackExchange.Redis/Enums/ReplicationChangeOptions.cs
@@ -25,7 +25,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Issue a REPLICAOF to all other known nodes, making this primary of all.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicateToOtherEndpoints) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicateToOtherEndpoints) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         EnslaveSubordinates = 4,
         /// <summary>

--- a/src/StackExchange.Redis/Enums/ReplicationChangeOptions.cs
+++ b/src/StackExchange.Redis/Enums/ReplicationChangeOptions.cs
@@ -4,36 +4,36 @@ using System.ComponentModel;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Additional operations to perform when making a server a master
+    /// Additional operations to perform when making a server a master.
     /// </summary>
     [Flags]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ReplicationChangeOptions
     {
         /// <summary>
-        /// No additional operations
+        /// No additional operations.
         /// </summary>
         None = 0,
         /// <summary>
-        /// Set the tie-breaker key on all available masters, to specify this server
+        /// Set the tie-breaker key on all available masters, to specify this server.
         /// </summary>
         SetTiebreaker = 1,
         /// <summary>
-        /// Broadcast to the pub-sub channel to listening clients to reconfigure themselves
+        /// Broadcast to the pub-sub channel to listening clients to reconfigure themselves.
         /// </summary>
         Broadcast = 2,
         /// <summary>
-        /// Issue a REPLICAOF to all other known nodes, making this this master of all
+        /// Issue a REPLICAOF to all other known nodes, making this primary of all.
         /// </summary>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicateToOtherEndpoints) + " instead.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         EnslaveSubordinates = 4,
         /// <summary>
-        /// Issue a REPLICAOF to all other known nodes, making this this master of all
+        /// Issue a REPLICAOF to all other known nodes, making this primary of all.
         /// </summary>
         ReplicateToOtherEndpoints = 4, // note ToString prefers *later* options
         /// <summary>
-        /// All additional operations
+        /// All additional operations.
         /// </summary>
         All = SetTiebreaker | Broadcast | ReplicateToOtherEndpoints,
     }

--- a/src/StackExchange.Redis/Enums/ResultType.cs
+++ b/src/StackExchange.Redis/Enums/ResultType.cs
@@ -1,33 +1,33 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// The underlying result type as defined by redis
+    /// The underlying result type as defined by Redis.
     /// </summary>
     public enum ResultType : byte
     {
         /// <summary>
-        /// No value was received
+        /// No value was received.
         /// </summary>
         None = 0,
         /// <summary>
-        /// Basic strings typically represent status results such as "OK"
+        /// Basic strings typically represent status results such as "OK".
         /// </summary>
         SimpleString = 1,
         /// <summary>
-        /// Error strings represent invalid operation results from the server
+        /// Error strings represent invalid operation results from the server.
         /// </summary>
         Error = 2,
         /// <summary>
-        /// Integers are returned for count operations and some integer-based increment operations
+        /// Integers are returned for count operations and some integer-based increment operations.
         /// </summary>
         Integer = 3,
         /// <summary>
-        /// Bulk strings represent typical user content values
+        /// Bulk strings represent typical user content values.
         /// </summary>
         BulkString = 4,
         /// <summary>
-        /// Multi-bulk replies represent complex results such as arrays
+        /// Multi-bulk replies represent complex results such as arrays.
         /// </summary>
-        MultiBulk = 5
+        MultiBulk = 5,
     }
 }

--- a/src/StackExchange.Redis/Enums/RetransmissionReasonType.cs
+++ b/src/StackExchange.Redis/Enums/RetransmissionReasonType.cs
@@ -13,16 +13,16 @@
     public enum RetransmissionReasonType
     {
         /// <summary>
-        /// No stated reason
+        /// No stated reason.
         /// </summary>
         None = 0,
         /// <summary>
-        /// Issued to investigate which node owns a key
+        /// Issued to investigate which node owns a key.
         /// </summary>
         Ask,
         /// <summary>
-        /// A node has indicated that it does *not* own the given key
+        /// A node has indicated that it does *not* own the given key.
         /// </summary>
-        Moved
+        Moved,
     }
 }

--- a/src/StackExchange.Redis/Enums/SaveType.cs
+++ b/src/StackExchange.Redis/Enums/SaveType.cs
@@ -3,25 +3,30 @@
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// The type of save operation to perform
+    /// The type of save operation to perform.
     /// </summary>
     public enum SaveType
     {
         /// <summary>
-        /// Instruct Redis to start an Append Only File rewrite process. The rewrite will create a small optimized version of the current Append Only File.
+        /// Instruct Redis to start an Append Only File rewrite process.
+        /// The rewrite will create a small optimized version of the current Append Only File.
         /// </summary>
         /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
         BackgroundRewriteAppendOnlyFile,
         /// <summary>
-        /// Save the DB in background. The OK code is immediately returned. Redis forks, the parent continues to serve the clients, the child saves the DB on disk then exits. A client my be able to check if the operation succeeded using the LASTSAVE command.
+        /// Save the DB in background. The OK code is immediately returned.
+        /// Redis forks, the parent continues to serve the clients, the child saves the DB on disk then exits.
+        /// A client my be able to check if the operation succeeded using the LASTSAVE command.
         /// </summary>
         /// <remarks>https://redis.io/commands/bgsave</remarks>
         BackgroundSave,
         /// <summary>
-        /// Save the DB in foreground. This is almost never a good thing to do, and could cause significant blocking. Only do this if you know you need to save
+        /// Save the DB in foreground.
+        /// This is almost never a good thing to do, and could cause significant blocking.
+        /// Only do this if you know you need to save.
         /// </summary>
         /// <remarks>https://redis.io/commands/save</remarks>
         [Obsolete("Saving on the foreground can cause significant blocking; use with extreme caution")]
-        ForegroundSave
+        ForegroundSave,
     }
 }

--- a/src/StackExchange.Redis/Enums/ServerType.cs
+++ b/src/StackExchange.Redis/Enums/ServerType.cs
@@ -1,25 +1,25 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Indicates the flavor of a particular redis server
+    /// Indicates the flavor of a particular redis server.
     /// </summary>
     public enum ServerType
     {
         /// <summary>
-        /// Classic redis-server server
+        /// Classic redis-server server.
         /// </summary>
         Standalone,
         /// <summary>
-        /// Monitoring/configuration redis-sentinel server
+        /// Monitoring/configuration redis-sentinel server.
         /// </summary>
         Sentinel,
         /// <summary>
-        /// Distributed redis-cluster server
+        /// Distributed redis-cluster server.
         /// </summary>
         Cluster,
         /// <summary>
-        /// Distributed redis installation via <a href="https://github.com/twitter/twemproxy">twemproxy</a>
+        /// Distributed redis installation via <a href="https://github.com/twitter/twemproxy">twemproxy</a>.
         /// </summary>
-        Twemproxy
+        Twemproxy,
     }
 }

--- a/src/StackExchange.Redis/Enums/SetOperation.cs
+++ b/src/StackExchange.Redis/Enums/SetOperation.cs
@@ -1,7 +1,7 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Describes an algebraic set operation that can be performed to combine multiple sets
+    /// Describes an algebraic set operation that can be performed to combine multiple sets.
     /// </summary>
     public enum SetOperation
     {
@@ -16,6 +16,6 @@
         /// <summary>
         /// Returns the members of the set resulting from the difference between the first set and all the successive sets.
         /// </summary>
-        Difference
+        Difference,
     }
 }

--- a/src/StackExchange.Redis/Enums/ShutdownMode.cs
+++ b/src/StackExchange.Redis/Enums/ShutdownMode.cs
@@ -1,21 +1,21 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Defines the persistence behaviour of the server during shutdown
+    /// Defines the persistence behaviour of the server during shutdown.
     /// </summary>
     public enum ShutdownMode
     {
         /// <summary>
-        /// The data is persisted if save points are configured
+        /// The data is persisted if save points are configured.
         /// </summary>
         Default,
         /// <summary>
-        /// The data is NOT persisted even if save points are configured
+        /// The data is NOT persisted even if save points are configured.
         /// </summary>
         Never,
         /// <summary>
-        /// The data is persisted even if save points are NOT configured
+        /// The data is persisted even if save points are NOT configured.
         /// </summary>
-        Always
+        Always,
     }
 }

--- a/src/StackExchange.Redis/Enums/SortType.cs
+++ b/src/StackExchange.Redis/Enums/SortType.cs
@@ -1,17 +1,18 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Specifies how to compare elements for sorting
+    /// Specifies how to compare elements for sorting.
     /// </summary>
     public enum SortType
     {
         /// <summary>
-        /// Elements are interpreted as a double-precision floating point number and sorted numerically
+        /// Elements are interpreted as a double-precision floating point number and sorted numerically.
         /// </summary>
         Numeric,
         /// <summary>
-        /// Elements are sorted using their alphabetic form (Redis is UTF-8 aware as long as the !LC_COLLATE environment variable is set at the server)
+        /// Elements are sorted using their alphabetic form
+        /// (Redis is UTF-8 aware as long as the !LC_COLLATE environment variable is set at the server).
         /// </summary>
-        Alphabetic
+        Alphabetic,
     }
 }

--- a/src/StackExchange.Redis/Enums/When.cs
+++ b/src/StackExchange.Redis/Enums/When.cs
@@ -1,7 +1,7 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Indicates when this operation should be performed (only some variations are legal in a given context)
+    /// Indicates when this operation should be performed (only some variations are legal in a given context).
     /// </summary>
     public enum When
     {
@@ -16,6 +16,6 @@
         /// <summary>
         /// The operation should only occur when there is not an existing value.
         /// </summary>
-        NotExists
+        NotExists,
     }
 }

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -156,9 +156,7 @@ namespace StackExchange.Redis
             return ex;
         }
 
-#pragma warning disable RCS1231 // Make parameter ref read-only. - spans are tiny!
         internal static Exception PopulateInnerExceptions(ReadOnlySpan<ServerEndPoint> serverSnapshot)
-#pragma warning restore RCS1231 // Make parameter ref read-only.
         {
             var innerExceptions = new List<Exception>();
 

--- a/src/StackExchange.Redis/Exceptions.cs
+++ b/src/StackExchange.Redis/Exceptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
-#pragma warning disable RCS1194 // Implement exception constructors.
 namespace StackExchange.Redis
 {
     /// <summary>

--- a/src/StackExchange.Redis/ExponentialRetry.cs
+++ b/src/StackExchange.Redis/ExponentialRetry.cs
@@ -13,7 +13,7 @@ namespace StackExchange.Redis
         private static Random r;
 
         /// <summary>
-        /// Initializes a new instance using the specified back off interval with default maxDeltaBackOffMilliseconds of 10 seconds
+        /// Initializes a new instance using the specified back off interval with default maxDeltaBackOffMilliseconds of 10 seconds.
         /// </summary>
         /// <param name="deltaBackOffMilliseconds">time in milliseconds for the back-off interval between retries</param>
         public ExponentialRetry(int deltaBackOffMilliseconds) : this(deltaBackOffMilliseconds, (int)TimeSpan.FromSeconds(10).TotalMilliseconds) {}
@@ -21,8 +21,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// Initializes a new instance using the specified back off interval.
         /// </summary>
-        /// <param name="deltaBackOffMilliseconds">time in milliseconds for the back-off interval between retries</param>
-        /// <param name="maxDeltaBackOffMilliseconds">time in milliseconds for the maximum value that the back-off interval can exponentially grow up to</param>
+        /// <param name="deltaBackOffMilliseconds">time in milliseconds for the back-off interval between retries.</param>
+        /// <param name="maxDeltaBackOffMilliseconds">time in milliseconds for the maximum value that the back-off interval can exponentially grow up to.</param>
         public ExponentialRetry(int deltaBackOffMilliseconds, int maxDeltaBackOffMilliseconds)
         {
             this.deltaBackOffMilliseconds = deltaBackOffMilliseconds;
@@ -32,8 +32,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// This method is called by the ConnectionMultiplexer to determine if a reconnect operation can be retried now.
         /// </summary>
-        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the ConnectionMultiplexer while it was in the connecting state</param>
-        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total elapsed time in milliseconds since the last reconnect retry was made</param>
+        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the ConnectionMultiplexer while it was in the connecting state.</param>
+        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total elapsed time in milliseconds since the last reconnect retry was made.</param>
         public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry)
         {
             var exponential = (int)Math.Min(maxDeltaBackOffMilliseconds, deltaBackOffMilliseconds * Math.Pow(1.1, currentRetryCount));

--- a/src/StackExchange.Redis/ExtensionMethods.cs
+++ b/src/StackExchange.Redis/ExtensionMethods.cs
@@ -188,7 +188,7 @@ namespace StackExchange.Redis
         public static string DecodeString(this Lease<byte> bytes, Encoding encoding = null)
         {
             if (bytes == null) return null;
-            if (encoding == null) encoding = Encoding.UTF8;
+            encoding ??= Encoding.UTF8;
             if (bytes.Length == 0) return "";
             var segment = bytes.ArraySegment;
             return encoding.GetString(segment.Array, segment.Offset, segment.Count);
@@ -202,7 +202,7 @@ namespace StackExchange.Redis
         public static Lease<char> DecodeLease(this Lease<byte> bytes, Encoding encoding = null)
         {
             if (bytes == null) return null;
-            if (encoding == null) encoding = Encoding.UTF8;
+            encoding ??= Encoding.UTF8;
             if (bytes.Length == 0) return Lease<char>.Empty;
             var bytesSegment = bytes.ArraySegment;
             var charCount = encoding.GetCharCount(bytesSegment.Array, bytesSegment.Offset, bytesSegment.Count);

--- a/src/StackExchange.Redis/ExtensionMethods.cs
+++ b/src/StackExchange.Redis/ExtensionMethods.cs
@@ -11,7 +11,7 @@ using Pipelines.Sockets.Unofficial.Arenas;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Utility methods
+    /// Utility methods.
     /// </summary>
     public static class ExtensionMethods
     {

--- a/src/StackExchange.Redis/GeoEntry.cs
+++ b/src/StackExchange.Redis/GeoEntry.cs
@@ -111,7 +111,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See <see cref="object.ToString"/>.
+        /// A "{long} {lat}" string representation of this position.
         /// </summary>
         public override string ToString() => string.Format("{0} {1}", Longitude, Latitude);
 
@@ -190,13 +190,11 @@ namespace StackExchange.Redis
         public double Latitude => Position.Latitude;
 
         /// <summary>
-        /// See <see cref="object.ToString"/>.
+        /// A "({Longitude},{Latitude})={Member}" string representation of this entry.
         /// </summary>
         public override string ToString() => $"({Longitude},{Latitude})={Member}";
 
-        /// <summary>
-        /// See <see cref="object.GetHashCode"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => Position.GetHashCode() ^ Member.GetHashCode();
 
         /// <summary>

--- a/src/StackExchange.Redis/HashEntry.cs
+++ b/src/StackExchange.Redis/HashEntry.cs
@@ -40,27 +40,25 @@ namespace StackExchange.Redis
         public RedisValue Key => name;
 
         /// <summary>
-        /// Converts to a key/value pair
+        /// Converts to a key/value pair.
         /// </summary>
         /// <param name="value">The <see cref="HashEntry"/> to create a <see cref="KeyValuePair{TKey, TValue}"/> from.</param>
         public static implicit operator KeyValuePair<RedisValue, RedisValue>(HashEntry value) =>
             new KeyValuePair<RedisValue, RedisValue>(value.name, value.value);
 
         /// <summary>
-        /// Converts from a key/value pair
+        /// Converts from a key/value pair.
         /// </summary>
         /// <param name="value">The <see cref="KeyValuePair{TKey, TValue}"/> to get a <see cref="HashEntry"/> from.</param>
         public static implicit operator HashEntry(KeyValuePair<RedisValue, RedisValue> value) =>
             new HashEntry(value.Key, value.Value);
 
         /// <summary>
-        /// See <see cref="object.ToString"/>.
+        /// A "{name}: {value}" string representation of this entry.
         /// </summary>
         public override string ToString() => name + ": " + value;
 
-        /// <summary>
-        /// See <see cref="object.GetHashCode"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => name.GetHashCode() ^ value.GetHashCode();
 
         /// <summary>

--- a/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
+++ b/src/StackExchange.Redis/HashSlotMovedEventArgs.cs
@@ -51,9 +51,6 @@ namespace StackExchange.Redis
 
         bool ICompletable.TryComplete(bool isAsync) => ConnectionMultiplexer.TryCompleteHandler(handler, sender, this, isAsync);
 
-        void ICompletable.AppendStormLog(StringBuilder sb)
-        {
-            sb.Append("event, slot-moved: ").Append(HashSlot);
-        }
+        void ICompletable.AppendStormLog(StringBuilder sb) => sb.Append("event, slot-moved: ").Append(HashSlot);
     }
 }

--- a/src/StackExchange.Redis/Interfaces/IBatch.cs
+++ b/src/StackExchange.Redis/Interfaces/IBatch.cs
@@ -1,8 +1,8 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents a block of operations that will be sent to the server together;
-    /// this can be useful to reduce packet fragmentation on slow connections - it
+    /// Represents a block of operations that will be sent to the server together.
+    /// This can be useful to reduce packet fragmentation on slow connections - it
     /// can improve the time to get *all* the operations processed, with the trade-off
     /// of a slower time to get the *first* operation processed; this is usually
     /// a good thing. Unless this batch is a <b>transaction</b>, there is no guarantee
@@ -12,9 +12,8 @@
     {
         /// <summary>
         /// Execute the batch operation, sending all queued commands to the server.
-        /// Note that this operation is neither synchronous nor truly asynchronous - it
-        /// simply enqueues the buffered messages. To check on completion, you should
-        /// check the individual responses.
+        /// Note that this operation is neither synchronous nor truly asynchronous - it simply enqueues the buffered messages.
+        /// To check on completion, you should check the individual responses.
         /// </summary>
         void Execute();
     }

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -112,7 +112,7 @@ namespace StackExchange.Redis
         event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast;
 
         /// <summary>
-        /// Gets all endpoints defined on the server.
+        /// Gets all endpoints defined on the multiplexer.
         /// </summary>
         /// <param name="configuredOnly">Whether to return only the explicitly configured endpoints.</param>
         EndPoint[] GetEndPoints(bool configuredOnly = false);

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -107,7 +107,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Raised when nodes are explicitly requested to reconfigure via broadcast.
-        /// This usually means primary/replica changes.
+        /// This usually means primary/replica role changes.
         /// </summary>
         event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast;
 

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -16,152 +16,152 @@ namespace StackExchange.Redis
     }
 
     /// <summary>
-    /// Represents the abstract multiplexer API
+    /// Represents the abstract multiplexer API.
     /// </summary>
     public interface IConnectionMultiplexer : IDisposable
     {
         /// <summary>
-        /// Gets the client-name that will be used on all new connections
+        /// Gets the client-name that will be used on all new connections.
         /// </summary>
         string ClientName { get; }
 
         /// <summary>
-        /// Gets the configuration of the connection
+        /// Gets the configuration of the connection.
         /// </summary>
         string Configuration { get; }
 
         /// <summary>
-        /// Gets the timeout associated with the connections
+        /// Gets the timeout associated with the connections.
         /// </summary>
         int TimeoutMilliseconds { get; }
 
         /// <summary>
-        /// The number of operations that have been performed on all connections
+        /// The number of operations that have been performed on all connections.
         /// </summary>
         long OperationCount { get; }
 
         /// <summary>
-        /// Gets or sets whether asynchronous operations should be invoked in a way that guarantees their original delivery order
+        /// Gets or sets whether asynchronous operations should be invoked in a way that guarantees their original delivery order.
         /// </summary>
         [Obsolete("Not supported; if you require ordered pub/sub, please see " + nameof(ChannelMessageQueue), false)]
         bool PreserveAsyncOrder { get; set; }
 
         /// <summary>
-        /// Indicates whether any servers are connected
+        /// Indicates whether any servers are connected.
         /// </summary>
         bool IsConnected { get; }
 
         /// <summary>
-        /// Indicates whether any servers are connected
+        /// Indicates whether any servers are connecting.
         /// </summary>
         bool IsConnecting { get; }
 
         /// <summary>
-        /// Should exceptions include identifiable details? (key names, additional .Data annotations)
+        /// Should exceptions include identifiable details? (key names, additional <see cref="Exception.Data"/> annotations).
         /// </summary>
         bool IncludeDetailInExceptions { get; set; }
 
         /// <summary>
-        /// Limit at which to start recording unusual busy patterns (only one log will be retained at a time;
-        /// set to a negative value to disable this feature)
+        /// Limit at which to start recording unusual busy patterns (only one log will be retained at a time.
+        /// Set to a negative value to disable this feature).
         /// </summary>
         int StormLogThreshold { get; set; }
 
         /// <summary>
-        /// Register a callback to provide an on-demand ambient session provider based on the
-        /// calling context; the implementing code is responsible for reliably resolving the same provider
-        /// based on ambient context, or returning null to not profile
+        /// Register a callback to provide an on-demand ambient session provider based on the calling context.
+        /// The implementing code is responsible for reliably resolving the same provider
+        /// based on ambient context, or returning null to not profile.
         /// </summary>
         /// <param name="profilingSessionProvider">The profiling session provider.</param>
         void RegisterProfiler(Func<ProfilingSession> profilingSessionProvider);
 
         /// <summary>
-        /// Get summary statistics associates with this server
+        /// Get summary statistics associates with this server.
         /// </summary>
         ServerCounters GetCounters();
 
         /// <summary>
-        /// A server replied with an error message;
+        /// A server replied with an error message.
         /// </summary>
         event EventHandler<RedisErrorEventArgs> ErrorMessage;
 
         /// <summary>
-        /// Raised whenever a physical connection fails
+        /// Raised whenever a physical connection fails.
         /// </summary>
         event EventHandler<ConnectionFailedEventArgs> ConnectionFailed;
 
         /// <summary>
-        /// Raised whenever an internal error occurs (this is primarily for debugging)
+        /// Raised whenever an internal error occurs (this is primarily for debugging).
         /// </summary>
         event EventHandler<InternalErrorEventArgs> InternalError;
 
         /// <summary>
-        /// Raised whenever a physical connection is established
+        /// Raised whenever a physical connection is established.
         /// </summary>
         event EventHandler<ConnectionFailedEventArgs> ConnectionRestored;
 
         /// <summary>
-        /// Raised when configuration changes are detected
+        /// Raised when configuration changes are detected.
         /// </summary>
         event EventHandler<EndPointEventArgs> ConfigurationChanged;
 
         /// <summary>
-        /// Raised when nodes are explicitly requested to reconfigure via broadcast;
-        /// this usually means master/replica changes
+        /// Raised when nodes are explicitly requested to reconfigure via broadcast.
+        /// This usually means primary/replica changes.
         /// </summary>
         event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast;
 
         /// <summary>
-        /// Gets all endpoints defined on the server
+        /// Gets all endpoints defined on the server.
         /// </summary>
         /// <param name="configuredOnly">Whether to return only the explicitly configured endpoints.</param>
         EndPoint[] GetEndPoints(bool configuredOnly = false);
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout)
+        /// Wait for a given asynchronous operation to complete (or timeout).
         /// </summary>
         /// <param name="task">The task to wait on.</param>
         void Wait(Task task);
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout)
+        /// Wait for a given asynchronous operation to complete (or timeout).
         /// </summary>
         /// <typeparam name="T">The type in <paramref name="task"/>.</typeparam>
         /// <param name="task">The task to wait on.</param>
         T Wait<T>(Task<T> task);
 
         /// <summary>
-        /// Wait for the given asynchronous operations to complete (or timeout)
+        /// Wait for the given asynchronous operations to complete (or timeout).
         /// </summary>
         /// <param name="tasks">The tasks to wait on.</param>
         void WaitAll(params Task[] tasks);
 
         /// <summary>
-        /// Raised when a hash-slot has been relocated
+        /// Raised when a hash-slot has been relocated.
         /// </summary>
         event EventHandler<HashSlotMovedEventArgs> HashSlotMoved;
 
         /// <summary>
-        /// Compute the hash-slot of a specified key
+        /// Compute the hash-slot of a specified key.
         /// </summary>
         /// <param name="key">The key to get a slot ID for.</param>
         int HashSlot(RedisKey key);
 
         /// <summary>
-        /// Obtain a pub/sub subscriber connection to the specified server
+        /// Obtain a pub/sub subscriber connection to the specified server.
         /// </summary>
         /// <param name="asyncState">The async state to pass to the created <see cref="ISubscriber"/>.</param>
         ISubscriber GetSubscriber(object asyncState = null);
 
         /// <summary>
-        /// Obtain an interactive connection to a database inside redis
+        /// Obtain an interactive connection to a database inside redis.
         /// </summary>
         /// <param name="db">The database ID to get.</param>
         /// <param name="asyncState">The async state to pass to the created <see cref="IDatabase"/>.</param>
         IDatabase GetDatabase(int db = -1, object asyncState = null);
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="host">The host to get a server for.</param>
         /// <param name="port">The specific port for <paramref name="host"/> to get a server for.</param>
@@ -169,98 +169,98 @@ namespace StackExchange.Redis
         IServer GetServer(string host, int port, object asyncState = null);
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="hostAndPort">The "host:port" string to get a server for.</param>
         /// <param name="asyncState">The async state to pass to the created <see cref="IServer"/>.</param>
         IServer GetServer(string hostAndPort, object asyncState = null);
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="host">The host to get a server for.</param>
         /// <param name="port">The specific port for <paramref name="host"/> to get a server for.</param>
         IServer GetServer(IPAddress host, int port);
 
         /// <summary>
-        /// Obtain a configuration API for an individual server
+        /// Obtain a configuration API for an individual server.
         /// </summary>
         /// <param name="endpoint">The endpoint to get a server for.</param>
         /// <param name="asyncState">The async state to pass to the created <see cref="IServer"/>.</param>
         IServer GetServer(EndPoint endpoint, object asyncState = null);
 
         /// <summary>
-        /// Reconfigure the current connections based on the existing configuration
+        /// Reconfigure the current connections based on the existing configuration.
         /// </summary>
         /// <param name="log">The log to write output to.</param>
         Task<bool> ConfigureAsync(TextWriter log = null);
 
         /// <summary>
-        /// Reconfigure the current connections based on the existing configuration
+        /// Reconfigure the current connections based on the existing configuration.
         /// </summary>
         /// <param name="log">The log to write output to.</param>
         bool Configure(TextWriter log = null);
 
         /// <summary>
-        /// Provides a text overview of the status of all connections
+        /// Provides a text overview of the status of all connections.
         /// </summary>
         string GetStatus();
 
         /// <summary>
-        /// Provides a text overview of the status of all connections
+        /// Provides a text overview of the status of all connections.
         /// </summary>
         /// <param name="log">The log to write output to.</param>
         void GetStatus(TextWriter log);
 
         /// <summary>
-        /// See Object.ToString()
+        /// See <see cref="object.ToString"/>.
         /// </summary>
         string ToString();
 
         /// <summary>
-        /// Close all connections and release all resources associated with this object
+        /// Close all connections and release all resources associated with this object.
         /// </summary>
         /// <param name="allowCommandsToComplete">Whether to allow in-queue commands to complete first.</param>
         void Close(bool allowCommandsToComplete = true);
 
         /// <summary>
-        /// Close all connections and release all resources associated with this object
+        /// Close all connections and release all resources associated with this object.
         /// </summary>
         /// <param name="allowCommandsToComplete">Whether to allow in-queue commands to complete first.</param>
         Task CloseAsync(bool allowCommandsToComplete = true);
 
         /// <summary>
-        /// Obtains the log of unusual busy patterns
+        /// Obtains the log of unusual busy patterns.
         /// </summary>
         string GetStormLog();
 
         /// <summary>
-        /// Resets the log of unusual busy patterns
+        /// Resets the log of unusual busy patterns.
         /// </summary>
         void ResetStormLog();
 
         /// <summary>
-        /// Request all compatible clients to reconfigure or reconnect
+        /// Request all compatible clients to reconfigure or reconnect.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <returns>The number of instances known to have received the message (however, the actual number can be higher; returns -1 if the operation is pending)</returns>
+        /// <returns>The number of instances known to have received the message (however, the actual number can be higher; returns -1 if the operation is pending).</returns>
         long PublishReconfigure(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Request all compatible clients to reconfigure or reconnect
+        /// Request all compatible clients to reconfigure or reconnect.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <returns>The number of instances known to have received the message (however, the actual number can be higher)</returns>
+        /// <returns>The number of instances known to have received the message (however, the actual number can be higher).</returns>
         Task<long> PublishReconfigureAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the hash-slot associated with a given key, if applicable; this can be useful for grouping operations
+        /// Get the hash-slot associated with a given key, if applicable; this can be useful for grouping operations.
         /// </summary>
         /// <param name="key">The key to get a the slot for.</param>
         int GetHashSlot(RedisKey key);
 
         /// <summary>
-        /// Write the configuration of all servers to an output stream
+        /// Write the configuration of all servers to an output stream.
         /// </summary>
         /// <param name="destination">The destination stream to write the export to.</param>
         /// <param name="options">The options to use for this export.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -623,7 +623,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Create a key associated with a value that is obtained by deserializing the provided serialized value (obtained via DUMP).
-        /// If <paramref name="expiry"/> is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
+        /// If <paramref name="expiry"/> is 0 the key is created without any expire, otherwise the specified expire time (in milliseconds) is set.
         /// </summary>
         /// <param name="key">The key to restore.</param>
         /// <param name="value">The value of the key.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -31,7 +31,8 @@ namespace StackExchange.Redis
         ITransaction CreateTransaction(object asyncState = null);
 
         /// <summary>
-        /// Atomically transfer a key from a source Redis instance to a destination Redis instance. On success the key is deleted from the original instance by default, and is guaranteed to exist in the target instance.
+        /// Atomically transfer a key from a source Redis instance to a destination Redis instance.
+        /// On success the key is deleted from the original instance by default, and is guaranteed to exist in the target instance.
         /// </summary>
         /// <param name="key">The key to migrate.</param>
         /// <param name="toServer">The server to migrate the key to.</param>
@@ -43,7 +44,8 @@ namespace StackExchange.Redis
         void KeyMigrate(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the raw DEBUG OBJECT output for a key; this command is not fully documented and should be avoided unless you have good reason, and then avoided anyway.
+        /// Returns the raw DEBUG OBJECT output for a key.
+        /// This command is not fully documented and should be avoided unless you have good reason, and then avoided anyway.
         /// </summary>
         /// <param name="key">The key to debug.</param>
         /// <param name="flags">The flags to use for this migration.</param>
@@ -52,29 +54,35 @@ namespace StackExchange.Redis
         RedisValue DebugObject(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
+        /// Add the specified member to the set stored at key.
+        /// Specified members that are already a member of this set are ignored.
+        /// If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="longitude">The longitude of geo entry.</param>
         /// <param name="latitude">The latitude of the geo entry.</param>
         /// <param name="member">The value to set at this entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was not already present in the set, else False.</returns>
+        /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/geoadd</remarks>
         bool GeoAdd(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
+        /// Add the specified member to the set stored at key.
+        /// Specified members that are already a member of this set are ignored.
+        /// If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The geo value to store.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was not already present in the set, else False</returns>
+        /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/geoadd</remarks>
         bool GeoAdd(RedisKey key, GeoEntry value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Add the specified members to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
+        /// Add the specified members to the set stored at key.
+        /// Specified members that are already a member of this set are ignored.
+        /// If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="values">The geo values add to the set.</param>
@@ -84,12 +92,13 @@ namespace StackExchange.Redis
         long GeoAdd(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the specified member from the geo sorted set stored at key. Non existing members are ignored.
+        /// Removes the specified member from the geo sorted set stored at key.
+        /// Non existing members are ignored.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="member">The geo value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the member existed in the sorted set and was removed; False otherwise.</returns>
+        /// <returns><see langword="true"/> if the member existed in the sorted set and was removed, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/zrem</remarks>
         bool GeoRemove(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
@@ -101,7 +110,7 @@ namespace StackExchange.Redis
         /// <param name="member2">The second member to check.</param>
         /// <param name="unit">The unit of distance to return (defaults to meters).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or NULL if one or both the elements are missing.</returns>
+        /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or <see langword="null"/> if one or both the elements are missing.</returns>
         /// <remarks>https://redis.io/commands/geodist</remarks>
         double? GeoDistance(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None);
 
@@ -131,7 +140,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="members">The members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.Non existing elements are reported as NULL elements of the array.</returns>
+        /// <returns>
+        /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
+        /// Non existing elements are reported as NULL elements of the array.
+        /// </returns>
         /// <remarks>https://redis.io/commands/geopos</remarks>
         GeoPosition?[] GeoPosition(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
@@ -141,12 +153,16 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="member">The member to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.Non existing elements are reported as NULL elements of the array.</returns>
+        /// <returns>
+        /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
+        /// Non existing elements are reported as NULL elements of the array.
+        /// </returns>
         /// <remarks>https://redis.io/commands/geopos</remarks>
         GeoPosition? GeoPosition(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
+        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are
+        /// within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="member">The member to get a radius of results from.</param>
@@ -161,7 +177,8 @@ namespace StackExchange.Redis
         GeoRadiusResult[] GeoRadius(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
+        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are
+        /// within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="longitude">The longitude of the point to get a radius of results from.</param>
@@ -177,7 +194,9 @@ namespace StackExchange.Redis
         GeoRadiusResult[] GeoRadius(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the number stored at field in the hash stored at key by decrement. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
+        /// Decrements the number stored at field in the hash stored at key by decrement.
+        /// If key does not exist, a new key holding a hash is created.
+        /// If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to decrement.</param>
@@ -189,7 +208,8 @@ namespace StackExchange.Redis
         long HashDecrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrement the specified field of an hash stored at key, and representing a floating point number, by the specified decrement. If the field does not exist, it is set to 0 before performing the operation.
+        /// Decrement the specified field of an hash stored at key, and representing a floating point number, by the specified decrement.
+        /// If the field does not exist, it is set to 0 before performing the operation.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to decrement.</param>
@@ -201,7 +221,8 @@ namespace StackExchange.Redis
         double HashDecrement(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the specified fields from the hash stored at key. Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
+        /// Removes the specified fields from the hash stored at key.
+        /// Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to delete.</param>
@@ -211,7 +232,8 @@ namespace StackExchange.Redis
         bool HashDelete(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the specified fields from the hash stored at key. Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
+        /// Removes the specified fields from the hash stored at key.
+        /// Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The fields in the hash to delete.</param>
@@ -226,7 +248,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the hash contains field. 0 if the hash does not contain field, or key does not exist.</returns>
+        /// <returns><see langword="true"/> if the hash contains field, <see langword="false"/> if the hash does not contain field, or key does not exist.</returns>
         /// <remarks>https://redis.io/commands/hexists</remarks>
         bool HashExists(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
@@ -271,7 +293,9 @@ namespace StackExchange.Redis
         HashEntry[] HashGetAll(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
+        /// Increments the number stored at field in the hash stored at key by increment.
+        /// If key does not exist, a new key holding a hash is created.
+        /// If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to increment.</param>
@@ -283,7 +307,8 @@ namespace StackExchange.Redis
         long HashIncrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. If the field does not exist, it is set to 0 before performing the operation.
+        /// Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment.
+        /// If the field does not exist, it is set to 0 before performing the operation.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to increment.</param>
@@ -324,7 +349,8 @@ namespace StackExchange.Redis
         IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
-        /// The HSCAN command is used to incrementally iterate over a hash; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// The HSCAN command is used to incrementally iterate over a hash.
+        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <see cref="IScanningCursor"/>.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="pattern">The pattern of keys to get entries for.</param>
@@ -337,7 +363,9 @@ namespace StackExchange.Redis
         IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any specified fields that already exist in the hash, leaving other unspecified fields untouched. If key does not exist, a new key holding a hash is created.
+        /// Sets the specified fields to their respective values in the hash stored at key.
+        /// This command overwrites any specified fields that already exist in the hash, leaving other unspecified fields untouched.
+        /// If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The entries to set in the hash.</param>
@@ -346,14 +374,16 @@ namespace StackExchange.Redis
         void HashSet(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
+        /// Sets field in the hash stored at key to value.
+        /// If key does not exist, a new key holding a hash is created.
+        /// If field already exists in the hash, it is overwritten.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field to set in the hash.</param>
         /// <param name="value">The value to set.</param>
         /// <param name="when">Which conditions under which to set the field value (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if field is a new field in the hash and value was set. False if field already exists in the hash and the value was updated.</returns>
+        /// <returns><see langword="true"/> if field is a new field in the hash and value was set, <see langword="false"/> if field already exists in the hash and the value was updated.</returns>
         /// <remarks>https://redis.io/commands/hset</remarks>
         /// <remarks>https://redis.io/commands/hsetnx</remarks>
         bool HashSet(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
@@ -364,7 +394,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field containing the string</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the length of the string at field, or 0 when key does not exist.</returns>
+        /// <returns>The length of the string at field, or 0 when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/hstrlen</remarks>
         long HashStringLength(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
@@ -383,7 +413,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hyperloglog.</param>
         /// <param name="value">The value to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if at least 1 HyperLogLog internal register was altered, false otherwise.</returns>
+        /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/pfadd</remarks>
         bool HyperLogLogAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -393,7 +423,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hyperloglog.</param>
         /// <param name="values">The values to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if at least 1 HyperLogLog internal register was altered, false otherwise.</returns>
+        /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/pfadd</remarks>
         bool HyperLogLogAdd(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
@@ -448,7 +478,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the key was removed.</returns>
+        /// <returns><see langword="true"/> if the key was removed.</returns>
         /// <remarks>https://redis.io/commands/del</remarks>
         /// <remarks>https://redis.io/commands/unlink</remarks>
         bool KeyDelete(RedisKey key, CommandFlags flags = CommandFlags.None);
@@ -465,11 +495,12 @@ namespace StackExchange.Redis
         long KeyDelete(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Serialize the value stored at key in a Redis-specific format and return it to the user. The returned value can be synthesized back into a Redis key using the RESTORE command.
+        /// Serialize the value stored at key in a Redis-specific format and return it to the user.
+        /// The returned value can be synthesized back into a Redis key using the RESTORE command.
         /// </summary>
         /// <param name="key">The key to dump.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the serialized value.</returns>
+        /// <returns>The serialized value.</returns>
         /// <remarks>https://redis.io/commands/dump</remarks>
         byte[] KeyDump(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -478,7 +509,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the key exists. 0 if the key does not exist.</returns>
+        /// <returns><see langword="true"/> if the key exists. <see langword="false"/> if the key does not exist.</returns>
         /// <remarks>https://redis.io/commands/exists</remarks>
         bool KeyExists(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -492,49 +523,71 @@ namespace StackExchange.Redis
         long KeyExists(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted. A key with an associated timeout is said to be volatile in Redis terminology.
+        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted.
+        /// A key with an associated timeout is said to be volatile in Redis terminology.
         /// </summary>
         /// <param name="key">The key to set the expiration for.</param>
         /// <param name="expiry">The timeout to set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the timeout was set. 0 if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
-        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten. So, if key already has an associated timeout, it will do nothing and return 0. Since Redis 2.1.3, you can update the timeout of a key. It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.</remarks>
+        /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
+        /// <remarks>
+        /// If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
+        /// <para>
+        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten.
+        /// So, if key already has an associated timeout, it will do nothing and return 0.
+        /// </para>
+        /// <para>
+        /// Since Redis 2.1.3, you can update the timeout of a key.
+        /// It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.
+        /// </para>
+        /// </remarks>
         /// <remarks>https://redis.io/commands/expire</remarks>
         /// <remarks>https://redis.io/commands/pexpire</remarks>
         /// <remarks>https://redis.io/commands/persist</remarks>
         bool KeyExpire(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted. A key with an associated timeout is said to be volatile in Redis terminology.
+        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted.
+        /// A key with an associated timeout is said to be volatile in Redis terminology.
         /// </summary>
         /// <param name="key">The key to set the expiration for.</param>
         /// <param name="expiry">The exact date to expiry to set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the timeout was set. 0 if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
-        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten. So, if key already has an associated timeout, it will do nothing and return 0. Since Redis 2.1.3, you can update the timeout of a key. It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.</remarks>
+        /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
+        /// <remarks>
+        /// If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
+        /// <para>
+        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten.
+        /// So, if key already has an associated timeout, it will do nothing and return 0.
+        /// </para>
+        /// <para>
+        /// Since Redis 2.1.3, you can update the timeout of a key.
+        /// It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.
+        /// </para>
+        /// </remarks>
         /// <remarks>https://redis.io/commands/expireat</remarks>
         /// <remarks>https://redis.io/commands/pexpireat</remarks>
         /// <remarks>https://redis.io/commands/persist</remarks>
         bool KeyExpire(RedisKey key, DateTime? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the time since the object stored at the specified key is idle (not requested by read or write operations)
+        /// Returns the time since the object stored at the specified key is idle (not requested by read or write operations).
         /// </summary>
         /// <param name="key">The key to get the time of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The time since the object stored at the specified key is idle</returns>
+        /// <returns>The time since the object stored at the specified key is idle.</returns>
         /// <remarks>https://redis.io/commands/object</remarks>
         TimeSpan? KeyIdleTime(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Move key from the currently selected database (see SELECT) to the specified destination database. When key already exists in the destination database, or it does not exist in the source database, it does nothing. It is possible to use MOVE as a locking primitive because of this.
+        /// Move key from the currently selected database (see SELECT) to the specified destination database.
+        /// When key already exists in the destination database, or it does not exist in the source database, it does nothing.
+        /// It is possible to use MOVE as a locking primitive because of this.
         /// </summary>
         /// <param name="key">The key to move.</param>
         /// <param name="database">The database to move the key to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if key was moved; 0 if key was not moved.</returns>
+        /// <returns><see langword="true"/> if key was moved. <see langword="false"/> if key was not moved.</returns>
         /// <remarks>https://redis.io/commands/move</remarks>
         bool KeyMove(RedisKey key, int database, CommandFlags flags = CommandFlags.None);
 
@@ -543,7 +596,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to persist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the timeout was removed. 0 if key does not exist or does not have an associated timeout.</returns>
+        /// <returns><see langword="true"/> if the timeout was removed. <see langword="false"/> if key does not exist or does not have an associated timeout.</returns>
         /// <remarks>https://redis.io/commands/persist</remarks>
         bool KeyPersist(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -556,20 +609,21 @@ namespace StackExchange.Redis
         RedisKey KeyRandom(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Renames key to newkey. It returns an error when the source and destination names are the same, or when key does not exist.
+        /// Renames <paramref name="key"/> to <paramref name="newKey"/>.
+        /// It returns an error when the source and destination names are the same, or when key does not exist.
         /// </summary>
         /// <param name="key">The key to rename.</param>
         /// <param name="newKey">The key to rename to.</param>
         /// <param name="when">What conditions to rename under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the key was renamed, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the key was renamed, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/rename</remarks>
         /// <remarks>https://redis.io/commands/renamenx</remarks>
         bool KeyRename(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Create a key associated with a value that is obtained by deserializing the provided serialized value (obtained via DUMP).
-        /// If ttl is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
+        /// If <paramref name="expiry"/> is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
         /// </summary>
         /// <param name="key">The key to restore.</param>
         /// <param name="value">The value of the key.</param>
@@ -579,7 +633,8 @@ namespace StackExchange.Redis
         void KeyRestore(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the remaining time to live of a key that has a timeout.  This introspection capability allows a Redis client to check how many seconds a given key will continue to be part of the dataset.
+        /// Returns the remaining time to live of a key that has a timeout.
+        /// This introspection capability allows a Redis client to check how many seconds a given key will continue to be part of the dataset.
         /// </summary>
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -588,7 +643,8 @@ namespace StackExchange.Redis
         TimeSpan? KeyTimeToLive(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the string representation of the type of the value stored at key. The different types that can be returned are: string, list, set, zset and hash.
+        /// Returns the string representation of the type of the value stored at key.
+        /// The different types that can be returned are: string, list, set, zset and hash.
         /// </summary>
         /// <param name="key">The key to get the type of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -597,10 +653,13 @@ namespace StackExchange.Redis
         RedisType KeyType(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the element at index index in the list stored at key. The index is zero-based, so 0 means the first element, 1 the second element and so on. Negative indices can be used to designate elements starting at the tail of the list. Here, -1 means the last element, -2 means the penultimate and so forth.
+        /// Returns the element at index in the list stored at key.
+        /// The index is zero-based, so 0 means the first element, 1 the second element and so on.
+        /// Negative indices can be used to designate elements starting at the tail of the list.
+        /// Here, -1 means the last element, -2 means the penultimate and so forth.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="index">The index position to ge the value at.</param>
+        /// <param name="index">The index position to get the value at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The requested element, or nil when index is out of range.</returns>
         /// <remarks>https://redis.io/commands/lindex</remarks>
@@ -640,18 +699,19 @@ namespace StackExchange.Redis
         RedisValue ListLeftPop(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes and returns count elements from the tail of the list stored at key.
-        /// If there are less elements in the list than count, removes and returns all the elements in the list.
+        /// Removes and returns count elements from the head of the list stored at key.
+        /// If the list contains less than count elements, removes and returns the number of elements in the list.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="count">The number of items to remove.</param>
+        /// <param name="count">The number of elements to remove</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
         /// <remarks>https://redis.io/commands/lpop</remarks>
         RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
+        /// Insert the specified value at the head of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="value">The value to add to the head of the list.</param>
@@ -663,10 +723,11 @@ namespace StackExchange.Redis
         long ListLeftPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
+        /// Insert the specified value at the head of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="values">The values to add to the head of the list.</param>
+        /// <param name="values">The value to add to the head of the list.</param>
         /// <param name="when">Which conditions to add to the list under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
@@ -675,8 +736,10 @@ namespace StackExchange.Redis
         long ListLeftPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert all the specified values at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
-        /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element. So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
+        /// Insert all the specified values at the head of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operations.
+        /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element.
+        /// So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the head of the list.</param>
@@ -695,7 +758,8 @@ namespace StackExchange.Redis
         long ListLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified elements of the list stored at key. The offsets start and stop are zero-based indexes, with 0 being the first element of the list (the head of the list), 1 being the next element and so on.
+        /// Returns the specified elements of the list stored at key.
+        /// The offsets start and stop are zero-based indexes, with 0 being the first element of the list (the head of the list), 1 being the next element and so on.
         /// These offsets can also be negative numbers indicating offsets starting at the end of the list.For example, -1 is the last element of the list, -2 the penultimate, and so on.
         /// Note that if you have a list of numbers from 0 to 100, LRANGE list 0 10 will return 11 elements, that is, the rightmost item is included.
         /// </summary>
@@ -708,10 +772,13 @@ namespace StackExchange.Redis
         RedisValue[] ListRange(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the first count occurrences of elements equal to value from the list stored at key. The count argument influences the operation in the following ways:
-        /// count &gt; 0: Remove elements equal to value moving from head to tail.
-        /// count &lt; 0: Remove elements equal to value moving from tail to head.
-        /// count = 0: Remove all elements equal to value.
+        /// Removes the first count occurrences of elements equal to value from the list stored at key.
+        /// The count argument influences the operation in the following ways:
+        /// <list type="bullet">
+        ///     <item>count &gt; 0: Remove elements equal to value moving from head to tail.</item>
+        ///     <item>count &lt; 0: Remove elements equal to value moving from tail to head.</item>
+        ///     <item>count = 0: Remove all elements equal to value.</item>
+        /// </list>
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="value">The value to remove from the list.</param>
@@ -731,11 +798,11 @@ namespace StackExchange.Redis
         RedisValue ListRightPop(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes and returns count elements from the head of the list stored at key.
-        /// If there are less elements in the list than count, removes and returns all the elements in the list.
+        /// Removes and returns count elements from the end the list stored at key.
+        /// If the list contains less than count elements, removes and returns the number of elements in the list.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="count">tThe number of items to remove.</param>
+        /// <param name="count">The number of elements to pop</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
         /// <remarks>https://redis.io/commands/rpop</remarks>
@@ -752,7 +819,8 @@ namespace StackExchange.Redis
         RedisValue ListRightPopLeftPush(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
+        /// Insert the specified value at the tail of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operation.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="value">The value to add to the tail of the list.</param>
@@ -764,7 +832,8 @@ namespace StackExchange.Redis
         long ListRightPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
+        /// Insert the specified value at the tail of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operation.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the tail of the list.</param>
@@ -776,8 +845,10 @@ namespace StackExchange.Redis
         long ListRightPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert all the specified values at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
-        /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element. So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
+        /// Insert all the specified values at the tail of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operation.
+        /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
+        /// So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the tail of the list.</param>
@@ -787,7 +858,9 @@ namespace StackExchange.Redis
         long ListRightPush(RedisKey key, RedisValue[] values, CommandFlags flags);
 
         /// <summary>
-        /// Sets the list element at index to value. For more information on the index argument, see ListGetByIndex. An error is returned for out of range indexes.
+        /// Sets the list element at index to value.
+        /// For more information on the index argument, see <see cref="ListGetByIndex(RedisKey, long, CommandFlags)"/>.
+        /// An error is returned for out of range indexes.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="index">The index to set the value at.</param>
@@ -797,7 +870,8 @@ namespace StackExchange.Redis
         void ListSetByIndex(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Trim an existing list so that it will contain only the specified range of elements specified. Both start and stop are zero-based indexes, where 0 is the first element of the list (the head), 1 the next element and so on.
+        /// Trim an existing list so that it will contain only the specified range of elements specified.
+        /// Both start and stop are zero-based indexes, where 0 is the first element of the list (the head), 1 the next element and so on.
         /// For example: LTRIM foobar 0 2 will modify the list stored at foobar so that only the first three elements of the list will remain.
         /// start and end can also be negative numbers indicating offsets from the end of the list, where -1 is the last element of the list, -2 the penultimate element and so on.
         /// </summary>
@@ -815,7 +889,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to set at the key.</param>
         /// <param name="expiry">The expiration of the lock key.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the lock was successfully extended.</returns>
+        /// <returns><see langword="true"/> if the lock was successfully extended.</returns>
         bool LockExtend(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -830,9 +904,9 @@ namespace StackExchange.Redis
         /// Releases a lock, if the token value is correct.
         /// </summary>
         /// <param name="key">The key of the lock.</param>
-        /// <param name="value">The value at the key tht must match.</param>
+        /// <param name="value">The value at the key that must match.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the lock was successfully released, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the lock was successfully released, <see langword="false"/> otherwise.</returns>
         bool LockRelease(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -842,7 +916,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to set at the key.</param>
         /// <param name="expiry">The expiration of the lock key.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the lock was successfully taken, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the lock was successfully taken, <see langword="false"/> otherwise.</returns>
         bool LockTake(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -856,26 +930,24 @@ namespace StackExchange.Redis
         long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Execute an arbitrary command against the server; this is primarily intended for
-        /// executing modules, but may also be used to provide access to new features that lack
-        /// a direct API.
+        /// Execute an arbitrary command against the server; this is primarily intended for executing modules,
+        /// but may also be used to provide access to new features that lack a direct API.
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
+        /// <returns>A dynamic representation of the command's result.</returns>
         RedisResult Execute(string command, params object[] args);
 
         /// <summary>
-        /// Execute an arbitrary command against the server; this is primarily intended for
-        /// executing modules, but may also be used to provide access to new features that lack
-        /// a direct API.
+        /// Execute an arbitrary command against the server; this is primarily intended for executing modules,
+        /// but may also be used to provide access to new features that lack a direct API.
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
+        /// <returns>A dynamic representation of the command's result.</returns>
         RedisResult Execute(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -885,19 +957,19 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to execute against.</param>
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/eval</remarks>
         /// <remarks>https://redis.io/commands/evalsha</remarks>
         RedisResult ScriptEvaluate(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Execute a Lua script against the server using just the SHA1 hash
+        /// Execute a Lua script against the server using just the SHA1 hash.
         /// </summary>
         /// <param name="hash">The hash of the script to execute.</param>
         /// <param name="keys">The keys to execute against.</param>
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/evalsha</remarks>
         RedisResult ScriptEvaluate(byte[] hash, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None);
 
@@ -908,7 +980,7 @@ namespace StackExchange.Redis
         /// <param name="script">The script to execute.</param>
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/eval</remarks>
         RedisResult ScriptEvaluate(LuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None);
 
@@ -920,7 +992,7 @@ namespace StackExchange.Redis
         /// <param name="script">The already-loaded script to execute.</param>
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/eval</remarks>
         RedisResult ScriptEvaluate(LoadedLuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None);
 
@@ -932,7 +1004,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The value to add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was not already present in the set, else False</returns>
+        /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/sadd</remarks>
         bool SetAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -974,7 +1046,8 @@ namespace StackExchange.Redis
         RedisValue[] SetCombine(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination. If destination already exists, it is overwritten.
+        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination.
+        /// If destination already exists, it is overwritten.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The key of the destination set.</param>
@@ -988,7 +1061,8 @@ namespace StackExchange.Redis
         long SetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination. If destination already exists, it is overwritten.
+        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination.
+        /// If destination already exists, it is overwritten.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The key of the destination set.</param>
@@ -1006,7 +1080,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The value to check for .</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the element is a member of the set. 0 if the element is not a member of the set, or if key does not exist.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the element is a member of the set.
+        /// <see langword="false"/> if the element is not a member of the set, or if key does not exist.
+        /// </returns>
         /// <remarks>https://redis.io/commands/sismember</remarks>
         bool SetContains(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -1029,14 +1106,18 @@ namespace StackExchange.Redis
         RedisValue[] SetMembers(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Move member from the set at source to the set at destination. This operation is atomic. In every given moment the element will appear to be a member of source or destination for other clients.
+        /// Move member from the set at source to the set at destination.
+        /// This operation is atomic. In every given moment the element will appear to be a member of source or destination for other clients.
         /// When the specified element already exists in the destination set, it is only removed from the source set.
         /// </summary>
         /// <param name="source">The key of the source set.</param>
         /// <param name="destination">The key of the destination set.</param>
         /// <param name="value">The value to move.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the element is moved. 0 if the element is not a member of source and no operation was performed.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the element is moved.
+        /// <see langword="false"/> if the element is not a member of source and no operation was performed.
+        /// </returns>
         /// <remarks>https://redis.io/commands/smove</remarks>
         bool SetMove(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -1064,33 +1145,36 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The randomly selected element, or nil when key does not exist</returns>
+        /// <returns>The randomly selected element, or nil when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/srandmember</remarks>
         RedisValue SetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return an array of count distinct elements if count is positive. If called with a negative count the behavior changes and the command is allowed to return the same element multiple times.
+        /// Return an array of count distinct elements if count is positive.
+        /// If called with a negative count the behavior changes and the command is allowed to return the same element multiple times.
         /// In this case the number of returned elements is the absolute value of the specified count.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="count">The count of members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An array of elements, or an empty array when key does not exist</returns>
+        /// <returns>An array of elements, or an empty array when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/srandmember</remarks>
         RedisValue[] SetRandomMembers(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Remove the specified member from the set stored at key.  Specified members that are not a member of this set are ignored.
+        /// Remove the specified member from the set stored at key.
+        /// Specified members that are not a member of this set are ignored.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was already present in the set, else False</returns>
+        /// <returns><see langword="true"/> if the specified member was already present in the set, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/srem</remarks>
         bool SetRemove(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Remove the specified members from the set stored at key. Specified members that are not a member of this set are ignored.
+        /// Remove the specified members from the set stored at key.
+        /// Specified members that are not a member of this set are ignored.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="values">The values to remove.</param>
@@ -1100,7 +1184,7 @@ namespace StackExchange.Redis
         long SetRemove(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The SSCAN command is used to incrementally iterate over set
+        /// The SSCAN command is used to incrementally iterate over a set.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="pattern">The pattern to match.</param>
@@ -1111,7 +1195,8 @@ namespace StackExchange.Redis
         IEnumerable<RedisValue> SetScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
-        /// The SSCAN command is used to incrementally iterate over set; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// The SSCAN command is used to incrementally iterate over set.
+		/// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <see cref="IScanningCursor"/>.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="pattern">The pattern to match.</param>
@@ -1124,11 +1209,12 @@ namespace StackExchange.Redis
         IEnumerable<RedisValue> SetScan(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default); By default, the elements themselves are compared, but the values can also be
-        /// used to perform external key-lookups using the <c>by</c> parameter. By default, the elements themselves are returned, but external key-lookups (one or many) can
-        /// be performed instead by specifying the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
-        /// can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
+        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default).
+        /// By default, the elements themselves are compared, but the values can also be used to perform external key-lookups using the <c>by</c> parameter.
+        /// By default, the elements themselves are returned, but external key-lookups (one or many) can be performed instead by specifying
+        /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
+        /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
         /// <param name="key">The key of the list, set, or sorted set.</param>
         /// <param name="skip">How many entries to skip on the return.</param>
@@ -1143,11 +1229,12 @@ namespace StackExchange.Redis
         RedisValue[] Sort(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default(RedisValue), RedisValue[] get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default); By default, the elements themselves are compared, but the values can also be
-        /// used to perform external key-lookups using the <c>by</c> parameter. By default, the elements themselves are returned, but external key-lookups (one or many) can
-        /// be performed instead by specifying the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
-        /// can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
+        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default).
+        /// By default, the elements themselves are compared, but the values can also be used to perform external key-lookups using the <c>by</c> parameter.
+        /// By default, the elements themselves are returned, but external key-lookups (one or many) can be performed instead by specifying
+        /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
+        /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
         /// <param name="destination">The destination key to store results in.</param>
         /// <param name="key">The key of the list, set, or sorted set.</param>
@@ -1163,30 +1250,33 @@ namespace StackExchange.Redis
         long SortAndStore(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default(RedisValue), RedisValue[] get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds the specified member with the specified score to the sorted set stored at key. If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds the specified member with the specified score to the sorted set stored at key.
+        /// If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to add to the sorted set.</param>
         /// <param name="score">The score for the member to add to the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the value was added, False if it already existed (the score is still updated)</returns>
+        /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
         /// <remarks>https://redis.io/commands/zadd</remarks>
         bool SortedSetAdd(RedisKey key, RedisValue member, double score, CommandFlags flags);
 
         /// <summary>
-        /// Adds the specified member with the specified score to the sorted set stored at key. If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds the specified member with the specified score to the sorted set stored at key.
+        /// If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to add to the sorted set.</param>
         /// <param name="score">The score for the member to add to the sorted set.</param>
         /// <param name="when">What conditions to add the element under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the value was added, False if it already existed (the score is still updated)</returns>
+        /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
         /// <remarks>https://redis.io/commands/zadd</remarks>
         bool SortedSetAdd(RedisKey key, RedisValue member, double score, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds all the specified members with the specified scores to the sorted set stored at key. If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds all the specified members with the specified scores to the sorted set stored at key.
+        /// If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="values">The members and values to add to the sorted set.</param>
@@ -1196,7 +1286,8 @@ namespace StackExchange.Redis
         long SortedSetAdd(RedisKey key, SortedSetEntry[] values, CommandFlags flags);
 
         /// <summary>
-        /// Adds all the specified members with the specified scores to the sorted set stored at key. If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds all the specified members with the specified scores to the sorted set stored at key.
+        /// If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="values">The members and values to add to the sorted set.</param>
@@ -1218,7 +1309,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zunionstore</remarks>
         /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <returns>the number of elements in the resulting sorted set at destination</returns>
+        /// <returns>The number of elements in the resulting sorted set at destination.</returns>
         long SortedSetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1233,11 +1324,12 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zunionstore</remarks>
         /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <returns>the number of elements in the resulting sorted set at destination</returns>
+        /// <returns>The number of elements in the resulting sorted set at destination.</returns>
         long SortedSetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the score of member in the sorted set stored at key by decrement. If member does not exist in the sorted set, it is added with -decrement as its score (as if its previous score was 0.0).
+        /// Decrements the score of member in the sorted set stored at key by decrement.
+        /// If member does not exist in the sorted set, it is added with -decrement as its score (as if its previous score was 0.0).
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to decrement.</param>
@@ -1271,7 +1363,8 @@ namespace StackExchange.Redis
         long SortedSetLength(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns the number of elements in the sorted set at key with a value between min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command returns the number of elements in the sorted set at key with a value between min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The min value to filter by.</param>
@@ -1283,8 +1376,11 @@ namespace StackExchange.Redis
         long SortedSetLengthByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.
+        /// They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The start index to get.</param>
@@ -1297,8 +1393,11 @@ namespace StackExchange.Redis
         RedisValue[] SortedSetRangeByRank(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.
+        /// They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The start index to get.</param>
@@ -1311,8 +1410,11 @@ namespace StackExchange.Redis
         SortedSetEntry[] SortedSetRangeByRankWithScores(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Start and stop are used to specify the min and max range for score values. Similar to other range methods the values are inclusive.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Start and stop are used to specify the min and max range for score values.
+        /// Similar to other range methods the values are inclusive.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The minimum score to filter by.</param>
@@ -1335,8 +1437,11 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Start and stop are used to specify the min and max range for score values. Similar to other range methods the values are inclusive.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Start and stop are used to specify the min and max range for score values.
+        /// Similar to other range methods the values are inclusive.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The minimum score to filter by.</param>
@@ -1359,7 +1464,8 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at key with a value between min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command returns all the elements in the sorted set at key with a value between min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The min value to filter by.</param>
@@ -1369,7 +1475,7 @@ namespace StackExchange.Redis
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zrangebylex</remarks>
-        /// <returns>list of elements in the specified score range.</returns>
+        /// <returns>List of elements in the specified score range.</returns>
         RedisValue[] SortedSetRangeByValue(RedisKey key,
             RedisValue min,
             RedisValue max,
@@ -1379,7 +1485,8 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None); // defaults removed to avoid ambiguity with overload with order
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at key with a value between min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command returns all the elements in the sorted set at key with a value between min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The min value to filter by.</param>
@@ -1391,7 +1498,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zrangebylex</remarks>
         /// <remarks>https://redis.io/commands/zrevrangebylex</remarks>
-        /// <returns>list of elements in the specified score range.</returns>
+        /// <returns>List of elements in the specified score range.</returns>
         RedisValue[] SortedSetRangeByValue(RedisKey key,
             RedisValue min = default(RedisValue),
             RedisValue max = default(RedisValue),
@@ -1402,13 +1509,14 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high. The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.
+        /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high.
+        /// The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to get the rank of.</param>
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>If member exists in the sorted set, the rank of member; If member does not exist in the sorted set or key does not exist, null</returns>
+        /// <returns>If member exists in the sorted set, the rank of member. If member does not exist in the sorted set or key does not exist, <see langword="null"/>.</returns>
         /// <remarks>https://redis.io/commands/zrank</remarks>
         /// <remarks>https://redis.io/commands/zrevrank</remarks>
         long? SortedSetRank(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
@@ -1419,7 +1527,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the member existed in the sorted set and was removed; False otherwise.</returns>
+        /// <returns><see langword="true"/> if the member existed in the sorted set and was removed. <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/zrem</remarks>
         bool SortedSetRemove(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
@@ -1434,7 +1542,10 @@ namespace StackExchange.Redis
         long SortedSetRemove(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes all elements in the sorted set stored at key with rank between start and stop. Both start and stop are 0 -based indexes with 0 being the element with the lowest score. These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score. For example: -1 is the element with the highest score, -2 the element with the second highest score and so forth.
+        /// Removes all elements in the sorted set stored at key with rank between start and stop.
+        /// Both start and stop are 0 -based indexes with 0 being the element with the lowest score.
+        /// These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score.
+        /// For example: -1 is the element with the highest score, -2 the element with the second highest score and so forth.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The minimum rank to remove.</param>
@@ -1457,19 +1568,20 @@ namespace StackExchange.Redis
         long SortedSetRemoveRangeByScore(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command removes all elements in the sorted set stored at key between the lexicographical range specified by min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command removes all elements in the sorted set stored at key between the lexicographical range specified by min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The minimum value to remove.</param>
         /// <param name="max">The maximum value to remove.</param>
         /// <param name="exclude">Which of <paramref name="min"/> and <paramref name="max"/> to exclude (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the number of elements removed.</returns>
+        /// <returns>The number of elements removed.</returns>
         /// <remarks>https://redis.io/commands/zremrangebylex</remarks>
         long SortedSetRemoveRangeByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The ZSCAN command is used to incrementally iterate over a sorted set
+        /// The ZSCAN command is used to incrementally iterate over a sorted set.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="pattern">The pattern to match.</param>
@@ -1480,7 +1592,8 @@ namespace StackExchange.Redis
         IEnumerable<SortedSetEntry> SortedSetScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
-        /// The ZSCAN command is used to incrementally iterate over a sorted set; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// The ZSCAN command is used to incrementally iterate over a sorted set
+		/// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="pattern">The pattern to match.</param>
@@ -1498,7 +1611,8 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the score of member in the sorted set at key; If member does not exist in the sorted set, or key does not exist, nil is returned.
+        /// Returns the score of member in the sorted set at key.
+        /// If member does not exist in the sorted set, or key does not exist, nil is returned.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to get a score for.</param>
@@ -1553,7 +1667,9 @@ namespace StackExchange.Redis
         long StreamAcknowledge(RedisKey key, RedisValue groupName, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds an entry using the specified values to the given stream key. If key does not exist, a new key holding a stream is created. The command returns the ID of the newly created stream entry.
+        /// Adds an entry using the specified values to the given stream key.
+        /// If key does not exist, a new key holding a stream is created.
+        /// The command returns the ID of the newly created stream entry.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="streamField">The field name for the stream entry.</param>
@@ -1567,7 +1683,9 @@ namespace StackExchange.Redis
         RedisValue StreamAdd(RedisKey key, RedisValue streamField, RedisValue streamValue, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds an entry using the specified values to the given stream key. If key does not exist, a new key holding a stream is created. The command returns the ID of the newly created stream entry.
+        /// Adds an entry using the specified values to the given stream key.
+        /// If key does not exist, a new key holding a stream is created.
+        /// The command returns the ID of the newly created stream entry.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="streamPairs">The fields and their associated values to set in the stream entry.</param>
@@ -1580,7 +1698,8 @@ namespace StackExchange.Redis
         RedisValue StreamAdd(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer. This method returns the complete message for the claimed message(s).
+        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer.
+        /// This method returns the complete message for the claimed message(s).
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="consumerGroup">The consumer group.</param>
@@ -1593,7 +1712,8 @@ namespace StackExchange.Redis
         StreamEntry[] StreamClaim(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer. This method returns the IDs for the claimed message(s).
+        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer.
+        /// This method returns the IDs for the claimed message(s).
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="consumerGroup">The consumer group.</param>
@@ -1612,16 +1732,17 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="position">The position from which to read for the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if successful, otherwise false.</returns>
+        /// <returns><see langword="true"/> if successful, <see langword="false"/> otherwise.</returns>
         bool StreamConsumerGroupSetPosition(RedisKey key, RedisValue groupName, RedisValue position, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Retrieve information about the consumers for the given consumer group. This is the equivalent of calling "XINFO GROUPS key group".
+        /// Retrieve information about the consumers for the given consumer group.
+        /// This is the equivalent of calling "XINFO GROUPS key group".
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The consumer group name.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An instance of <see cref="Redis.StreamConsumerInfo"/> for each of the consumer group's consumers.</returns>
+        /// <returns>An instance of <see cref="StreamConsumerInfo"/> for each of the consumer group's consumers.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         StreamConsumerInfo[] StreamConsumerInfo(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
@@ -1632,7 +1753,7 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the group to create.</param>
         /// <param name="position">The position to begin reading the stream. Defaults to <see cref="StreamPosition.NewMessages"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the group was created.</returns>
+        /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         bool StreamCreateConsumerGroup(RedisKey key, RedisValue groupName, RedisValue? position, CommandFlags flags);
 
@@ -1644,7 +1765,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position to begin reading the stream. Defaults to <see cref="StreamPosition.NewMessages"/>.</param>
         /// <param name="createStream">Create the stream if it does not already exist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the group was created.</returns>
+        /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         bool StreamCreateConsumerGroup(RedisKey key, RedisValue groupName, RedisValue? position = null, bool createStream = true, CommandFlags flags = CommandFlags.None);
 
@@ -1674,7 +1795,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if deleted, otherwise false.</returns>
+        /// <returns><see langword="true"/> if deleted, <see langword="false"/> otherwise.</returns>
         bool StreamDeleteConsumerGroup(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1682,7 +1803,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An instance of <see cref="Redis.StreamGroupInfo"/> for each of the stream's groups.</returns>
+        /// <returns>An instance of <see cref="StreamGroupInfo"/> for each of the stream's groups.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         StreamGroupInfo[] StreamGroupInfo(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -1691,7 +1812,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A <see cref="Redis.StreamInfo"/> instance with information about the stream.</returns>
+        /// <returns>A <see cref="StreamInfo"/> instance with information about the stream.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         StreamInfo StreamInfo(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -1706,11 +1827,16 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// View information about pending messages for a stream.
+        /// A pending message is a message read using StreamReadGroup (XREADGROUP) but not yet acknowledged.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An instance of <see cref="StreamPendingInfo"/>. <see cref="StreamPendingInfo"/> contains the number of pending messages, the highest and lowest ID of the pending messages, and the consumers with their pending message count.</returns>
+        /// <returns>
+        /// An instance of <see cref="StreamPendingInfo"/>.
+        /// <see cref="StreamPendingInfo"/> contains the number of pending messages.
+        /// The highest and lowest ID of the pending messages, and the consumers with their pending message count.
+        /// </returns>
         /// <remarks>The equivalent of calling XPENDING key group.</remarks>
         /// <remarks>https://redis.io/commands/xpending</remarks>
         StreamPendingInfo StreamPending(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
@@ -1737,7 +1863,7 @@ namespace StackExchange.Redis
         /// <param name="minId">The minimum ID from which to read the stream. The method will default to reading from the beginning of the stream.</param>
         /// <param name="maxId">The maximum ID to read to within the stream. The method will default to reading to the end of the stream.</param>
         /// <param name="count">The maximum number of messages to return.</param>
-        /// <param name="messageOrder">The order of the messages. <see cref="Order.Ascending"/> will execute XRANGE and <see cref="Order.Descending"/> wil execute XREVRANGE.</param>
+        /// <param name="messageOrder">The order of the messages. <see cref="Order.Ascending"/> will execute XRANGE and <see cref="Order.Descending"/> will execute XREVRANGE.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>https://redis.io/commands/xrange</remarks>
@@ -1750,7 +1876,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position from which to read the stream.</param>
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
+        /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key id.</remarks>
         /// <remarks>https://redis.io/commands/xread</remarks>
         StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None);
@@ -1772,7 +1898,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="consumerName">The consumer name.</param>
-        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when null.</param>
+        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when <see langword="null"/>.</param>
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
@@ -1785,7 +1911,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="consumerName">The consumer name.</param>
-        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when null.</param>
+        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when <see langword="null"/>.</param>
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="noAck">When true, the message will not be added to the pending message list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1794,8 +1920,8 @@ namespace StackExchange.Redis
         StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Read from multiple streams into the given consumer group. The consumer group with the given <paramref name="groupName"/>
-        /// will need to have been created for each stream prior to calling this method.
+        /// Read from multiple streams into the given consumer group.
+        /// The consumer group with the given <paramref name="groupName"/> will need to have been created for each stream prior to calling this method.
         /// </summary>
         /// <param name="streamPositions">Array of streams and the positions from which to begin reading for each stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
@@ -1808,8 +1934,8 @@ namespace StackExchange.Redis
         RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream, CommandFlags flags);
 
         /// <summary>
-        /// Read from multiple streams into the given consumer group. The consumer group with the given <paramref name="groupName"/>
-        /// will need to have been created for each stream prior to calling this method.
+        /// Read from multiple streams into the given consumer group.
+        /// The consumer group with the given <paramref name="groupName"/> will need to have been created for each stream prior to calling this method.
         /// </summary>
         /// <param name="streamPositions">Array of streams and the positions from which to begin reading for each stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
@@ -1834,8 +1960,8 @@ namespace StackExchange.Redis
         long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// If key already exists and is a string, this command appends the value at the end of the string. If key does not exist it is created and set as an empty string,
-        /// so APPEND will be similar to SET in this special case.
+        /// If key already exists and is a string, this command appends the value at the end of the string.
+        /// If key does not exist it is created and set as an empty string, so APPEND will be similar to SET in this special case.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The value to append to the string.</param>
@@ -1846,7 +1972,8 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Count the number of set bits (population counting) in a string.
-        /// By default all the bytes contained in the string are examined. It is possible to specify the counting operation only in an interval passing the additional arguments start and end.
+        /// By default all the bytes contained in the string are examined.
+        /// It is possible to specify the counting operation only in an interval passing the additional arguments start and end.
         /// Like for the GETRANGE command start and end can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
         /// </summary>
         /// <param name="key">The key of the string.</param>
@@ -1861,7 +1988,7 @@ namespace StackExchange.Redis
         /// Perform a bitwise operation between multiple keys (containing string values) and store the result in the destination key.
         /// The BITOP command supports four bitwise operations; note that NOT is a unary operator: the second key should be omitted in this case
         /// and only the first key will be considered.
-        /// The result of the operation is always stored at destkey.
+        /// The result of the operation is always stored at <paramref name="destination"/>.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The destination key to store the result in.</param>
@@ -1875,7 +2002,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Perform a bitwise operation between multiple keys (containing string values) and store the result in the destination key.
         /// The BITOP command supports four bitwise operations; note that NOT is a unary operator.
-        /// The result of the operation is always stored at destkey.
+        /// The result of the operation is always stored at <paramref name="destination"/>.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The destination key to store the result in.</param>
@@ -1888,7 +2015,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// Return the position of the first bit set to 1 or 0 in a string.
         /// The position is returned thinking at the string as an array of bits from left to right where the first byte most significant bit is at position 0, the second byte most significant bit is at position 8 and so forth.
-        /// An start and end may be specified; these are in bytes, not bits; start and end can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
+        /// A <paramref name="start"/> and <paramref name="end"/> may be specified - these are in bytes, not bits.
+        /// <paramref name="start"/> and <paramref name="end"/> can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="bit">True to check for the first 1 bit, false to check for the first 0 bit.</param>
@@ -1901,8 +2029,10 @@ namespace StackExchange.Redis
         long StringBitPosition(RedisKey key, bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the number stored at key by decrement. If the key does not exist, it is set to 0 before performing the operation.
-        /// An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer. This operation is limited to 64 bit signed integers.
+        /// Decrements the number stored at key by decrement.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer.
+        /// This operation is limited to 64 bit signed integers.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
@@ -1913,7 +2043,9 @@ namespace StackExchange.Redis
         long StringDecrement(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the string representing a floating point number stored at key by the specified decrement. If the key does not exist, it is set to 0 before performing the operation. The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
+        /// Decrements the string representing a floating point number stored at key by the specified decrement.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
@@ -1923,7 +2055,8 @@ namespace StackExchange.Redis
         double StringDecrement(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key. If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1932,7 +2065,8 @@ namespace StackExchange.Redis
         RedisValue StringGet(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the values of all specified keys. For every key that does not hold a string value or does not exist, the special value nil is returned.
+        /// Returns the values of all specified keys.
+        /// For every key that does not hold a string value or does not exist, the special value nil is returned.
         /// </summary>
         /// <param name="keys">The keys of the strings.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1941,7 +2075,8 @@ namespace StackExchange.Redis
         RedisValue[] StringGet(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key. If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1961,7 +2096,9 @@ namespace StackExchange.Redis
         bool StringGetBit(RedisKey key, long offset, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the substring of the string value stored at key, determined by the offsets start and end (both are inclusive). Negative offsets can be used in order to provide an offset starting from the end of the string. So -1 means the last character, -2 the penultimate and so forth.
+        /// Returns the substring of the string value stored at key, determined by the offsets start and end (both are inclusive).
+        /// Negative offsets can be used in order to provide an offset starting from the end of the string.
+        /// So -1 means the last character, -2 the penultimate and so forth.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="start">The start index of the substring to get.</param>
@@ -1982,7 +2119,9 @@ namespace StackExchange.Redis
         RedisValue StringGetSet(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key and delete the key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key and delete the key.
+        /// If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1991,7 +2130,9 @@ namespace StackExchange.Redis
         RedisValue StringGetDelete(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key.
+        /// If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -2000,7 +2141,10 @@ namespace StackExchange.Redis
         RedisValueWithExpiry StringGetWithExpiry(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the number stored at key by increment. If the key does not exist, it is set to 0 before performing the operation. An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer. This operation is limited to 64 bit signed integers.
+        /// Increments the number stored at key by increment.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer.
+        /// This operation is limited to 64 bit signed integers.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to increment by (defaults to 1).</param>
@@ -2011,7 +2155,9 @@ namespace StackExchange.Redis
         long StringIncrement(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the string representing a floating point number stored at key by the specified increment. If the key does not exist, it is set to 0 before performing the operation. The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
+        /// Increments the string representing a floating point number stored at key by the specified increment.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to increment by (defaults to 1).</param>
@@ -2025,7 +2171,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the length of the string at key, or 0 when key does not exist.</returns>
+        /// <returns>The length of the string at key, or 0 when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/strlen</remarks>
         long StringLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -2037,24 +2183,26 @@ namespace StackExchange.Redis
         /// <param name="expiry">The expiry to set.</param>
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the string was set, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the string was set, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/set</remarks>
         bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets the given keys to their respective values. If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
+        /// Sets the given keys to their respective values.
+        /// If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
         /// </summary>
         /// <param name="values">The keys and values to set.</param>
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the keys were set, else False</returns>
+        /// <returns><see langword="true"/> if the keys were set, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/mset</remarks>
         /// <remarks>https://redis.io/commands/msetnx</remarks>
         bool StringSet(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Sets or clears the bit at offset in the string value stored at key.
-        /// The bit is either set or cleared depending on value, which can be either 0 or 1. When key does not exist, a new string value is created.The string is grown to make sure it can hold a bit at offset.
+        /// The bit is either set or cleared depending on value, which can be either 0 or 1.
+        /// When key does not exist, a new string value is created.The string is grown to make sure it can hold a bit at offset.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="offset">The offset in the string to set <paramref name="bit"/>.</param>
@@ -2065,7 +2213,9 @@ namespace StackExchange.Redis
         bool StringSetBit(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Overwrites part of the string stored at key, starting at the specified offset, for the entire length of value. If the offset is larger than the current length of the string at key, the string is padded with zero-bytes to make offset fit. Non-existing keys are considered as empty strings, so this command will make sure it holds a string large enough to be able to set value at offset.
+        /// Overwrites part of the string stored at key, starting at the specified offset, for the entire length of value.
+        /// If the offset is larger than the current length of the string at key, the string is padded with zero-bytes to make offset fit.
+        /// Non-existing keys are considered as empty strings, so this command will make sure it holds a string large enough to be able to set value at offset.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="offset">The offset in the string to overwrite.</param>
@@ -2080,7 +2230,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the key was touched.</returns>
+        /// <returns><see langword="true"/> if the key was touched, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/touch</remarks>
         bool KeyTouch(RedisKey key, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -2192,7 +2192,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Sets the given keys to their respective values.
-        /// If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
+        /// If <see cref="When.NotExists"/> is specified, this will not perform any operation at all even if just a single key already exists.
         /// </summary>
         /// <param name="values">The keys and values to set.</param>
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
@@ -2238,7 +2238,7 @@ namespace StackExchange.Redis
         bool KeyTouch(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Alters the last access time of a keys. A key is ignored if it does not exist.
+        /// Alters the last access time of the specified <paramref name="keys"/>. A key is ignored if it does not exist.
         /// </summary>
         /// <param name="keys">The keys to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -2145,7 +2145,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Sets the given keys to their respective values.
-        /// If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
+        /// If <see cref="When.NotExists"/> is specified, this will not perform any operation at all even if just a single key already exists.
         /// </summary>
         /// <param name="values">The keys and values to set.</param>
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
@@ -2191,7 +2191,7 @@ namespace StackExchange.Redis
         Task<bool> KeyTouchAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Alters the last access time of a keys. A key is ignored if it does not exist.
+        /// Alters the last access time of the specified <paramref name="keys"/>. A key is ignored if it does not exist.
         /// </summary>
         /// <param name="keys">The keys to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -599,7 +599,7 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Create a key associated with a value that is obtained by deserializing the provided serialized value (obtained via DUMP).
-        /// If <paramref name="expiry"/> is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
+        /// If <paramref name="expiry"/> is 0 the key is created without any expire, otherwise the specified expire time (in milliseconds) is set.
         /// </summary>
         /// <param name="key">The key to restore.</param>
         /// <param name="value">The value of the key.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -6,20 +6,20 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Describes functionality that is common to both standalone redis servers and redis clusters
+    /// Describes functionality that is common to both standalone redis servers and redis clusters.
     /// </summary>
     public interface IDatabaseAsync : IRedisAsync
     {
         /// <summary>
-        /// Indicates whether the instance can communicate with the server (resolved
-        /// using the supplied key and optional flags)
+        /// Indicates whether the instance can communicate with the server (resolved using the supplied key and optional flags).
         /// </summary>
         /// <param name="key">The key to check for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         bool IsConnected(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Atomically transfer a key from a source Redis instance to a destination Redis instance. On success the key is deleted from the original instance by default, and is guaranteed to exist in the target instance.
+        /// Atomically transfer a key from a source Redis instance to a destination Redis instance.
+        /// On success the key is deleted from the original instance by default, and is guaranteed to exist in the target instance.
         /// </summary>
         /// <param name="key">The key to migrate.</param>
         /// <param name="toServer">The server to migrate the key to.</param>
@@ -31,7 +31,8 @@ namespace StackExchange.Redis
         Task KeyMigrateAsync(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the raw DEBUG OBJECT output for a key; this command is not fully documented and should be avoided unless you have good reason, and then avoided anyway.
+        /// Returns the raw DEBUG OBJECT output for a key.
+        /// This command is not fully documented and should be avoided unless you have good reason, and then avoided anyway.
         /// </summary>
         /// <param name="key">The key to debug.</param>
         /// <param name="flags">The flags to use for this migration.</param>
@@ -40,29 +41,35 @@ namespace StackExchange.Redis
         Task<RedisValue> DebugObjectAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
+        /// Add the specified member to the set stored at key.
+        /// Specified members that are already a member of this set are ignored.
+        /// If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="longitude">The longitude of geo entry.</param>
         /// <param name="latitude">The latitude of the geo entry.</param>
         /// <param name="member">The value to set at this entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was not already present in the set, else False.</returns>
+        /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/geoadd</remarks>
         Task<bool> GeoAddAsync(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Add the specified member to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
+        /// Add the specified member to the set stored at key.
+        /// Specified members that are already a member of this set are ignored.
+        /// If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The geo value to store.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was not already present in the set, else False</returns>
+        /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/geoadd</remarks>
         Task<bool> GeoAddAsync(RedisKey key, StackExchange.Redis.GeoEntry value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Add the specified members to the set stored at key. Specified members that are already a member of this set are ignored. If key does not exist, a new set is created before adding the specified members.
+        /// Add the specified members to the set stored at key.
+        /// Specified members that are already a member of this set are ignored.
+        /// If key does not exist, a new set is created before adding the specified members.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="values">The geo values add to the set.</param>
@@ -72,12 +79,13 @@ namespace StackExchange.Redis
         Task<long> GeoAddAsync(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the specified member from the geo sorted set stored at key. Non existing members are ignored.
+        /// Removes the specified member from the geo sorted set stored at key.
+        /// Non existing members are ignored.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="member">The geo value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the member existed in the sorted set and was removed; False otherwise.</returns>
+        /// <returns><see langword="true"/> if the member existed in the sorted set and was removed, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/zrem</remarks>
         Task<bool> GeoRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
@@ -89,7 +97,7 @@ namespace StackExchange.Redis
         /// <param name="member2">The second member to check.</param>
         /// <param name="unit">The unit of distance to return (defaults to meters).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or NULL if one or both the elements are missing.</returns>
+        /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or <see langword="null"/> if one or both the elements are missing.</returns>
         /// <remarks>https://redis.io/commands/geodist</remarks>
         Task<double?> GeoDistanceAsync(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None);
 
@@ -119,7 +127,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="members">The members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.Non existing elements are reported as NULL elements of the array.</returns>
+        /// <returns>
+        /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
+        /// Non existing elements are reported as NULL elements of the array.
+        /// </returns>
         /// <remarks>https://redis.io/commands/geopos</remarks>
         Task<GeoPosition?[]> GeoPositionAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
@@ -129,12 +140,16 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="member">The member to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.Non existing elements are reported as NULL elements of the array.</returns>
+        /// <returns>
+        /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
+        /// Non existing elements are reported as NULL elements of the array.
+        /// </returns>
         /// <remarks>https://redis.io/commands/geopos</remarks>
         Task<GeoPosition?> GeoPositionAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
+        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are
+        /// within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="member">The member to get a radius of results from.</param>
@@ -149,7 +164,8 @@ namespace StackExchange.Redis
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
+        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are
+        /// within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="longitude">The longitude of the point to get a radius of results from.</param>
@@ -165,7 +181,9 @@ namespace StackExchange.Redis
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the number stored at field in the hash stored at key by decrement. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
+        /// Decrements the number stored at field in the hash stored at key by decrement.
+        /// If key does not exist, a new key holding a hash is created.
+        /// If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to decrement.</param>
@@ -177,7 +195,8 @@ namespace StackExchange.Redis
         Task<long> HashDecrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrement the specified field of an hash stored at key, and representing a floating point number, by the specified decrement. If the field does not exist, it is set to 0 before performing the operation.
+        /// Decrement the specified field of an hash stored at key, and representing a floating point number, by the specified decrement.
+        /// If the field does not exist, it is set to 0 before performing the operation.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to decrement.</param>
@@ -189,7 +208,8 @@ namespace StackExchange.Redis
         Task<double> HashDecrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the specified fields from the hash stored at key. Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
+        /// Removes the specified fields from the hash stored at key.
+        /// Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to delete.</param>
@@ -199,7 +219,8 @@ namespace StackExchange.Redis
         Task<bool> HashDeleteAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the specified fields from the hash stored at key. Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
+        /// Removes the specified fields from the hash stored at key.
+        /// Non-existing fields are ignored. Non-existing keys are treated as empty hashes and this command returns 0.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The fields in the hash to delete.</param>
@@ -214,7 +235,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the hash contains field. 0 if the hash does not contain field, or key does not exist.</returns>
+        /// <returns><see langword="true"/> if the hash contains field, <see langword="false"/> if the hash does not contain field, or key does not exist.</returns>
         /// <remarks>https://redis.io/commands/hexists</remarks>
         Task<bool> HashExistsAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
@@ -259,7 +280,9 @@ namespace StackExchange.Redis
         Task<HashEntry[]> HashGetAllAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the number stored at field in the hash stored at key by increment. If key does not exist, a new key holding a hash is created. If field does not exist the value is set to 0 before the operation is performed.
+        /// Increments the number stored at field in the hash stored at key by increment.
+        /// If key does not exist, a new key holding a hash is created.
+        /// If field does not exist the value is set to 0 before the operation is performed.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to increment.</param>
@@ -271,7 +294,8 @@ namespace StackExchange.Redis
         Task<long> HashIncrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment. If the field does not exist, it is set to 0 before performing the operation.
+        /// Increment the specified field of an hash stored at key, and representing a floating point number, by the specified increment.
+        /// If the field does not exist, it is set to 0 before performing the operation.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field in the hash to increment.</param>
@@ -301,7 +325,8 @@ namespace StackExchange.Redis
         Task<long> HashLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The HSCAN command is used to incrementally iterate over a hash; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// The HSCAN command is used to incrementally iterate over a hash.
+        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <see cref="IScanningCursor"/>.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="pattern">The pattern of keys to get entries for.</param>
@@ -314,7 +339,9 @@ namespace StackExchange.Redis
         IAsyncEnumerable<HashEntry> HashScanAsync(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets the specified fields to their respective values in the hash stored at key. This command overwrites any specified fields that already exist in the hash, leaving other unspecified fields untouched. If key does not exist, a new key holding a hash is created.
+        /// Sets the specified fields to their respective values in the hash stored at key.
+        /// This command overwrites any specified fields that already exist in the hash, leaving other unspecified fields untouched.
+        /// If key does not exist, a new key holding a hash is created.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The entries to set in the hash.</param>
@@ -323,14 +350,16 @@ namespace StackExchange.Redis
         Task HashSetAsync(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created. If field already exists in the hash, it is overwritten.
+        /// Sets field in the hash stored at key to value.
+        /// If key does not exist, a new key holding a hash is created.
+        /// If field already exists in the hash, it is overwritten.
         /// </summary>
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field to set in the hash.</param>
         /// <param name="value">The value to set.</param>
         /// <param name="when">Which conditions under which to set the field value (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if field is a new field in the hash and value was set. 0 if field already exists in the hash and the value was updated.</returns>
+        /// <returns><see langword="true"/> if field is a new field in the hash and value was set, <see langword="false"/> if field already exists in the hash and the value was updated.</returns>
         /// <remarks>https://redis.io/commands/hset</remarks>
         /// <remarks>https://redis.io/commands/hsetnx</remarks>
         Task<bool> HashSetAsync(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
@@ -341,7 +370,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashField">The field containing the string</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the length of the string at field, or 0 when key does not exist.</returns>
+        /// <returns>The length of the string at field, or 0 when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/hstrlen</remarks>
         Task<long> HashStringLengthAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
@@ -360,7 +389,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hyperloglog.</param>
         /// <param name="value">The value to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if at least 1 HyperLogLog internal register was altered, false otherwise.</returns>
+        /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/pfadd</remarks>
         Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -370,7 +399,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hyperloglog.</param>
         /// <param name="values">The values to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if at least 1 HyperLogLog internal register was altered, false otherwise.</returns>
+        /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/pfadd</remarks>
         Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
@@ -425,7 +454,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the key was removed.</returns>
+        /// <returns><see langword="true"/> if the key was removed.</returns>
         /// <remarks>https://redis.io/commands/del</remarks>
         /// <remarks>https://redis.io/commands/unlink</remarks>
         Task<bool> KeyDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
@@ -442,11 +471,12 @@ namespace StackExchange.Redis
         Task<long> KeyDeleteAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Serialize the value stored at key in a Redis-specific format and return it to the user. The returned value can be synthesized back into a Redis key using the RESTORE command.
+        /// Serialize the value stored at key in a Redis-specific format and return it to the user.
+        /// The returned value can be synthesized back into a Redis key using the RESTORE command.
         /// </summary>
         /// <param name="key">The key to dump.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the serialized value.</returns>
+        /// <returns>The serialized value.</returns>
         /// <remarks>https://redis.io/commands/dump</remarks>
         Task<byte[]> KeyDumpAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -455,7 +485,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the key exists. 0 if the key does not exist.</returns>
+        /// <returns><see langword="true"/> if the key exists. <see langword="false"/> if the key does not exist.</returns>
         /// <remarks>https://redis.io/commands/exists</remarks>
         Task<bool> KeyExistsAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -469,49 +499,71 @@ namespace StackExchange.Redis
         Task<long> KeyExistsAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted. A key with an associated timeout is said to be volatile in Redis terminology.
+        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted.
+        /// A key with an associated timeout is said to be volatile in Redis terminology.
         /// </summary>
         /// <param name="key">The key to set the expiration for.</param>
         /// <param name="expiry">The timeout to set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the timeout was set. 0 if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
-        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten. So, if key already has an associated timeout, it will do nothing and return 0. Since Redis 2.1.3, you can update the timeout of a key. It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.</remarks>
+        /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
+        /// <remarks>
+        /// If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
+        /// <para>
+        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten.
+        /// So, if key already has an associated timeout, it will do nothing and return 0.
+        /// </para>
+        /// <para>
+        /// Since Redis 2.1.3, you can update the timeout of a key.
+        /// It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.
+        /// </para>
+        /// </remarks>
         /// <remarks>https://redis.io/commands/expire</remarks>
         /// <remarks>https://redis.io/commands/pexpire</remarks>
         /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted. A key with an associated timeout is said to be volatile in Redis terminology.
+        /// Set a timeout on key. After the timeout has expired, the key will automatically be deleted.
+        /// A key with an associated timeout is said to be volatile in Redis terminology.
         /// </summary>
         /// <param name="key">The key to set the expiration for.</param>
         /// <param name="expiry">The exact date to expiry to set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the timeout was set. 0 if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
-        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten. So, if key already has an associated timeout, it will do nothing and return 0. Since Redis 2.1.3, you can update the timeout of a key. It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.</remarks>
+        /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
+        /// <remarks>
+        /// If key is updated before the timeout has expired, then the timeout is removed as if the PERSIST command was invoked on key.
+        /// <para>
+        /// For Redis versions &lt; 2.1.3, existing timeouts cannot be overwritten.
+        /// So, if key already has an associated timeout, it will do nothing and return 0.
+        /// </para>
+        /// <para>
+        /// Since Redis 2.1.3, you can update the timeout of a key.
+        /// It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.
+        /// </para>
+        /// </remarks>
         /// <remarks>https://redis.io/commands/expireat</remarks>
         /// <remarks>https://redis.io/commands/pexpireat</remarks>
         /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the time since the object stored at the specified key is idle (not requested by read or write operations)
+        /// Returns the time since the object stored at the specified key is idle (not requested by read or write operations).
         /// </summary>
         /// <param name="key">The key to get the time of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The time since the object stored at the specified key is idle</returns>
+        /// <returns>The time since the object stored at the specified key is idle.</returns>
         /// <remarks>https://redis.io/commands/object</remarks>
         Task<TimeSpan?> KeyIdleTimeAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Move key from the currently selected database (see SELECT) to the specified destination database. When key already exists in the destination database, or it does not exist in the source database, it does nothing. It is possible to use MOVE as a locking primitive because of this.
+        /// Move key from the currently selected database (see SELECT) to the specified destination database.
+        /// When key already exists in the destination database, or it does not exist in the source database, it does nothing.
+        /// It is possible to use MOVE as a locking primitive because of this.
         /// </summary>
         /// <param name="key">The key to move.</param>
         /// <param name="database">The database to move the key to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if key was moved; 0 if key was not moved.</returns>
+        /// <returns><see langword="true"/> if key was moved. <see langword="false"/> if key was not moved.</returns>
         /// <remarks>https://redis.io/commands/move</remarks>
         Task<bool> KeyMoveAsync(RedisKey key, int database, CommandFlags flags = CommandFlags.None);
 
@@ -520,7 +572,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key to persist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the timeout was removed. 0 if key does not exist or does not have an associated timeout.</returns>
+        /// <returns><see langword="true"/> if the timeout was removed. <see langword="false"/> if key does not exist or does not have an associated timeout.</returns>
         /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyPersistAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -533,20 +585,21 @@ namespace StackExchange.Redis
         Task<RedisKey> KeyRandomAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Renames key to newkey. It returns an error when the source and destination names are the same, or when key does not exist.
+        /// Renames <paramref name="key"/> to <paramref name="newKey"/>.
+        /// It returns an error when the source and destination names are the same, or when key does not exist.
         /// </summary>
         /// <param name="key">The key to rename.</param>
         /// <param name="newKey">The key to rename to.</param>
         /// <param name="when">What conditions to rename under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the key was renamed, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the key was renamed, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/rename</remarks>
         /// <remarks>https://redis.io/commands/renamenx</remarks>
         Task<bool> KeyRenameAsync(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Create a key associated with a value that is obtained by deserializing the provided serialized value (obtained via DUMP).
-        /// If ttl is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
+        /// If <paramref name="expiry"/> is 0 the key is created without any expire, otherwise the specified expire time(in milliseconds) is set.
         /// </summary>
         /// <param name="key">The key to restore.</param>
         /// <param name="value">The value of the key.</param>
@@ -556,7 +609,8 @@ namespace StackExchange.Redis
         Task KeyRestoreAsync(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the remaining time to live of a key that has a timeout.  This introspection capability allows a Redis client to check how many seconds a given key will continue to be part of the dataset.
+        /// Returns the remaining time to live of a key that has a timeout.
+        /// This introspection capability allows a Redis client to check how many seconds a given key will continue to be part of the dataset.
         /// </summary>
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -565,7 +619,8 @@ namespace StackExchange.Redis
         Task<TimeSpan?> KeyTimeToLiveAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the string representation of the type of the value stored at key. The different types that can be returned are: string, list, set, zset and hash.
+        /// Returns the string representation of the type of the value stored at key.
+        /// The different types that can be returned are: string, list, set, zset and hash.
         /// </summary>
         /// <param name="key">The key to get the type of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -574,10 +629,13 @@ namespace StackExchange.Redis
         Task<RedisType> KeyTypeAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the element at index index in the list stored at key. The index is zero-based, so 0 means the first element, 1 the second element and so on. Negative indices can be used to designate elements starting at the tail of the list. Here, -1 means the last element, -2 means the penultimate and so forth.
+        /// Returns the element at index in the list stored at key.
+        /// The index is zero-based, so 0 means the first element, 1 the second element and so on.
+        /// Negative indices can be used to designate elements starting at the tail of the list.
+        /// Here, -1 means the last element, -2 means the penultimate and so forth.
         /// </summary>
         /// <param name="key">The key of the list.</param>
-        /// <param name="index">The index position to ge the value at.</param>
+        /// <param name="index">The index position to get the value at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The requested element, or nil when index is out of range.</returns>
         /// <remarks>https://redis.io/commands/lindex</remarks>
@@ -618,17 +676,18 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Removes and returns count elements from the head of the list stored at key.
-        /// If the list contains less than count elements, removes and returns the number of elements in the list
+        /// If the list contains less than count elements, removes and returns the number of elements in the list.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="count">The number of elements to remove</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
         /// <remarks>https://redis.io/commands/lpop</remarks>
         Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
+        /// Insert the specified value at the head of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="value">The value to add to the head of the list.</param>
@@ -640,7 +699,8 @@ namespace StackExchange.Redis
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
+        /// Insert the specified value at the head of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operations.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The value to add to the head of the list.</param>
@@ -652,8 +712,10 @@ namespace StackExchange.Redis
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert all the specified values at the head of the list stored at key. If key does not exist, it is created as empty list before performing the push operations.
-        /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element. So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
+        /// Insert all the specified values at the head of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operations.
+        /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element.
+        /// So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the head of the list.</param>
@@ -672,7 +734,8 @@ namespace StackExchange.Redis
         Task<long> ListLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified elements of the list stored at key. The offsets start and stop are zero-based indexes, with 0 being the first element of the list (the head of the list), 1 being the next element and so on.
+        /// Returns the specified elements of the list stored at key.
+        /// The offsets start and stop are zero-based indexes, with 0 being the first element of the list (the head of the list), 1 being the next element and so on.
         /// These offsets can also be negative numbers indicating offsets starting at the end of the list.For example, -1 is the last element of the list, -2 the penultimate, and so on.
         /// Note that if you have a list of numbers from 0 to 100, LRANGE list 0 10 will return 11 elements, that is, the rightmost item is included.
         /// </summary>
@@ -685,10 +748,13 @@ namespace StackExchange.Redis
         Task<RedisValue[]> ListRangeAsync(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes the first count occurrences of elements equal to value from the list stored at key. The count argument influences the operation in the following ways:
-        /// count &gt; 0: Remove elements equal to value moving from head to tail.
-        /// count &lt; 0: Remove elements equal to value moving from tail to head.
-        /// count = 0: Remove all elements equal to value.
+        /// Removes the first count occurrences of elements equal to value from the list stored at key.
+        /// The count argument influences the operation in the following ways:
+        /// <list type="bullet">
+        ///     <item>count &gt; 0: Remove elements equal to value moving from head to tail.</item>
+        ///     <item>count &lt; 0: Remove elements equal to value moving from tail to head.</item>
+        ///     <item>count = 0: Remove all elements equal to value.</item>
+        /// </list>
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="value">The value to remove from the list.</param>
@@ -709,12 +775,12 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Removes and returns count elements from the end the list stored at key.
-        /// If the list contains less than count elements, removes and returns the number of elements in the list
+        /// If the list contains less than count elements, removes and returns the number of elements in the list.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="count">The number of elements to pop</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>Array of values that were popped, or nil if the key doesn't exist</returns>
+        /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
         /// <remarks>https://redis.io/commands/rpop</remarks>
         Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
@@ -729,7 +795,8 @@ namespace StackExchange.Redis
         Task<RedisValue> ListRightPopLeftPushAsync(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
+        /// Insert the specified value at the tail of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operation.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="value">The value to add to the tail of the list.</param>
@@ -741,7 +808,8 @@ namespace StackExchange.Redis
         Task<long> ListRightPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert the specified value at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
+        /// Insert the specified value at the tail of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operation.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the tail of the list.</param>
@@ -753,8 +821,10 @@ namespace StackExchange.Redis
         Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Insert all the specified values at the tail of the list stored at key. If key does not exist, it is created as empty list before performing the push operation.
-        /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element. So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
+        /// Insert all the specified values at the tail of the list stored at key.
+        /// If key does not exist, it is created as empty list before performing the push operation.
+        /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
+        /// So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the tail of the list.</param>
@@ -764,7 +834,9 @@ namespace StackExchange.Redis
         Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags);
 
         /// <summary>
-        /// Sets the list element at index to value. For more information on the index argument, see ListGetByIndex. An error is returned for out of range indexes.
+        /// Sets the list element at index to value.
+        /// For more information on the index argument, see <see cref="ListGetByIndexAsync(RedisKey, long, CommandFlags)"/>.
+        /// An error is returned for out of range indexes.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="index">The index to set the value at.</param>
@@ -774,7 +846,8 @@ namespace StackExchange.Redis
         Task ListSetByIndexAsync(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Trim an existing list so that it will contain only the specified range of elements specified. Both start and stop are zero-based indexes, where 0 is the first element of the list (the head), 1 the next element and so on.
+        /// Trim an existing list so that it will contain only the specified range of elements specified.
+        /// Both start and stop are zero-based indexes, where 0 is the first element of the list (the head), 1 the next element and so on.
         /// For example: LTRIM foobar 0 2 will modify the list stored at foobar so that only the first three elements of the list will remain.
         /// start and end can also be negative numbers indicating offsets from the end of the list, where -1 is the last element of the list, -2 the penultimate element and so on.
         /// </summary>
@@ -792,7 +865,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to set at the key.</param>
         /// <param name="expiry">The expiration of the lock key.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the lock was successfully extended.</returns>
+        /// <returns><see langword="true"/> if the lock was successfully extended.</returns>
         Task<bool> LockExtendAsync(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -807,9 +880,9 @@ namespace StackExchange.Redis
         /// Releases a lock, if the token value is correct.
         /// </summary>
         /// <param name="key">The key of the lock.</param>
-        /// <param name="value">The value at the key tht must match.</param>
+        /// <param name="value">The value at the key that must match.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the lock was successfully released, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the lock was successfully released, <see langword="false"/> otherwise.</returns>
         Task<bool> LockReleaseAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -819,7 +892,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to set at the key.</param>
         /// <param name="expiry">The expiration of the lock key.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the lock was successfully taken, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the lock was successfully taken, <see langword="false"/> otherwise.</returns>
         Task<bool> LockTakeAsync(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -833,26 +906,24 @@ namespace StackExchange.Redis
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Execute an arbitrary command against the server; this is primarily intended for
-        /// executing modules, but may also be used to provide access to new features that lack
-        /// a direct API.
+        /// Execute an arbitrary command against the server; this is primarily intended for executing modules,
+        /// but may also be used to provide access to new features that lack a direct API.
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
+        /// <returns>A dynamic representation of the command's result.</returns>
         Task<RedisResult> ExecuteAsync(string command, params object[] args);
 
         /// <summary>
-        /// Execute an arbitrary command against the server; this is primarily intended for
-        /// executing modules, but may also be used to provide access to new features that lack
-        /// a direct API.
+        /// Execute an arbitrary command against the server; this is primarily intended for executing modules,
+        /// but may also be used to provide access to new features that lack a direct API.
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
+        /// <returns>A dynamic representation of the command's result.</returns>
         Task<RedisResult> ExecuteAsync(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -862,19 +933,19 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to execute against.</param>
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/eval</remarks>
         /// <remarks>https://redis.io/commands/evalsha</remarks>
         Task<RedisResult> ScriptEvaluateAsync(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Execute a Lua script against the server using just the SHA1 hash
+        /// Execute a Lua script against the server using just the SHA1 hash.
         /// </summary>
         /// <param name="hash">The hash of the script to execute.</param>
         /// <param name="keys">The keys to execute against.</param>
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/evalsha</remarks>
         Task<RedisResult> ScriptEvaluateAsync(byte[] hash, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None);
 
@@ -885,7 +956,7 @@ namespace StackExchange.Redis
         /// <param name="script">The script to execute.</param>
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/eval</remarks>
         Task<RedisResult> ScriptEvaluateAsync(LuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None);
 
@@ -897,7 +968,7 @@ namespace StackExchange.Redis
         /// <param name="script">The already-loaded script to execute.</param>
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>A dynamic representation of the script's result</returns>
+        /// <returns>A dynamic representation of the script's result.</returns>
         /// <remarks>https://redis.io/commands/eval</remarks>
         Task<RedisResult> ScriptEvaluateAsync(LoadedLuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None);
 
@@ -909,7 +980,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The value to add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was not already present in the set, else False</returns>
+        /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
         /// <remarks>https://redis.io/commands/sadd</remarks>
         Task<bool> SetAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -951,7 +1022,8 @@ namespace StackExchange.Redis
         Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination. If destination already exists, it is overwritten.
+        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination.
+        /// If destination already exists, it is overwritten.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The key of the destination set.</param>
@@ -965,7 +1037,8 @@ namespace StackExchange.Redis
         Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination. If destination already exists, it is overwritten.
+        /// This command is equal to SetCombine, but instead of returning the resulting set, it is stored in destination.
+        /// If destination already exists, it is overwritten.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The key of the destination set.</param>
@@ -983,7 +1056,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The value to check for .</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the element is a member of the set. 0 if the element is not a member of the set, or if key does not exist.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the element is a member of the set.
+        /// <see langword="false"/> if the element is not a member of the set, or if key does not exist.
+        /// </returns>
         /// <remarks>https://redis.io/commands/sismember</remarks>
         Task<bool> SetContainsAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -1006,14 +1082,18 @@ namespace StackExchange.Redis
         Task<RedisValue[]> SetMembersAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Move member from the set at source to the set at destination. This operation is atomic. In every given moment the element will appear to be a member of source or destination for other clients.
+        /// Move member from the set at source to the set at destination.
+        /// This operation is atomic. In every given moment the element will appear to be a member of source or destination for other clients.
         /// When the specified element already exists in the destination set, it is only removed from the source set.
         /// </summary>
         /// <param name="source">The key of the source set.</param>
         /// <param name="destination">The key of the destination set.</param>
         /// <param name="value">The value to move.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>1 if the element is moved. 0 if the element is not a member of source and no operation was performed.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the element is moved.
+        /// <see langword="false"/> if the element is not a member of source and no operation was performed.
+        /// </returns>
         /// <remarks>https://redis.io/commands/smove</remarks>
         Task<bool> SetMoveAsync(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None);
 
@@ -1041,33 +1121,36 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The randomly selected element, or nil when key does not exist</returns>
+        /// <returns>The randomly selected element, or nil when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/srandmember</remarks>
         Task<RedisValue> SetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return an array of count distinct elements if count is positive. If called with a negative count the behavior changes and the command is allowed to return the same element multiple times.
+        /// Return an array of count distinct elements if count is positive.
+        /// If called with a negative count the behavior changes and the command is allowed to return the same element multiple times.
         /// In this case the number of returned elements is the absolute value of the specified count.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="count">The count of members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An array of elements, or an empty array when key does not exist</returns>
+        /// <returns>An array of elements, or an empty array when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/srandmember</remarks>
         Task<RedisValue[]> SetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Remove the specified member from the set stored at key.  Specified members that are not a member of this set are ignored.
+        /// Remove the specified member from the set stored at key.
+        /// Specified members that are not a member of this set are ignored.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="value">The value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the specified member was already present in the set, else False</returns>
+        /// <returns><see langword="true"/> if the specified member was already present in the set, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/srem</remarks>
         Task<bool> SetRemoveAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Remove the specified members from the set stored at key. Specified members that are not a member of this set are ignored.
+        /// Remove the specified members from the set stored at key.
+        /// Specified members that are not a member of this set are ignored.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="values">The values to remove.</param>
@@ -1077,11 +1160,26 @@ namespace StackExchange.Redis
         Task<long> SetRemoveAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default); By default, the elements themselves are compared, but the values can also be
-        /// used to perform external key-lookups using the <c>by</c> parameter. By default, the elements themselves are returned, but external key-lookups (one or many) can
-        /// be performed instead by specifying the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
-        /// can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
+        /// The SSCAN command is used to incrementally iterate over set.
+		/// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <see cref="IScanningCursor"/>.
+        /// </summary>
+        /// <param name="key">The key of the set.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <param name="pageSize">The page size to iterate by.</param>
+        /// <param name="cursor">The cursor position to start at.</param>
+        /// <param name="pageOffset">The page offset to start at.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>Yields all matching elements of the set.</returns>
+        /// <remarks>https://redis.io/commands/sscan</remarks>
+        IAsyncEnumerable<RedisValue> SetScanAsync(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default).
+        /// By default, the elements themselves are compared, but the values can also be used to perform external key-lookups using the <c>by</c> parameter.
+        /// By default, the elements themselves are returned, but external key-lookups (one or many) can be performed instead by specifying
+        /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
+        /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
         /// <param name="key">The key of the list, set, or sorted set.</param>
         /// <param name="skip">How many entries to skip on the return.</param>
@@ -1096,11 +1194,12 @@ namespace StackExchange.Redis
         Task<RedisValue[]> SortAsync(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default(RedisValue), RedisValue[] get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default); By default, the elements themselves are compared, but the values can also be
-        /// used to perform external key-lookups using the <c>by</c> parameter. By default, the elements themselves are returned, but external key-lookups (one or many) can
-        /// be performed instead by specifying the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended. When used in hashes, <c>by</c> and <c>get</c>
-        /// can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
+        /// Sorts a list, set or sorted set (numerically or alphabetically, ascending by default).
+        /// By default, the elements themselves are compared, but the values can also be used to perform external key-lookups using the <c>by</c> parameter.
+        /// By default, the elements themselves are returned, but external key-lookups (one or many) can be performed instead by specifying
+        /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
+        /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
         /// <param name="destination">The destination key to store results in.</param>
         /// <param name="key">The key of the list, set, or sorted set.</param>
@@ -1116,30 +1215,33 @@ namespace StackExchange.Redis
         Task<long> SortAndStoreAsync(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default(RedisValue), RedisValue[] get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds the specified member with the specified score to the sorted set stored at key. If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds the specified member with the specified score to the sorted set stored at key.
+        /// If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to add to the sorted set.</param>
         /// <param name="score">The score for the member to add to the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the value was added, False if it already existed (the score is still updated)</returns>
+        /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
         /// <remarks>https://redis.io/commands/zadd</remarks>
         Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, CommandFlags flags);
 
         /// <summary>
-        /// Adds the specified member with the specified score to the sorted set stored at key. If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds the specified member with the specified score to the sorted set stored at key.
+        /// If the specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to add to the sorted set.</param>
         /// <param name="score">The score for the member to add to the sorted set.</param>
         /// <param name="when">What conditions to add the element under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the value was added, False if it already existed (the score is still updated)</returns>
+        /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
         /// <remarks>https://redis.io/commands/zadd</remarks>
         Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds all the specified members with the specified scores to the sorted set stored at key. If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds all the specified members with the specified scores to the sorted set stored at key.
+        /// If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="values">The members and values to add to the sorted set.</param>
@@ -1149,7 +1251,8 @@ namespace StackExchange.Redis
         Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, CommandFlags flags);
 
         /// <summary>
-        /// Adds all the specified members with the specified scores to the sorted set stored at key. If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
+        /// Adds all the specified members with the specified scores to the sorted set stored at key.
+        /// If a specified member is already a member of the sorted set, the score is updated and the element reinserted at the right position to ensure the correct ordering.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="values">The members and values to add to the sorted set.</param>
@@ -1171,7 +1274,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zunionstore</remarks>
         /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <returns>the number of elements in the resulting sorted set at destination</returns>
+        /// <returns>The number of elements in the resulting sorted set at destination.</returns>
         Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1186,11 +1289,12 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zunionstore</remarks>
         /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <returns>the number of elements in the resulting sorted set at destination</returns>
+        /// <returns>The number of elements in the resulting sorted set at destination.</returns>
         Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, double[] weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the score of member in the sorted set stored at key by decrement. If member does not exist in the sorted set, it is added with -decrement as its score (as if its previous score was 0.0).
+        /// Decrements the score of member in the sorted set stored at key by decrement.
+        /// If member does not exist in the sorted set, it is added with -decrement as its score (as if its previous score was 0.0).
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to decrement.</param>
@@ -1224,7 +1328,8 @@ namespace StackExchange.Redis
         Task<long> SortedSetLengthAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns the number of elements in the sorted set at key with a value between min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command returns the number of elements in the sorted set at key with a value between min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The min value to filter by.</param>
@@ -1236,8 +1341,11 @@ namespace StackExchange.Redis
         Task<long> SortedSetLengthByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.
+        /// They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The start index to get.</param>
@@ -1250,8 +1358,11 @@ namespace StackExchange.Redis
         Task<RedisValue[]> SortedSetRangeByRankAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on. They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.
+        /// They can also be negative numbers indicating offsets from the end of the sorted set, with -1 being the last element of the sorted set, -2 the penultimate element and so on.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The start index to get.</param>
@@ -1264,8 +1375,11 @@ namespace StackExchange.Redis
         Task<SortedSetEntry[]> SortedSetRangeByRankWithScoresAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Start and stop are used to specify the min and max range for score values. Similar to other range methods the values are inclusive.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Start and stop are used to specify the min and max range for score values.
+        /// Similar to other range methods the values are inclusive.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The minimum score to filter by.</param>
@@ -1288,8 +1402,11 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the specified range of elements in the sorted set stored at key. By default the elements are considered to be ordered from the lowest to the highest score. Lexicographical order is used for elements with equal score.
-        /// Start and stop are used to specify the min and max range for score values. Similar to other range methods the values are inclusive.
+        /// Returns the specified range of elements in the sorted set stored at key.
+        /// By default the elements are considered to be ordered from the lowest to the highest score.
+        /// Lexicographical order is used for elements with equal score.
+        /// Start and stop are used to specify the min and max range for score values.
+        /// Similar to other range methods the values are inclusive.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The minimum score to filter by.</param>
@@ -1312,7 +1429,8 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at key with a value between min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command returns all the elements in the sorted set at key with a value between min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The min value to filter by.</param>
@@ -1322,7 +1440,7 @@ namespace StackExchange.Redis
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zrangebylex</remarks>
-        /// <returns>list of elements in the specified score range.</returns>
+        /// <returns>List of elements in the specified score range.</returns>
         Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key,
             RedisValue min,
             RedisValue max,
@@ -1332,7 +1450,8 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None); // defaults removed to avoid ambiguity with overload with order
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command returns all the elements in the sorted set at key with a value between min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command returns all the elements in the sorted set at key with a value between min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The min value to filter by.</param>
@@ -1344,7 +1463,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <remarks>https://redis.io/commands/zrangebylex</remarks>
         /// <remarks>https://redis.io/commands/zrevrangebylex</remarks>
-        /// <returns>list of elements in the specified score range.</returns>
+        /// <returns>List of elements in the specified score range.</returns>
         Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key,
             RedisValue min = default(RedisValue),
             RedisValue max = default(RedisValue),
@@ -1355,13 +1474,14 @@ namespace StackExchange.Redis
             CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high. The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.
+        /// Returns the rank of member in the sorted set stored at key, by default with the scores ordered from low to high.
+        /// The rank (or index) is 0-based, which means that the member with the lowest score has rank 0.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to get the rank of.</param>
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>If member exists in the sorted set, the rank of member; If member does not exist in the sorted set or key does not exist, null</returns>
+        /// <returns>If member exists in the sorted set, the rank of member. If member does not exist in the sorted set or key does not exist, <see langword="null"/>.</returns>
         /// <remarks>https://redis.io/commands/zrank</remarks>
         /// <remarks>https://redis.io/commands/zrevrank</remarks>
         Task<long?> SortedSetRankAsync(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
@@ -1372,7 +1492,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the member existed in the sorted set and was removed; False otherwise.</returns>
+        /// <returns><see langword="true"/> if the member existed in the sorted set and was removed. <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/zrem</remarks>
         Task<bool> SortedSetRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
@@ -1387,7 +1507,10 @@ namespace StackExchange.Redis
         Task<long> SortedSetRemoveAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes all elements in the sorted set stored at key with rank between start and stop. Both start and stop are 0 -based indexes with 0 being the element with the lowest score. These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score. For example: -1 is the element with the highest score, -2 the element with the second highest score and so forth.
+        /// Removes all elements in the sorted set stored at key with rank between start and stop.
+        /// Both start and stop are 0 -based indexes with 0 being the element with the lowest score.
+        /// These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score.
+        /// For example: -1 is the element with the highest score, -2 the element with the second highest score and so forth.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="start">The minimum rank to remove.</param>
@@ -1410,45 +1533,39 @@ namespace StackExchange.Redis
         Task<long> SortedSetRemoveRangeByScoreAsync(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering, this command removes all elements in the sorted set stored at key between the lexicographical range specified by min and max.
+        /// When all the elements in a sorted set are inserted with the same score, in order to force lexicographical ordering.
+        /// This command removes all elements in the sorted set stored at key between the lexicographical range specified by min and max.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="min">The minimum value to remove.</param>
         /// <param name="max">The maximum value to remove.</param>
         /// <param name="exclude">Which of <paramref name="min"/> and <paramref name="max"/> to exclude (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the number of elements removed.</returns>
+        /// <returns>The number of elements removed.</returns>
         /// <remarks>https://redis.io/commands/zremrangebylex</remarks>
         Task<long> SortedSetRemoveRangeByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The SSCAN command is used to incrementally iterate over set; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
-        /// </summary>
-        /// <param name="key">The key of the set.</param>
-        /// <param name="pattern">The pattern to match.</param>
-        /// <param name="pageSize">The page size to iterate by.</param>
-        /// <param name="cursor">The cursor position to start at.</param>
-        /// <param name="pageOffset">The page offset to start at.</param>
-        /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>Yields all matching elements of the set.</returns>
-        /// <remarks>https://redis.io/commands/sscan</remarks>
-        IAsyncEnumerable<RedisValue> SetScanAsync(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// The ZSCAN command is used to incrementally iterate over a sorted set
+        /// The ZSCAN command is used to incrementally iterate over a sorted set.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="pattern">The pattern to match.</param>
         /// <param name="pageSize">The page size to iterate by.</param>
-        /// <param name="flags">The flags to use for this operation.</param>
         /// <param name="cursor">The cursor position to start at.</param>
         /// <param name="pageOffset">The page offset to start at.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the sorted set.</returns>
         /// <remarks>https://redis.io/commands/zscan</remarks>
-        IAsyncEnumerable<SortedSetEntry> SortedSetScanAsync(RedisKey key, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
+        IAsyncEnumerable<SortedSetEntry> SortedSetScanAsync(RedisKey key,
+            RedisValue pattern = default(RedisValue),
+            int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize,
+            long cursor = RedisBase.CursorUtils.Origin,
+            int pageOffset = 0,
+            CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the score of member in the sorted set at key; If member does not exist in the sorted set, or key does not exist, nil is returned.
+        /// Returns the score of member in the sorted set at key.
+        /// If member does not exist in the sorted set, or key does not exist, nil is returned.
         /// </summary>
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="member">The member to get a score for.</param>
@@ -1503,7 +1620,9 @@ namespace StackExchange.Redis
         Task<long> StreamAcknowledgeAsync(RedisKey key, RedisValue groupName, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds an entry using the specified values to the given stream key. If key does not exist, a new key holding a stream is created. The command returns the ID of the newly created stream entry.
+        /// Adds an entry using the specified values to the given stream key.
+        /// If key does not exist, a new key holding a stream is created.
+        /// The command returns the ID of the newly created stream entry.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="streamField">The field name for the stream entry.</param>
@@ -1517,7 +1636,9 @@ namespace StackExchange.Redis
         Task<RedisValue> StreamAddAsync(RedisKey key, RedisValue streamField, RedisValue streamValue, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Adds an entry using the specified values to the given stream key. If key does not exist, a new key holding a stream is created. The command returns the ID of the newly created stream entry.
+        /// Adds an entry using the specified values to the given stream key.
+        /// If key does not exist, a new key holding a stream is created.
+        /// The command returns the ID of the newly created stream entry.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="streamPairs">The fields and their associated values to set in the stream entry.</param>
@@ -1530,11 +1651,12 @@ namespace StackExchange.Redis
         Task<RedisValue> StreamAddAsync(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer. This method returns the complete message for the claimed message(s).
+        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer.
+        /// This method returns the complete message for the claimed message(s).
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="consumerGroup">The consumer group.</param>
-        /// <param name="claimingConsumer">The consumer claiming the given messages.</param>
+        /// <param name="claimingConsumer">The consumer claiming the given message(s).</param>
         /// <param name="minIdleTimeInMs">The minimum message idle time to allow the reassignment of the message(s).</param>
         /// <param name="messageIds">The IDs of the messages to claim for the given consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1543,7 +1665,8 @@ namespace StackExchange.Redis
         Task<StreamEntry[]> StreamClaimAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer. This method returns the IDs for the claimed message(s).
+        /// Change ownership of messages consumed, but not yet acknowledged, by a different consumer.
+        /// This method returns the IDs for the claimed message(s).
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="consumerGroup">The consumer group.</param>
@@ -1562,11 +1685,12 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="position">The position from which to read for the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if successful, otherwise false.</returns>
+        /// <returns><see langword="true"/> if successful, <see langword="false"/> otherwise.</returns>
         Task<bool> StreamConsumerGroupSetPositionAsync(RedisKey key, RedisValue groupName, RedisValue position, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Retrieve information about the consumers for the given consumer group. This is the equivalent of calling "XINFO GROUPS key group".
+        /// Retrieve information about the consumers for the given consumer group.
+        /// This is the equivalent of calling "XINFO GROUPS key group".
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The consumer group name.</param>
@@ -1582,7 +1706,7 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the group to create.</param>
         /// <param name="position">The position to begin reading the stream. Defaults to <see cref="StreamPosition.NewMessages"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the group was created.</returns>
+        /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         Task<bool> StreamCreateConsumerGroupAsync(RedisKey key, RedisValue groupName, RedisValue? position, CommandFlags flags);
 
@@ -1594,7 +1718,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position to begin reading the stream. Defaults to <see cref="StreamPosition.NewMessages"/>.</param>
         /// <param name="createStream">Create the stream if it does not already exist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the group was created.</returns>
+        /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/topics/streams-intro</remarks>
         Task<bool> StreamCreateConsumerGroupAsync(RedisKey key, RedisValue groupName, RedisValue? position = null, bool createStream = true, CommandFlags flags = CommandFlags.None);
 
@@ -1624,7 +1748,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if deleted, otherwise false.</returns>
+        /// <returns><see langword="true"/> if deleted, <see langword="false"/> otherwise.</returns>
         Task<bool> StreamDeleteConsumerGroupAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1655,12 +1779,17 @@ namespace StackExchange.Redis
         Task<long> StreamLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// View information about pending messages for a stream. A pending message is a message read using StreamReadGroup (XREADGROUP) but not yet acknowledged.
+        /// View information about pending messages for a stream.
+        /// A pending message is a message read using StreamReadGroup (XREADGROUP) but not yet acknowledged.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An instance of <see cref="StreamPendingInfo"/>. <see cref="StreamPendingInfo"/> contains the number of pending messages, the highest and lowest ID of the pending messages, and the consumers with their pending message count.</returns>
+        /// <returns>
+        /// An instance of <see cref="StreamPendingInfo"/>.
+        /// <see cref="StreamPendingInfo"/> contains the number of pending messages.
+        /// The highest and lowest ID of the pending messages, and the consumers with their pending message count.
+        /// </returns>
         /// <remarks>The equivalent of calling XPENDING key group.</remarks>
         /// <remarks>https://redis.io/commands/xpending</remarks>
         Task<StreamPendingInfo> StreamPendingAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
@@ -1687,7 +1816,7 @@ namespace StackExchange.Redis
         /// <param name="minId">The minimum ID from which to read the stream. The method will default to reading from the beginning of the stream.</param>
         /// <param name="maxId">The maximum ID to read to within the stream. The method will default to reading to the end of the stream.</param>
         /// <param name="count">The maximum number of messages to return.</param>
-        /// <param name="messageOrder">The order of the messages. <see cref="Order.Ascending"/> will execute XRANGE and <see cref="Order.Descending"/> wil execute XREVRANGE.</param>
+        /// <param name="messageOrder">The order of the messages. <see cref="Order.Ascending"/> will execute XRANGE and <see cref="Order.Descending"/> will execute XREVRANGE.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
         /// <remarks>https://redis.io/commands/xrange</remarks>
@@ -1722,7 +1851,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="consumerName">The consumer name.</param>
-        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when null.</param>
+        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when <see langword="null"/>.</param>
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
@@ -1735,7 +1864,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="consumerName">The consumer name.</param>
-        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when null.</param>
+        /// <param name="position">The position from which to read the stream. Defaults to <see cref="StreamPosition.NewMessages"/> when <see langword="null"/>.</param>
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="noAck">When true, the message will not be added to the pending message list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1744,8 +1873,8 @@ namespace StackExchange.Redis
         Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Read from multiple streams into the given consumer group. The consumer group with the given <paramref name="groupName"/>
-        /// will need to have been created for each stream prior to calling this method.
+        /// Read from multiple streams into the given consumer group.
+        /// The consumer group with the given <paramref name="groupName"/> will need to have been created for each stream prior to calling this method.
         /// </summary>
         /// <param name="streamPositions">Array of streams and the positions from which to begin reading for each stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
@@ -1758,8 +1887,8 @@ namespace StackExchange.Redis
         Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream, CommandFlags flags);
 
         /// <summary>
-        /// Read from multiple streams into the given consumer group. The consumer group with the given <paramref name="groupName"/>
-        /// will need to have been created for each stream prior to calling this method.
+        /// Read from multiple streams into the given consumer group.
+        /// The consumer group with the given <paramref name="groupName"/> will need to have been created for each stream prior to calling this method.
         /// </summary>
         /// <param name="streamPositions">Array of streams and the positions from which to begin reading for each stream.</param>
         /// <param name="groupName">The name of the consumer group.</param>
@@ -1784,8 +1913,8 @@ namespace StackExchange.Redis
         Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// If key already exists and is a string, this command appends the value at the end of the string. If key does not exist it is created and set as an empty string,
-        /// so APPEND will be similar to SET in this special case.
+        /// If key already exists and is a string, this command appends the value at the end of the string.
+        /// If key does not exist it is created and set as an empty string, so APPEND will be similar to SET in this special case.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The value to append to the string.</param>
@@ -1796,7 +1925,8 @@ namespace StackExchange.Redis
 
         /// <summary>
         /// Count the number of set bits (population counting) in a string.
-        /// By default all the bytes contained in the string are examined. It is possible to specify the counting operation only in an interval passing the additional arguments start and end.
+        /// By default all the bytes contained in the string are examined.
+        /// It is possible to specify the counting operation only in an interval passing the additional arguments start and end.
         /// Like for the GETRANGE command start and end can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
         /// </summary>
         /// <param name="key">The key of the string.</param>
@@ -1811,7 +1941,7 @@ namespace StackExchange.Redis
         /// Perform a bitwise operation between multiple keys (containing string values) and store the result in the destination key.
         /// The BITOP command supports four bitwise operations; note that NOT is a unary operator: the second key should be omitted in this case
         /// and only the first key will be considered.
-        /// The result of the operation is always stored at destkey.
+        /// The result of the operation is always stored at <paramref name="destination"/>.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The destination key to store the result in.</param>
@@ -1825,7 +1955,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Perform a bitwise operation between multiple keys (containing string values) and store the result in the destination key.
         /// The BITOP command supports four bitwise operations; note that NOT is a unary operator.
-        /// The result of the operation is always stored at destkey.
+        /// The result of the operation is always stored at <paramref name="destination"/>.
         /// </summary>
         /// <param name="operation">The operation to perform.</param>
         /// <param name="destination">The destination key to store the result in.</param>
@@ -1838,7 +1968,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// Return the position of the first bit set to 1 or 0 in a string.
         /// The position is returned thinking at the string as an array of bits from left to right where the first byte most significant bit is at position 0, the second byte most significant bit is at position 8 and so forth.
-        /// An start and end may be specified; these are in bytes, not bits; start and end can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
+        /// A <paramref name="start"/> and <paramref name="end"/> may be specified - these are in bytes, not bits.
+        /// <paramref name="start"/> and <paramref name="end"/> can contain negative values in order to index bytes starting from the end of the string, where -1 is the last byte, -2 is the penultimate, and so forth.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="bit">True to check for the first 1 bit, false to check for the first 0 bit.</param>
@@ -1851,8 +1982,10 @@ namespace StackExchange.Redis
         Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the number stored at key by decrement. If the key does not exist, it is set to 0 before performing the operation.
-        /// An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer. This operation is limited to 64 bit signed integers.
+        /// Decrements the number stored at key by decrement.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer.
+        /// This operation is limited to 64 bit signed integers.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
@@ -1863,7 +1996,9 @@ namespace StackExchange.Redis
         Task<long> StringDecrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Decrements the string representing a floating point number stored at key by the specified decrement. If the key does not exist, it is set to 0 before performing the operation. The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
+        /// Decrements the string representing a floating point number stored at key by the specified decrement.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
@@ -1873,7 +2008,8 @@ namespace StackExchange.Redis
         Task<double> StringDecrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key. If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1882,7 +2018,8 @@ namespace StackExchange.Redis
         Task<RedisValue> StringGetAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the values of all specified keys. For every key that does not hold a string value or does not exist, the special value nil is returned.
+        /// Returns the values of all specified keys.
+        /// For every key that does not hold a string value or does not exist, the special value nil is returned.
         /// </summary>
         /// <param name="keys">The keys of the strings.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1891,7 +2028,8 @@ namespace StackExchange.Redis
         Task<RedisValue[]> StringGetAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key. If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1911,7 +2049,9 @@ namespace StackExchange.Redis
         Task<bool> StringGetBitAsync(RedisKey key, long offset, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the substring of the string value stored at key, determined by the offsets start and end (both are inclusive). Negative offsets can be used in order to provide an offset starting from the end of the string. So -1 means the last character, -2 the penultimate and so forth.
+        /// Returns the substring of the string value stored at key, determined by the offsets start and end (both are inclusive).
+        /// Negative offsets can be used in order to provide an offset starting from the end of the string.
+        /// So -1 means the last character, -2 the penultimate and so forth.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="start">The start index of the substring to get.</param>
@@ -1932,7 +2072,9 @@ namespace StackExchange.Redis
         Task<RedisValue> StringGetSetAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key and delete the key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key and delete the key.
+        /// If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1941,7 +2083,9 @@ namespace StackExchange.Redis
         Task<RedisValue> StringGetDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.
+        /// Get the value of key.
+        /// If the key does not exist the special value nil is returned.
+        /// An error is returned if the value stored at key is not a string, because GET only handles string values.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
@@ -1950,7 +2094,10 @@ namespace StackExchange.Redis
         Task<RedisValueWithExpiry> StringGetWithExpiryAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the number stored at key by increment. If the key does not exist, it is set to 0 before performing the operation. An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer. This operation is limited to 64 bit signed integers.
+        /// Increments the number stored at key by increment.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// An error is returned if the key contains a value of the wrong type or contains a string that is not representable as integer.
+        /// This operation is limited to 64 bit signed integers.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to increment by (defaults to 1).</param>
@@ -1961,7 +2108,9 @@ namespace StackExchange.Redis
         Task<long> StringIncrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Increments the string representing a floating point number stored at key by the specified increment. If the key does not exist, it is set to 0 before performing the operation. The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
+        /// Increments the string representing a floating point number stored at key by the specified increment.
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="value">The amount to increment by (defaults to 1).</param>
@@ -1975,7 +2124,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>the length of the string at key, or 0 when key does not exist.</returns>
+        /// <returns>The length of the string at key, or 0 when key does not exist.</returns>
         /// <remarks>https://redis.io/commands/strlen</remarks>
         Task<long> StringLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
@@ -1987,24 +2136,26 @@ namespace StackExchange.Redis
         /// <param name="expiry">The expiry to set.</param>
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the string was set, false otherwise.</returns>
+        /// <returns><see langword="true"/> if the string was set, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/set</remarks>
         Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Sets the given keys to their respective values. If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
+        /// Sets the given keys to their respective values.
+        /// If "not exists" is specified, this will not perform any operation at all even if just a single key already exists.
         /// </summary>
         /// <param name="values">The keys and values to set.</param>
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the keys were set, else False</returns>
+        /// <returns><see langword="true"/> if the keys were set, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/mset</remarks>
         /// <remarks>https://redis.io/commands/msetnx</remarks>
         Task<bool> StringSetAsync(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Sets or clears the bit at offset in the string value stored at key.
-        /// The bit is either set or cleared depending on value, which can be either 0 or 1. When key does not exist, a new string value is created.The string is grown to make sure it can hold a bit at offset.
+        /// The bit is either set or cleared depending on value, which can be either 0 or 1.
+        /// When key does not exist, a new string value is created.The string is grown to make sure it can hold a bit at offset.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="offset">The offset in the string to set <paramref name="bit"/>.</param>
@@ -2015,7 +2166,9 @@ namespace StackExchange.Redis
         Task<bool> StringSetBitAsync(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Overwrites part of the string stored at key, starting at the specified offset, for the entire length of value. If the offset is larger than the current length of the string at key, the string is padded with zero-bytes to make offset fit. Non-existing keys are considered as empty strings, so this command will make sure it holds a string large enough to be able to set value at offset.
+        /// Overwrites part of the string stored at key, starting at the specified offset, for the entire length of value.
+        /// If the offset is larger than the current length of the string at key, the string is padded with zero-bytes to make offset fit.
+        /// Non-existing keys are considered as empty strings, so this command will make sure it holds a string large enough to be able to set value at offset.
         /// </summary>
         /// <param name="key">The key of the string.</param>
         /// <param name="offset">The offset in the string to overwrite.</param>
@@ -2025,17 +2178,17 @@ namespace StackExchange.Redis
         /// <remarks>https://redis.io/commands/setrange</remarks>
         Task<RedisValue> StringSetRangeAsync(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None);
 
-                /// <summary>
-        /// Touch the specified key.
+        /// <summary>
+        /// Alters the last access time of a key.
         /// </summary>
         /// <param name="key">The key to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>True if the key was touched.</returns>
+        /// <returns><see langword="true"/> if the key was touched, <see langword="false"/> otherwise.</returns>
         /// <remarks>https://redis.io/commands/touch</remarks>
         Task<bool> KeyTouchAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Youch the specified keys. A key is ignored if it does not exist.
+        /// Alters the last access time of a keys. A key is ignored if it does not exist.
         /// </summary>
         /// <param name="keys">The keys to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>

--- a/src/StackExchange.Redis/Interfaces/IReconnectRetryPolicy.cs
+++ b/src/StackExchange.Redis/Interfaces/IReconnectRetryPolicy.cs
@@ -1,15 +1,15 @@
-namespace StackExchange.Redis
+﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Describes retry policy functionality that can be provided to the multiplexer to be used for connection reconnects
+    /// Describes retry policy functionality that can be provided to the multiplexer to be used for connection reconnects.
     /// </summary>
     public interface IReconnectRetryPolicy
     {
         /// <summary>
         /// This method is called by the multiplexer to determine if a reconnect operation can be retried now.
         /// </summary>
-        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the multiplexer while it was in connecting state</param>
-        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total time elapsed in milliseconds since the last reconnect retry was made</param>
+        /// <param name="currentRetryCount">The number of times reconnect retries have already been made by the multiplexer while it was in connecting state.</param>
+        /// <param name="timeElapsedMillisecondsSinceLastRetry">Total time elapsed in milliseconds since the last reconnect retry was made.</param>
         bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry);
     }
 }

--- a/src/StackExchange.Redis/Interfaces/IRedis.cs
+++ b/src/StackExchange.Redis/Interfaces/IRedis.cs
@@ -3,7 +3,7 @@
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Common operations available to all redis connections
+    /// Common operations available to all redis connections.
     /// </summary>
     public partial interface IRedis : IRedisAsync
     {

--- a/src/StackExchange.Redis/Interfaces/IRedisAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IRedisAsync.cs
@@ -4,12 +4,12 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Common operations available to all redis connections
+    /// Common operations available to all redis connections.
     /// </summary>
     public partial interface IRedisAsync
     {
         /// <summary>
-        /// Gets the multiplexer that created this instance
+        /// Gets the multiplexer that created this instance.
         /// </summary>
         IConnectionMultiplexer Multiplexer { get; }
 
@@ -22,26 +22,26 @@ namespace StackExchange.Redis
         Task<TimeSpan> PingAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout), reporting which
+        /// Wait for a given asynchronous operation to complete (or timeout), reporting which.
         /// </summary>
         /// <param name="task">The task to wait on.</param>
         bool TryWait(Task task);
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout)
+        /// Wait for a given asynchronous operation to complete (or timeout).
         /// </summary>
         /// <param name="task">The task to wait on.</param>
         void Wait(Task task);
 
         /// <summary>
-        /// Wait for a given asynchronous operation to complete (or timeout)
+        /// Wait for a given asynchronous operation to complete (or timeout).
         /// </summary>
         /// <typeparam name="T">The type of task to wait on.</typeparam>
         /// <param name="task">The task to wait on.</param>
         T Wait<T>(Task<T> task);
 
         /// <summary>
-        /// Wait for the given asynchronous operations to complete (or timeout)
+        /// Wait for the given asynchronous operations to complete (or timeout).
         /// </summary>
         /// <param name="tasks">The tasks to wait on.</param>
         void WaitAll(params Task[] tasks);

--- a/src/StackExchange.Redis/Interfaces/IScanningCursor.cs
+++ b/src/StackExchange.Redis/Interfaces/IScanningCursor.cs
@@ -1,22 +1,22 @@
 ﻿namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents a resumable, cursor-based scanning operation
+    /// Represents a resumable, cursor-based scanning operation.
     /// </summary>
     public interface IScanningCursor
     {
         /// <summary>
-        /// Returns the cursor that represents the *active* page of results (not the pending/next page of results as returned by SCAN/HSCAN/ZSCAN/SSCAN)
+        /// Returns the cursor that represents the *active* page of results (not the pending/next page of results as returned by SCAN/HSCAN/ZSCAN/SSCAN).
         /// </summary>
         long Cursor { get; }
 
         /// <summary>
-        /// The page size of the current operation
+        /// The page size of the current operation.
         /// </summary>
         int PageSize { get; }
 
         /// <summary>
-        /// The offset into the current page
+        /// The offset into the current page.
         /// </summary>
         int PageOffset { get; }
     }

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -75,10 +75,9 @@ namespace StackExchange.Redis
         /// <summary>
         /// The CLIENT KILL command closes a given client connection identified by ip:port.
         /// The ip:port should match a line returned by the CLIENT LIST command.
-        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection
-        /// while it is executing a command.From the client point of view, the connection can never be
-        /// closed in the middle of the execution of a command.However, the client will notice the connection
-        /// has been closed only when the next command is sent (and results in network error).
+        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection while it is executing a command.
+        /// From the client point of view, the connection can never be closed in the middle of the execution of a command.
+        /// However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
         /// </summary>
         /// <param name="endpoint">The endpoint of the client to kill.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -88,10 +87,9 @@ namespace StackExchange.Redis
         /// <summary>
         /// The CLIENT KILL command closes a given client connection identified by ip:port.
         /// The ip:port should match a line returned by the CLIENT LIST command.
-        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection
-        /// while it is executing a command.From the client point of view, the connection can never be
-        /// closed in the middle of the execution of a command.However, the client will notice the connection
-        /// has been closed only when the next command is sent (and results in network error).
+        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection while it is executing a command.
+        /// From the client point of view, the connection can never be closed in the middle of the execution of a command.
+        /// However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
         /// </summary>
         /// <param name="endpoint">The endpoint of the client to kill.</param>
         /// <param name="flags">The command flags to use.</param>

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -9,73 +9,76 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Provides configuration controls of a redis server
+    /// Provides configuration controls of a redis server.
     /// </summary>
     public partial interface IServer : IRedis
     {
         /// <summary>
-        /// Gets the cluster configuration associated with this server, if known
+        /// Gets the cluster configuration associated with this server, if known.
         /// </summary>
         ClusterConfiguration ClusterConfiguration { get; }
 
         /// <summary>
-        /// Gets the address of the connected server
+        /// Gets the address of the connected server.
         /// </summary>
         EndPoint EndPoint { get; }
 
         /// <summary>
-        /// Gets the features available to the connected server
+        /// Gets the features available to the connected server.
         /// </summary>
         RedisFeatures Features { get; }
 
         /// <summary>
-        /// Gets whether the connection to the server is active and usable
+        /// Gets whether the connection to the server is active and usable.
         /// </summary>
         bool IsConnected { get; }
 
         /// <summary>
-        /// Gets whether the connected server is a replica
+        /// Gets whether the connected server is a replica.
         /// </summary>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(IsReplica) + " instead.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         bool IsSlave { get; }
 
         /// <summary>
-        /// Gets whether the connected server is a replica
+        /// Gets whether the connected server is a replica.
         /// </summary>
         bool IsReplica { get; }
 
         /// <summary>
-        /// Explicitly opt in for replica writes on writable replica
+        /// Explicitly opt in for replica writes on writable replica.
         /// </summary>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(AllowReplicaWrites) + " instead.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         bool AllowSlaveWrites { get; set; }
 
         /// <summary>
-        /// Explicitly opt in for replica writes on writable replica
+        /// Explicitly opt in for replica writes on writable replica.
         /// </summary>
         bool AllowReplicaWrites { get; set; }
 
         /// <summary>
-        /// Gets the operating mode of the connected server
+        /// Gets the operating mode of the connected server.
         /// </summary>
         ServerType ServerType { get; }
 
         /// <summary>
-        /// Gets the version of the connected server
+        /// Gets the version of the connected server.
         /// </summary>
         Version Version { get; }
 
         /// <summary>
-        /// The number of databases supported on this server
+        /// The number of databases supported on this server.
         /// </summary>
         int DatabaseCount { get; }
 
         /// <summary>
         /// The CLIENT KILL command closes a given client connection identified by ip:port.
         /// The ip:port should match a line returned by the CLIENT LIST command.
-        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection while it is executing a command.From the client point of view, the connection can never be closed in the middle of the execution of a command.However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
+        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection
+        /// while it is executing a command.From the client point of view, the connection can never be
+        /// closed in the middle of the execution of a command.However, the client will notice the connection
+        /// has been closed only when the next command is sent (and results in network error).
         /// </summary>
         /// <param name="endpoint">The endpoint of the client to kill.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -85,7 +88,10 @@ namespace StackExchange.Redis
         /// <summary>
         /// The CLIENT KILL command closes a given client connection identified by ip:port.
         /// The ip:port should match a line returned by the CLIENT LIST command.
-        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection while it is executing a command.From the client point of view, the connection can never be closed in the middle of the execution of a command.However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
+        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection
+        /// while it is executing a command.From the client point of view, the connection can never be
+        /// closed in the middle of the execution of a command.However, the client will notice the connection
+        /// has been closed only when the next command is sent (and results in network error).
         /// </summary>
         /// <param name="endpoint">The endpoint of the client to kill.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -93,24 +99,24 @@ namespace StackExchange.Redis
         Task ClientKillAsync(EndPoint endpoint, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CLIENT KILL command closes multiple connections that match the specified filters
+        /// The CLIENT KILL command closes multiple connections that match the specified filters.
         /// </summary>
         /// <param name="id">The ID of the client to kill.</param>
         /// <param name="clientType">The type of client.</param>
         /// <param name="endpoint">The endpoint to kill.</param>
-        /// <param name="skipMe">Whether to kskip the current connection.</param>
+        /// <param name="skipMe">Whether to skip the current connection.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>the number of clients killed.</returns>
         /// <remarks>https://redis.io/commands/client-kill</remarks>
         long ClientKill(long? id = null, ClientType? clientType = null, EndPoint endpoint = null, bool skipMe = true, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CLIENT KILL command closes multiple connections that match the specified filters
+        /// The CLIENT KILL command closes multiple connections that match the specified filters.
         /// </summary>
         /// <param name="id">The ID of the client to kill.</param>
         /// <param name="clientType">The type of client.</param>
         /// <param name="endpoint">The endpoint to kill.</param>
-        /// <param name="skipMe">Whether to kskip the current connection.</param>
+        /// <param name="skipMe">Whether to skip the current connection.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>the number of clients killed.</returns>
         /// <remarks>https://redis.io/commands/client-kill</remarks>
@@ -131,25 +137,25 @@ namespace StackExchange.Redis
         Task<ClientInfo[]> ClientListAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Obtains the current CLUSTER NODES output from a cluster server
+        /// Obtains the current CLUSTER NODES output from a cluster server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         ClusterConfiguration ClusterNodes(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Obtains the current CLUSTER NODES output from a cluster server
+        /// Obtains the current CLUSTER NODES output from a cluster server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         Task<ClusterConfiguration> ClusterNodesAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Obtains the current raw CLUSTER NODES output from a cluster server
+        /// Obtains the current raw CLUSTER NODES output from a cluster server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         string ClusterNodesRaw(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Obtains the current raw CLUSTER NODES output from a cluster server
+        /// Obtains the current raw CLUSTER NODES output from a cluster server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         Task<string> ClusterNodesRawAsync(CommandFlags flags = CommandFlags.None);
@@ -187,21 +193,26 @@ namespace StackExchange.Redis
         Task ConfigResetStatisticsAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with, applying the minimal changes needed to make it reflecting the configuration currently used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
+        /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with,
+        /// applying the minimal changes needed to make it reflecting the configuration currently
+        /// used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/config-rewrite</remarks>
         void ConfigRewrite(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with, applying the minimal changes needed to make it reflecting the configuration currently used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
+        /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with,
+        /// applying the minimal changes needed to make it reflecting the configuration currently
+        /// used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/config-rewrite</remarks>
         Task ConfigRewriteAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis. You can change both trivial parameters or switch from one to another persistence option using this command.
+        /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis.
+        /// You can change both trivial parameters or switch from one to another persistence option using this command.
         /// </summary>
         /// <param name="setting">The setting name.</param>
         /// <param name="value">The new setting value.</param>
@@ -210,7 +221,8 @@ namespace StackExchange.Redis
         void ConfigSet(RedisValue setting, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis. You can change both trivial parameters or switch from one to another persistence option using this command.
+        /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis.
+        /// You can change both trivial parameters or switch from one to another persistence option using this command.
         /// </summary>
         /// <param name="setting">The setting name.</param>
         /// <param name="value">The new setting value.</param>
@@ -327,7 +339,7 @@ namespace StackExchange.Redis
         Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Get summary statistics associates with this server
+        /// Get summary statistics associates with this server.
         /// </summary>
         ServerCounters GetCounters();
 
@@ -376,7 +388,9 @@ namespace StackExchange.Redis
         IEnumerable<RedisKey> Keys(int database, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
-        /// Returns all keys matching pattern; the KEYS or SCAN commands will be used based on the server capabilities; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// Returns all keys matching pattern.
+        /// The KEYS or SCAN commands will be used based on the server capabilities.
+        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
         /// </summary>
         /// <param name="database">The database ID.</param>
         /// <param name="pattern">The pattern to use.</param>
@@ -390,7 +404,9 @@ namespace StackExchange.Redis
         IEnumerable<RedisKey> Keys(int database = -1, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns all keys matching pattern; the KEYS or SCAN commands will be used based on the server capabilities; note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// Returns all keys matching pattern.
+        /// The KEYS or SCAN commands will be used based on the server capabilities.
+        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
         /// </summary>
         /// <param name="database">The database ID.</param>
         /// <param name="pattern">The pattern to use.</param>
@@ -404,14 +420,18 @@ namespace StackExchange.Redis
         IAsyncEnumerable<RedisKey> KeysAsync(int database = -1, RedisValue pattern = default(RedisValue), int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the time of the last DB save executed with success. A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command and checking at regular intervals every N seconds if LASTSAVE changed.
+        /// Return the time of the last DB save executed with success.
+        /// A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command
+        /// and checking at regular intervals every N seconds if LASTSAVE changed.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/lastsave</remarks>
         DateTime LastSave(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the time of the last DB save executed with success. A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command and checking at regular intervals every N seconds if LASTSAVE changed.
+        /// Return the time of the last DB save executed with success.
+        /// A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command
+        /// and checking at regular intervals every N seconds if LASTSAVE changed.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/lastsave</remarks>
@@ -445,7 +465,7 @@ namespace StackExchange.Redis
         Task<Role> RoleAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Explicitly request the database to persist the current state to disk
+        /// Explicitly request the database to persist the current state to disk.
         /// </summary>
         /// <param name="type">The method of the save (e.g. background or foreground).</param>
         /// <param name="flags">The command flags to use.</param>
@@ -456,7 +476,7 @@ namespace StackExchange.Redis
         void Save(SaveType type, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Explicitly request the database to persist the current state to disk
+        /// Explicitly request the database to persist the current state to disk.
         /// </summary>
         /// <param name="type">The method of the save (e.g. background or foreground).</param>
         /// <param name="flags">The command flags to use.</param>
@@ -467,68 +487,68 @@ namespace StackExchange.Redis
         Task SaveAsync(SaveType type, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicates whether the specified script is defined on the server
+        /// Indicates whether the specified script is defined on the server.
         /// </summary>
         /// <param name="script">The text of the script to check for on the server.</param>
         /// <param name="flags">The command flags to use.</param>
         bool ScriptExists(string script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicates whether the specified script hash is defined on the server
+        /// Indicates whether the specified script hash is defined on the server.
         /// </summary>
         /// <param name="sha1">The SHA1 of the script to check for on the server.</param>
         /// <param name="flags">The command flags to use.</param>
         bool ScriptExists(byte[] sha1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicates whether the specified script is defined on the server
+        /// Indicates whether the specified script is defined on the server.
         /// </summary>
         /// <param name="script">The text of the script to check for on the server.</param>
         /// <param name="flags">The command flags to use.</param>
         Task<bool> ScriptExistsAsync(string script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicates whether the specified script hash is defined on the server
+        /// Indicates whether the specified script hash is defined on the server.
         /// </summary>
         /// <param name="sha1">The SHA1 of the script to check for on the server.</param>
         /// <param name="flags">The command flags to use.</param>
         Task<bool> ScriptExistsAsync(byte[] sha1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes all cached scripts on this server
+        /// Removes all cached scripts on this server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         void ScriptFlush(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Removes all cached scripts on this server
+        /// Removes all cached scripts on this server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         Task ScriptFlushAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Explicitly defines a script on the server
+        /// Explicitly defines a script on the server.
         /// </summary>
         /// <param name="script">The script to load.</param>
         /// <param name="flags">The command flags to use.</param>
         byte[] ScriptLoad(string script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Explicitly defines a script on the server
+        /// Explicitly defines a script on the server.
         /// </summary>
         /// <param name="script">The script to load.</param>
         /// <param name="flags">The command flags to use.</param>
         LoadedLuaScript ScriptLoad(LuaScript script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Explicitly defines a script on the server
+        /// Explicitly defines a script on the server.
         /// </summary>
         /// <param name="script">The script to load.</param>
         /// <param name="flags">The command flags to use.</param>
         Task<byte[]> ScriptLoadAsync(string script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Explicitly defines a script on the server
+        /// Explicitly defines a script on the server.
         /// </summary>
         /// <param name="script">The script to load.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -543,7 +563,10 @@ namespace StackExchange.Redis
         void Shutdown(ShutdownMode shutdownMode = ShutdownMode.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly. If a Redis server is already acting as replica, specifying a null master will turn off the replication, turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of another server listening at the specified hostname and port.
+        /// The REPLICAOF command can change the replication settings of a replica on the fly.
+        /// If a Redis server is already acting as replica, specifying a null master will turn off the replication,
+        /// turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of
+        /// another server listening at the specified hostname and port.
         /// </summary>
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -553,7 +576,10 @@ namespace StackExchange.Redis
         void SlaveOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly. If a Redis server is already acting as replica, specifying a null master will turn off the replication, turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of another server listening at the specified hostname and port.
+        /// The REPLICAOF command can change the replication settings of a replica on the fly.
+        /// If a Redis server is already acting as replica, specifying a null master will turn off the replication,
+        /// turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of
+        /// another server listening at the specified hostname and port.
         /// </summary>
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -562,7 +588,10 @@ namespace StackExchange.Redis
         void ReplicaOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly. If a Redis server is already acting as replica, specifying a null master will turn off the replication, turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of another server listening at the specified hostname and port.
+        /// The REPLICAOF command can change the replication settings of a replica on the fly.
+        /// If a Redis server is already acting as replica, specifying a null master will turn off the replication,
+        /// turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of
+        /// another server listening at the specified hostname and port.
         /// </summary>
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -572,7 +601,10 @@ namespace StackExchange.Redis
         Task SlaveOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly. If a Redis server is already acting as replica, specifying a null master will turn off the replication, turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of another server listening at the specified hostname and port.
+        /// The REPLICAOF command can change the replication settings of a replica on the fly.
+        /// If a Redis server is already acting as replica, specifying a null master will turn off the replication,
+        /// turning the Redis server into a MASTER. Specifying a non-null master will make the server a replica of
+        /// another server listening at the specified hostname and port.
         /// </summary>
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -580,7 +612,8 @@ namespace StackExchange.Redis
         Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log. It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
+        /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log.
+        /// It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
         /// </summary>
         /// <param name="count">The count of items to get.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -588,7 +621,8 @@ namespace StackExchange.Redis
         CommandTrace[] SlowlogGet(int count = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log. It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
+        /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log.
+        /// It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
         /// </summary>
         /// <param name="count">The count of items to get.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -610,7 +644,8 @@ namespace StackExchange.Redis
         Task SlowlogResetAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Lists the currently active channels. An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
+        /// Lists the currently active channels.
+        /// An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
         /// </summary>
         /// <param name="pattern">The channel name pattern to get channels for.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -619,7 +654,8 @@ namespace StackExchange.Redis
         RedisChannel[] SubscriptionChannels(RedisChannel pattern = default(RedisChannel), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Lists the currently active channels. An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
+        /// Lists the currently active channels.
+        /// An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
         /// </summary>
         /// <param name="pattern">The channel name pattern to get channels for.</param>
         /// <param name="flags">The command flags to use.</param>
@@ -628,7 +664,8 @@ namespace StackExchange.Redis
         Task<RedisChannel[]> SubscriptionChannelsAsync(RedisChannel pattern = default(RedisChannel), CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command). Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
+        /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command).
+        /// Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>the number of patterns all the clients are subscribed to.</returns>
@@ -636,7 +673,8 @@ namespace StackExchange.Redis
         long SubscriptionPatternCount(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command). Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
+        /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command).
+        /// Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>the number of patterns all the clients are subscribed to.</returns>

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -36,7 +36,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets whether the connected server is a replica.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(IsReplica) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(IsReplica) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         bool IsSlave { get; }
 
@@ -48,7 +48,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Explicitly opt in for replica writes on writable replica.
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(AllowReplicaWrites) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(AllowReplicaWrites) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         bool AllowSlaveWrites { get; set; }
 
@@ -922,7 +922,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The command flags to use.</param>
         /// <returns>an array of replica state KeyValuePair arrays</returns>
         /// <remarks>https://redis.io/topics/sentinel</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(SentinelReplicas) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(SentinelReplicas) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         KeyValuePair<string, string>[][] SentinelSlaves(string serviceName, CommandFlags flags = CommandFlags.None);
 
@@ -942,7 +942,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The command flags to use.</param>
         /// <returns>an array of replica state KeyValuePair arrays</returns>
         /// <remarks>https://redis.io/topics/sentinel</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(SentinelReplicasAsync) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(SentinelReplicasAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Task<KeyValuePair<string, string>[][]> SentinelSlavesAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -418,11 +418,19 @@ namespace StackExchange.Redis
         Task<DateTime> LastSaveAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Promote the selected node to be master
+        /// Promote the selected node to be primary.
         /// </summary>
         /// <param name="options">The options to use for this topology change.</param>
         /// <param name="log">The log to write output to.</param>
+        [Obsolete("Please use " + nameof(MakePrimaryAsync) + ", this will be removed in 3.0.")]
         void MakeMaster(ReplicationChangeOptions options, TextWriter log = null);
+
+        /// <summary>
+        /// Promote the selected node to be primary.
+        /// </summary>
+        /// <param name="options">The options to use for this topology change.</param>
+        /// <param name="log">The log to write output to.</param>
+        Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter log = null);
 
         /// <summary>
         /// Returns the role info for the current server.
@@ -540,7 +548,7 @@ namespace StackExchange.Redis
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/replicaof</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOf) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         void SlaveOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
@@ -550,6 +558,7 @@ namespace StackExchange.Redis
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/replicaof</remarks>
+        [Obsolete("Please use " + nameof(ReplicaOfAsync) + ", this will be removed in 3.0.")]
         void ReplicaOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -558,7 +567,7 @@ namespace StackExchange.Redis
         /// <param name="master">Endpoint of the new master to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/replicaof</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Task SlaveOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/Interfaces/ISubscriber.cs
+++ b/src/StackExchange.Redis/Interfaces/ISubscriber.cs
@@ -5,27 +5,27 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// A redis connection used as the subscriber in a pub/sub scenario
+    /// A redis connection used as the subscriber in a pub/sub scenario.
     /// </summary>
     public interface ISubscriber : IRedis
     {
         /// <summary>
-        /// Indicate exactly which redis server we are talking to
+        /// Indicate exactly which redis server we are talking to.
         /// </summary>
         /// <param name="channel">The channel to identify the server endpoint by.</param>
         /// <param name="flags">The command flags to use.</param>
         EndPoint IdentifyEndpoint(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicate exactly which redis server we are talking to
+        /// Indicate exactly which redis server we are talking to.
         /// </summary>
         /// <param name="channel">The channel to identify the server endpoint by.</param>
         /// <param name="flags">The command flags to use.</param>
         Task<EndPoint> IdentifyEndpointAsync(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicates whether the instance can communicate with the server;
-        /// if a channel is specified, the existing subscription map is queried to
+        /// Indicates whether the instance can communicate with the server.
+        /// If a channel is specified, the existing subscription map is queried to
         /// resolve the server responsible for that subscription - otherwise the
         /// server is chosen arbitrarily from the masters.
         /// </summary>
@@ -93,16 +93,16 @@ namespace StackExchange.Redis
         Task<ChannelMessageQueue> SubscribeAsync(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Indicate to which redis server we are actively subscribed for a given channel; returns null if
-        /// the channel is not actively subscribed
+        /// Indicate to which redis server we are actively subscribed for a given channel.
         /// </summary>
         /// <param name="channel">The channel to check which server endpoint was subscribed on.</param>
+        /// <returns>The subscribed endpoint for the given <paramref name="channel"/>, <see langword="null"/> if the channel is not actively subscribed.</returns>
         EndPoint SubscribedEndpoint(RedisChannel channel);
 
         /// <summary>
-        /// Unsubscribe from a specified message channel; note; if no handler is specified, the subscription is canceled regardless
-        /// of the subscribers; if a handler is specified, the subscription is only canceled if this handler is the
-        /// last handler remaining against the channel
+        /// Unsubscribe from a specified message channel.
+        /// Note: if no handler is specified, the subscription is canceled regardless of the subscribers.
+        /// If a handler is specified, the subscription is only canceled if this handler is the last handler remaining against the channel.
         /// </summary>
         /// <param name="channel">The channel that was subscribed to.</param>
         /// <param name="handler">The handler to no longer invoke when a message is received on <paramref name="channel"/>.</param>
@@ -112,7 +112,7 @@ namespace StackExchange.Redis
         void Unsubscribe(RedisChannel channel, Action<RedisChannel, RedisValue> handler = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Unsubscribe all subscriptions on this instance
+        /// Unsubscribe all subscriptions on this instance.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/unsubscribe</remarks>
@@ -120,7 +120,7 @@ namespace StackExchange.Redis
         void UnsubscribeAll(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Unsubscribe all subscriptions on this instance
+        /// Unsubscribe all subscriptions on this instance.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <remarks>https://redis.io/commands/unsubscribe</remarks>
@@ -128,9 +128,9 @@ namespace StackExchange.Redis
         Task UnsubscribeAllAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Unsubscribe from a specified message channel; note; if no handler is specified, the subscription is canceled regardless
-        /// of the subscribers; if a handler is specified, the subscription is only canceled if this handler is the
-        /// last handler remaining against the channel
+        /// Unsubscribe from a specified message channel.
+        /// Note: if no handler is specified, the subscription is canceled regardless of the subscribers.
+        /// If a handler is specified, the subscription is only canceled if this handler is the last handler remaining against the channel.
         /// </summary>
         /// <param name="channel">The channel that was subscribed to.</param>
         /// <param name="handler">The handler to no longer invoke when a message is received on <paramref name="channel"/>.</param>

--- a/src/StackExchange.Redis/Interfaces/ITransaction.cs
+++ b/src/StackExchange.Redis/Interfaces/ITransaction.cs
@@ -11,12 +11,13 @@ namespace StackExchange.Redis
     /// the constraint checks have arrived.
     /// </summary>
     /// <remarks>https://redis.io/topics/transactions</remarks>
-    /// <remarks>Note that on a cluster, it may be required that all keys involved in the transaction
-    /// (including constraints) are in the same hash-slot</remarks>
+    /// <remarks>
+    /// Note that on a cluster, it may be required that all keys involved in the transaction (including constraints) are in the same hash-slot.
+    /// </remarks>
     public interface ITransaction : IBatch
     {
         /// <summary>
-        /// Adds a precondition for this transaction
+        /// Adds a precondition for this transaction.
         /// </summary>
         /// <param name="condition">The condition to add to the transaction.</param>
         ConditionResult AddCondition(Condition condition);

--- a/src/StackExchange.Redis/InternalErrorEventArgs.cs
+++ b/src/StackExchange.Redis/InternalErrorEventArgs.cs
@@ -27,7 +27,7 @@ namespace StackExchange.Redis
         /// <param name="sender">The source of the event.</param>
         /// <param name="endpoint"></param>
         /// <param name="connectionType">Redis connection type.</param>
-        /// <param name="exception">The exception occurred.</param>
+        /// <param name="exception">The exception that occurred.</param>
         /// <param name="origin">Origin.</param>
         public InternalErrorEventArgs(object sender, EndPoint endpoint, ConnectionType connectionType, Exception exception, string origin)
             : this (null, sender, endpoint, connectionType, exception, origin)

--- a/src/StackExchange.Redis/InternalErrorEventArgs.cs
+++ b/src/StackExchange.Redis/InternalErrorEventArgs.cs
@@ -27,7 +27,7 @@ namespace StackExchange.Redis
         /// <param name="sender">The source of the event.</param>
         /// <param name="endpoint"></param>
         /// <param name="connectionType">Redis connection type.</param>
-        /// <param name="exception">The exception occured.</param>
+        /// <param name="exception">The exception occurred.</param>
         /// <param name="origin">Origin.</param>
         public InternalErrorEventArgs(object sender, EndPoint endpoint, ConnectionType connectionType, Exception exception, string origin)
             : this (null, sender, endpoint, connectionType, exception, origin)
@@ -57,7 +57,10 @@ namespace StackExchange.Redis
         void ICompletable.AppendStormLog(StringBuilder sb)
         {
             sb.Append("event, internal-error: ").Append(Origin);
-            if (EndPoint != null) sb.Append(", ").Append(Format.ToString(EndPoint));
+            if (EndPoint != null)
+            {
+                sb.Append(", ").Append(Format.ToString(EndPoint));
+            }
         }
 
         bool ICompletable.TryComplete(bool isAsync) => ConnectionMultiplexer.TryCompleteHandler(handler, sender, this, isAsync);

--- a/src/StackExchange.Redis/KeyspaceIsolation/BatchWrapper.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/BatchWrapper.cs
@@ -2,13 +2,8 @@
 {
     internal sealed class BatchWrapper : WrapperBase<IBatch>, IBatch
     {
-        public BatchWrapper(IBatch inner, byte[] prefix) : base(inner, prefix)
-        {
-        }
+        public BatchWrapper(IBatch inner, byte[] prefix) : base(inner, prefix) { }
 
-        public void Execute()
-        {
-            Inner.Execute();
-        }
+        public void Execute() => Inner.Execute();
     }
 }

--- a/src/StackExchange.Redis/KeyspaceIsolation/DatabaseExtension.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/DatabaseExtension.cs
@@ -9,7 +9,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
     {
         /// <summary>
         ///     Creates a new <see cref="IDatabase"/> instance that provides an isolated key space
-        ///     of the specified underyling database instance.
+        ///     of the specified underlying database instance.
         /// </summary>
         /// <param name="database">
         ///     The underlying database instance that the returned instance shall use.
@@ -20,7 +20,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
         /// <returns>
         ///     A new <see cref="IDatabase"/> instance that invokes the specified underlying
         ///     <paramref name="database"/> but prepends the specified <paramref name="keyPrefix"/>
-        ///     to all key paramters and thus forms a logical key space isolation.
+        ///     to all key parameters and thus forms a logical key space isolation.
         /// </returns>
         /// <remarks>
         /// <para>

--- a/src/StackExchange.Redis/KeyspaceIsolation/TransactionWrapper.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/TransactionWrapper.cs
@@ -4,28 +4,14 @@ namespace StackExchange.Redis.KeyspaceIsolation
 {
     internal sealed class TransactionWrapper : WrapperBase<ITransaction>, ITransaction
     {
-        public TransactionWrapper(ITransaction inner, byte[] prefix) : base(inner, prefix)
-        {
-        }
+        public TransactionWrapper(ITransaction inner, byte[] prefix) : base(inner, prefix) { }
 
-        public ConditionResult AddCondition(Condition condition)
-        {
-            return Inner.AddCondition(condition?.MapKeys(GetMapFunction()));
-        }
+        public ConditionResult AddCondition(Condition condition) => Inner.AddCondition(condition?.MapKeys(GetMapFunction()));
 
-        public bool Execute(CommandFlags flags = CommandFlags.None)
-        {
-            return Inner.Execute(flags);
-        }
+        public bool Execute(CommandFlags flags = CommandFlags.None) => Inner.Execute(flags);
 
-        public Task<bool> ExecuteAsync(CommandFlags flags = CommandFlags.None)
-        {
-            return Inner.ExecuteAsync(flags);
-        }
+        public Task<bool> ExecuteAsync(CommandFlags flags = CommandFlags.None) => Inner.ExecuteAsync(flags);
 
-        public void Execute()
-        {
-            Inner.Execute();
-        }
+        public void Execute() => Inner.Execute();
     }
 }

--- a/src/StackExchange.Redis/Lease.cs
+++ b/src/StackExchange.Redis/Lease.cs
@@ -12,7 +12,7 @@ namespace StackExchange.Redis
     public sealed class Lease<T> : IMemoryOwner<T>
     {
         /// <summary>
-        /// A lease of length zero
+        /// A lease of length zero.
         /// </summary>
         public static Lease<T> Empty { get; } = new Lease<T>(System.Array.Empty<T>(), 0);
 

--- a/src/StackExchange.Redis/LinearRetry.cs
+++ b/src/StackExchange.Redis/LinearRetry.cs
@@ -11,10 +11,8 @@
         /// Initializes a new instance using the specified maximum retry elapsed time allowed.
         /// </summary>
         /// <param name="maxRetryElapsedTimeAllowedMilliseconds">maximum elapsed time in milliseconds to be allowed for it to perform retries.</param>
-        public LinearRetry(int maxRetryElapsedTimeAllowedMilliseconds)
-        {
+        public LinearRetry(int maxRetryElapsedTimeAllowedMilliseconds) =>
             this.maxRetryElapsedTimeAllowedMilliseconds = maxRetryElapsedTimeAllowedMilliseconds;
-        }
 
         /// <summary>
         /// This method is called by the ConnectionMultiplexer to determine if a reconnect operation can be retried now.

--- a/src/StackExchange.Redis/LuaScript.cs
+++ b/src/StackExchange.Redis/LuaScript.cs
@@ -58,7 +58,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Finalizer, used to prompt cleanups of the script cache when a LuaScript reference goes out of scope.
+        /// Finalizer - used to prompt cleanups of the script cache when a LuaScript reference goes out of scope.
         /// </summary>
         ~LuaScript()
         {
@@ -257,7 +257,7 @@ namespace StackExchange.Redis
         /// <para>Evaluates this LoadedLuaScript against the given database, extracting parameters for the passed in object if any.</para>
         /// <para>
         /// This method sends the SHA1 hash of the ExecutableScript instead of the script itself.
-        /// If the script has not been loaded into the passed Redis instance it will fail.
+        /// If the script has not been loaded into the passed Redis instance, it will fail.
         /// </para>
         /// </summary>
         /// <param name="db">The redis database to evaluate against.</param>
@@ -274,7 +274,7 @@ namespace StackExchange.Redis
         /// <para>Evaluates this LoadedLuaScript against the given database, extracting parameters for the passed in object if any.</para>
         /// <para>
         /// This method sends the SHA1 hash of the ExecutableScript instead of the script itself.
-        /// If the script has not been loaded into the passed Redis instance it will fail.
+        /// If the script has not been loaded into the passed Redis instance, it will fail.
         /// </para>
         /// </summary>
         /// <param name="db">The redis database to evaluate against.</param>

--- a/src/StackExchange.Redis/LuaScript.cs
+++ b/src/StackExchange.Redis/LuaScript.cs
@@ -19,8 +19,10 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed class LuaScript
     {
-        // Since the mapping of "script text" -> LuaScript doesn't depend on any particular details of
-        // the redis connection itself, this cache is global.
+        /// <summary>
+        /// Since the mapping of "script text" -> LuaScript doesn't depend on any particular details of
+        /// the redis connection itself, this cache is global.
+        /// </summary>
         private static readonly ConcurrentDictionary<string, WeakReference> Cache = new();
 
         /// <summary>
@@ -56,8 +58,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Finalizer, used to prompt cleanups of the script cache when
-        /// a LuaScript reference goes out of scope.
+        /// Finalizer, used to prompt cleanups of the script cache when a LuaScript reference goes out of scope.
         /// </summary>
         ~LuaScript()
         {
@@ -255,8 +256,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// <para>Evaluates this LoadedLuaScript against the given database, extracting parameters for the passed in object if any.</para>
         /// <para>
-        /// This method sends the SHA1 hash of the ExecutableScript instead of the script itself.  If the script has not
-        /// been loaded into the passed Redis instance it will fail.
+        /// This method sends the SHA1 hash of the ExecutableScript instead of the script itself.
+        /// If the script has not been loaded into the passed Redis instance it will fail.
         /// </para>
         /// </summary>
         /// <param name="db">The redis database to evaluate against.</param>
@@ -272,8 +273,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// <para>Evaluates this LoadedLuaScript against the given database, extracting parameters for the passed in object if any.</para>
         /// <para>
-        /// This method sends the SHA1 hash of the ExecutableScript instead of the script itself.  If the script has not
-        /// been loaded into the passed Redis instance it will fail.
+        /// This method sends the SHA1 hash of the ExecutableScript instead of the script itself.
+        /// If the script has not been loaded into the passed Redis instance it will fail.
         /// </para>
         /// </summary>
         /// <param name="db">The redis database to evaluate against.</param>

--- a/src/StackExchange.Redis/Maintenance/AzureMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/Maintenance/AzureMaintenanceEvent.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Net;
 using System.Threading.Tasks;
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETCOREAPP
 using System.Buffers.Text;
 #endif
 
@@ -58,7 +58,7 @@ namespace StackExchange.Redis.Maintenance
 
                     if (key.Length > 0 && value.Length > 0)
                     {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETCOREAPP
                         switch (key)
                         {
                             case var _ when key.SequenceEqual(nameof(NotificationType).AsSpan()):

--- a/src/StackExchange.Redis/Maintenance/ServerMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/Maintenance/ServerMaintenanceEvent.cs
@@ -46,7 +46,6 @@ namespace StackExchange.Redis.Maintenance
         /// <summary>
         /// Returns a string representing the maintenance event with all of its properties.
         /// </summary>
-        public override string ToString()
-            => RawMessage;
+        public override string ToString() => RawMessage;
     }
 }

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -58,7 +58,7 @@ namespace StackExchange.Redis
 
         private const CommandFlags AskingFlag = (CommandFlags)32,
                                    ScriptUnavailableFlag = (CommandFlags)256,
-                                   DemandSubscriptionConnection = (CommandFlags)2048;
+                                   DemandSubscriptionConnection = (CommandFlags)1024;
 
         private const CommandFlags MaskMasterServerPreference = CommandFlags.DemandMaster
                                                               | CommandFlags.DemandReplica

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -70,7 +70,7 @@ namespace StackExchange.Redis
                                                        | CommandFlags.DemandReplica
                                                        | CommandFlags.PreferMaster
                                                        | CommandFlags.PreferReplica
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                                                        | CommandFlags.HighPriority
 #pragma warning restore CS0618
                                                        | CommandFlags.FireAndForget

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -686,7 +686,7 @@ namespace StackExchange.Redis
         /// Sets the processor and box for this message to execute.
         /// </summary>
         /// <remarks>
-        /// Note order here reversed to prevent overload resolution errors
+        /// Note order here is reversed to prevent overload resolution errors.
         /// </remarks>
         internal void SetSource(ResultProcessor resultProcessor, IResultBox resultBox)
         {
@@ -698,7 +698,7 @@ namespace StackExchange.Redis
         /// Sets the box and processor for this message to execute.
         /// </summary>
         /// <remarks>
-        /// Note order here reversed to prevent overload resolution errors
+        /// Note order here is reversed to prevent overload resolution errors.
         /// </remarks>
         internal void SetSource<T>(IResultBox<T> resultBox, ResultProcessor<T> resultProcessor)
         {

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -693,9 +693,11 @@ namespace StackExchange.Redis
         internal void SetPreferReplica() =>
             Flags = (Flags & ~MaskMasterServerPreference) | CommandFlags.PreferReplica;
 
+        /// <remarks>
+        /// Note order here reversed to prevent overload resolution errors
+        /// </remarks>
         internal void SetSource(ResultProcessor resultProcessor, IResultBox resultBox)
         {
-            // note order here reversed to prevent overload resolution errors
             this.resultBox = resultBox;
             this.resultProcessor = resultProcessor;
         }

--- a/src/StackExchange.Redis/MessageCompletable.cs
+++ b/src/StackExchange.Redis/MessageCompletable.cs
@@ -48,9 +48,6 @@ namespace StackExchange.Redis
             }
         }
 
-        void ICompletable.AppendStormLog(StringBuilder sb)
-        {
-            sb.Append("event, pub/sub: ").Append((string)channel);
-        }
+        void ICompletable.AppendStormLog(StringBuilder sb) => sb.Append("event, pub/sub: ").Append((string)channel);
     }
 }

--- a/src/StackExchange.Redis/NameValueEntry.cs
+++ b/src/StackExchange.Redis/NameValueEntry.cs
@@ -32,27 +32,25 @@ namespace StackExchange.Redis
         public RedisValue Value => value;
 
         /// <summary>
-        /// Converts to a key/value pair
+        /// Converts to a key/value pair.
         /// </summary>
         /// <param name="value">The <see cref="NameValueEntry"/> to create a <see cref="KeyValuePair{TKey, TValue}"/> from.</param>
         public static implicit operator KeyValuePair<RedisValue, RedisValue>(NameValueEntry value) =>
             new KeyValuePair<RedisValue, RedisValue>(value.name, value.value);
 
         /// <summary>
-        /// Converts from a key/value pair
+        /// Converts from a key/value pair.
         /// </summary>
         /// <param name="value">The <see cref="KeyValuePair{TKey, TValue}"/> to get a <see cref="NameValueEntry"/> from.</param>
         public static implicit operator NameValueEntry(KeyValuePair<RedisValue, RedisValue> value) =>
             new NameValueEntry(value.Key, value.Value);
 
         /// <summary>
-        /// See Object.ToString()
+        /// The "{name}: {value}" string representation.
         /// </summary>
         public override string ToString() => name + ": " + value;
 
-        /// <summary>
-        /// See Object.GetHashCode()
-        /// </summary>
+        /// <inheritdoc />
         public override int GetHashCode() => name.GetHashCode() ^ value.GetHashCode();
 
         /// <summary>

--- a/src/StackExchange.Redis/PerfCounterHelper.cs
+++ b/src/StackExchange.Redis/PerfCounterHelper.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Threading;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
 
 namespace StackExchange.Redis
 {

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -203,7 +203,7 @@ namespace StackExchange.Redis
         public ValueTask<WriteResult> TryWriteAsync(Message message, bool isReplica, bool isHandshake = false)
         {
             if (isDisposed) throw new ObjectDisposedException(Name);
-            if (!IsConnected) return new ValueTask<WriteResult>(QueueOrFailMessage(message));
+            if (!IsConnected && !isHandshake) return new ValueTask<WriteResult>(QueueOrFailMessage(message));
 
             var physical = this.physical;
             if (physical == null)

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -366,7 +366,7 @@ namespace StackExchange.Redis
                 Multiplexer.Trace("Enqueue: " + msg);
                 Multiplexer.OnInfoMessage($"heartbeat ({physical?.LastWriteSecondsAgo}s >= {ServerEndPoint?.WriteEverySeconds}s, {physical?.GetSentAwaitingResponseCount()} waiting) '{msg.CommandAndKey}' on '{PhysicalName}' (v{features.Version})");
                 physical?.UpdateLastWriteTime(); // preemptively
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                 var result = TryWriteSync(msg, ServerEndPoint.IsReplica);
 #pragma warning restore CS0618
 
@@ -634,7 +634,7 @@ namespace StackExchange.Redis
                 // deliberately not taking a single lock here; we don't care if
                 // other threads manage to interleave - in fact, it would be desirable
                 // (to avoid a batch monopolising the connection)
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                 WriteMessageTakingWriteLockSync(physical, message);
 #pragma warning restore CS0618
                 LogNonPreferred(message.Flags, isReplica);

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1029,7 +1029,7 @@ namespace StackExchange.Redis
 #endif
                             message.SetExceptionAndComplete(ex, this);
                         }
-                        else if (physical?.HasOuputPipe == true)
+                        else if (physical?.HasOutputPipe == true)
                         {
                             _backlogStatus = BacklogStatus.WritingMessage;
                             var result = WriteMessageInsideLock(physical, message);
@@ -1103,7 +1103,7 @@ namespace StackExchange.Redis
             // AVOID REORDERING MESSAGES
             // Prefer to add it to the backlog if this thread can see that there might already be a message backlog.
             // We do this before attempting to take the writelock, because we won't actually write, we'll just let the backlog get processed in due course
-            if (TryPushToBacklog(message, onlyIfExists: physical.HasOuputPipe, isHandshake: isHandshake))
+            if (TryPushToBacklog(message, onlyIfExists: physical.HasOutputPipe, isHandshake: isHandshake))
             {
                 return new ValueTask<WriteResult>(WriteResult.Success); // queued counts as success
             }

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -926,6 +926,10 @@ namespace StackExchange.Redis
         }
 
         private volatile BacklogStatus _backlogStatus;
+        /// <summary>
+        /// Process the backlog(s) in play if any.
+        /// This means flushing commands to an available/active connection (if any) or spinning until timeout if not.
+        /// </summary>
         private async Task ProcessBacklogsAsync()
         {
             _backlogStatus = BacklogStatus.Starting;

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -794,7 +794,7 @@ namespace StackExchange.Redis
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void BacklogEnqueue(Message message, PhysicalConnection physical)
-        {   
+        {
             _backlog.Enqueue(message);
             Interlocked.Increment(ref _backlogTotalEnqueued);
         }

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -804,7 +804,7 @@ namespace StackExchange.Redis
                 if (!token.Success)
 #endif
                 {
-                    // If we can't get it *instantaneously*; pass it to the backlog for throughput
+                    // If we can't get it *instantaneously*, pass it to the backlog for throughput
                     if (TryPushToBacklog(message, onlyIfExists: false))
                     {
                         return WriteResult.Success; // queued counts as success
@@ -1189,7 +1189,7 @@ namespace StackExchange.Redis
                 if (!token.Success)
 #endif
                 {
-                    // If we can't get it *instantaneously*; pass it to the backlog for throughput
+                    // If we can't get it *instantaneously*, pass it to the backlog for throughput
                     if (TryPushToBacklog(message, onlyIfExists: false, bypassBacklog: bypassBacklog))
                     {
                         return new ValueTask<WriteResult>(WriteResult.Success); // queued counts as success

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -68,7 +68,7 @@ namespace StackExchange.Redis
         }
 
         private IDuplexPipe _ioPipe;
-        internal bool HasOuputPipe => _ioPipe?.Output != null;
+        internal bool HasOutputPipe => _ioPipe?.Output != null;
 
         private Socket _socket;
         private Socket VolatileSocket => Volatile.Read(ref _socket);

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1311,6 +1311,9 @@ namespace StackExchange.Redis
             /// </summary>
             public WriteStatus WriteStatus { get; init; }
 
+            public override string ToString() =>
+                $"SentAwaitingResponse: {MessagesSentAwaitingResponse}, AvailableOnSocket: {BytesAvailableOnSocket} byte(s), InReadPipe: {BytesInReadPipe} byte(s), InWritePipe: {BytesInWritePipe} byte(s), ReadStatus: {ReadStatus}, WriteStatus: {WriteStatus}";
+
             /// <summary>
             /// The default connection stats, notable *not* the same as <code>default</code> since initializers don't run.
             /// </summary>

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -975,10 +975,8 @@ namespace StackExchange.Redis
                 WriteUnifiedSpan(writer, new ReadOnlySpan<byte>(value));
             }
         }
-
-#pragma warning disable RCS1231 // Make parameter ref read-only.
+        
         private static void WriteUnifiedSpan(PipeWriter writer, ReadOnlySpan<byte> value)
-#pragma warning restore RCS1231 // Make parameter ref read-only.
         {
             // ${len}\r\n           = 3 + MaxInt32TextLen
             // {value}\r\n          = 2 + value.Length
@@ -1020,9 +1018,7 @@ namespace StackExchange.Redis
             return WriteCrlf(span, offset);
         }
 
-#pragma warning disable RCS1231 // Make parameter ref read-only. - spans are tiny
         private static int AppendToSpan(Span<byte> span, ReadOnlySpan<byte> value, int offset = 0)
-#pragma warning restore RCS1231 // Make parameter ref read-only.
         {
             offset = WriteRaw(span, value.Length, offset: offset);
             value.CopyTo(span.Slice(offset, value.Length));

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -633,7 +633,8 @@ namespace StackExchange.Redis
                     var timeout = bridge.Multiplexer.AsyncTimeoutMilliseconds;
                     foreach (var msg in _writtenAwaitingResponse)
                     {
-                        if (msg.HasAsyncTimedOut(now, timeout, out var elapsed))
+                        // We only handle async timeouts here, synchronous timeouts are handled upstream.
+                        if (msg.ResultBoxIsAsync && msg.HasTimedOut(now, timeout, out var elapsed))
                         {
                             bool haveDeltas = msg.TryGetPhysicalState(out _, out _, out long sentDelta, out var receivedDelta) && sentDelta >= 0 && receivedDelta >= 0;
                             var timeoutEx = ExceptionFactory.Timeout(bridge.Multiplexer, haveDeltas
@@ -643,7 +644,7 @@ namespace StackExchange.Redis
                             msg.SetExceptionAndComplete(timeoutEx, bridge); // tell the message that it is doomed
                             bridge.Multiplexer.OnAsyncTimeout();
                         }
-                        // note: it is important that we **do not** remove the message unless we're tearing down the socket; that
+                        // Note: it is important that we **do not** remove the message unless we're tearing down the socket; that
                         // would disrupt the chain for MatchResult; we just pre-emptively abort the message from the caller's
                         // perspective, and set a flag on the message so we don't keep doing it
                     }

--- a/src/StackExchange.Redis/Profiling/ProfiledCommand.cs
+++ b/src/StackExchange.Redis/Profiling/ProfiledCommand.cs
@@ -116,10 +116,8 @@ namespace StackExchange.Redis.Profiling
             }
         }
 
-        public override string ToString()
-        {
-            return
-                $@"EndPoint = {EndPoint}
+        public override string ToString() =>
+$@"EndPoint = {EndPoint}
 Db = {Db}
 Command = {Command}
 CommandCreated = {CommandCreated:u}
@@ -129,7 +127,6 @@ SentToResponse = {SentToResponse}
 ResponseToCompletion = {ResponseToCompletion}
 ElapsedTime = {ElapsedTime}
 Flags = {Flags}
-RetransmissionOf = ({RetransmissionOf})";
-        }
+RetransmissionOf = ({RetransmissionOf?.ToString() ?? "nothing"})";
     }
 }

--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using Pipelines.Sockets.Unofficial.Arenas;
 

--- a/src/StackExchange.Redis/RedisBase.cs
+++ b/src/StackExchange.Redis/RedisBase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace StackExchange.Redis

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -86,10 +86,8 @@ namespace StackExchange.Redis
             return task;
         }
 
-        internal override T ExecuteSync<T>(Message message, ResultProcessor<T> processor, ServerEndPoint server = null)
-        {
+        internal override T ExecuteSync<T>(Message message, ResultProcessor<T> processor, ServerEndPoint server = null) =>
             throw new NotSupportedException("ExecuteSync cannot be used inside a batch");
-        }
 
         private static void FailNoServer(List<Message> messages)
         {

--- a/src/StackExchange.Redis/RedisChannel.cs
+++ b/src/StackExchange.Redis/RedisChannel.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents a pub/sub channel name
+    /// Represents a pub/sub channel name.
     /// </summary>
     public readonly struct RedisChannel : IEquatable<RedisChannel>
     {
@@ -12,21 +12,21 @@ namespace StackExchange.Redis
         internal readonly bool IsPatternBased;
 
         /// <summary>
-        /// Indicates whether the channel-name is either null or a zero-length value
+        /// Indicates whether the channel-name is either null or a zero-length value.
         /// </summary>
         public bool IsNullOrEmpty => Value == null || Value.Length == 0;
 
         internal bool IsNull => Value == null;
 
         /// <summary>
-        /// Create a new redis channel from a buffer, explicitly controlling the pattern mode
+        /// Create a new redis channel from a buffer, explicitly controlling the pattern mode.
         /// </summary>
         /// <param name="value">The name of the channel to create.</param>
         /// <param name="mode">The mode for name matching.</param>
         public RedisChannel(byte[] value, PatternMode mode) : this(value, DeterminePatternBased(value, mode)) {}
 
         /// <summary>
-        /// Create a new redis channel from a string, explicitly controlling the pattern mode
+        /// Create a new redis channel from a string, explicitly controlling the pattern mode.
         /// </summary>
         /// <param name="value">The string name of the channel to create.</param>
         /// <param name="mode">The mode for name matching.</param>
@@ -47,42 +47,42 @@ namespace StackExchange.Redis
         };
 
         /// <summary>
-        /// Indicate whether two channel names are not equal
+        /// Indicate whether two channel names are not equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator !=(RedisChannel x, RedisChannel y) => !(x == y);
 
         /// <summary>
-        /// Indicate whether two channel names are not equal
+        /// Indicate whether two channel names are not equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator !=(string x, RedisChannel y) => !(x == y);
 
         /// <summary>
-        /// Indicate whether two channel names are not equal
+        /// Indicate whether two channel names are not equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator !=(byte[] x, RedisChannel y) => !(x == y);
 
         /// <summary>
-        /// Indicate whether two channel names are not equal
+        /// Indicate whether two channel names are not equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator !=(RedisChannel x, string y) => !(x == y);
 
         /// <summary>
-        /// Indicate whether two channel names are not equal
+        /// Indicate whether two channel names are not equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator !=(RedisChannel x, byte[] y) => !(x == y);
 
         /// <summary>
-        /// Indicate whether two channel names are equal
+        /// Indicate whether two channel names are equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
@@ -90,7 +90,7 @@ namespace StackExchange.Redis
             x.IsPatternBased == y.IsPatternBased && RedisValue.Equals(x.Value, y.Value);
 
         /// <summary>
-        /// Indicate whether two channel names are equal
+        /// Indicate whether two channel names are equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
@@ -98,14 +98,14 @@ namespace StackExchange.Redis
             RedisValue.Equals(x == null ? null : Encoding.UTF8.GetBytes(x), y.Value);
 
         /// <summary>
-        /// Indicate whether two channel names are equal
+        /// Indicate whether two channel names are equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator ==(byte[] x, RedisChannel y) => RedisValue.Equals(x, y.Value);
 
         /// <summary>
-        /// Indicate whether two channel names are equal
+        /// Indicate whether two channel names are equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
@@ -113,14 +113,14 @@ namespace StackExchange.Redis
             RedisValue.Equals(x.Value, y == null ? null : Encoding.UTF8.GetBytes(y));
 
         /// <summary>
-        /// Indicate whether two channel names are equal
+        /// Indicate whether two channel names are equal.
         /// </summary>
         /// <param name="x">The first <see cref="RedisChannel"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisChannel"/> to compare.</param>
         public static bool operator ==(RedisChannel x, byte[] y) => RedisValue.Equals(x.Value, y);
 
         /// <summary>
-        /// See Object.Equals
+        /// See <see cref="object.Equals(object)"/>.
         /// </summary>
         /// <param name="obj">The <see cref="RedisChannel"/> to compare to.</param>
         public override bool Equals(object obj) => obj switch
@@ -132,18 +132,16 @@ namespace StackExchange.Redis
         };
 
         /// <summary>
-        /// Indicate whether two channel names are equal
+        /// Indicate whether two channel names are equal.
         /// </summary>
         /// <param name="other">The <see cref="RedisChannel"/> to compare to.</param>
         public bool Equals(RedisChannel other) => IsPatternBased == other.IsPatternBased && RedisValue.Equals(Value, other.Value);
 
-        /// <summary>
-        /// See Object.GetHashCode
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => RedisValue.GetHashCode(Value) + (IsPatternBased ? 1 : 0);
 
         /// <summary>
-        /// Obtains a string representation of the channel name
+        /// Obtains a string representation of the channel name.
         /// </summary>
         public override string ToString() => ((string)this) ?? "(null)";
 
@@ -164,20 +162,20 @@ namespace StackExchange.Redis
         internal RedisChannel Clone() => (byte[])Value?.Clone();
 
         /// <summary>
-        /// The matching pattern for this channel
+        /// The matching pattern for this channel.
         /// </summary>
         public enum PatternMode
         {
             /// <summary>
-            /// Will be treated as a pattern if it includes *
+            /// Will be treated as a pattern if it includes *.
             /// </summary>
             Auto = 0,
             /// <summary>
-            /// Never a pattern
+            /// Never a pattern.
             /// </summary>
             Literal = 1,
             /// <summary>
-            /// Always a pattern
+            /// Always a pattern.
             /// </summary>
             Pattern = 2
         }

--- a/src/StackExchange.Redis/RedisErrorEventArgs.cs
+++ b/src/StackExchange.Redis/RedisErrorEventArgs.cs
@@ -42,10 +42,7 @@ namespace StackExchange.Redis
         /// </summary>
         public string Message { get; }
 
-        void ICompletable.AppendStormLog(StringBuilder sb)
-        {
-            sb.Append("event, error: ").Append(Message);
-        }
+        void ICompletable.AppendStormLog(StringBuilder sb) => sb.Append("event, error: ").Append(Message);
 
         bool ICompletable.TryComplete(bool isAsync) => ConnectionMultiplexer.TryCompleteHandler(handler, sender, this, isAsync);
     }

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Provides basic information about the features available on a particular version of Redis
+    /// Provides basic information about the features available on a particular version of Redis.
     /// </summary>
     public readonly struct RedisFeatures
     {
@@ -41,7 +41,7 @@ namespace StackExchange.Redis
         private readonly Version version;
 
         /// <summary>
-        /// Create a new RedisFeatures instance for the given version
+        /// Create a new RedisFeatures instance for the given version.
         /// </summary>
         /// <param name="version">The version of redis to base the feature set on.</param>
         public RedisFeatures(Version version)
@@ -80,7 +80,7 @@ namespace StackExchange.Redis
         public bool HashStringLength => Version >= v3_2_0;
 
         /// <summary>
-        /// Does HDEL support varadic usage?
+        /// Does HDEL support variadic usage?
         /// </summary>
         public bool HashVaradicDelete => Version >= v2_4_0;
 
@@ -145,7 +145,7 @@ namespace StackExchange.Redis
         public bool SetConditional => Version >= v2_6_12;
 
         /// <summary>
-        /// Does SADD support varadic usage?
+        /// Does SADD support variadic usage?
         /// </summary>
         public bool SetVaradicAddRemove => Version >= v2_4_0;
 
@@ -237,7 +237,7 @@ namespace StackExchange.Redis
         public bool PushMultiple => Version >= v4_0_0;
 
         /// <summary>
-        /// Create a string representation of the available features
+        /// Create a string representation of the available features.
         /// </summary>
         public override string ToString()
         {
@@ -266,18 +266,22 @@ namespace StackExchange.Redis
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode() => Version.GetHashCode();
 
-        /// <summary>Indicates whether this instance and a specified object are equal.</summary>
-        /// <returns>true if <paramref name="obj" /> and this instance are the same type and represent the same value; otherwise, false. </returns>
-        /// <param name="obj">The object to compare with the current instance. </param>
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="obj" /> and this instance are the same type and represent the same value, <see langword="false"/> otherwise.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current instance.</param>
         public override bool Equals(object obj) => obj is RedisFeatures f && f.Version == Version;
 
         /// <summary>
-        /// Checks if 2 RedisFeatures are .Equal().
+        /// Checks if 2 <see cref="RedisFeatures"/> are .Equal().
         /// </summary>
         public static bool operator ==(RedisFeatures left, RedisFeatures right) => left.Equals(right);
 
         /// <summary>
-        /// Checks if 2 RedisFeatures are not .Equal().
+        /// Checks if 2 <see cref="RedisFeatures"/> are not .Equal().
         /// </summary>
         public static bool operator !=(RedisFeatures left, RedisFeatures right) => !left.Equals(right);
     }

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -192,7 +192,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Is PFCOUNT supported on replicas?
         /// </summary>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(HyperLogLogCountReplicaSafe) + " instead.")]
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(HyperLogLogCountReplicaSafe) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool HyperLogLogCountSlaveSafe => HyperLogLogCountReplicaSafe;
 

--- a/src/StackExchange.Redis/RedisKey.cs
+++ b/src/StackExchange.Redis/RedisKey.cs
@@ -144,9 +144,7 @@ namespace StackExchange.Redis
             return RedisValue.Equals(ConcatenateBytes(keyPrefix0, keyValue0, null), ConcatenateBytes(keyPrefix1, keyValue1, null));
         }
 
-        /// <summary>
-        /// See <see cref="object.GetHashCode"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             int chk0 = KeyPrefix == null ? 0 : RedisValue.GetHashCode(KeyPrefix),

--- a/src/StackExchange.Redis/RedisResult.cs
+++ b/src/StackExchange.Redis/RedisResult.cs
@@ -44,9 +44,10 @@ namespace StackExchange.Redis
         /// </summary>
         internal static RedisResult NullArray { get; } = new ArrayRedisResult(null);
 
-        // internally, this is very similar to RawResult, except it is designed to be usable
-        // outside of the IO-processing pipeline: the buffers are standalone, etc
-
+        /// <summary>
+        /// Internally, this is very similar to RawResult, except it is designed to be usable,
+        /// outside of the IO-processing pipeline: the buffers are standalone, etc.
+        /// </summary>
         internal static RedisResult TryCreate(PhysicalConnection connection, in RawResult result)
         {
             try

--- a/src/StackExchange.Redis/RedisResult.cs
+++ b/src/StackExchange.Redis/RedisResult.cs
@@ -535,38 +535,24 @@ namespace StackExchange.Redis
             {
                 switch (System.Type.GetTypeCode(conversionType))
                 {
-                    case TypeCode.Boolean:
-                        return AsBoolean();
-                    case TypeCode.Char:
-                        checked { return (char)AsInt32(); }
-                    case TypeCode.SByte:
-                        checked { return (sbyte)AsInt32(); }
-                    case TypeCode.Byte:
-                        checked { return (byte)AsInt32(); }
-                    case TypeCode.Int16:
-                        checked { return (short)AsInt32(); }
-                    case TypeCode.UInt16:
-                        checked { return (ushort)AsInt32(); }
-                    case TypeCode.Int32:
-                        return AsInt32();
-                    case TypeCode.UInt32:
-                        checked { return (uint)AsInt64(); }
-                    case TypeCode.Int64:
-                        return AsInt64();
-                    case TypeCode.UInt64:
-                        checked { return (ulong)AsInt64(); }
-                    case TypeCode.Single:
-                        return (float)AsDouble();
-                    case TypeCode.Double:
-                        return AsDouble();
-                    case TypeCode.Decimal:
-                        if (Type == ResultType.Integer) return AsInt64();
-                        break;
-                    case TypeCode.String:
-                        return AsString();
+                    case TypeCode.Boolean: return AsBoolean();
+                    case TypeCode.Char: checked { return (char)AsInt32(); }
+                    case TypeCode.SByte: checked { return (sbyte)AsInt32(); }
+                    case TypeCode.Byte: checked { return (byte)AsInt32(); }
+                    case TypeCode.Int16: checked { return (short)AsInt32(); }
+                    case TypeCode.UInt16: checked { return (ushort)AsInt32(); }
+                    case TypeCode.Int32: return AsInt32();
+                    case TypeCode.UInt32: checked { return (uint)AsInt64(); }
+                    case TypeCode.Int64: return AsInt64();
+                    case TypeCode.UInt64: checked { return (ulong)AsInt64(); }
+                    case TypeCode.Single: return (float)AsDouble();
+                    case TypeCode.Double: return AsDouble();
+                    case TypeCode.Decimal when Type == ResultType.Integer: return AsInt64();
+                    case TypeCode.String: return AsString();
+                    default:
+                        ThrowNotSupported();
+                        return default;
                 }
-                ThrowNotSupported();
-                return default;
             }
 
             void ThrowNotSupported([CallerMemberName] string caller = null)

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -10,8 +10,6 @@ using System.Threading.Tasks;
 using Pipelines.Sockets.Unofficial.Arenas;
 using static StackExchange.Redis.ConnectionMultiplexer;
 
-#pragma warning disable RCS1231 // Make parameter ref read-only.
-
 namespace StackExchange.Redis
 {
     internal sealed class RedisServer : RedisBase, IServer
@@ -661,7 +659,7 @@ namespace StackExchange.Redis
                 throw new ArgumentException("Cannot replicate to self");
             }
 
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
             // attempt to cease having an opinion on the master; will resume that when replication completes
             // (note that this may fail; we aren't depending on it)
             if (GetTiebreakerRemovalMessage() is Message tieBreakerRemoval)
@@ -732,9 +730,9 @@ namespace StackExchange.Redis
         {
             SaveType.BackgroundRewriteAppendOnlyFile => Message.Create(-1, flags, RedisCommand.BGREWRITEAOF),
             SaveType.BackgroundSave => Message.Create(-1, flags, RedisCommand.BGSAVE),
-#pragma warning disable 0618
+#pragma warning disable CS0618 // Type or member is obsolete
             SaveType.ForegroundSave => Message.Create(-1, flags, RedisCommand.SAVE),
-#pragma warning restore 0618
+#pragma warning restore CS0618
             _ => throw new ArgumentOutOfRangeException(nameof(type)),
         };
 
@@ -742,9 +740,9 @@ namespace StackExchange.Redis
         {
             SaveType.BackgroundRewriteAppendOnlyFile => ResultProcessor.DemandOK,
             SaveType.BackgroundSave => ResultProcessor.BackgroundSaveStarted,
-#pragma warning disable 0618
+#pragma warning disable CS0618 // Type or member is obsolete
             SaveType.ForegroundSave => ResultProcessor.DemandOK,
-#pragma warning restore 0618
+#pragma warning restore CS0618
             _ => throw new ArgumentOutOfRangeException(nameof(type)),
         };
 

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -336,7 +336,16 @@ namespace StackExchange.Redis
         {
             using (var proxy = LogProxy.TryCreate(log))
             {
-                multiplexer.MakeMaster(server, options, proxy);
+                // Do you believe in magic?
+                multiplexer.MakePrimaryAsync(server, options, proxy).Wait(60000);
+            }
+        }
+
+        public async Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter log = null)
+        {
+            using (var proxy = LogProxy.TryCreate(log))
+            {
+                await multiplexer.MakePrimaryAsync(server, options, proxy);
             }
         }
 
@@ -571,6 +580,32 @@ namespace StackExchange.Redis
             return Message.Create(-1, flags, sendMessageTo.GetFeatures().ReplicaCommands ? RedisCommand.REPLICAOF : RedisCommand.SLAVEOF, host, port);
         }
 
+        private Message GetTiebreakerRemovalMessage()
+        {
+            var configuration = multiplexer.RawConfig;
+
+            if (!string.IsNullOrWhiteSpace(configuration.TieBreaker) && multiplexer.CommandMap.IsAvailable(RedisCommand.DEL))
+            {
+                var msg = Message.Create(0, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.DEL, (RedisKey)configuration.TieBreaker);
+                msg.SetInternalCall();
+                return msg;
+            }
+            return null;
+        }
+
+        private Message GetConfigChangeMessage()
+        {
+            // attempt to broadcast a reconfigure message to anybody listening to this server
+            var channel = multiplexer.ConfigurationChangedChannel;
+            if (channel != null && multiplexer.CommandMap.IsAvailable(RedisCommand.PUBLISH))
+            {
+                var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.PUBLISH, (RedisValue)channel, RedisLiterals.Wildcard);
+                msg.SetInternalCall();
+                return msg;
+            }
+            return null;
+        }
+
         internal override Task<T> ExecuteAsync<T>(Message message, ResultProcessor<T> processor, ServerEndPoint server = null)
         {   // inject our expected server automatically
             if (server == null) server = this.server;
@@ -614,46 +649,56 @@ namespace StackExchange.Redis
             {
                 throw new ArgumentException("Cannot replicate to self");
             }
-            // prepare the actual replicaof message (not sent yet)
-            var replicaOfMsg = CreateReplicaOfMessage(server, master, flags);
 
-            var configuration = multiplexer.RawConfig;
-
+#pragma warning disable CS0618
             // attempt to cease having an opinion on the master; will resume that when replication completes
             // (note that this may fail; we aren't depending on it)
-            if (!string.IsNullOrWhiteSpace(configuration.TieBreaker)
-                && multiplexer.CommandMap.IsAvailable(RedisCommand.DEL))
+            if (GetTiebreakerRemovalMessage() is Message tieBreakerRemoval)
             {
-                var del = Message.Create(0, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.DEL, (RedisKey)configuration.TieBreaker);
-                del.SetInternalCall();
-#pragma warning disable CS0618
-                server.WriteDirectFireAndForgetSync(del, ResultProcessor.Boolean);
-#pragma warning restore CS0618
+                tieBreakerRemoval.SetSource(ResultProcessor.Boolean, null);
+                server.GetBridge(tieBreakerRemoval).TryWriteSync(tieBreakerRemoval, server.IsReplica);
             }
+
+            var replicaOfMsg = CreateReplicaOfMessage(server, master, flags);
             ExecuteSync(replicaOfMsg, ResultProcessor.DemandOK);
 
             // attempt to broadcast a reconfigure message to anybody listening to this server
-            var channel = multiplexer.ConfigurationChangedChannel;
-            if (channel != null && multiplexer.CommandMap.IsAvailable(RedisCommand.PUBLISH))
+            if (GetConfigChangeMessage() is Message configChangeMessage)
             {
-                var pub = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.PUBLISH, (RedisValue)channel, RedisLiterals.Wildcard);
-                pub.SetInternalCall();
-#pragma warning disable CS0618
-                server.WriteDirectFireAndForgetSync(pub, ResultProcessor.Int64);
-#pragma warning restore CS0618
+                configChangeMessage.SetSource(ResultProcessor.Int64, null);
+                server.GetBridge(configChangeMessage).TryWriteSync(configChangeMessage, server.IsReplica);
             }
+#pragma warning restore CS0618
         }
 
         Task IServer.SlaveOfAsync(EndPoint master, CommandFlags flags) => ReplicaOfAsync(master, flags);
 
-        public Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None)
+        public async Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None)
         {
-            var msg = CreateReplicaOfMessage(server, master, flags);
             if (master == server.EndPoint)
             {
                 throw new ArgumentException("Cannot replicate to self");
             }
-            return ExecuteAsync(msg, ResultProcessor.DemandOK);
+
+            // attempt to cease having an opinion on the master; will resume that when replication completes
+            // (note that this may fail; we aren't depending on it)
+            if (GetTiebreakerRemovalMessage() is Message tieBreakerRemoval && !server.IsReplica)
+            {
+                try
+                {
+                    await server.WriteDirectAsync(tieBreakerRemoval, ResultProcessor.Boolean);
+                }
+                catch { }
+            }
+
+            var msg = CreateReplicaOfMessage(server, master, flags);
+            await ExecuteAsync(msg, ResultProcessor.DemandOK);
+
+            // attempt to broadcast a reconfigure message to anybody listening to this server
+            if (GetConfigChangeMessage() is Message configChangeMessage)
+            {
+                await server.WriteDirectAsync(configChangeMessage, ResultProcessor.Int64);
+            }
         }
 
         private static void FixFlags(Message message, ServerEndPoint server)

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -43,7 +43,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets the subscriber counts for a channel.
         /// </summary>
-        /// <returns>True if there's a subscription registered at all.</returns>
+        /// <returns><see langword="true"/> if there's a subscription registered at all.</returns>
         internal bool GetSubscriberCounts(in RedisChannel channel, out int handlers, out int queues)
         {
             if (subscriptions.TryGetValue(channel, out var sub))
@@ -291,10 +291,10 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.ConnectionIdentity);
         }
 
-        /// <remarks>
+        /// <summary>
         /// This is *could* we be connected, as in "what's the theoretical endpoint for this channel?",
         /// rather than if we're actually connected and actually listening on that channel.
-        /// </remarks>
+        /// </summary>
         public bool IsConnected(RedisChannel channel = default(RedisChannel))
         {
             var server = multiplexer.GetSubscribedServer(channel) ?? multiplexer.SelectServer(RedisCommand.SUBSCRIBE, CommandFlags.DemandMaster, channel);
@@ -338,7 +338,7 @@ namespace StackExchange.Redis
             return msg;
         }
 
-        private void ThrowIfNull(in RedisChannel channel)
+        private static void ThrowIfNull(in RedisChannel channel)
         {
             if (channel.IsNullOrEmpty)
             {
@@ -474,7 +474,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Unregisters a handler or queue and returns if we should remove it from the server.
         /// </summary>
-        /// <returns>True if we should remove the subscription from the server, false otherwise.</returns>
+        /// <returns><see langword="true"/> if we should remove the subscription from the server, <see langword="false"/> otherwise.</returns>
         private bool UnregisterSubscription(in RedisChannel channel, Action<RedisChannel, RedisValue> handler, ChannelMessageQueue queue, out Subscription sub)
         {
             ThrowIfNull(channel);

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -13,6 +13,14 @@ namespace StackExchange.Redis
     {
         private readonly Dictionary<RedisChannel, Subscription> subscriptions = new Dictionary<RedisChannel, Subscription>();
 
+        internal int GetSubscriptionsCount()
+        {
+            lock (subscriptions)
+            {
+                return subscriptions.Count;
+            }
+        }
+
         internal static void CompleteAsWorker(ICompletable completable)
         {
             if (completable != null) ThreadPool.QueueUserWorkItem(s_CompleteAsWorker, completable);

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -173,7 +173,7 @@ namespace StackExchange.Redis
                 {
                     if (message is QueuedMessage q)
                     {
-                        connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog($"observed QUEUED for " + q.Wrapped?.CommandAndKey);
+                        connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog("Observed QUEUED for " + q.Wrapped?.CommandAndKey);
                         q.WasQueued = true;
                     }
                     return true;
@@ -250,15 +250,15 @@ namespace StackExchange.Redis
                 {
                     try
                     {
-                        // Important: if the server supports EXECABORT, then we can check the pre-conditions (pause there),
-                        // which will usually be pretty small and cheap to do - if that passes, we can just isue all the commands
+                        // Important: if the server supports EXECABORT, then we can check the preconditions (pause there),
+                        // which will usually be pretty small and cheap to do - if that passes, we can just issue all the commands
                         // and rely on EXECABORT to kick us if we are being idiotic inside the MULTI. However, if the server does
                         // *not* support EXECABORT, then we need to explicitly check for QUEUED anyway; we might as well defer
                         // checking the preconditions to the same time to avoid having to pause twice. This will mean that on
-                        // up-version servers, pre-condition failures exit with UNWATCH; and on down-version servers pre-condition
-                        // failures exit with DISCARD - but that's ok : both work fine
+                        // up-version servers, precondition failures exit with UNWATCH; and on down-version servers precondition
+                        // failures exit with DISCARD - but that's okay : both work fine
 
-                        // PART 1: issue the pre-conditions
+                        // PART 1: issue the preconditions
                         if (!IsAborted && conditions.Length != 0)
                         {
                             sb.AppendLine("issuing conditions...");
@@ -287,7 +287,7 @@ namespace StackExchange.Redis
                                 // need to get those sent ASAP; if they are stuck in the buffers, we die
                                 multiplexer.Trace("Flushing and waiting for precondition responses");
 #pragma warning disable CS0618
-                                connection.FlushSync(true, multiplexer.TimeoutMilliseconds); // make sure they get sent, so we can check for QUEUED (and the pre-conditions if necessary)
+                                connection.FlushSync(true, multiplexer.TimeoutMilliseconds); // make sure they get sent, so we can check for QUEUED (and the preconditions if necessary)
 #pragma warning restore CS0618
 
                                 if (Monitor.Wait(lastBox, multiplexer.TimeoutMilliseconds))
@@ -298,7 +298,7 @@ namespace StackExchange.Redis
                                     sb.Append("after condition check, we are ").Append(command).AppendLine();
                                 }
                                 else
-                                { // timeout running pre-conditions
+                                { // timeout running preconditions
                                     multiplexer.Trace("Timeout checking preconditions");
                                     command = RedisCommand.UNWATCH;
 
@@ -312,7 +312,7 @@ namespace StackExchange.Redis
                         // PART 2: begin the transaction
                         if (!IsAborted)
                         {
-                            multiplexer.Trace("Begining transaction");
+                            multiplexer.Trace("Beginning transaction");
                             yield return Message.Create(-1, CommandFlags.None, RedisCommand.MULTI);
                             sb.AppendLine("issued MULTI");
                         }
@@ -346,7 +346,7 @@ namespace StackExchange.Redis
 
                                 multiplexer.Trace("Flushing and waiting for precondition+queued responses");
 #pragma warning disable CS0618
-                                connection.FlushSync(true, multiplexer.TimeoutMilliseconds); // make sure they get sent, so we can check for QUEUED (and the pre-conditions if necessary)
+                                connection.FlushSync(true, multiplexer.TimeoutMilliseconds); // make sure they get sent, so we can check for QUEUED (and the preconditions if necessary)
 #pragma warning restore CS0618
                                 if (Monitor.Wait(lastBox, multiplexer.TimeoutMilliseconds))
                                 {
@@ -485,7 +485,7 @@ namespace StackExchange.Redis
                                 var arr = result.GetItems();
                                 if (result.IsNull)
                                 {
-                                    connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog($"aborting wrapped messages (failed watch)");
+                                    connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog("Aborting wrapped messages (failed watch)");
                                     connection.Trace("Server aborted due to failed WATCH");
                                     foreach (var op in wrapped)
                                     {
@@ -499,7 +499,7 @@ namespace StackExchange.Redis
                                 else if (wrapped.Length == arr.Length)
                                 {
                                     connection.Trace("Server committed; processing nested replies");
-                                    connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog($"processing {arr.Length} wrapped messages");
+                                    connection?.BridgeCouldBeNull?.Multiplexer?.OnTransactionLog($"Processing {arr.Length} wrapped messages");
 
                                     int i = 0;
                                     foreach(ref RawResult item in arr)
@@ -523,7 +523,7 @@ namespace StackExchange.Redis
                     {
                         if (op?.Wrapped is Message inner)
                         {
-                            inner.Fail(ConnectionFailureType.ProtocolFailure, null, "transaction failure");
+                            inner.Fail(ConnectionFailureType.ProtocolFailure, null, "Transaction failure");
                             inner.Complete();
                         }
                     }

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -286,7 +286,7 @@ namespace StackExchange.Redis
                                 sb.AppendLine("checking conditions in the *early* path");
                                 // need to get those sent ASAP; if they are stuck in the buffers, we die
                                 multiplexer.Trace("Flushing and waiting for precondition responses");
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                                 connection.FlushSync(true, multiplexer.TimeoutMilliseconds); // make sure they get sent, so we can check for QUEUED (and the preconditions if necessary)
 #pragma warning restore CS0618
 
@@ -345,7 +345,7 @@ namespace StackExchange.Redis
                                 sb.AppendLine("checking conditions in the *late* path");
 
                                 multiplexer.Trace("Flushing and waiting for precondition+queued responses");
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                                 connection.FlushSync(true, multiplexer.TimeoutMilliseconds); // make sure they get sent, so we can check for QUEUED (and the preconditions if necessary)
 #pragma warning restore CS0618
                                 if (Monitor.Wait(lastBox, multiplexer.TimeoutMilliseconds))

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -973,7 +973,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Convert to a <see cref="int"/> if possible.
+        /// Convert to an <see cref="int"/> if possible.
         /// </summary>
         /// <param name="val">The <see cref="int"/> value, if conversion was possible.</param>
         /// <returns><see langword="true"/> if successfully parsed, <see langword="false"/> otherwise.</returns>

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -41,10 +41,10 @@ namespace StackExchange.Redis
         /// </summary>
         public RedisValue(string value) : this(0, default, value) { }
 
-#pragma warning disable RCS1085 // Use auto-implemented property.
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1085:Use auto-implemented property.", Justification = "Intentional field ref")]
         internal object DirectObject => _objectOrSentinel;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1085:Use auto-implemented property.", Justification = "Intentional field ref")]
         internal long DirectOverlappedBits64 => _overlappedBits64;
-#pragma warning restore RCS1085 // Use auto-implemented property.
 
         private readonly static object Sentinel_SignedInteger = new();
         private readonly static object Sentinel_UnsignedInteger = new();

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -11,7 +11,7 @@ using System.Text;
 namespace StackExchange.Redis
 {
     /// <summary>
-    /// Represents values that can be stored in redis
+    /// Represents values that can be stored in redis.
     /// </summary>
     public readonly struct RedisValue : IEquatable<RedisValue>, IComparable<RedisValue>, IComparable, IConvertible
     {
@@ -21,7 +21,6 @@ namespace StackExchange.Redis
         private readonly ReadOnlyMemory<byte> _memory;
         private readonly long _overlappedBits64;
 
-        // internal bool IsNullOrDefaultValue {  get { return (valueBlob == null && valueInt64 == 0L) || ((object)valueBlob == (object)NullSentinel); } }
         private RedisValue(long overlappedValue64, ReadOnlyMemory<byte> memory, object objectOrSentinel)
         {
             _overlappedBits64 = overlappedValue64;
@@ -93,7 +92,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Represents the string <c>""</c>
+        /// Represents the string <c>""</c>.
         /// </summary>
         public static RedisValue EmptyString { get; } = new RedisValue(0, default, Sentinel_Raw);
 
@@ -103,22 +102,22 @@ namespace StackExchange.Redis
         static readonly object[] s_CommonInt32 = Enumerable.Range(-1, 22).Select(i => (object)i).ToArray(); // [-1,20] = 22 values
 
         /// <summary>
-        /// A null value
+        /// A null value.
         /// </summary>
         public static RedisValue Null { get; } = new RedisValue(0, default, null);
 
         /// <summary>
-        /// Indicates whether the value is a primitive integer (signed or unsigned)
+        /// Indicates whether the value is a primitive integer (signed or unsigned).
         /// </summary>
         public bool IsInteger => _objectOrSentinel == Sentinel_SignedInteger || _objectOrSentinel == Sentinel_UnsignedInteger;
 
         /// <summary>
-        /// Indicates whether the value should be considered a null value
+        /// Indicates whether the value should be considered a null value.
         /// </summary>
         public bool IsNull => _objectOrSentinel == null;
 
         /// <summary>
-        /// Indicates whether the value is either null or a zero-length value
+        /// Indicates whether the value is either null or a zero-length value.
         /// </summary>
         public bool IsNullOrEmpty
         {
@@ -133,12 +132,12 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Indicates whether the value is greater than zero-length or has an integer value
+        /// Indicates whether the value is greater than zero-length or has an integer value.
         /// </summary>
         public bool HasValue => !IsNullOrEmpty;
 
         /// <summary>
-        /// Indicates whether two RedisValue values are equivalent
+        /// Indicates whether two RedisValue values are equivalent.
         /// </summary>
         /// <param name="x">The first <see cref="RedisValue"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisValue"/> to compare.</param>
@@ -163,7 +162,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Indicates whether two RedisValue values are equivalent
+        /// Indicates whether two RedisValue values are equivalent.
         /// </summary>
         /// <param name="x">The first <see cref="RedisValue"/> to compare.</param>
         /// <param name="y">The second <see cref="RedisValue"/> to compare.</param>
@@ -214,7 +213,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// See Object.Equals()
+        /// See <see cref="object.Equals(object)"/>.
         /// </summary>
         /// <param name="obj">The other <see cref="RedisValue"/> to compare.</param>
         public override bool Equals(object obj)
@@ -226,14 +225,12 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Indicates whether two RedisValue values are equivalent
+        /// Indicates whether two RedisValue values are equivalent.
         /// </summary>
         /// <param name="other">The <see cref="RedisValue"/> to compare to.</param>
         public bool Equals(RedisValue other) => this == other;
 
-        /// <summary>
-        /// See Object.GetHashCode()
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => GetHashCode(this);
         private static int GetHashCode(RedisValue x)
         {
@@ -249,7 +246,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Returns a string representation of the value
+        /// Returns a string representation of the value.
         /// </summary>
         public override string ToString() => (string)this;
 
@@ -341,7 +338,7 @@ namespace StackExchange.Redis
         };
 
         /// <summary>
-        /// Compare against a RedisValue for relative order
+        /// Compare against a RedisValue for relative order.
         /// </summary>
         /// <param name="other">The other <see cref="RedisValue"/> to compare.</param>
         public int CompareTo(RedisValue other) => CompareTo(this, other);

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -847,7 +847,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Converts a <see cref="RedisValue"/> to a ReadOnlyMemory
+        /// Converts a <see cref="RedisValue"/> to a <see cref="ReadOnlyMemory{T}"/>.
         /// </summary>
         /// <param name="value">The <see cref="RedisValue"/> to convert.</param>
         public static implicit operator ReadOnlyMemory<byte>(RedisValue value)
@@ -942,10 +942,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// <para>Convert to a signed long if possible, returning true.</para>
-        /// <para>Returns false otherwise.</para>
+        /// Convert to a signed <see cref="long"/> if possible.
         /// </summary>
         /// <param name="val">The <see cref="long"/> value, if conversion was possible.</param>
+        /// <returns><see langword="true"/> if successfully parsed, <see langword="false"/> otherwise.</returns>
         public bool TryParse(out long val)
         {
             switch (Type)
@@ -976,10 +976,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// <para>Convert to a int if possible, returning true.</para>
-        /// <para>Returns false otherwise.</para>
+        /// Convert to a <see cref="int"/> if possible.
         /// </summary>
         /// <param name="val">The <see cref="int"/> value, if conversion was possible.</param>
+        /// <returns><see langword="true"/> if successfully parsed, <see langword="false"/> otherwise.</returns>
         public bool TryParse(out int val)
         {
             if (!TryParse(out long l) || l > int.MaxValue || l < int.MinValue)
@@ -993,10 +993,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// <para>Convert to a double if possible, returning true.</para>
-        /// <para>Returns false otherwise.</para>
+        /// Convert to a <see cref="double"/> if possible.
         /// </summary>
         /// <param name="val">The <see cref="double"/> value, if conversion was possible.</param>
+        /// <returns><see langword="true"/> if successfully parsed, <see langword="false"/> otherwise.</returns>
         public bool TryParse(out double val)
         {
             switch (Type)
@@ -1024,8 +1024,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Create a RedisValue from a MemoryStream; it will *attempt* to use the internal buffer
-        /// directly, but if this isn't possible it will fallback to ToArray
+        /// Create a <see cref="RedisValue"/> from a <see cref="MemoryStream"/>.
+        /// It will *attempt* to use the internal buffer directly, but if this isn't possible it will fallback to <see cref="MemoryStream.ToArray"/>.
         /// </summary>
         /// <param name="stream">The <see cref="MemoryStream"/> to create a value from.</param>
         public static RedisValue CreateFrom(MemoryStream stream)

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -511,7 +511,7 @@ namespace StackExchange.Redis
                         byte[] hash = null;
                         if (!message.IsInternalCall)
                         {
-                            hash = ParseSHA1(asciiHash); // external caller wants the hex bytes, not the ascii bytes
+                            hash = ParseSHA1(asciiHash); // external caller wants the hex bytes, not the ASCII bytes
                         }
                         if (message is RedisDatabase.ScriptLoadMessage sl)
                         {
@@ -738,7 +738,8 @@ namespace StackExchange.Redis
                                     }
                                 }
                                 if (roleSeen)
-                                { // these are in the same section, if presnt
+                                {
+                                    // these are in the same section, if present
                                     server.MasterEndPoint = Format.TryParseEndPoint(masterHost, masterPort);
                                 }
                             }
@@ -957,7 +958,7 @@ namespace StackExchange.Redis
                             case 2:
                                 if (arr[0].TryGetInt64(out unixTime) && arr[1].TryGetInt64(out long micros))
                                 {
-                                    var time = RedisBase.UnixEpoch.AddSeconds(unixTime).AddTicks(micros * 10); // datetime ticks are 100ns
+                                    var time = RedisBase.UnixEpoch.AddSeconds(unixTime).AddTicks(micros * 10); // DateTime ticks are 100ns
                                     SetResult(message, time);
                                     return true;
                                 }
@@ -1715,8 +1716,13 @@ The coordinates as a two items x,y array (longitude,latitude).
         private static class KeyValuePairParser
         {
             internal static readonly CommandBytes
-                Name = "name", Consumers = "consumers", Pending = "pending", Idle = "idle", LastDeliveredId = "last-delivered-id",
-                IP = "ip", Port = "port";
+                Name = "name",
+                Consumers = "consumers",
+                Pending = "pending",
+                Idle = "idle",
+                LastDeliveredId = "last-delivered-id",
+                IP = "ip",
+                Port = "port";
 
             internal static bool TryRead(Sequence<RawResult> pairs, in CommandBytes key, ref long value)
             {

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -739,7 +739,7 @@ namespace StackExchange.Redis
                                 }
                                 if (roleSeen)
                                 {
-                                    // these are in the same section, if present
+                                    // These are in the same section, if present
                                     server.MasterEndPoint = Format.TryParseEndPoint(masterHost, masterPort);
                                 }
                             }

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -39,7 +39,7 @@ namespace StackExchange.Redis
                 {
                     var prevChar = script[ix];
 
-                    // don't consider this a parameter if it's in the middle of word (ie. if it's preceeded by a letter)
+                    // don't consider this a parameter if it's in the middle of word (i.e. if it's preceded by a letter)
                     if (char.IsLetterOrDigit(prevChar) || prevChar == '_') continue;
 
                     // this is an escape, ignore it
@@ -137,23 +137,23 @@ namespace StackExchange.Redis
             return new LuaScript(script, ordinalScript, ps);
         }
 
-        private static readonly HashSet<Type> ConvertableTypes =
-            new HashSet<Type> {
-                typeof(int),
-                typeof(int?),
-                typeof(long),
-                typeof(long?),
-                typeof(double),
-                typeof(double?),
-                typeof(string),
-                typeof(byte[]),
-                typeof(ReadOnlyMemory<byte>),
-                typeof(bool),
-                typeof(bool?),
+        private static readonly HashSet<Type> ConvertableTypes = new()
+        {
+            typeof(int),
+            typeof(int?),
+            typeof(long),
+            typeof(long?),
+            typeof(double),
+            typeof(double?),
+            typeof(string),
+            typeof(byte[]),
+            typeof(ReadOnlyMemory<byte>),
+            typeof(bool),
+            typeof(bool?),
 
-                typeof(RedisKey),
-                typeof(RedisValue)
-            };
+            typeof(RedisKey),
+            typeof(RedisValue)
+        };
 
         /// <summary>
         /// Determines whether or not the given type can be used to provide parameters for the given LuaScript.
@@ -279,7 +279,7 @@ namespace StackExchange.Redis
                 valuesResult = Expression.NewArrayInit(typeof(RedisValue), args.Select(arg =>
                 {
                     var member = GetMember(objTyped, arg);
-                    if (member.Type == typeof(RedisValue)) return member; // pass-thru
+                    if (member.Type == typeof(RedisValue)) return member; // pass-through
                     if (member.Type == typeof(RedisKey))
                     { // need to apply prefix (note we can re-use the body from earlier)
                         var val = keysResultArr[keys.IndexOf(arg)];

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -125,8 +125,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Turns a script with @namedParameters into a LuaScript that can be executed
-        /// against a given IDatabase(Async) object
+        /// Turns a script with @namedParameters into a LuaScript that can be executed against a given IDatabase(Async) object.
         /// </summary>
         /// <param name="script">The script to prepare.</param>
         public static LuaScript PrepareScript(string script)
@@ -156,7 +155,7 @@ namespace StackExchange.Redis
         };
 
         /// <summary>
-        /// Determines whether or not the given type can be used to provide parameters for the given LuaScript.
+        /// Determines whether or not the given type can be used to provide parameters for the given <see cref="LuaScript"/>.
         /// </summary>
         /// <param name="t">The type of the parameter.</param>
         /// <param name="script">The script to match against.</param>

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -73,6 +73,7 @@ namespace StackExchange.Redis
         public bool HasDatabases => serverType == ServerType.Standalone;
 
         public bool IsConnected => interactive?.IsConnected == true;
+        public bool IsSubscriberConnected => subscription?.IsConnected == true;
 
         public bool IsConnecting => interactive?.IsConnecting == true;
 

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -804,7 +804,7 @@ namespace StackExchange.Redis
                 if (connection == null)
                 {
                     Multiplexer.Trace($"{Format.ToString(this)}: Enqueue (async): " + message);
-                    result = GetBridge(message.Command).TryWriteAsync(message, isReplica, isHandshake: true);
+                    result = GetBridge(message.Command).TryWriteAsync(message, isReplica, bypassBacklog: true);
                 }
                 else
                 {
@@ -816,7 +816,7 @@ namespace StackExchange.Redis
                     }
                     else
                     {
-                        result = bridge.WriteMessageTakingWriteLockAsync(connection, message, isHandshake: true);
+                        result = bridge.WriteMessageTakingWriteLockAsync(connection, message, bypassBacklog: true);
                     }
                 }
 

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -671,7 +671,7 @@ namespace StackExchange.Redis
                 var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.INFO, RedisLiterals.replication);
                 msg.SetInternalCall();
                 msg.SetSource(ResultProcessor.AutoConfigure, null);
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                 bridge.TryWriteSync(msg, isReplica);
 #pragma warning restore CS0618
                 return true;

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -693,7 +693,7 @@ namespace StackExchange.Redis
             }
         }
 
-        internal Task<T> WriteDirectAsync<T>(Message message, ResultProcessor<T> processor, object asyncState = null, PhysicalBridge bridge = null, bool isHandshake = false)
+        internal Task<T> WriteDirectAsync<T>(Message message, ResultProcessor<T> processor, object asyncState = null, PhysicalBridge bridge = null)
         {
             static async Task<T> Awaited(ServerEndPoint @this, Message message, ValueTask<WriteResult> write, TaskCompletionSource<T> tcs)
             {
@@ -717,7 +717,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var write = bridge.TryWriteAsync(message, isReplica, isHandshake: isHandshake);
+                var write = bridge.TryWriteAsync(message, isReplica);
                 if (!write.IsCompletedSuccessfully)
                 {
                     return Awaited(this, message, write, tcs);

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -333,9 +333,7 @@ namespace StackExchange.Redis
             log?.WriteLine($"{Format.ToString(this)}: Auto-configuring...");
 
             var commandMap = Multiplexer.CommandMap;
-#pragma warning disable CS0618
-            const CommandFlags flags = CommandFlags.FireAndForget | CommandFlags.HighPriority | CommandFlags.NoRedirect;
-#pragma warning restore CS0618
+            const CommandFlags flags = CommandFlags.FireAndForget | CommandFlags.NoRedirect;
             var features = GetFeatures();
             Message msg;
 
@@ -670,10 +668,11 @@ namespace StackExchange.Redis
             if (version >= RedisFeatures.v2_8_0 && Multiplexer.CommandMap.IsAvailable(RedisCommand.INFO)
                 && (bridge = GetBridge(ConnectionType.Interactive, false)) != null)
             {
-#pragma warning disable CS0618
-                var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.HighPriority | CommandFlags.NoRedirect, RedisCommand.INFO, RedisLiterals.replication);
+                var msg = Message.Create(-1, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.INFO, RedisLiterals.replication);
                 msg.SetInternalCall();
-                WriteDirectFireAndForgetSync(msg, ResultProcessor.AutoConfigure, bridge);
+                msg.SetSource(ResultProcessor.AutoConfigure, null);
+#pragma warning disable CS0618
+                bridge.TryWriteSync(msg, isReplica);
 #pragma warning restore CS0618
                 return true;
             }
@@ -762,17 +761,6 @@ namespace StackExchange.Redis
                 ConnectionMultiplexer.ThrowFailed(tcs, ex);
             }
             return tcs.Task;
-        }
-
-        [Obsolete("prefer async")]
-        internal void WriteDirectFireAndForgetSync<T>(Message message, ResultProcessor<T> processor, PhysicalBridge bridge = null)
-        {
-            if (message != null)
-            {
-                message.SetSource(processor, null);
-                Multiplexer.Trace("Enqueue: " + message);
-                (bridge ?? GetBridge(message)).TryWriteSync(message, isReplica);
-            }
         }
 
         internal void ReportNextFailure()

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -140,7 +140,7 @@ namespace StackExchange.Redis
             get
             {
                 var tmp = interactive;
-                return tmp.ConnectionState;
+                return tmp?.ConnectionState ?? State.Disconnected;
             }
         }
 
@@ -678,7 +678,7 @@ namespace StackExchange.Redis
             }
         }
 
-        internal Task<T> WriteDirectAsync<T>(Message message, ResultProcessor<T> processor, object asyncState = null, PhysicalBridge bridge = null)
+        internal Task<T> WriteDirectAsync<T>(Message message, ResultProcessor<T> processor, object asyncState = null, PhysicalBridge bridge = null, bool isHandshake = false)
         {
             static async Task<T> Awaited(ServerEndPoint @this, Message message, ValueTask<WriteResult> write, TaskCompletionSource<T> tcs)
             {
@@ -702,7 +702,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                var write = bridge.TryWriteAsync(message, isReplica);
+                var write = bridge.TryWriteAsync(message, isReplica, isHandshake: isHandshake);
                 if (!write.IsCompletedSuccessfully)
                 {
                     return Awaited(this, message, write, tcs);

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -127,7 +127,7 @@ namespace StackExchange.Redis
                 var subEx = subscription?.LastException;
                 var subExData = subEx?.Data;
 
-                //check if subscription endpoint has a better lastexception
+                //check if subscription endpoint has a better last exception
                 if (subExData != null && subExData.Contains("Redis-FailureType") && subExData["Redis-FailureType"]?.ToString() != nameof(ConnectionFailureType.UnableToConnect))
                 {
                     return subEx;
@@ -136,14 +136,7 @@ namespace StackExchange.Redis
             }
         }
 
-        internal PhysicalBridge.State ConnectionState
-        {
-            get
-            {
-                var tmp = interactive;
-                return tmp?.ConnectionState ?? State.Disconnected;
-            }
-        }
+        internal State ConnectionState => interactive?.ConnectionState ?? State.Disconnected;
 
         public bool IsReplica { get { return isReplica; } set { SetConfig(ref isReplica, value); } }
 
@@ -162,15 +155,31 @@ namespace StackExchange.Redis
 
         public bool RequiresReadMode => serverType == ServerType.Cluster && IsReplica;
 
-        public ServerType ServerType { get { return serverType; } set { SetConfig(ref serverType, value); } }
+        public ServerType ServerType
+        {
+            get => serverType;
+            set => SetConfig(ref serverType, value);
+        }
 
-        public bool ReplicaReadOnly { get { return replicaReadOnly; } set { SetConfig(ref replicaReadOnly, value); } }
+        public bool ReplicaReadOnly
+        {
+            get => replicaReadOnly;
+            set => SetConfig(ref replicaReadOnly, value);
+        }
 
         public bool AllowReplicaWrites { get; set; }
 
-        public Version Version { get { return version; } set { SetConfig(ref version, value); } }
+        public Version Version
+        {
+            get => version;
+            set => SetConfig(ref version, value);
+        }
 
-        public int WriteEverySeconds { get { return writeEverySeconds; } set { SetConfig(ref writeEverySeconds, value); } }
+        public int WriteEverySeconds
+        {
+            get => writeEverySeconds;
+            set => SetConfig(ref writeEverySeconds, value);
+        }
 
         internal ConnectionMultiplexer Multiplexer { get; }
 
@@ -308,10 +317,7 @@ namespace StackExchange.Redis
 
         public ValueTask<WriteResult> TryWriteAsync(Message message) => GetBridge(message)?.TryWriteAsync(message, isReplica) ?? new ValueTask<WriteResult>(WriteResult.NoConnectionAvailable);
 
-        internal void Activate(ConnectionType type, LogProxy log)
-        {
-            GetBridge(type, true, log);
-        }
+        internal void Activate(ConnectionType type, LogProxy log) => GetBridge(type, true, log);
 
         internal void AddScript(string script, byte[] hash)
         {
@@ -411,7 +417,7 @@ namespace StackExchange.Redis
 
         private int _nextReplicaOffset;
         internal uint NextReplicaOffset() // used to round-robin between multiple replicas
-            => (uint)System.Threading.Interlocked.Increment(ref _nextReplicaOffset);
+            => (uint)Interlocked.Increment(ref _nextReplicaOffset);
 
         internal Task Close(ConnectionType connectionType)
         {
@@ -505,11 +511,7 @@ namespace StackExchange.Redis
             return found;
         }
 
-        internal string GetStormLog(Message message)
-        {
-            var bridge = GetBridge(message);
-            return bridge?.GetStormLog();
-        }
+        internal string GetStormLog(Message message) => GetBridge(message)?.GetStormLog();
 
         internal Message GetTracerMessage(bool assertIdentity)
         {
@@ -643,16 +645,14 @@ namespace StackExchange.Redis
             }
         }
 
-        internal int LastInfoReplicationCheckSecondsAgo
-        {
-            get { return unchecked(Environment.TickCount - Thread.VolatileRead(ref lastInfoReplicationCheckTicks)) / 1000; }
-        }
+        internal int LastInfoReplicationCheckSecondsAgo =>
+            unchecked(Environment.TickCount - Thread.VolatileRead(ref lastInfoReplicationCheckTicks)) / 1000;
 
         private EndPoint masterEndPoint;
         public EndPoint MasterEndPoint
         {
-            get { return masterEndPoint; }
-            set { SetConfig(ref masterEndPoint, value); }
+            get => masterEndPoint;
+            set => SetConfig(ref masterEndPoint, value);
         }
 
         /// <summary>
@@ -903,8 +903,8 @@ namespace StackExchange.Redis
             {
                 return;
             }
-            var connType = bridge.ConnectionType;
 
+            var connType = bridge.ConnectionType;
             if (connType == ConnectionType.Interactive)
             {
                 await AutoConfigureAsync(connection, log);

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -897,7 +897,7 @@ namespace StackExchange.Redis
             log?.WriteLine($"{Format.ToString(this)}: Sending critical tracer (handshake): {tracer.CommandAndKey}");
             await WriteDirectOrQueueFireAndForgetAsync(connection, tracer, ResultProcessor.EstablishConnection).ForAwait();
 
-            // note: this **must** be the last thing on the subscription handshake, because after this
+            // Note: this **must** be the last thing on the subscription handshake, because after this
             // we will be in subscriber mode: regular commands cannot be sent
             if (connType == ConnectionType.Subscription)
             {
@@ -905,7 +905,7 @@ namespace StackExchange.Redis
                 if (configChannel != null)
                 {
                     msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.SUBSCRIBE, (RedisChannel)configChannel);
-                    msg.SetInternalCall();
+                    // Note: this is NOT internal, we want it to queue in a backlog for sending when ready if necessary
                     await WriteDirectOrQueueFireAndForgetAsync(connection, msg, ResultProcessor.TrackSubscriptions).ForAwait();
                 }
             }

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -123,10 +123,10 @@ namespace StackExchange.Redis
             return Select(slot, command, flags, allowDisconnected);
         }
 
-        public ServerEndPoint Select(RedisCommand command, in RedisChannel channel, CommandFlags flags)
+        public ServerEndPoint Select(RedisCommand command, in RedisChannel channel, CommandFlags flags, bool allowDisconnected = false)
         {
             int slot = ServerType == ServerType.Cluster ? HashSlot(channel) : NoSlot;
-            return Select(slot, command, flags);
+            return Select(slot, command, flags, allowDisconnected);
         }
 
         public bool TryResend(int hashSlot, Message message, EndPoint endpoint, bool isMoved)

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -71,6 +71,9 @@ namespace StackExchange.Redis
         public int HashSlot(in RedisChannel channel)
             => ServerType == ServerType.Standalone || channel.IsNull ? NoSlot : GetClusterSlot((byte[])channel);
 
+        /// <summary>
+        /// Gets the hashslot for a given byte sequence.
+        /// </summary>
         /// <remarks>
         /// HASH_SLOT = CRC16(key) mod 16384
         /// </remarks>
@@ -107,7 +110,7 @@ namespace StackExchange.Redis
             switch (ServerType)
             {
                 case ServerType.Cluster:
-                case ServerType.Twemproxy: // strictly speaking twemproxy uses a different hashing algo, but the hash-tag behavior is
+                case ServerType.Twemproxy: // strictly speaking twemproxy uses a different hashing algorithm, but the hash-tag behavior is
                                            // the same, so this does a pretty good job of spotting illegal commands before sending them
 
                     slot = message.GetHashSlot(this);
@@ -171,13 +174,13 @@ namespace StackExchange.Redis
                         else
                         {
                             message.PrepareToResend(resendVia, isMoved);
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
                             retry = resendVia.TryWriteSync(message) == WriteResult.Success;
 #pragma warning restore CS0618
                         }
                     }
 
-                    if (isMoved) // update map; note we can still update the map even if we aren't actually goint to resend
+                    if (isMoved) // update map; note we can still update the map even if we aren't actually going to resend
                     {
                         var arr = MapForMutation();
                         var oldServer = arr[hashSlot];

--- a/src/StackExchange.Redis/SortedSetEntry.cs
+++ b/src/StackExchange.Redis/SortedSetEntry.cs
@@ -60,13 +60,11 @@ namespace StackExchange.Redis
         public static implicit operator SortedSetEntry(KeyValuePair<RedisValue, double> value) => new SortedSetEntry(value.Key, value.Value);
 
         /// <summary>
-        /// See <see cref="object.ToString"/>.
+        /// A "{element}: {score}" string representation of the entry.
         /// </summary>
         public override string ToString() => element + ": " + score;
 
-        /// <summary>
-        /// See <see cref="object.GetHashCode"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode() => element.GetHashCode() ^ score.GetHashCode();
 
         /// <summary>

--- a/tests/StackExchange.Redis.Tests/BacklogTests.cs
+++ b/tests/StackExchange.Redis.Tests/BacklogTests.cs
@@ -60,7 +60,7 @@ namespace StackExchange.Redis.Tests
                 await db.PingAsync();
 
                 var server = muxer.GetServerSnapshot()[0];
-                var stats = server.GetBridgeStatus(RedisCommand.PING);
+                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
 
                 // Fail the connection
@@ -73,7 +73,7 @@ namespace StackExchange.Redis.Tests
                 Writer.WriteLine("Test: Disconnected pings");
                 await Assert.ThrowsAsync<RedisConnectionException>(() => db.PingAsync());
 
-                var disconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.False(muxer.IsConnected);
                 Assert.Equal(0, disconnectedStats.BacklogMessagesPending);
 
@@ -85,7 +85,7 @@ namespace StackExchange.Redis.Tests
                 Writer.WriteLine("Test: Reconnecting");
                 Assert.True(muxer.IsConnected);
                 Assert.True(server.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
 
                 _ = db.PingAsync();
@@ -137,7 +137,7 @@ namespace StackExchange.Redis.Tests
                 await db.PingAsync();
 
                 var server = muxer.GetServerSnapshot()[0];
-                var stats = server.GetBridgeStatus(RedisCommand.PING);
+                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
 
                 // Fail the connection
@@ -154,7 +154,7 @@ namespace StackExchange.Redis.Tests
 
                 // TODO: Add specific server call
 
-                var disconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.False(muxer.IsConnected);
                 Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
 
@@ -169,7 +169,7 @@ namespace StackExchange.Redis.Tests
                 Writer.WriteLine("Test: ignoredA Status: " + ignoredA.Status);
                 Writer.WriteLine("Test: ignoredB Status: " + ignoredB.Status);
                 Writer.WriteLine("Test: lastPing Status: " + lastPing.Status);
-                var afterConnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
 
                 Writer.WriteLine("Test: Awaiting lastPing 1");
@@ -177,7 +177,7 @@ namespace StackExchange.Redis.Tests
 
                 Writer.WriteLine("Test: Checking reconnected 2");
                 Assert.True(muxer.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
 
                 Writer.WriteLine("Test: Pinging again...");
@@ -230,7 +230,7 @@ namespace StackExchange.Redis.Tests
                 await db.PingAsync();
 
                 var server = muxer.GetServerSnapshot()[0];
-                var stats = server.GetBridgeStatus(RedisCommand.PING);
+                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
 
                 // Fail the connection
@@ -257,9 +257,9 @@ namespace StackExchange.Redis.Tests
 
                 Assert.False(muxer.IsConnected);
                 // Give the tasks time to queue
-                await UntilCondition(TimeSpan.FromSeconds(5), () => server.GetBridgeStatus(RedisCommand.PING).BacklogMessagesPending >= 3);
+                await UntilCondition(TimeSpan.FromSeconds(5), () => server.GetBridgeStatus(ConnectionType.Interactive).BacklogMessagesPending >= 3);
 
-                var disconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Log($"Test Stats: (BacklogMessagesPending: {disconnectedStats.BacklogMessagesPending}, TotalBacklogMessagesQueued: {disconnectedStats.TotalBacklogMessagesQueued})");
                 Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
 
@@ -271,7 +271,7 @@ namespace StackExchange.Redis.Tests
                 Writer.WriteLine("Test: Checking reconnected 1");
                 Assert.True(muxer.IsConnected);
 
-                var afterConnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
 
                 Writer.WriteLine("Test: Awaiting 3 pings");
@@ -279,7 +279,7 @@ namespace StackExchange.Redis.Tests
 
                 Writer.WriteLine("Test: Checking reconnected 2");
                 Assert.True(muxer.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
+                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
 
                 Writer.WriteLine("Test: Pinging again...");

--- a/tests/StackExchange.Redis.Tests/BacklogTests.cs
+++ b/tests/StackExchange.Redis.Tests/BacklogTests.cs
@@ -106,7 +106,6 @@ namespace StackExchange.Redis.Tests
             }
         }
 
-
         [Fact]
         public async Task QueuesAndFlushesAfterReconnecting()
         {
@@ -122,7 +121,8 @@ namespace StackExchange.Redis.Tests
                     KeepAlive = 10000,
                     AsyncTimeout = 5000,
                     AllowAdmin = true,
-                };                
+                    SocketManager = SocketManager.ThreadPool,
+                };
                 options.EndPoints.Add(TestConfig.Current.MasterServerAndPort);
 
                 using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
@@ -166,13 +166,18 @@ namespace StackExchange.Redis.Tests
                 var reconnectedStats = server.GetBridgeStatus(RedisCommand.PING);
                 Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
 
+                Writer.WriteLine("Test: Pinging again...");
                 _ = db.PingAsync();
                 _ = db.PingAsync();
+                Writer.WriteLine("Test: Last Ping issued");
                 lastPing = db.PingAsync();
 
                 // We should see none queued
+                Writer.WriteLine("Test: BacklogMessagesPending check");
                 Assert.Equal(0, stats.BacklogMessagesPending);
+                Writer.WriteLine("Test: Awaiting lastPing");
                 await lastPing;
+                Writer.WriteLine("Test: Done");
             }
             finally
             {

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -463,9 +463,9 @@ namespace StackExchange.Redis.Tests
         [Theory]
         [InlineData("myDNS:myPort,password=myPassword,connectRetry=3,connectTimeout=15000,syncTimeout=15000,defaultDatabase=0,abortConnect=false,ssl=true,sslProtocols=Tls12", SslProtocols.Tls12)]
         [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Tls12", SslProtocols.Tls12)]
-#pragma warning disable CS0618 // obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
         [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Ssl3", SslProtocols.Ssl3)]
-#pragma warning restore CS0618 // obsolete
+#pragma warning restore CS0618
         [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Tls12 ", SslProtocols.Tls12)]
         public void ParseTlsWithoutTrailingComma(string configString, SslProtocols expected)
         {

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -106,7 +106,7 @@ namespace StackExchange.Redis.Tests
 
             int failCount = 0, restoreCount = 0;
 
-            using (var muxer = ConnectionMultiplexer.Connect(config))
+            using (var muxer = ConnectionMultiplexer.Connect(config, log: Writer))
             {
                 muxer.ConnectionFailed += delegate { Interlocked.Increment(ref failCount); };
                 muxer.ConnectionRestored += delegate { Interlocked.Increment(ref restoreCount); };

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -124,12 +124,16 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(0, Volatile.Read(ref restoreCount));
 
                 var server = muxer.GetServer(TestConfig.Current.MasterServerAndPort);
-                server.SimulateConnectionFailure(SimulatedFailureType.InteractiveInbound | SimulatedFailureType.InteractiveOutbound);
+                server.SimulateConnectionFailure(SimulatedFailureType.All);
 
-                await UntilCondition(TimeSpan.FromSeconds(10), () => Volatile.Read(ref failCount) + Volatile.Read(ref restoreCount) == 4);
+                await UntilCondition(TimeSpan.FromSeconds(10), () => Volatile.Read(ref failCount) >= 2 && Volatile.Read(ref restoreCount) >= 2);
+
                 // interactive+subscriber = 2
-                Assert.Equal(2, Volatile.Read(ref failCount));
-                Assert.Equal(2, Volatile.Read(ref restoreCount));
+                var failCountSnapshot = Volatile.Read(ref failCount);
+                Assert.True(failCountSnapshot >= 2, $"failCount {failCountSnapshot} >= 2");
+
+                var restoreCountSnapshot = Volatile.Read(ref restoreCount);
+                Assert.True(restoreCountSnapshot >= 2, $"restoreCount ({restoreCountSnapshot}) >= 2");
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -116,7 +116,7 @@ namespace StackExchange.Redis.Tests
                 muxer.ConnectionRestored += (s, e) =>
                 {
                     Interlocked.Increment(ref restoreCount);
-                    Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+                    Log($"Connection Restored ({e.ConnectionType},{e.FailureType}): {e.Exception}");
                 };
 
                 muxer.GetDatabase();

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -108,8 +108,16 @@ namespace StackExchange.Redis.Tests
 
             using (var muxer = ConnectionMultiplexer.Connect(config, log: Writer))
             {
-                muxer.ConnectionFailed += delegate { Interlocked.Increment(ref failCount); };
-                muxer.ConnectionRestored += delegate { Interlocked.Increment(ref restoreCount); };
+                muxer.ConnectionFailed += (s, e) =>
+                {
+                    Interlocked.Increment(ref failCount);
+                    Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+                };
+                muxer.ConnectionRestored += (s, e) =>
+                {
+                    Interlocked.Increment(ref restoreCount);
+                    Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+                };
 
                 muxer.GetDatabase();
                 Assert.Equal(0, Volatile.Read(ref failCount));

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -124,7 +124,7 @@ namespace StackExchange.Redis.Tests
                 Assert.Equal(0, Volatile.Read(ref restoreCount));
 
                 var server = muxer.GetServer(TestConfig.Current.MasterServerAndPort);
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
+                server.SimulateConnectionFailure(SimulatedFailureType.InteractiveInbound | SimulatedFailureType.InteractiveOutbound);
 
                 await UntilCondition(TimeSpan.FromSeconds(10), () => Volatile.Read(ref failCount) + Volatile.Read(ref restoreCount) == 4);
                 // interactive+subscriber = 2

--- a/tests/StackExchange.Redis.Tests/Deprecated.cs
+++ b/tests/StackExchange.Redis.Tests/Deprecated.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 namespace StackExchange.Redis.Tests
 {
     /// <summary>
-    /// Testing that things we depcreate still parse, but are otherwise defaults.
+    /// Testing that things we deprecate still parse, but are otherwise defaults.
     /// </summary>
     public class Deprecated : TestBase
     {
@@ -52,6 +52,6 @@ namespace StackExchange.Redis.Tests
             options = ConfigurationOptions.Parse("responseTimeout=1000");
             Assert.Equal(0, options.ResponseTimeout);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618
     }
 }

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -152,7 +152,6 @@ namespace StackExchange.Redis.Tests
                 {
                     AbortOnConnectFail = abortOnConnect,
                     BacklogPolicy = BacklogPolicy.FailFast,
-                    ConnectRetry = 1,
                     ConnectTimeout = 500,
                     SyncTimeout = 500,
                     KeepAlive = 5000

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -152,7 +152,7 @@ namespace StackExchange.Redis.Tests
                 {
                     AbortOnConnectFail = abortOnConnect,
                     BacklogPolicy = BacklogPolicy.FailFast,
-                    ConnectTimeout = 500,
+                    ConnectTimeout = 1000,
                     SyncTimeout = 500,
                     KeepAlive = 5000
                 };

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -63,7 +63,7 @@ namespace StackExchange.Redis.Tests
         {
             try
             {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false))
+                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast))
                 {
                     muxer.GetDatabase();
                     muxer.AllowConnect = false;

--- a/tests/StackExchange.Redis.Tests/Helpers/Skip.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Skip.cs
@@ -42,12 +42,10 @@ namespace StackExchange.Redis.Tests
         }
     }
 
-#pragma warning disable RCS1194 // Implement exception constructors.
     public class SkipTestException : Exception
     {
         public string MissingFeatures { get; set; }
 
         public SkipTestException(string reason) : base(reason) { }
     }
-#pragma warning restore RCS1194 // Implement exception constructors.
 }

--- a/tests/StackExchange.Redis.Tests/Helpers/redis-sharp.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/redis-sharp.cs
@@ -32,13 +32,11 @@ namespace RedisSharp
             None, String, List, Set
         }
 
-#pragma warning disable RCS1194 // Implement exception constructors.
         public class ResponseException : Exception
         {
             public string Code { get; }
             public ResponseException(string code) : base("Response error") => Code = code;
         }
-#pragma warning restore RCS1194 // Implement exception constructors.
 
         public Redis(string host, int port)
         {

--- a/tests/StackExchange.Redis.Tests/MassiveOps.cs
+++ b/tests/StackExchange.Redis.Tests/MassiveOps.cs
@@ -47,9 +47,11 @@ namespace StackExchange.Redis.Tests
                 for (int i = 0; i <= AsyncOpsQty; i++)
                 {
                     var t = conn.StringSetAsync(key, i);
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                    if (withContinuation) t.ContinueWith(nonTrivial);
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                    if (withContinuation)
+                    {
+                        // Intentionally unawaited
+                        _ = t.ContinueWith(nonTrivial);
+                    }
                 }
                 Assert.Equal(AsyncOpsQty, await conn.StringGetAsync(key).ForAwait());
                 watch.Stop();

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -793,8 +793,8 @@ namespace StackExchange.Redis.Tests
                 Log("Failing connection");
                 // Fail all connections
                 server.SimulateConnectionFailure(SimulatedFailureType.All);
-                // Trigger failure
-                Assert.Throws<RedisConnectionException>(() => sub.Ping());
+                // Trigger failure (RedisTimeoutException because of backlog behavior)
+                Assert.Throws<RedisTimeoutException>(() => sub.Ping());
                 Assert.False(sub.IsConnected(channel));
 
                 // Now reconnect...

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -520,6 +520,9 @@ namespace StackExchange.Redis.Tests
                 });
                 await sub.PingAsync().ForAwait();
 
+                // Give a delay between subscriptions and when we try to publish to be safe
+                await Task.Delay(1000).ForAwait();
+
                 lock (syncLock)
                 {
                     for (int i = 0; i < count; i++)

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -326,8 +326,20 @@ namespace StackExchange.Redis.Tests
                 }
                 //Assert.True(false, $"There were {privateFailCount} private ambient exceptions.");
             }
-            var pool = SocketManager.Shared?.SchedulerPool;
-            TestBase.Log(output, $"Service Counts: (Scheduler) By Queue: {pool?.TotalServicedByQueue.ToString()}, By Pool: {pool?.TotalServicedByPool.ToString()}, Workers: {pool?.WorkerCount.ToString()}, Available: {pool?.AvailableCount.ToString()}");
+
+            if (_actualConnection != null)
+            {
+                TestBase.Log(output, "Connection Counts: " + _actualConnection.GetCounters().ToString());
+                foreach (var ep in _actualConnection.GetServerSnapshot())
+                {
+                    var interactive = ep.GetBridge(ConnectionType.Interactive);
+                    TestBase.Log(output, $"  {Format.ToString(interactive)}: " + interactive.GetStatus());
+
+                    var subscription = ep.GetBridge(ConnectionType.Subscription);
+                    TestBase.Log(output, $"  {Format.ToString(subscription)}: " + subscription.GetStatus());
+                }
+
+            }
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -62,7 +62,7 @@ namespace StackExchange.Redis.Tests
 
             public long OperationCount => _inner.OperationCount;
 
-#pragma warning disable CS0618
+#pragma warning disable CS0618 // Type or member is obsolete
             public bool PreserveAsyncOrder { get => _inner.PreserveAsyncOrder; set => _inner.PreserveAsyncOrder = value; }
 #pragma warning restore CS0618
 

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -195,7 +195,8 @@ namespace StackExchange.Redis.Tests
                 }
                 Skip.Inconclusive($"There were {privateFailCount} private and {sharedFailCount.Value} ambient exceptions; expected {expectedFailCount}.");
             }
-            Log($"Service Counts: (Scheduler) Queue: {SocketManager.Shared?.SchedulerPool?.TotalServicedByQueue.ToString()}, Pool: {SocketManager.Shared?.SchedulerPool?.TotalServicedByPool.ToString()}");
+            var pool = SocketManager.Shared?.SchedulerPool;
+            Log($"Service Counts: (Scheduler) Queue: {pool?.TotalServicedByQueue.ToString()}, Pool: {pool?.TotalServicedByPool.ToString()}, Workers: {pool?.WorkerCount.ToString()}, Available: {pool?.AvailableCount.ToString()}");
         }
 
         protected IServer GetServer(IConnectionMultiplexer muxer)

--- a/tests/StackExchange.Redis.Tests/Transactions.cs
+++ b/tests/StackExchange.Redis.Tests/Transactions.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'.
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -22,12 +22,10 @@ namespace StackExchange.Redis.Tests
             wrapper = new WrapperBase<IDatabaseAsync>(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
         }
 
-#pragma warning disable RCS1047 // Non-asynchronous method name should not end with 'Async'.
-
         [Fact]
-        public void DebugObjectAsync()
+        public async Task DebugObjectAsync()
         {
-            wrapper.DebugObjectAsync("key", CommandFlags.None);
+            await wrapper.DebugObjectAsync("key", CommandFlags.None);
             mock.Verify(_ => _.DebugObjectAsync("prefix:key", CommandFlags.None));
         }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2",
+  "version": "2.5-prerelease",
   "versionHeightOffset": -1,
   "assemblyVersion": "2.0",
   "publicReleaseRefSpec": [


### PR DESCRIPTION
This one's a big docs cleanup across the board. There's a few very minor code tweaks in here but mostly: docs. We had some typos, some wrong words, and a lot of inconsistency so this is a pass at tightening all that up.

It's based on top of #1969 (for minimal merge conflicts), so currently last in the merge list. But: ready for review. Highly recommend using the "Viewed" checkbox on files in case there are merge conflicts later...this one's got a few in it.