### PR TITLE
Fix for #1236

### DIFF
--- a/src/StackExchange.Redis/RedisLiterals.cs
+++ b/src/StackExchange.Redis/RedisLiterals.cs
@@ -9,6 +9,7 @@ namespace StackExchange.Redis
             ASK = "ASK ",
             authFail_trimmed = CommandBytes.TrimToFit("ERR operation not permitted"),
             backgroundSavingStarted_trimmed = CommandBytes.TrimToFit("Background saving started"),
+            backgroundSavingAOFStarted_trimmed = CommandBytes.TrimToFit("Background append only file rewriting started"),
             databases = "databases",
             loading = "LOADING ",
             MOVED = "MOVED ",

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -695,7 +695,7 @@ namespace StackExchange.Redis
 
         private static ResultProcessor<bool> GetSaveResultProcessor(SaveType type) => type switch
         {
-            SaveType.BackgroundRewriteAppendOnlyFile => ResultProcessor.DemandOK,
+            SaveType.BackgroundRewriteAppendOnlyFile => ResultProcessor.BackgroundSaveAOFStarted,
             SaveType.BackgroundSave => ResultProcessor.BackgroundSaveStarted,
 #pragma warning disable 0618
             SaveType.ForegroundSave => ResultProcessor.DemandOK,

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -21,7 +21,8 @@ namespace StackExchange.Redis
             TrackSubscriptions = new TrackSubscriptionsProcessor(null),
             Tracer = new TracerProcessor(false),
             EstablishConnection = new TracerProcessor(true),
-            BackgroundSaveStarted = new ExpectBasicStringProcessor(CommonReplies.backgroundSavingStarted_trimmed, startsWith: true);
+            BackgroundSaveStarted = new ExpectBasicStringProcessor(CommonReplies.backgroundSavingStarted_trimmed, startsWith: true),
+            BackgroundSaveAOFStarted = new ExpectBasicStringProcessor(CommonReplies.backgroundSavingAOFStarted_trimmed, startsWith: true);
 
         public static readonly ResultProcessor<byte[]>
             ByteArray = new ByteArrayProcessor(),

--- a/tests/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests.Issues
@@ -10,12 +11,13 @@ namespace StackExchange.Redis.Tests.Issues
         [Theory (Skip = "We don't need to test this, and it really screws local testing hard.")]
         [InlineData(SaveType.BackgroundSave)]
         [InlineData(SaveType.BackgroundRewriteAppendOnlyFile)]
-        public void ShouldntThrowException(SaveType saveType)
+        public async Task ShouldntThrowException(SaveType saveType)
         {
             using (var conn = Create(null, null, true))
             {
                 var Server = GetServer(conn);
                 Server.Save(saveType);
+                await Task.Delay(1000);
             }
         }
     }


### PR DESCRIPTION
Not enabling this test because it hoses things, but have manually tested local - this now handles the response properly on a `BGREWRITEAOF`.