### PR TITLE
Client name: append library version suffix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://github.com/StackExchange/StackExchange.Redis/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/StackExchange.Redis/</RepositoryUrl>
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -14,6 +14,7 @@
   - Fixes a race in subscribing immediately before a publish
   - Fixes subscription routing on clusters (spreading instead of choosing 1 node)
   - More correctly reconnects subscriptions on connection failures, including to other endpoints
+- Adds "(vX.X.X)" version suffix to the default client ID so server-side `CLIENT LIST` can more easily see what's connected (#1985 via NickCraver)
 
 ## 2.2.88
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -149,12 +149,15 @@ namespace StackExchange.Redis
 
         private static string defaultClientName;
 
+        /// <summary>
+        /// Gets the client name for a connection, with the library version appended.
+        /// </summary>
         private static string GetDefaultClientName()
         {
-            return defaultClientName ??= TryGetAzureRoleInstanceIdNoThrow()
+            return defaultClientName ??= (TryGetAzureRoleInstanceIdNoThrow()
                     ?? Environment.MachineName
                     ?? Environment.GetEnvironmentVariable("ComputerName")
-                    ?? "StackExchange.Redis";
+                    ?? "StackExchange.Redis") + "(v" + Utils.GetLibVersion() + ")";
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -199,17 +199,6 @@ namespace StackExchange.Redis
             return new RedisCommandException("Command cannot be used with a cursor: " + s);
         }
 
-        private static string _libVersion;
-        internal static string GetLibVersion()
-        {
-            if (_libVersion == null)
-            {
-                var assembly = typeof(ConnectionMultiplexer).Assembly;
-                _libVersion = ((AssemblyFileVersionAttribute)Attribute.GetCustomAttribute(assembly, typeof(AssemblyFileVersionAttribute)))?.Version
-                    ?? assembly.GetName().Version.ToString();
-            }
-            return _libVersion;
-        }
         private static void Add(List<Tuple<string, string>> data, StringBuilder sb, string lk, string sk, string v)
         {
             if (v != null)
@@ -365,7 +354,7 @@ namespace StackExchange.Redis
                 Add(data, sb, "Local-CPU", "Local-CPU", PerfCounterHelper.GetSystemCpuPercent());
             }
 
-            Add(data, sb, "Version", "v", GetLibVersion());
+            Add(data, sb, "Version", "v", Utils.GetLibVersion());
         }
 
         private static void AddExceptionDetail(Exception exception, Message message, ServerEndPoint server, string label)

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -434,7 +434,7 @@ namespace StackExchange.Redis
                         }
                     }
 
-                    add("Version", "v", ExceptionFactory.GetLibVersion());
+                    add("Version", "v", Utils.GetLibVersion());
 
                     outerException = new RedisConnectionException(failureType, exMessage.ToString(), innerException);
 

--- a/src/StackExchange.Redis/Utils.cs
+++ b/src/StackExchange.Redis/Utils.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace StackExchange.Redis;
+
+internal static class Utils
+{
+    private static string _libVersion;
+    internal static string GetLibVersion()
+    {
+        if (_libVersion == null)
+        {
+            var assembly = typeof(ConnectionMultiplexer).Assembly;
+            _libVersion = ((AssemblyFileVersionAttribute)Attribute.GetCustomAttribute(assembly, typeof(AssemblyFileVersionAttribute)))?.Version
+                ?? assembly.GetName().Version.ToString();
+        }
+        return _libVersion;
+    }
+}

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -243,12 +243,12 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create(allowAdmin: true, caller: null)) // force default naming to kick in
             {
-                Assert.Equal(Environment.MachineName, muxer.ClientName);
+                Assert.Equal($"{Environment.MachineName}(v{Utils.GetLibVersion()})", muxer.ClientName);
                 var conn = muxer.GetDatabase();
                 conn.Ping();
 
                 var name = (string)GetAnyMaster(muxer).Execute("CLIENT", "GETNAME");
-                Assert.Equal(Environment.MachineName, name);
+                Assert.Equal($"{Environment.MachineName}(v{Utils.GetLibVersion()})", name);
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -23,7 +23,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void CanGetVersion()
         {
-            var libVer = ExceptionFactory.GetLibVersion();
+            var libVer = Utils.GetLibVersion();
             Assert.Matches(@"2\.[0-9]+\.[0-9]+(\.[0-9]+)?", libVer);
         }
 


### PR DESCRIPTION
This changes the default client name to append "(v2.5.x)" on the end (no spaces because Redis doesn't support spaces in client names). It won't append if someone is setting their client name explicitly in options, only for our default, so should be a safe change.

I'm not sure if a `Utils` class (internal) is best here, but seemed like the right path. I really didn't want to ref version from `ExceptionFactory` in the multiplexer...