### PR TITLE
Fix for #1967: Sanitizing message failures

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,6 +15,7 @@
   - Fixes subscription routing on clusters (spreading instead of choosing 1 node)
   - More correctly reconnects subscriptions on connection failures, including to other endpoints
 - Adds "(vX.X.X)" version suffix to the default client ID so server-side `CLIENT LIST` can more easily see what's connected (#1985 via NickCraver)
+- Fix for including (or not including) key names on some message failures (#1990 via NickCraver)
 
 ## 2.2.88
 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -668,7 +668,7 @@ namespace StackExchange.Redis
                         // we screwed up; abort; note that WriteMessageToServer already
                         // killed the underlying connection
                         Trace("Unable to write to server");
-                        message.Fail(ConnectionFailureType.ProtocolFailure, null, "failure before write: " + result.ToString());
+                        message.Fail(ConnectionFailureType.ProtocolFailure, null, "failure before write: " + result.ToString(), Multiplexer);
                         message.Complete();
                         return result;
                     }
@@ -1425,7 +1425,7 @@ namespace StackExchange.Redis
             catch (RedisCommandException ex) when (!isQueued)
             {
                 Trace("Write failed: " + ex.Message);
-                message.Fail(ConnectionFailureType.InternalFailure, ex, null);
+                message.Fail(ConnectionFailureType.InternalFailure, ex, null, Multiplexer);
                 message.Complete();
                 // this failed without actually writing; we're OK with that... unless there's a transaction
 
@@ -1440,7 +1440,7 @@ namespace StackExchange.Redis
             catch (Exception ex)
             {
                 Trace("Write failed: " + ex.Message);
-                message.Fail(ConnectionFailureType.InternalFailure, ex, null);
+                message.Fail(ConnectionFailureType.InternalFailure, ex, null, Multiplexer);
                 message.Complete();
 
                 // we're not sure *what* happened here; probably an IOException; kill the connection

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -27,13 +27,13 @@ namespace StackExchange.Redis
                 var server = multiplexer.SelectServer(message);
                 if (server == null)
                 {
-                    FailNoServer(snapshot);
+                    FailNoServer(multiplexer, snapshot);
                     throw ExceptionFactory.NoConnectionAvailable(multiplexer, message, server);
                 }
                 var bridge = server.GetBridge(message);
                 if (bridge == null)
                 {
-                    FailNoServer(snapshot);
+                    FailNoServer(multiplexer, snapshot);
                     throw ExceptionFactory.NoConnectionAvailable(multiplexer, message, server);
                 }
 
@@ -58,7 +58,7 @@ namespace StackExchange.Redis
             {
                 if (!pair.Key.TryEnqueue(pair.Value, pair.Key.ServerEndPoint.IsReplica))
                 {
-                    FailNoServer(pair.Value);
+                    FailNoServer(multiplexer, pair.Value);
                 }
             }
         }
@@ -89,12 +89,12 @@ namespace StackExchange.Redis
         internal override T ExecuteSync<T>(Message message, ResultProcessor<T> processor, ServerEndPoint server = null) =>
             throw new NotSupportedException("ExecuteSync cannot be used inside a batch");
 
-        private static void FailNoServer(List<Message> messages)
+        private static void FailNoServer(ConnectionMultiplexer muxer, List<Message> messages)
         {
             if (messages == null) return;
             foreach(var msg in messages)
             {
-                msg.Fail(ConnectionFailureType.UnableToResolvePhysicalConnection, null, "unable to write batch");
+                msg.Fail(ConnectionFailureType.UnableToResolvePhysicalConnection, null, "unable to write batch", muxer);
                 msg.Complete();
             }
         }

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -523,7 +523,7 @@ namespace StackExchange.Redis
                     {
                         if (op?.Wrapped is Message inner)
                         {
-                            inner.Fail(ConnectionFailureType.ProtocolFailure, null, "Transaction failure");
+                            inner.Fail(ConnectionFailureType.ProtocolFailure, null, "Transaction failure", connection?.BridgeCouldBeNull?.Multiplexer);
                             inner.Complete();
                         }
                     }

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using Pipelines.Sockets.Unofficial.Arenas;
 
@@ -150,16 +151,22 @@ namespace StackExchange.Redis
             HashEntryArray = new HashEntryArrayProcessor();
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Conditionally run on instance")]
-        public void ConnectionFail(Message message, ConnectionFailureType fail, Exception innerException, string annotation)
+        public void ConnectionFail(Message message, ConnectionFailureType fail, Exception innerException, string annotation, ConnectionMultiplexer muxer)
         {
             PhysicalConnection.IdentifyFailureType(innerException, ref fail);
 
-            string exMessage = fail.ToString() + (message == null ? "" : (" on " + (
-                fail == ConnectionFailureType.ProtocolFailure ? message.ToString() : message.CommandAndKey)));
-            if (!string.IsNullOrWhiteSpace(annotation)) exMessage += ", " + annotation;
-
-            var ex = innerException == null ? new RedisConnectionException(fail, exMessage)
-                : new RedisConnectionException(fail, exMessage, innerException);
+            var sb = new StringBuilder(fail.ToString());
+            if (message is not null)
+            {
+                sb.Append(" on ");
+                sb.Append(muxer?.IncludeDetailInExceptions == true ? message.ToString() : message.ToStringCommandOnly());
+            }
+            if (!string.IsNullOrWhiteSpace(annotation))
+            {
+                sb.Append(", ");
+                sb.Append(annotation);
+            }
+            var ex = new RedisConnectionException(fail, sb.ToString(), innerException);
             SetException(message, ex);
         }
 


### PR DESCRIPTION
There seems to be just 1 case not covered by the `IncludeDetailsInExceptions` option on `ConnectionMultiplexer` - this remedies that. The option is on by default so this shouldn't break people like I thought initially.

Overall, we should probably also move this option to `ConfigurationOptions` and defaults if we do that (#1987).