### PR TITLE
Fix for #1564: Return empty array instead of single element nil array in value array processor

### DIFF
--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1242,7 +1242,10 @@ namespace StackExchange.Redis
                 {
                     // allow a single item to pass explicitly pretending to be an array; example: SPOP {key} 1
                     case ResultType.BulkString:
-                        var arr = new[] { result.AsRedisValue() };
+                        // If the result is nil, the result should be an empty array
+                        var arr = result.IsNull
+                            ? Array.Empty<RedisValue>()
+                            : new[] { result.AsRedisValue() };
                         SetResult(message, arr);
                         return true;
                     case ResultType.MultiBulk:


### PR DESCRIPTION
This changes the return of a nil result through the `RedisValueArrayProcessor` so that it's a `[]` instead of a single element `[ nil ]` in our handling.

This affects the following commands, which are multibulk when a count is provided (even if it's 1), otherwise they are bulkstring. This change affects the non-count case when it's null. Instead of a single element array with a nil value, we'd return an empty array as the Redis surface area intends:
- `LPOP`/`RPOP`
- `SRANDMEMBER`
- `SPOP`

The other usages of `RedisValueArrayProcessor` are _always_ multibulk and are not affected:
- `HMGET`
- `HKEYS`
- `HVALS`
- `LRANGE`
- `MGET`
- `SDIFF`
- `SINTER`
- `SUNION`
- `SMEMBERS`
- `SORT`
- `XCLAIM`
- `Z(REV)RANGE`
- `Z(REV)RANGEBYLEX`
- `Z(REV)RANGEBYSCORE`