### PR TITLE
Misc connection/subscription fixes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Adds bounds checking for `ExponentialRetry` backoff policy (#1921 via gliljas) 
+- When `SUBSCRIBE` is disabled, give proper errors and connect faster (#2001 via NickCraver)
 
 ## 2.5.27 (prerelease)
 

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -26,17 +26,11 @@ namespace StackExchange.Redis
         {
             // see https://github.com/twitter/twemproxy/blob/master/notes/redis.md
             RedisCommand.KEYS, RedisCommand.MIGRATE, RedisCommand.MOVE, RedisCommand.OBJECT, RedisCommand.RANDOMKEY,
-            RedisCommand.RENAME, RedisCommand.RENAMENX, RedisCommand.SORT, RedisCommand.SCAN,
+            RedisCommand.RENAME, RedisCommand.RENAMENX, RedisCommand.SCAN,
 
-            RedisCommand.BITOP, RedisCommand.MSET, RedisCommand.MSETNX,
-
-            RedisCommand.HSCAN,
+            RedisCommand.BITOP, RedisCommand.MSETNX,
 
             RedisCommand.BLPOP, RedisCommand.BRPOP, RedisCommand.BRPOPLPUSH, // yeah, me neither!
-
-            RedisCommand.SSCAN,
-
-            RedisCommand.ZSCAN,
 
             RedisCommand.PSUBSCRIBE, RedisCommand.PUBLISH, RedisCommand.PUNSUBSCRIBE, RedisCommand.SUBSCRIBE, RedisCommand.UNSUBSCRIBE,
 
@@ -44,7 +38,7 @@ namespace StackExchange.Redis
 
             RedisCommand.SCRIPT,
 
-            RedisCommand.ECHO, RedisCommand.PING, RedisCommand.QUIT, RedisCommand.SELECT,
+            RedisCommand.ECHO, RedisCommand.PING, RedisCommand.SELECT,
 
             RedisCommand.BGREWRITEAOF, RedisCommand.BGSAVE, RedisCommand.CLIENT, RedisCommand.CLUSTER, RedisCommand.CONFIG, RedisCommand.DBSIZE,
             RedisCommand.DEBUG, RedisCommand.FLUSHALL, RedisCommand.FLUSHDB, RedisCommand.INFO, RedisCommand.LASTSAVE, RedisCommand.MONITOR, RedisCommand.REPLICAOF,

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1654,7 +1654,7 @@ namespace StackExchange.Redis
             foreach (var server in GetServerSnapshot())
             {
                 server.Activate(ConnectionType.Interactive, log);
-                if (CommandMap.IsAvailable(RedisCommand.SUBSCRIBE))
+                if (server.SupportsSubscriptions)
                 {
                     // Intentionally not logging the sub connection
                     server.Activate(ConnectionType.Subscription, null);

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -378,7 +378,7 @@ namespace StackExchange.Redis
             sub.SetCurrentServer(null); // we're not appropriately connected, so blank it out for eligible reconnection
             var message = sub.GetMessage(channel, SubscriptionAction.Subscribe, flags, internalCall);
             var selected = multiplexer.SelectServer(message);
-            return multiplexer.ExecuteSyncImpl(message, sub.Processor, selected);
+            return ExecuteSync(message, sub.Processor, selected);
         }
 
         Task ISubscriber.SubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags)

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -75,6 +75,8 @@ namespace StackExchange.Redis
         public bool IsConnected => interactive?.IsConnected == true;
         public bool IsSubscriberConnected => subscription?.IsConnected == true;
 
+        public bool SupportsSubscriptions => Multiplexer.CommandMap.IsAvailable(RedisCommand.SUBSCRIBE);
+
         public bool IsConnecting => interactive?.IsConnecting == true;
 
         private readonly List<TaskCompletionSource<string>> _pendingConnectionMonitors = new List<TaskCompletionSource<string>>();
@@ -629,9 +631,10 @@ namespace StackExchange.Redis
                         // Since we're issuing commands inside a SetResult path in a message, we'd create a deadlock by waiting.
                         Multiplexer.EnsureSubscriptions(CommandFlags.FireAndForget);
                     }
-                    if (IsConnected && IsSubscriberConnected)
+                    if (IsConnected && (IsSubscriberConnected || !SupportsSubscriptions))
                     {
                         // Only connect on the second leg - we can accomplish this by checking both
+                        // Or the first leg, if we're only making 1 connection because subscriptions aren't supported
                         CompletePendingConnectionMonitors(source);
                     }
 

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -264,6 +264,21 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public void ConnectWithSubscribeDisabled()
+        {
+            using (var muxer = Create(allowAdmin: true, disabledCommands: new[] { "subscribe" }))
+            {
+                Assert.True(muxer.IsConnected);
+                var servers = muxer.GetServerSnapshot();
+                Assert.True(servers[0].IsConnected);
+                Assert.False(servers[0].IsSubscriberConnected);
+
+                var ex = Assert.Throws<RedisCommandException>(() => muxer.GetSubscriber().Subscribe(Me(), (_, _) => GC.KeepAlive(this)));
+                Assert.Equal("This operation has been disabled in the command-map and cannot be used: SUBSCRIBE", ex.Message);
+            }
+        }
+
+        [Fact]
         public void ReadConfig()
         {
             using (var muxer = Create(allowAdmin: true))


### PR DESCRIPTION
In investigating an issue in #1989, I found a few gaps. Overall:
1. Twemproxy has an out of date CommandMap, which propagated to Envoy.
2. We were expecting both interactive and subscription connections to complete to complete the async handler...but we shouldn't because subscriptions may be disabled.
3. RedisSubscriber changes on the sync path weren't validating the message (asserting the command map has it enabled).

This fixes all of the above and adds another test considering all 3.