### PR TITLE
Add a client name suffix option

### DIFF
--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -76,6 +76,7 @@ namespace StackExchange.Redis
                 HighPrioritySocketThreads = "highPriorityThreads",
                 KeepAlive = "keepAlive",
                 ClientName = "name",
+                ClientNameSuffix = "nameSuffix",
                 User = "user",
                 Password = "password",
                 PreserveAsyncOrder = "preserveAsyncOrder",
@@ -257,6 +258,12 @@ namespace StackExchange.Redis
         /// The client name to use for all connections.
         /// </summary>
         public string ClientName { get; set; }
+
+        /// <summary>
+        /// A suffix to append onto the client name name for all connections.
+        /// This will be appended to the default generated client name, or to <see cref="ClientName"/> (if specified).
+        /// </summary>
+        public string ClientNameSuffix { get; set; }
 
         /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly.
@@ -523,6 +530,7 @@ namespace StackExchange.Redis
             var options = new ConfigurationOptions
             {
                 ClientName = ClientName,
+                ClientNameSuffix = ClientNameSuffix,
                 ServiceName = ServiceName,
                 keepAlive = keepAlive,
                 syncTimeout = syncTimeout,
@@ -612,6 +620,7 @@ namespace StackExchange.Redis
                 Append(sb, Format.ToString(endpoint));
             }
             Append(sb, OptionKeys.ClientName, ClientName);
+            Append(sb, OptionKeys.ClientNameSuffix, ClientNameSuffix);
             Append(sb, OptionKeys.ServiceName, ServiceName);
             Append(sb, OptionKeys.KeepAlive, keepAlive);
             Append(sb, OptionKeys.SyncTimeout, syncTimeout);
@@ -719,7 +728,7 @@ namespace StackExchange.Redis
 
         private void Clear()
         {
-            ClientName = ServiceName = User = Password = tieBreaker = sslHost = configChannel = null;
+            ClientName = ClientNameSuffix = ServiceName = User = Password = tieBreaker = sslHost = configChannel = null;
             keepAlive = syncTimeout = asyncTimeout = connectTimeout = writeBuffer = connectRetry = configCheckSeconds = DefaultDatabase = null;
             allowAdmin = abortOnConnectFail = highPrioritySocketThreads = resolveDns = ssl = null;
             SslProtocols = null;
@@ -790,6 +799,9 @@ namespace StackExchange.Redis
                             break;
                         case OptionKeys.ClientName:
                             ClientName = value;
+                            break;
+                        case OptionKeys.ClientNameSuffix:
+                            ClientNameSuffix = value;
                             break;
                         case OptionKeys.ChannelPrefix:
                             ChannelPrefix = value;

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -260,8 +260,8 @@ namespace StackExchange.Redis
         public string ClientName { get; set; }
 
         /// <summary>
-        /// A suffix to append onto the client name name for all connections.
-        /// This will be appended to the default generated client name, or to <see cref="ClientName"/> (if specified).
+        /// A suffix to append onto the default client name for all connections.
+        /// If a <see cref="ClientName"/> is specified, this suffix will not be applied.
         /// </summary>
         public string ClientNameSuffix { get; set; }
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -145,7 +145,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets the client-name that will be used on all new connections.
         /// </summary>
-        public string ClientName => RawConfig.ClientName ?? GetDefaultClientName();
+        public string ClientName => $"{RawConfig.ClientName ?? GetDefaultClientName()}{RawConfig.ClientNameSuffix ?? string.Empty}";
 
         private static string defaultClientName;
 
@@ -157,7 +157,7 @@ namespace StackExchange.Redis
             return defaultClientName ??= (TryGetAzureRoleInstanceIdNoThrow()
                     ?? Environment.MachineName
                     ?? Environment.GetEnvironmentVariable("ComputerName")
-                    ?? "StackExchange.Redis") + "(v" + Utils.GetLibVersion() + ")";
+                    ?? "StackExchange.Redis") + $"(lib:SER,v{Utils.GetLibVersion()})";
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -145,7 +145,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets the client-name that will be used on all new connections.
         /// </summary>
-        public string ClientName => $"{RawConfig.ClientName ?? GetDefaultClientName()}{RawConfig.ClientNameSuffix ?? string.Empty}";
+        public string ClientName => RawConfig.ClientName ?? GetDefaultClientName() + (RawConfig.ClientNameSuffix ?? string.Empty);
 
         private static string defaultClientName;
 

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -243,13 +243,14 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create(clientName: "Test Rig", clientNameSuffix: ",Test Suffix", allowAdmin: true))
             {
-                Assert.Equal("Test Rig,Test Suffix", muxer.ClientName);
+                // Suffix should not be applied when ClientName is specified
+                Assert.Equal("Test Rig", muxer.ClientName);
 
                 var conn = muxer.GetDatabase();
                 conn.Ping();
 
                 var name = (string)GetAnyMaster(muxer).Execute("CLIENT", "GETNAME");
-                Assert.Equal("TestRig,TestSuffix", name);
+                Assert.Equal("TestRig", name);
             }
         }
 
@@ -264,6 +265,20 @@ namespace StackExchange.Redis.Tests
 
                 var name = (string)GetAnyMaster(muxer).Execute("CLIENT", "GETNAME");
                 Assert.Equal($"{Environment.MachineName}(lib:SER,v{Utils.GetLibVersion()})", name);
+            }
+        }
+
+        [Fact]
+        public void DefaultClientNameSuffix()
+        {
+            using (var muxer = Create(clientNameSuffix: ",Test Suffix", allowAdmin: true, caller: null)) // Null caller forces default naming to kick in
+            {
+                Assert.Equal($"{Environment.MachineName}(lib:SER,v{Utils.GetLibVersion()}),Test Suffix", muxer.ClientName);
+                var conn = muxer.GetDatabase();
+                conn.Ping();
+
+                var name = (string)GetAnyMaster(muxer).Execute("CLIENT", "GETNAME");
+                Assert.Equal($"{Environment.MachineName}(lib:SER,v{Utils.GetLibVersion()}),TestSuffix", name);
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -239,16 +239,31 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public void DefaultClientName()
+        public void ClientNameSuffix()
         {
-            using (var muxer = Create(allowAdmin: true, caller: null)) // force default naming to kick in
+            using (var muxer = Create(clientName: "Test Rig", clientNameSuffix: ",Test Suffix", allowAdmin: true))
             {
-                Assert.Equal($"{Environment.MachineName}(v{Utils.GetLibVersion()})", muxer.ClientName);
+                Assert.Equal("Test Rig,Test Suffix", muxer.ClientName);
+
                 var conn = muxer.GetDatabase();
                 conn.Ping();
 
                 var name = (string)GetAnyMaster(muxer).Execute("CLIENT", "GETNAME");
-                Assert.Equal($"{Environment.MachineName}(v{Utils.GetLibVersion()})", name);
+                Assert.Equal("TestRig,TestSuffix", name);
+            }
+        }
+
+        [Fact]
+        public void DefaultClientName()
+        {
+            using (var muxer = Create(allowAdmin: true, caller: null)) // force default naming to kick in
+            {
+                Assert.Equal($"{Environment.MachineName}(lib:SER,v{Utils.GetLibVersion()})", muxer.ClientName);
+                var conn = muxer.GetDatabase();
+                conn.Ping();
+
+                var name = (string)GetAnyMaster(muxer).Execute("CLIENT", "GETNAME");
+                Assert.Equal($"{Environment.MachineName}(lib:SER,v{Utils.GetLibVersion()})", name);
             }
         }
 
@@ -510,8 +525,9 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void Apply()
         {
-            var options = ConfigurationOptions.Parse("127.0.0.1,name=FooApply");
+            var options = ConfigurationOptions.Parse("127.0.0.1,name=FooApply,nameSuffix=FooApplySuffix");
             Assert.Equal("FooApply", options.ClientName);
+            Assert.Equal("FooApplySuffix", options.ClientNameSuffix);
 
             var randomName = Guid.NewGuid().ToString();
             var result = options.Apply(options => options.ClientName = randomName);

--- a/tests/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
@@ -13,7 +13,7 @@ namespace StackExchange.Redis.Tests.Issues
         [InlineData(SaveType.BackgroundRewriteAppendOnlyFile)]
         public async Task ShouldntThrowException(SaveType saveType)
         {
-            using (var conn = Create(null, null, true))
+            using (var conn = Create(allowAdmin: true))
             {
                 var Server = GetServer(conn);
                 Server.Save(saveType);

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -246,6 +246,7 @@ namespace StackExchange.Redis.Tests
 
         internal virtual IInternalConnectionMultiplexer Create(
             string clientName = null,
+            string clientNameSuffix = null,
             int? syncTimeout = null,
             bool? allowAdmin = null,
             int? keepAlive = null,
@@ -297,7 +298,7 @@ namespace StackExchange.Redis.Tests
 
             var muxer = CreateDefault(
                 Writer,
-                clientName, syncTimeout, allowAdmin, keepAlive,
+                clientName, clientNameSuffix, syncTimeout, allowAdmin, keepAlive,
                 connectTimeout, password, tieBreaker, log,
                 fail, disabledCommands, enabledCommands,
                 checkConnect, failMessage,
@@ -315,6 +316,7 @@ namespace StackExchange.Redis.Tests
         public static ConnectionMultiplexer CreateDefault(
             TextWriter output,
             string clientName = null,
+            string clientNameSuffix = null,
             int? syncTimeout = null,
             bool? allowAdmin = null,
             int? keepAlive = null,
@@ -362,6 +364,7 @@ namespace StackExchange.Redis.Tests
                 if (password != null) config.Password = string.IsNullOrEmpty(password) ? null : password;
                 if (clientName != null) config.ClientName = clientName;
                 else if (caller != null) config.ClientName = caller;
+                if (clientNameSuffix != null) config.ClientNameSuffix = clientNameSuffix;
                 if (syncTimeout != null) config.SyncTimeout = syncTimeout.Value;
                 if (allowAdmin != null) config.AllowAdmin = allowAdmin.Value;
                 if (keepAlive != null) config.KeepAlive = keepAlive.Value;


### PR DESCRIPTION
The suffix enables a couple of scenarios:
- A client application adds a suffix to identify its connections on the server, while still relying on the default client name logic to use its machine name or instance name as the unique root of the client name
- An extension package adds a suffix to identify connections where it's being used

Also add to the library version tag on default client names:
- A "lib:" token to facilitate parsing
- A library identifier "SER" to distinguish from other libraries that may use a similar version tag