### PR TITLE
Tests: Improve QueuesAndFlushesAfterReconnectingClusterAsync

### DIFF
--- a/tests/StackExchange.Redis.Tests/BacklogTests.cs
+++ b/tests/StackExchange.Redis.Tests/BacklogTests.cs
@@ -326,7 +326,10 @@ namespace StackExchange.Redis.Tests
                 RedisKey meKey = Me();
                 var getMsg = Message.Create(0, CommandFlags.None, RedisCommand.GET, meKey);
 
-                var server = muxer.SelectServer(getMsg); // Get the server specifically for this message's hash slot
+                ServerEndPoint server = null; // Get the server specifically for this message's hash slot
+                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => (server = muxer.SelectServer(getMsg)) != null);
+
+                Assert.NotNull(server);
                 var stats = server.GetBridgeStatus(ConnectionType.Interactive);
                 Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
 


### PR DESCRIPTION
Make this a bit more resilient as the cluster changes members from other tests firing in CI.