### PR TITLE
Backlog locking fixes - more #2008 follow-up

### DIFF
--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -308,10 +308,7 @@ namespace StackExchange.Redis
                 Add(data, sb, "Queue-Awaiting-Write", "qu", bs.BacklogMessagesPending.ToString());
                 Add(data, sb, "Queue-Awaiting-Response", "qs", bs.Connection.MessagesSentAwaitingResponse.ToString());
                 Add(data, sb, "Active-Writer", "aw", bs.IsWriterActive.ToString());
-                if (bs.BacklogMessagesPending != 0)
-                {
-                    Add(data, sb, "Backlog-Writer", "bw", bs.BacklogStatus.ToString());
-                }
+                Add(data, sb, "Backlog-Writer", "bw", bs.BacklogStatus.ToString());
                 if (bs.Connection.ReadStatus != PhysicalConnection.ReadStatus.NA) Add(data, sb, "Read-State", "rs", bs.Connection.ReadStatus.ToString());
                 if (bs.Connection.WriteStatus != PhysicalConnection.WriteStatus.NA) Add(data, sb, "Write-State", "ws", bs.Connection.WriteStatus.ToString());
 

--- a/tests/StackExchange.Redis.Tests/BasicOps.cs
+++ b/tests/StackExchange.Redis.Tests/BasicOps.cs
@@ -42,7 +42,7 @@ namespace StackExchange.Redis.Tests
                     }
                 }
                 // Give it a moment to get through the pipe...they were fire and forget
-                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => 10 == (int)conn.StringGet(key));
+                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => 10 == (int)conn.StringGet(key));
                 Assert.Equal(10, (int)conn.StringGet(key));
             }
         }

--- a/tests/StackExchange.Redis.Tests/BasicOps.cs
+++ b/tests/StackExchange.Redis.Tests/BasicOps.cs
@@ -26,7 +26,7 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public void RapidDispose()
+        public async Task RapidDispose()
         {
             RedisKey key = Me();
             using (var primary = Create())
@@ -41,6 +41,8 @@ namespace StackExchange.Redis.Tests
                         secondary.GetDatabase().StringIncrement(key, flags: CommandFlags.FireAndForget);
                     }
                 }
+                // Give it a moment to get through the pipe...they were fire and forget
+                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => 10 == (int)conn.StringGet(key));
                 Assert.Equal(10, (int)conn.StringGet(key));
             }
         }

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -120,7 +120,7 @@ namespace StackExchange.Redis.Tests
                     Assert.StartsWith("Test Timeout, command=PING", ex.Message);
                     Assert.Contains("clientName: " + nameof(TimeoutException), ex.Message);
                     // Ensure our pipe numbers are in place
-                    Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
+                    Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
                     Assert.Contains("mc: 1/1/0", ex.Message);
                     Assert.Contains("serverEndpoint: " + server.EndPoint, ex.Message);
                     Assert.Contains("IOCP: ", ex.Message);
@@ -194,13 +194,13 @@ namespace StackExchange.Redis.Tests
                     // Ensure our pipe numbers are in place if they should be
                     if (hasDetail)
                     {
-                        Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
+                        Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
                         Assert.Contains($"mc: {connCount}/{completeCount}/0", ex.Message);
                         Assert.Contains("serverEndpoint: " + server.EndPoint.ToString().Replace("Unspecified/", ""), ex.Message);
                     }
                     else
                     {
-                        Assert.DoesNotContain("inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
+                        Assert.DoesNotContain("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
                         Assert.DoesNotContain($"mc: {connCount}/{completeCount}/0", ex.Message);
                         Assert.DoesNotContain("serverEndpoint: " + server.EndPoint.ToString().Replace("Unspecified/", ""), ex.Message);
                     }

--- a/tests/StackExchange.Redis.Tests/PubSubMultiserver.cs
+++ b/tests/StackExchange.Redis.Tests/PubSubMultiserver.cs
@@ -155,13 +155,13 @@ namespace StackExchange.Redis.Tests
             else
             {
                 // This subscription shouldn't be able to reconnect by flags (demanding an unavailable server)
-                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => subscription.IsConnected);
+                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
                 Assert.False(subscription.IsConnected);
                 Log("Unable to reconnect (as expected)");
 
                 // Allow connecting back to the original
                 muxer.AllowConnect = true;
-                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => subscription.IsConnected);
+                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
                 Assert.True(subscription.IsConnected);
 
                 var newServer = subscription.GetCurrentServer();


### PR DESCRIPTION
In troubleshooting these 2 tests, I realized what's happening: a really dumb placement mistake in #2008. Now, instead of locking _inside the damn lock_, it loops outside a bit cleaner and higher up. Performance wins are the same but it's a lot sander and doesn't block both the backlog and the writer for another 5 seconds. Now _only_ the thread lingers and it'll try to get the lock when running another pass, if it gets any in the next 5 seconds.