### PR TITLE
Fix for #1988 - respect SELECT missing from command map

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+- Fix [#1988](https://github.com/StackExchange/StackExchange.Redis/issues/1988): Don't issue `SELECT` commands if explicitly disabled ([#2023 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2023))
+
 ## 2.5.43
 
 - Adds: Bounds checking for `ExponentialRetry` backoff policy ([#1921 by gliljas](https://github.com/StackExchange/StackExchange.Redis/pull/1921)) 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1372,7 +1372,7 @@ namespace StackExchange.Redis
                 LastCommand = cmd;
                 bool isMasterOnly = message.IsMasterOnly();
 
-                if (isMasterOnly && ServerEndPoint.IsReplica && (ServerEndPoint.ReplicaReadOnly || !ServerEndPoint.AllowReplicaWrites))
+                if (isMasterOnly && !ServerEndPoint.SupportsPrimaryWrites)
                 {
                     throw ExceptionFactory.MasterOnly(Multiplexer.IncludeDetailInExceptions, message.Command, message, ServerEndPoint);
                 }
@@ -1447,7 +1447,10 @@ namespace StackExchange.Redis
                     case RedisCommand.UNKNOWN:
                     case RedisCommand.DISCARD:
                     case RedisCommand.EXEC:
-                        connection.SetUnknownDatabase();
+                        if (ServerEndPoint.SupportsDatabases)
+                        {
+                            connection.SetUnknownDatabase();
+                        }
                         break;
                 }
                 return WriteResult.Success;

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -573,7 +573,8 @@ namespace StackExchange.Redis
             }
             int available = serverEndpoint.Databases;
 
-            if (!serverEndpoint.HasDatabases) // only db0 is available on cluster/twemproxy/envoyproxy
+            // Only db0 is available on cluster/twemproxy/envoyproxy
+            if (!serverEndpoint.SupportsDatabases)
             {
                 if (targetDatabase != 0)
                 { // should never see this, since the API doesn't allow it; thus not too worried about ExceptionFactory


### PR DESCRIPTION
This resolves #1988 by respecting when the `SELECT` command has been disabled. It's memoized which seems  bit extreme here but that's because we're inside the lock and every op matters. Measured locally to ensure no regressions.