### PR TITLE
Allow XTRIM maxLength equal 0

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Fix [#1988](https://github.com/StackExchange/StackExchange.Redis/issues/1988): Don't issue `SELECT` commands if explicitly disabled ([#2023 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2023))
-- Adds: `ConfigurationOptions.BeforeSocketConnect` for configuring sockets between creation and connection ([#2031 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2031))
 - Fix: Allow `XTRIM` `MAXLEN` argument to be `0` ([#2030 by NicoAvanzDev](https://github.com/StackExchange/StackExchange.Redis/pull/2030))
+- Adds: `ConfigurationOptions.BeforeSocketConnect` for configuring sockets between creation and connection ([#2031 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2031))
 
 ## 2.5.43
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,7 @@
 
 - Fix [#1988](https://github.com/StackExchange/StackExchange.Redis/issues/1988): Don't issue `SELECT` commands if explicitly disabled ([#2023 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2023))
 - Adds: `ConfigurationOptions.BeforeSocketConnect` for configuring sockets between creation and connection ([#2031 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2031))
+- Fix: Allow `XTRIM` `MAXLEN` argument to be `0` ([#2030 by NicoAvanzDev](https://github.com/StackExchange/StackExchange.Redis/pull/2030))
 
 ## 2.5.43
 

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3402,9 +3402,9 @@ namespace StackExchange.Redis
 
         private Message GetStreamTrimMessage(RedisKey key, int maxLength, bool useApproximateMaxLength, CommandFlags flags)
         {
-            if (maxLength <= 0)
+            if (maxLength < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxLength), "maxLength must be greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(maxLength), "maxLength must be equal or greater than 0.");
             }
 
             var values = new RedisValue[2 + (useApproximateMaxLength ? 1 : 0)];

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3404,7 +3404,7 @@ namespace StackExchange.Redis
         {
             if (maxLength < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxLength), "maxLength must be equal or greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(maxLength), "maxLength must be equal to or greater than 0.");
             }
 
             var values = new RedisValue[2 + (useApproximateMaxLength ? 1 : 0)];


### PR DESCRIPTION
Since "XTRIM key MAXLEN 0" is allowed by Redis, it may be useful remove the coded constraint "MAXLEN > 0" in order to clean the whole stream