### PR TITLE
Add ConfigurationOptions.BeforeSocketConnect

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -100,7 +100,11 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 
 Additional code-only options:
 - ReconnectRetryPolicy (`IReconnectRetryPolicy`) - Default: `ReconnectRetryPolicy = ExponentialRetry(ConnectTimeout / 2);`
+  - Determines how often a multiplexer will try to reconnect after a failure
 - BacklogPolicy - Default: `BacklogPolicy = BacklogPolicy.Default;`
+  - Determines how commands will be queued (or not) during a disconnect, for sending when it's available again
+- BeforeSocketConnect - Default: `null`
+  - Allows modifying a `Socket` before connecting (for advanced scenarios)
 
 Tokens in the configuration string are comma-separated; any without an `=` sign are assumed to be redis server endpoints. Endpoints without an explicit port will use 6379 if ssl is not enabled, and 6380 if ssl is enabled.
 Tokens starting with `$` are taken to represent command maps, for example: `$config=cfg`.

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix [#1988](https://github.com/StackExchange/StackExchange.Redis/issues/1988): Don't issue `SELECT` commands if explicitly disabled ([#2023 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2023))
+- Adds: `ConfigurationOptions.BeforeSocketConnect` for configuring sockets between creation and connection ([#2031 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2031))
 
 ## 2.5.43
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -170,6 +171,13 @@ namespace StackExchange.Redis
             get => defaultOptions ??= DefaultOptionsProvider.GetForEndpoints(EndPoints);
             set => defaultOptions = value;
         }
+
+        /// <summary>
+        /// Allows modification of a <see cref="Socket"/> between creation and connection.
+        /// Passed in is the endpoint we're connecting to, which type of connection it is, and the socket itself.
+        /// For example, a specific local IP endpoint could be bound, linger time altered, etc.
+        /// </summary>
+        public Action<EndPoint, ConnectionType, Socket> BeforeSocketConnect { get; set; }
 
         internal Func<ConnectionMultiplexer, Action<string>, Task> AfterConnectAsync => Defaults.AfterConnectAsync;
 
@@ -557,6 +565,7 @@ namespace StackExchange.Redis
                 BacklogPolicy = backlogPolicy,
                 SslProtocols = SslProtocols,
                 checkCertificateRevocation = checkCertificateRevocation,
+                BeforeSocketConnect = BeforeSocketConnect,
             };
             foreach (var item in EndPoints)
             {

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -69,7 +69,7 @@ namespace StackExchange.Redis
         internal bool HasOutputPipe => _ioPipe?.Output != null;
 
         private Socket _socket;
-        private Socket VolatileSocket => Volatile.Read(ref _socket);
+        internal Socket VolatileSocket => Volatile.Read(ref _socket);
 
         public PhysicalConnection(PhysicalBridge bridge)
         {
@@ -96,6 +96,7 @@ namespace StackExchange.Redis
 
             Trace("Connecting...");
             _socket = SocketManager.CreateSocket(endpoint);
+            bridge.Multiplexer.RawConfig.BeforeSocketConnect?.Invoke(endpoint, bridge.ConnectionType, _socket);
             bridge.Multiplexer.OnConnecting(endpoint, bridge.ConnectionType);
             log?.WriteLine($"{Format.ToString(endpoint)}: BeginConnectAsync");
 


### PR DESCRIPTION
This adds a new config `Action` that allows modification of a socket after creating it and before connecting. It's passing the endpoint and connection type as well so if necessary per-connection options can be set.

Resolves #1472.