### PR TITLE
Add support for a credentials provider.

### DIFF
--- a/src/StackExchange.Redis/ConstantCredentialsProvider.cs
+++ b/src/StackExchange.Redis/ConstantCredentialsProvider.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StackExchange.Redis.Interfaces;
+
+namespace StackExchange.Redis
+{
+    /// <summary>
+    /// A credentials provider with constant password and user.
+    /// </summary>
+    public class ConstantCredentialsProvider : ICredentialsProvider
+    {
+        private readonly string user;
+        private readonly string password;
+
+        /// <summary>
+        /// Returns a new credentials provider with the given user and password.
+        /// </summary>
+        public ConstantCredentialsProvider(string user, string password)
+        {
+            this.user = user;
+            this.password = password;
+        }
+
+        string ICredentialsProvider.getPassword() => this.password;
+        string ICredentialsProvider.getUser() => this.user;
+
+        /// <summary>
+        /// Equality based on fields.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (obj == this)
+            {
+                return true;
+            }
+
+            var provider = obj as ConstantCredentialsProvider;
+
+            return provider != null && provider.user == this.user && provider.password == this.password;
+        }
+
+        /// <summary>
+        /// Returns a simple hash of the fields.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return this.user.GetHashCode()
+                 ^ this.password.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns an equivalent credentials provider.
+        /// </summary>
+        public object Clone() => new ConstantCredentialsProvider(user, password);
+    }
+}

--- a/src/StackExchange.Redis/Interfaces/ICredentialsProvider.cs
+++ b/src/StackExchange.Redis/Interfaces/ICredentialsProvider.cs
@@ -1,0 +1,24 @@
+﻿
+using System;
+
+namespace StackExchange.Redis.Interfaces
+{
+    /// <summary>
+    /// Describes a provider of credentials for connection authentication.
+    /// </summary>
+    public interface ICredentialsProvider : ICloneable
+    {
+
+        /// <summary>
+        /// This method returns the user name for the connection.
+        /// The returned value can potentially change time, and shouldn't be cached.
+        /// </summary>
+        string getUser();
+
+        /// <summary>
+        /// This method returns the password for the connection.
+        /// The returned value can potentially change time, and shouldn't be cached.
+        /// </summary>
+        string getPassword();
+    }
+}


### PR DESCRIPTION
This allows the client to support servers that authenticates using ephemeral passwords, that are only usable for a limited amount of time.

If a server authenticates using ephemeral passwords, such as IAM or HashiCorp Vault, the set `Password` would become eventually unusable. Even if the user modified the `Password` property externally, since the client manages authentication internally at opaque points in time, the user would have to update the password regularly, regardless of whether it was actually required or not.

This change allows the user to define and inject a credentials provider, so that new credentials will be generated when needed.