### PR TITLE
Solution: Centralized package versions and test/toy dependency updates

### DIFF
--- a/.github/.github.csproj
+++ b/.github/.github.csproj
@@ -1,5 +1,5 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/1.0.94">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.3.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
     <IncludeSymbols>false</IncludeSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IsPackable>false</IsPackable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
@@ -35,6 +36,6 @@
     <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,30 +1,5 @@
 <Project>
-  <!-- workaround for deterministic builds; see https://github.com/clairernovotny/DeterministicBuilds -->
-  <PropertyGroup>
-    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
-  </PropertyGroup>
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
-  </ItemGroup>
-  <ItemGroup>
-      <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Update="GitHubActionsTestLogger" Version="1.1.2" />
-      <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-      <PackageReference Update="Moq" Version="4.15.1" />
-      <PackageReference Update="NSubstitute" Version="4.2.2" />
-      <PackageReference Update="Pipelines.Sockets.Unofficial" Version="2.2.2" />
-      <PackageReference Update="System.Diagnostics.PerformanceCounter" Version="5.0.0" />
-      <PackageReference Update="System.IO.Compression" Version="4.3.0" />
-      <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-      <PackageReference Update="System.Threading.Channels" Version="5.0.0" />
-      <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Update="xunit" Version="2.4.1" />
-      <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
-
-      <!-- note that it is only the tests that have a dependency on this; the main lib takes the
-      transitive dependency from Pipelines.Sockets.Unofficial; this is for testing some binding
-      redirect problems (something new and different for us!) -->
-      <PackageReference Update="System.IO.Pipelines" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="Moq" Version="4.15.1" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageVersion Include="NSubstitute" Version="4.2.2" />
+    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.2" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.5.43" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="5.0.0" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    <PackageVersion Include="System.Runtime.Caching" Version="5.0.0" />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+
+    <!-- note that it is only the tests that have a dependency on this; the main lib takes the
+      transitive dependency from Pipelines.Sockets.Unofficial; this is for testing some binding
+      redirect problems (something new and different for us!) -->
+    <PackageVersion Include="System.IO.Pipelines" Version="5.0.1" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,28 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
+    <!-- Packages we depend on for StackExchange.Redis, upgrades can create binding redirect pain! -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Moq" Version="4.15.1" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.3.37" />
-    <PackageVersion Include="NSubstitute" Version="4.2.2" />
     <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.5.43" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="5.0.0" />
-    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.Runtime.Caching" Version="5.0.0" />
-    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    
+    <!-- Packages only used in the solution, upgrade at will -->
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Moq" Version="4.17.2" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.4.255" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="NSubstitute" Version="4.3.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.5.43" />
+    <!-- For binding redirect testing, main package gets this transitively -->
+    <PackageVersion Include="System.IO.Pipelines" Version="5.0.1" />
+    <PackageVersion Include="System.Runtime.Caching" Version="5.0.0" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
-
-    <!-- note that it is only the tests that have a dependency on this; the main lib takes the
-      transitive dependency from Pipelines.Sockets.Unofficial; this is for testing some binding
-      redirect problems (something new and different for us!) -->
-    <PackageVersion Include="System.IO.Pipelines" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/StackExchange.Redis.sln
+++ b/StackExchange.Redis.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.ps1 = build.ps1
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		NuGet.Config = NuGet.Config
 		README.md = README.md

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,8 +5,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>  
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" Condition=" '$(DEVCONTAINER)' != 'true' " />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" Condition=" '$(DEVCONTAINER)' != 'true' " />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/BasicTestBaseline/BasicTestBaseline.csproj
+++ b/tests/BasicTestBaseline/BasicTestBaseline.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="StackExchange.Redis" Version="[2.0.558]" />
+    <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 
 </Project>

--- a/tests/ConsoleTestBaseline/ConsoleTestBaseline.csproj
+++ b/tests/ConsoleTestBaseline/ConsoleTestBaseline.csproj
@@ -12,8 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="StackExchange.Redis" Version="1.2.6" />-->
-    <!--<PackageReference Include="StackExchange.Redis" Version="2.2.88" />-->
-    <PackageReference Include="StackExchange.Redis" Version="2.5.43" />
+    <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 </Project>

--- a/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
+++ b/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />
-    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Caching" />
   </ItemGroup>
 </Project>

--- a/toys/TestConsoleBaseline/TestConsoleBaseline.csproj
+++ b/toys/TestConsoleBaseline/TestConsoleBaseline.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="[2.0.558]" /> <!-- [1.2.6] for previous major -->
+    <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This migrates to Directory.Pacakges.props and bumps versions of things we don't want to cause binding redirect pain on.