### PR TITLE
Fix for #1813 - don't actually connect to a null endpoint

### DIFF
--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -92,6 +92,7 @@ namespace StackExchange.Redis
             if (endpoint == null)
             {
                 log?.WriteLine("No endpoint");
+                return;
             }
 
             Trace("Connecting...");


### PR DESCRIPTION
We log this, but then forgot to abort, woops. Actually bail in this case, no reason to rapidly issue sockets to nowhere.