### PR TITLE
Bug: fix ClientKill/ClientKillAsync when by ClientType

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,8 @@
 - Adds: `KEEPTTL` support on `SET` operations ([#2029 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2029))
 - Fix: Allow `XTRIM` `MAXLEN` argument to be `0` ([#2030 by NicoAvanzDev](https://github.com/StackExchange/StackExchange.Redis/pull/2030))
 - Adds: `ConfigurationOptions.BeforeSocketConnect` for configuring sockets between creation and connection ([#2031 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2031))
+- Fix [#1813](https://github.com/StackExchange/StackExchange.Redis/issues/1813): Don't connect to endpoints we failed to parse ([#2042 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2042))
+- Fix: `ClientKill`/`ClientKillAsync` when using `ClientType` ([#2048 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2048))
 
 ## 2.5.43
 

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -100,7 +100,6 @@ namespace StackExchange.Redis
                     default:
                         throw new ArgumentOutOfRangeException(nameof(clientType));
                 }
-                parts.Add(id.Value);
             }
             if (endpoint != null)
             {


### PR DESCRIPTION
This is an errant addition to client kill I guess no one tripped on for 8+ years, just happened across it in NRT deep dives.