### PR TITLE
ConfigurationOptions: allow modification after ConnectionMultiplexer start

### DIFF
--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis.Configuration
     public class DefaultOptionsProvider
     {
         /// <summary>
-        /// The known providers to match against (built into the lbirary) - the default set.
+        /// The known providers to match against (built into the library) - the default set.
         /// If none of these match, <see cref="DefaultOptionsProvider"/> is used.
         /// </summary>
         private static readonly List<DefaultOptionsProvider> BuiltInProviders = new()
@@ -108,6 +108,19 @@ namespace StackExchange.Redis.Configuration
         /// The server version to assume.
         /// </summary>
         public virtual Version DefaultVersion => RedisFeatures.v3_0_0;
+
+        /// <summary>
+        /// Should exceptions include identifiable details? (key names, additional .Data annotations)
+        /// </summary>
+        public virtual bool IncludeDetailInExceptions => true;
+
+        /// <summary>
+        /// Should exceptions include performance counter details?
+        /// </summary>
+        /// <remarks>
+        /// CPU usage, etc - note that this can be problematic on some platforms.
+        /// </remarks>
+        public virtual bool IncludePerformanceCountersInExceptions => false;
 
         /// <summary>
         /// Specifies the time interval at which connections should be pinged to ensure validity.
@@ -230,7 +243,7 @@ namespace StackExchange.Redis.Configuration
         /// Note: this setting then applies for *all* endpoints.
         /// </summary>
         /// <param name="endPoints">The configured endpoints to determine SSL usage from (e.g. from the port).</param>
-        /// <returns>Whether to enable SSL for connections (unless excplicitly overriden in a direct <see cref="ConfigurationOptions.Ssl"/> set).</returns>
+        /// <returns>Whether to enable SSL for connections (unless explicitly overridden in a direct <see cref="ConfigurationOptions.Ssl"/> set).</returns>
         public virtual bool GetDefaultSsl(EndPointCollection endPoints) => false;
 
         /// <summary>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -14,7 +14,7 @@ public partial class ConnectionMultiplexer
     internal EndPoint currentSentinelPrimaryEndPoint;
     internal Timer sentinelPrimaryReconnectTimer;
     internal Dictionary<string, ConnectionMultiplexer> sentinelConnectionChildren = new Dictionary<string, ConnectionMultiplexer>();
-    internal ConnectionMultiplexer sentinelConnection = null;
+    internal ConnectionMultiplexer sentinelConnection;
 
     /// <summary>
     /// Initializes the connection as a Sentinel connection and adds the necessary event handlers to track changes to the managed primaries.
@@ -79,7 +79,6 @@ public partial class ConnectionMultiplexer
         }
     }
 
-
     /// <summary>
     /// Create a new <see cref="ConnectionMultiplexer"/> instance that connects to a Sentinel server.
     /// </summary>
@@ -104,7 +103,7 @@ public partial class ConnectionMultiplexer
     public static ConnectionMultiplexer SentinelConnect(ConfigurationOptions configuration, TextWriter log = null)
     {
         SocketConnection.AssertDependencies();
-        return ConnectImpl(PrepareConfig(configuration, sentinel: true), log);
+        return ConnectImpl(configuration, log, ServerType.Sentinel);
     }
 
     /// <summary>
@@ -115,7 +114,7 @@ public partial class ConnectionMultiplexer
     public static Task<ConnectionMultiplexer> SentinelConnectAsync(ConfigurationOptions configuration, TextWriter log = null)
     {
         SocketConnection.AssertDependencies();
-        return ConnectImplAsync(PrepareConfig(configuration, sentinel: true), log);
+        return ConnectImplAsync(configuration, log, ServerType.Sentinel);
     }
 
     /// <summary>
@@ -243,7 +242,7 @@ public partial class ConnectionMultiplexer
         }
 
         // Perform the initial switchover
-        SwitchPrimary(RawConfig.EndPoints[0], connection, log);
+        SwitchPrimary(EndPoints[0], connection, log);
 
         return connection;
     }
@@ -368,11 +367,11 @@ public partial class ConnectionMultiplexer
                                            ?? GetReplicasForService(serviceName);
 
                 connection.servers.Clear();
-                connection.RawConfig.EndPoints.Clear();
-                connection.RawConfig.EndPoints.TryAdd(newPrimaryEndPoint);
+                connection.EndPoints.Clear();
+                connection.EndPoints.TryAdd(newPrimaryEndPoint);
                 foreach (var replicaEndPoint in replicaEndPoints)
                 {
-                    connection.RawConfig.EndPoints.TryAdd(replicaEndPoint);
+                    connection.EndPoints.TryAdd(replicaEndPoint);
                 }
                 Trace($"Switching primary to {newPrimaryEndPoint}");
                 // Trigger a reconfigure
@@ -402,16 +401,16 @@ public partial class ConnectionMultiplexer
             return;
 
         bool hasNew = false;
-        foreach (EndPoint newSentinel in firstCompleteRequest.Where(x => !RawConfig.EndPoints.Contains(x)))
+        foreach (EndPoint newSentinel in firstCompleteRequest.Where(x => !EndPoints.Contains(x)))
         {
             hasNew = true;
-            RawConfig.EndPoints.TryAdd(newSentinel);
+            EndPoints.TryAdd(newSentinel);
         }
 
         if (hasNew)
         {
             // Reconfigure the sentinel multiplexer if we added new endpoints
-            ReconfigureAsync(first: false, reconfigureAll: true, null, RawConfig.EndPoints[0], "Updating Sentinel List", false).Wait();
+            ReconfigureAsync(first: false, reconfigureAll: true, null, EndPoints[0], "Updating Sentinel List", false).Wait();
         }
     }
 }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -629,7 +629,7 @@ namespace StackExchange.Redis
             }
         }
 
-        private static ConfigurationOptions Validate(ConfigurationOptions config)
+        private static void Validate(ConfigurationOptions config)
         {
             if (config is null)
             {
@@ -639,7 +639,6 @@ namespace StackExchange.Redis
             {
                 throw new ArgumentException("No endpoints specified", nameof(config));
             }
-            return config;
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -12,6 +12,13 @@ namespace StackExchange.Redis
     /// </summary>
     public sealed class EndPointCollection : Collection<EndPoint>, IEnumerable<EndPoint>
     {
+        private static class DefaultPorts
+        {
+            public static int Standard => 6379;
+            public static int Ssl => 6380;
+            public static int Sentinel => 26379;
+        }
+
         /// <summary>
         /// Create a new <see cref="EndPointCollection"/>.
         /// </summary>
@@ -133,8 +140,14 @@ namespace StackExchange.Redis
             base.SetItem(index, item);
         }
 
-        internal void SetDefaultPorts(int defaultPort)
+        internal void SetDefaultPorts(ServerType? serverType, bool ssl = false)
         {
+            int defaultPort = serverType switch
+            {
+                ServerType.Sentinel => DefaultPorts.Sentinel,
+                _ => ssl ? DefaultPorts.Ssl : DefaultPorts.Standard,
+            };
+
             for (int i = 0; i < Count; i++)
             {
                 switch (this[i])
@@ -215,5 +228,7 @@ namespace StackExchange.Redis
                 }
             }
         }
+
+        internal EndPointCollection Clone() => new EndPointCollection(this);
     }
 }

--- a/src/StackExchange.Redis/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI.Shipped.txt
@@ -221,6 +221,10 @@ StackExchange.Redis.ConfigurationOptions.EndPoints.get -> StackExchange.Redis.En
 StackExchange.Redis.ConfigurationOptions.EndPoints.init -> void
 StackExchange.Redis.ConfigurationOptions.HighPrioritySocketThreads.get -> bool
 StackExchange.Redis.ConfigurationOptions.HighPrioritySocketThreads.set -> void
+StackExchange.Redis.ConfigurationOptions.IncludeDetailInExceptions.get -> bool
+StackExchange.Redis.ConfigurationOptions.IncludeDetailInExceptions.set -> void
+StackExchange.Redis.ConfigurationOptions.IncludePerformanceCountersInExceptions.get -> bool
+StackExchange.Redis.ConfigurationOptions.IncludePerformanceCountersInExceptions.set -> void
 StackExchange.Redis.ConfigurationOptions.KeepAlive.get -> int
 StackExchange.Redis.ConfigurationOptions.KeepAlive.set -> void
 StackExchange.Redis.ConfigurationOptions.Password.get -> string
@@ -1591,6 +1595,8 @@ virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.DefaultVersion.
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.GetDefaultClientName() -> string
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.GetDefaultSsl(StackExchange.Redis.EndPointCollection endPoints) -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.GetSslHostFromEndpoints(StackExchange.Redis.EndPointCollection endPoints) -> string
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IncludeDetailInExceptions.get -> bool
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IncludePerformanceCountersInExceptions.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IsMatch(System.Net.EndPoint endpoint) -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.KeepAliveInterval.get -> System.TimeSpan
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.Proxy.get -> StackExchange.Redis.Proxy

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -580,9 +580,9 @@ namespace StackExchange.Redis
         {
             var configuration = multiplexer.RawConfig;
 
-            if (!string.IsNullOrWhiteSpace(configuration.TieBreaker) && multiplexer.CommandMap.IsAvailable(RedisCommand.DEL))
+            if (configuration.TryGetTieBreaker(out var tieBreakerKey) && multiplexer.CommandMap.IsAvailable(RedisCommand.DEL))
             {
-                var msg = Message.Create(0, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.DEL, (RedisKey)configuration.TieBreaker);
+                var msg = Message.Create(0, CommandFlags.FireAndForget | CommandFlags.NoRedirect, RedisCommand.DEL, tieBreakerKey);
                 msg.SetInternalCall();
                 return msg;
             }

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -83,7 +83,7 @@ namespace StackExchange.Redis
         /// This is memoized because it's accessed on hot paths inside the write lock.
         /// </remarks>
         public bool SupportsDatabases =>
-            supportsDatabases ??= (serverType == ServerType.Standalone && Multiplexer.RawConfig.CommandMap.IsAvailable(RedisCommand.SELECT));
+            supportsDatabases ??= (serverType == ServerType.Standalone && Multiplexer.CommandMap.IsAvailable(RedisCommand.SELECT));
 
         public int Databases
         {
@@ -426,7 +426,7 @@ namespace StackExchange.Redis
             }
             // If we are going to fetch a tie breaker, do so last and we'll get it in before the tracer fires completing the connection
             // But if GETs are disabled on this, do not fail the connection - we just don't get tiebreaker benefits
-            if (Multiplexer.RawConfig.TryGetTieBreaker(out var tieBreakerKey) && Multiplexer.RawConfig.CommandMap.IsAvailable(RedisCommand.GET))
+            if (Multiplexer.RawConfig.TryGetTieBreaker(out var tieBreakerKey) && Multiplexer.CommandMap.IsAvailable(RedisCommand.GET))
             {
                 log?.WriteLine($"{Format.ToString(EndPoint)}: Requesting tie-break (Key=\"{tieBreakerKey}\")...");
                 msg = Message.Create(0, flags, RedisCommand.GET, tieBreakerKey);

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -426,9 +426,8 @@ namespace StackExchange.Redis
             }
             // If we are going to fetch a tie breaker, do so last and we'll get it in before the tracer fires completing the connection
             // But if GETs are disabled on this, do not fail the connection - we just don't get tiebreaker benefits
-            if (!string.IsNullOrEmpty(Multiplexer.RawConfig.TieBreaker) && Multiplexer.RawConfig.CommandMap.IsAvailable(RedisCommand.GET))
+            if (Multiplexer.RawConfig.TryGetTieBreaker(out var tieBreakerKey) && Multiplexer.RawConfig.CommandMap.IsAvailable(RedisCommand.GET))
             {
-                RedisKey tieBreakerKey = Multiplexer.RawConfig.TieBreaker;
                 log?.WriteLine($"{Format.ToString(EndPoint)}: Requesting tie-break (Key=\"{tieBreakerKey}\")...");
                 msg = Message.Create(0, flags, RedisCommand.GET, tieBreakerKey);
                 msg.SetInternalCall();

--- a/tests/StackExchange.Redis.Tests/SSL.cs
+++ b/tests/StackExchange.Redis.Tests/SSL.cs
@@ -336,11 +336,11 @@ namespace StackExchange.Redis.Tests
                 Writer.WriteLine($"Checking {all.Length} cultures...");
                 foreach (var ci in all)
                 {
-                    Writer.WriteLine("Tessting: " + ci.Name);
+                    Writer.WriteLine("Testing: " + ci.Name);
                     CultureInfo.CurrentCulture = ci;
 
-                    var a = ConnectionMultiplexer.PrepareConfig(ConfigurationOptions.Parse("myDNS:883,password=mypassword,connectRetry=3,connectTimeout=5000,syncTimeout=5000,defaultDatabase=0,ssl=true,abortConnect=false"));
-                    var b = ConnectionMultiplexer.PrepareConfig(new ConfigurationOptions
+                    var a = ConfigurationOptions.Parse("myDNS:883,password=mypassword,connectRetry=3,connectTimeout=5000,syncTimeout=5000,defaultDatabase=0,ssl=true,abortConnect=false");
+                    var b = new ConfigurationOptions
                     {
                         EndPoints = { { "myDNS", 883 } },
                         Password = "mypassword",
@@ -350,7 +350,7 @@ namespace StackExchange.Redis.Tests
                         DefaultDatabase = 0,
                         Ssl = true,
                         AbortOnConnectFail = false,
-                    });
+                    };
                     Writer.WriteLine($"computed: {b.ToString(true)}");
 
                     Writer.WriteLine("Checking endpoints...");


### PR DESCRIPTION
Overall changes:
- **Biggest**: `ConfgurationOptions` passed into a `ConnectionMultiplexer.Connect*()` method is no longer cloned. This means it can be modified after connecting and changes will take effect on the next access. For example a user can rotate passwords or change timeouts on the fly.
  - A few things like `EndPoints` _are_ cloned and memoized to `ConnectionMultiplexer` and changing them is not respected because this creates paradoxes and races in the multiplexer. These are explicitly called out in `ConfigurationOptions` docs.
- Moves `IncludeDetailInExceptions` and `IncludePerformanceCountersInExceptions` from `ConnectionMultiplexer` to `ConfigurationOptions` (with backwards compatible APIs).
  - Should we `[Obsolete]` now?
- Move to a cleaner `TryGetTieBreaker` approach instead of Sentinel defaults needing to set it.
- `SetDefaultPorts` is now more cleanly based on `ServerType` (rather than a `sentinel` bool everywhere...that felt icky.
- Config validation is centralized

TODO:
- [ ] Docs on each `ConfigurationOptions` memoized property to make clear it was copied and has no effect after connection.
- [ ] Tests exercising config changes post-connect
- [ ] Question: obsolete `ConnectionMultiplexer.IncludeDetailInExceptions` and `ConnectionMultiplexer.IncludePerformanceCountersInExceptions`?