### PR TITLE
Fix for #1520: Add support for retry on transactions for resharding

### DIFF
--- a/src/StackExchange.Redis/Exceptions.cs
+++ b/src/StackExchange.Redis/Exceptions.cs
@@ -152,6 +152,51 @@ namespace StackExchange.Redis
     }
 
     /// <summary>
+    /// Indicates an exception raised by a redis server due to a hashslot being migrated, but command had a flag set to not
+    /// allow redirects
+    /// </summary>
+    [Serializable]
+    public sealed partial class RedisHashslotMigratedAndNoRedirectException : RedisException
+    {
+        /// <summary>
+        /// The hashslot that was migrated
+        /// </summary>
+        public int HashSlot
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The new endpoint that hashslot is located on
+        /// </summary>
+        public string Endpoint
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RedisHashslotMigratedAndNoRedirectException"/>.
+        /// </summary>
+        /// <param name="message">The message for the exception.</param>
+        /// <param name="hashSlot">The hashslot that was migrated.</param>
+        /// <param name="endpoint">The endpoint where the hashslot is now located</param>
+        public RedisHashslotMigratedAndNoRedirectException(string message, int hashSlot, string endpoint) : base(message)
+        {
+            HashSlot = hashSlot;
+            Endpoint = endpoint;
+        }
+
+        /// <summary>
+        /// Returns the error message in the format MOVED [HASH_SLOT] [NEW ENDPOINT]
+        /// </summary>
+        /// <returns></returns>
+        public string GetMovedErrorMessage()
+        {
+            return CommonReplies.MOVED.ToString() + HashSlot.ToString() + " " + Endpoint;
+        }
+    }
+
+    /// <summary>
     /// Indicates an exception raised by a redis server.
     /// </summary>
     [Serializable]

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -447,7 +447,7 @@ namespace StackExchange.Redis
 
         bool ICompletable.TryComplete(bool isAsync) { Complete(); return true; }
 
-        public void Complete()
+        public virtual void Complete()
         {
             //Ensure we can never call Complete on the same resultBox from two threads by grabbing it now
             var currBox = Interlocked.Exchange(ref resultBox, null);

--- a/src/StackExchange.Redis/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
-﻿
+﻿StackExchange.Redis.RedisHashslotMigratedAndNoRedirectException
+StackExchange.Redis.RedisHashslotMigratedAndNoRedirectException.Endpoint.get -> string
+StackExchange.Redis.RedisHashslotMigratedAndNoRedirectException.GetMovedErrorMessage() -> string
+StackExchange.Redis.RedisHashslotMigratedAndNoRedirectException.HashSlot.get -> int
+StackExchange.Redis.RedisHashslotMigratedAndNoRedirectException.RedisHashslotMigratedAndNoRedirectException(string message, int hashSlot, string endpoint) -> void

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -58,6 +58,12 @@ namespace StackExchange.Redis
             return base.ExecuteAsync(msg, proc); // need base to avoid our local wrapping override
         }
 
+        internal bool ExecuteInternal(CommandFlags flags, ServerEndPoint endpoint = null)
+        {
+            var msg = CreateMessage(flags, out ResultProcessor<bool> proc);
+            return base.ExecuteSync(msg, proc, endpoint); // need base to avoid our local "not supported" override
+        }
+
         internal override Task<T> ExecuteAsync<T>(Message message, ResultProcessor<T> processor, ServerEndPoint server = null)
         {
             if (message == null) return CompletedTask<T>.Default(asyncState);

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -188,7 +188,7 @@ namespace StackExchange.Redis.Tests
                     string e = StringGet(conn.GetServer(node.EndPoint), key);
                     Assert.Equal(value, e); // wrong replica, allow redirect
 
-                    var ex = Assert.Throws<RedisServerException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
+                    var ex = Assert.Throws<RedisHashslotMigratedAndNoRedirectException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
                     Assert.StartsWith($"Key has MOVED to Endpoint {rightPrimaryNode.EndPoint} and hashslot {slot}", ex.Message);
                 }
             }

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -171,7 +171,7 @@ namespace StackExchange.Redis.Tests
                     string b = StringGet(conn.GetServer(node.EndPoint), key);
                     Assert.Equal(value, b); // wrong primary, allow redirect
 
-                    var ex = Assert.Throws<RedisServerException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
+                    var ex = Assert.Throws<RedisHashslotMigratedAndNoRedirectException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
                     Assert.StartsWith($"Key has MOVED to Endpoint {rightPrimaryNode.EndPoint} and hashslot {slot}", ex.Message);
                 }
 

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -195,7 +195,7 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public void IntentionalWrongServeronTransaction()
+        public void IntentionalWrongServerForTransaction()
         {
             static string[] TransactionalReplace(IServer server, RedisKey key, RedisValue newRedisValue, CommandFlags flags = CommandFlags.None)
             {
@@ -241,6 +241,9 @@ namespace StackExchange.Redis.Tests
                 string[] responses = TransactionalReplace(conn.GetServer(rightPrimaryNode.EndPoint), key, newValue);
                 Assert.Equal(value, responses[0]); // right primary
                 Assert.Equal(newValue, responses[1]);
+
+                db.KeyDelete(key, CommandFlags.FireAndForget);
+                db.StringSet(key, value, flags: CommandFlags.FireAndForget);
 
                 var node = config.Nodes.FirstOrDefault(x => !x.IsReplica && x.NodeId != rightPrimaryNode.NodeId);
                 Assert.NotNull(node);


### PR DESCRIPTION
A proposed solution for #1520. I ask that the proposed change be thoroughly reviewed by those who are experienced with the repo, and the Redis Transaction code in the library.

**Investigation:**
In order to investigate, I took one of the many transaction errors we saw when increasing/decreasing the number of shards in our cluster, and used the associated keys + nodes to reply the the exact same transaction using the debugger.

The error for the transaction EXEC was the same as what we saw in our logs:
```
EXECABORT Transaction discarded because of previous errors.
```
![image](https://user-images.githubusercontent.com/12927576/161442868-17216824-415d-46e9-ac7e-f4e84178763b.png)

Looking at the InnerOperations of the TransactionMessage, I was surprised to find that the ResultBox was null, and the result was already lost by the time the SetResult() for transaction message was called.
![image](https://user-images.githubusercontent.com/12927576/161443053-52320acd-b742-46e5-be75-b2cc36d7264d.png)

I eventually tracked the cause down to base Message class' Complete() method. This removed the resultbox to ensure it couldn't be called twice, but it also mean't that the result of the InnerOperations result aren't available when the transaction result is being processed.
![image](https://user-images.githubusercontent.com/12927576/161443173-18b83108-48b1-4eee-b12e-07faf2d93b43.png)

This required additional changes to ensure that the result of the InnerOperations were available to the TransactionMessage when it was processing the result, but that they were also cleaned up when the TransactionMessage itself was complete.

Digging into the ResultProcessor, also showed that it RELIED on the RawResult error message following a very particular format in order to detect, and thus retry, messages where the hashslot had been moved. 

Based on these facts, the RawResult error message had to be edited to include:
- prefix the "MOVED (HASHSLOT) (endpoint) " to the entire raw result error if we determine that the ONLY reason that the transaction failed was due to a single hashslot being moved.
- Also aggregate all the InnerOperation errors/fault messages, and append them to the existing RawResult from the EXEC call.

This required changes to the TransactionMessage and QueueMessage's lifecycle (Complete() method), relying heavily on the TransactionMessage Complete() to mark the QueueMessages actually completed.


**Important Notes:**
- I attempted to write unit tests for these changes that didn't rely on a cluster, but most of the nested classes involved are private. Changing those to internal, also revealed that many of the dependencies, such as ServerEndPoint, PhysicalBridge, PhysicalConnection... are all sealed and cannot be mocked using MOQ.
- In order to test these changes, you require a REDIS cluster that has at least two primaries. One that had keys written to it originally, then the hashslot with that key is moved to the other primary.
- I've also added/updated a functional test to cover this case.
- I noticed the "src/StackExchange.Redis/PublicAPI.Unshipped.txt", and "src/StackExchange.Redis/PublicAPI.Shipped.txt", but I'm not aware of what process you follow for moving an API from being considered Unshipped to Shipped.

Due to the challenges in testing, I resorted to the following for testing:
- Taking a transaction that had failed in our pre-production cluster due to re-sharding, and then retrying it again using these changes.
- After proving the solution worked on a smaller scale, we deployed the change to our pre-production environment, and scaled our cluster (resharding) from 25 to 30 shards, while having active traffic on the cluster.


cluster | CLUSTER | April 3 2022 17:50:50 UTC | Scaling out cluster ---- from 25 shards to 30 shards
cluster | CLUSTER | April 3 2022 18:13:00 UTC | Added node n  in availability zone <AZ>
...
cluster | CLUSTE> | April 3 2022 18:13:00 UTC | Added node n+1  in availability zone <AZ>
cluster | CLUSTER | April 3 2022 18:14:39 UTC | Migrating slots from shard 0001 to 0026 to rebalance slots
...
cluster | CLUSTER| April 3 2022 18:15:40 UTC | Moved a total of 109 slots out of 109 slots from shard 0001 to shard 0026
....

During this time we saw no errors in our logs.