### PR TITLE
Tests: move to skip by version

### DIFF
--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -38,7 +38,7 @@ namespace StackExchange.Redis
                                          v5_0_0 = new Version(5, 0, 0),
                                          v6_0_0 = new Version(6, 0, 0),
                                          v6_2_0 = new Version(6, 2, 0),
-                                         v6_9_240 = new Version(6, 9, 240); // 7.0 RC1 is version 6.9.240
+                                         v7_0_0_rc1 = new Version(6, 9, 240); // 7.0 RC1 is version 6.9.240
 
         private readonly Version version;
 
@@ -54,7 +54,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Does BITOP / BITCOUNT exist?
         /// </summary>
-        public bool BitwiseOperations => Version >= v2_5_10;
+        public bool BitwiseOperations => Version >= v2_6_0;
 
         /// <summary>
         /// Is CLIENT SETNAME available?
@@ -89,7 +89,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Does INCRBYFLOAT / HINCRBYFLOAT exist?
         /// </summary>
-        public bool IncrementFloat => Version >= v2_5_7;
+        public bool IncrementFloat => Version >= v2_6_0;
 
         /// <summary>
         /// Does INFO support sections?
@@ -139,7 +139,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Does EVAL / EVALSHA / etc exist?
         /// </summary>
-        public bool Scripting => Version >= v2_5_7;
+        public bool Scripting => Version >= v2_6_0;
 
         /// <summary>
         /// Does SET support the GET option?
@@ -159,7 +159,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Does SET allow the NX and GET options to be used together?
         /// </summary>
-        public bool SetNotExistsAndGet => Version >= v6_9_240;
+        public bool SetNotExistsAndGet => Version >= v7_0_0_rc1;
 
         /// <summary>
         /// Does SADD support variadic usage?
@@ -169,7 +169,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Is ZPOPMAX and ZPOPMIN available?
         /// </summary>
-        public bool SortedSetPop => Version >= v4_9_1;
+        public bool SortedSetPop => Version >= v5_0_0;
 
         /// <summary>
         /// Is ZRANGESTORE available?

--- a/tests/StackExchange.Redis.Tests/Databases.cs
+++ b/tests/StackExchange.Redis.Tests/Databases.cs
@@ -91,7 +91,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.SwapDB), r => r.SwapDB);
+                Skip.IfBelow(muxer, RedisFeatures.v4_0_0);
 
                 RedisKey key = Me();
                 var db0id = TestConfig.GetDedicatedDB(muxer);
@@ -127,7 +127,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.SwapDB), r => r.SwapDB);
+                Skip.IfBelow(muxer, RedisFeatures.v4_0_0);
 
                 RedisKey key = Me();
                 var db0id = TestConfig.GetDedicatedDB(muxer);

--- a/tests/StackExchange.Redis.Tests/GeoTests.cs
+++ b/tests/StackExchange.Redis.Tests/GeoTests.cs
@@ -22,7 +22,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -50,7 +50,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -69,7 +69,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -95,7 +95,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -116,7 +116,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -139,7 +139,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -185,7 +185,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Geo), r => r.Geo);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
                 var db = conn.GetDatabase();
                 RedisKey key = Me();
                 db.KeyDelete(key, CommandFlags.FireAndForget);

--- a/tests/StackExchange.Redis.Tests/Hashes.cs
+++ b/tests/StackExchange.Redis.Tests/Hashes.cs
@@ -44,7 +44,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.Scan), r => r.Scan);
+                Skip.IfBelow(muxer, RedisFeatures.v2_8_0);
+
                 var conn = muxer.GetDatabase();
                 var key = Me();
                 await conn.KeyDeleteAsync(key);
@@ -92,7 +93,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.Scan), r => r.Scan);
+                Skip.IfBelow(muxer, RedisFeatures.v2_8_0);
+
                 var conn = muxer.GetDatabase();
 
                 var key = Me();
@@ -146,7 +148,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.IncrementFloat), r => r.IncrementFloat);
+                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
                 var conn = muxer.GetDatabase();
                 var key = Me();
                 _ = conn.KeyDeleteAsync(key).ForAwait();

--- a/tests/StackExchange.Redis.Tests/Keys.cs
+++ b/tests/StackExchange.Redis.Tests/Keys.cs
@@ -205,7 +205,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.KeyTouch), r => r.KeyTouch);
+                Skip.IfBelow(muxer, RedisFeatures.v3_2_1);
 
                 RedisKey key = Me();
                 var db = muxer.GetDatabase();
@@ -249,7 +249,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.KeyTouch), r => r.KeyTouch);
+                Skip.IfBelow(muxer, RedisFeatures.v3_2_1);
 
                 RedisKey key = Me();
                 var db = muxer.GetDatabase();

--- a/tests/StackExchange.Redis.Tests/Lists.cs
+++ b/tests/StackExchange.Redis.Tests/Lists.cs
@@ -86,7 +86,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.PushMultiple), f => f.PushMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var db = conn.GetDatabase();
                 RedisKey key = "testlist";
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -156,7 +156,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.PushMultiple), f => f.PushMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var db = conn.GetDatabase();
                 RedisKey key = "testlist";
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -226,7 +226,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.PushMultiple), f => f.PushMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var db = conn.GetDatabase();
                 RedisKey key = "testlist";
                 db.KeyDelete(key, CommandFlags.FireAndForget);
@@ -296,7 +296,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.PushMultiple), f => f.PushMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var db = conn.GetDatabase();
                 RedisKey key = "testlist";
                 db.KeyDelete(key, CommandFlags.FireAndForget);

--- a/tests/StackExchange.Redis.Tests/Memory.cs
+++ b/tests/StackExchange.Redis.Tests/Memory.cs
@@ -14,7 +14,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Memory), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
                 string? doctor = server.MemoryDoctor();
                 Assert.NotNull(doctor);
@@ -31,7 +31,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Memory), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
                 server.MemoryPurge();
                 await server.MemoryPurgeAsync();
@@ -45,7 +45,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Memory), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
 
                 var stats = server.MemoryAllocatorStats();
@@ -61,7 +61,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Memory), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
                 var stats = server.MemoryStats();
                 Assert.NotNull(stats);

--- a/tests/StackExchange.Redis.Tests/Scans.cs
+++ b/tests/StackExchange.Redis.Tests/Scans.cs
@@ -104,8 +104,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create(allowAdmin: true))
             {
-                // only goes up to 3.*, so...
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scan), x => x.Scan);
+                Skip.IfBelow(conn, RedisFeatures.v2_8_0);
+
                 var dbId = TestConfig.GetDedicatedDB(conn);
                 var db = conn.GetDatabase(dbId);
                 var prefix = Me();

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -20,7 +20,7 @@ namespace StackExchange.Redis.Tests
             if (Debugger.IsAttached) syncTimeout = 500000;
             var muxer = Create(allowAdmin: allowAdmin, syncTimeout: syncTimeout);
 
-            Skip.IfMissingFeature(muxer, nameof(RedisFeatures.Scripting), r => r.Scripting);
+            Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
             return muxer;
         }
 
@@ -388,7 +388,8 @@ return timeTaken
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 RedisValue newId = Guid.NewGuid().ToString();
                 RedisKey key = Me();
                 var db = conn.GetDatabase();
@@ -414,7 +415,8 @@ return timeTaken
             using (var conn0 = Create(allowAdmin: true))
             using (var conn1 = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn0, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn0, RedisFeatures.v2_6_0);
+
                 // note that these are on different connections (so we wouldn't expect
                 // the flush to drop the local cache - assume it is a surprise!)
                 var server = conn0.GetServer(TestConfig.Current.PrimaryServerAndPort);
@@ -465,7 +467,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -516,7 +519,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -546,7 +550,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -602,7 +607,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -656,7 +662,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -686,7 +693,8 @@ return timeTaken
             const string Script = "redis.call('set', @key, 'hello@example')";
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -722,7 +730,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -779,7 +788,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
                 server.ScriptFlush();
 
@@ -852,7 +862,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var script = LuaScript.Prepare(Script);
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -876,7 +887,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var script = LuaScript.Prepare(Script);
                 var server = conn.GetServer(conn.GetEndPoints()[0]);
                 var db = conn.GetDatabase();
@@ -917,7 +929,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var db = conn.GetDatabase();
                 var wrappedDb = db.WithKeyPrefix("prefix-");
                 var key = Me();
@@ -943,7 +956,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var db = conn.GetDatabase();
                 var wrappedDb = db.WithKeyPrefix("prefix-");
                 var key = Me();
@@ -969,7 +983,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var db = conn.GetDatabase();
                 var wrappedDb = db.WithKeyPrefix("prefix2-");
                 var key = Me();
@@ -996,7 +1011,8 @@ return timeTaken
 
             using (var conn = Create(allowAdmin: true))
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Scripting), f => f.Scripting);
+                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+
                 var db = conn.GetDatabase();
                 var wrappedDb = db.WithKeyPrefix("prefix2-");
                 var key = Me();

--- a/tests/StackExchange.Redis.Tests/Sets.cs
+++ b/tests/StackExchange.Redis.Tests/Sets.cs
@@ -61,7 +61,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SetPopMultiple), r => r.SetPopMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -117,7 +117,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SetPopMultiple), r => r.SetPopMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -232,7 +232,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SetPopMultiple), r => r.SetPopMultiple);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();

--- a/tests/StackExchange.Redis.Tests/SortedSets.cs
+++ b/tests/StackExchange.Redis.Tests/SortedSets.cs
@@ -57,7 +57,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetPop), r => r.SortedSetPop);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -83,7 +83,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetPop), r => r.SortedSetPop);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -108,7 +108,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetPop), r => r.SortedSetPop);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -134,7 +134,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetPop), r => r.SortedSetPop);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -159,7 +159,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetPop), r => r.SortedSetPop);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var key = Me();
@@ -181,7 +181,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByRankAsync()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
             var db = conn.GetDatabase();
             var me = Me();
             var sourceKey = $"{me}:ZSetSource";
@@ -197,7 +197,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByRankLimitedAsync()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -219,7 +219,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByScoreAsync()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -241,7 +241,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByScoreAsyncDefault()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -263,7 +263,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByScoreAsyncLimited()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -285,7 +285,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByScoreAsyncExclusiveRange()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -307,7 +307,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByScoreAsyncReverse()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -329,7 +329,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByLexAsync()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -351,7 +351,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByLexExclusiveRangeAsync()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -373,7 +373,7 @@ namespace StackExchange.Redis.Tests
         public async Task SortedSetRangeStoreByLexRevRangeAsync()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -395,7 +395,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByRank()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -412,7 +412,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByRankLimited()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -434,7 +434,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByScore()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -456,7 +456,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByScoreDefault()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -478,7 +478,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByScoreLimited()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -500,7 +500,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByScoreExclusiveRange()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -522,7 +522,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByScoreReverse()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -544,7 +544,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByLex()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -566,7 +566,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByLexExclusiveRange()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -588,7 +588,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreByLexRevRange()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -610,7 +610,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreFailErroneousTake()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();
@@ -627,7 +627,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRangeStoreFailExclude()
         {
             using var conn = Create();
-            Skip.IfMissingFeature(conn, nameof(RedisFeatures.SortedSetRangeStore), r=> r.SortedSetRangeStore);
+            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
 
             var db = conn.GetDatabase();
             var me = Me();

--- a/tests/StackExchange.Redis.Tests/Streams.cs
+++ b/tests/StackExchange.Redis.Tests/Streams.cs
@@ -17,9 +17,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
                 var key = GetUniqueKey("type_check");
-
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
 
                 var db = conn.GetDatabase();
                 db.StreamAdd(key, "field1", "value1");
@@ -35,7 +34,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var messageId = db.StreamAdd(GetUniqueKey("auto_id"), "field1", "value1");
@@ -49,7 +48,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var key = GetUniqueKey("multiple_value_pairs");
 
@@ -84,7 +83,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 var messageId = db.StreamAdd(key, "field1", "value1", id);
@@ -101,7 +100,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -130,7 +129,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -164,7 +163,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -189,7 +188,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -210,7 +209,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -235,7 +234,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -256,7 +255,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -282,7 +281,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -308,7 +307,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -333,7 +332,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -363,7 +362,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -406,7 +405,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -457,7 +456,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -511,7 +510,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -553,7 +552,7 @@ namespace StackExchange.Redis.Tests
             var stream2 = GetUniqueKey("stream2b");
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -589,7 +588,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -632,7 +631,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -673,7 +672,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -699,7 +698,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -727,7 +726,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -769,7 +768,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -810,7 +809,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -847,7 +846,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -882,7 +881,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -913,7 +912,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -937,7 +936,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -965,7 +964,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 db.KeyDelete(key);
@@ -1015,7 +1014,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1048,7 +1047,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1074,7 +1073,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1101,7 +1100,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1122,7 +1121,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1184,7 +1183,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1209,7 +1208,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1236,7 +1235,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1268,7 +1267,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var streamPositions = new []
                 {
@@ -1288,7 +1287,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(key, "0-0", 0));
@@ -1300,7 +1299,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 Assert.Throws<ArgumentNullException>(() => db.StreamRead(null!));
@@ -1312,7 +1311,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1330,7 +1329,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1370,7 +1369,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1408,7 +1407,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1443,7 +1442,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1473,7 +1472,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1495,7 +1494,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1517,7 +1516,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1541,7 +1540,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1562,7 +1561,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1584,7 +1583,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1605,7 +1604,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1628,7 +1627,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1653,7 +1652,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1678,7 +1677,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1699,7 +1698,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 await db.StreamAddAsync(key, "field", "value", maxLength: 10, useApproximateMaxLength: true, flags: CommandFlags.None).ConfigureAwait(false);
@@ -1713,7 +1712,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
                 db.StreamAdd(key, "field", "value", maxLength: 10, useApproximateMaxLength: true, flags: CommandFlags.None);
@@ -1729,7 +1728,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1760,7 +1759,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 
@@ -1800,7 +1799,7 @@ namespace StackExchange.Redis.Tests
 
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
 
                 var db = conn.GetDatabase();
 

--- a/tests/StackExchange.Redis.Tests/Strings.cs
+++ b/tests/StackExchange.Redis.Tests/Strings.cs
@@ -192,7 +192,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.GetDelete), r => r.GetDelete);
+                Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
 
                 var conn = muxer.GetDatabase();
                 var prefix = Me();
@@ -217,7 +217,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.GetDelete), r => r.GetDelete);
+                Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
 
                 var conn = muxer.GetDatabase();
                 var prefix = Me();
@@ -279,7 +279,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.SetKeepTtl), r => r.SetKeepTtl);
+                Skip.IfBelow(muxer, RedisFeatures.v6_0_0);
 
                 var conn = muxer.GetDatabase();
                 var prefix = Me();
@@ -320,7 +320,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.SetAndGet), r => r.SetAndGet);
+                Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
 
                 var conn = muxer.GetDatabase();
                 var prefix = Me();
@@ -391,7 +391,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.SetNotExistsAndGet), r => r.SetNotExistsAndGet);
+                Skip.IfBelow(muxer, RedisFeatures.v7_0_0_rc1);
 
                 var conn = muxer.GetDatabase();
                 var prefix = Me();
@@ -424,7 +424,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.StringSetRange), r => r.StringSetRange);
+                Skip.IfBelow(muxer, RedisFeatures.v2_1_8);
                 var conn = muxer.GetDatabase();
                 var key = Me();
 
@@ -473,7 +473,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.IncrementFloat), r => r.IncrementFloat);
+                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
                 var conn = muxer.GetDatabase();
                 var key = Me();
                 conn.KeyDelete(key, CommandFlags.FireAndForget);
@@ -521,7 +521,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.BitwiseOperations), r => r.BitwiseOperations);
+                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
 
                 var conn = muxer.GetDatabase();
                 var key = Me();
@@ -541,7 +541,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.BitwiseOperations), r => r.BitwiseOperations);
+                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
+
                 var conn = muxer.GetDatabase();
                 var prefix = Me();
                 var key1 = prefix + "1";
@@ -591,7 +592,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.HashStringLength), r => r.HashStringLength);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
+
                 var database = conn.GetDatabase();
                 var key = Me();
                 const string value = "hello world";
@@ -608,7 +610,8 @@ namespace StackExchange.Redis.Tests
         {
             using (var conn = Create())
             {
-                Skip.IfMissingFeature(conn, nameof(RedisFeatures.HashStringLength), r => r.HashStringLength);
+                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
+
                 var database = conn.GetDatabase();
                 var key = Me();
                 const string value = "hello world";

--- a/tests/StackExchange.Redis.Tests/Transactions.cs
+++ b/tests/StackExchange.Redis.Tests/Transactions.cs
@@ -1110,7 +1110,7 @@ namespace StackExchange.Redis.Tests
         {
             using (var muxer = Create())
             {
-                Skip.IfMissingFeature(muxer, nameof(RedisFeatures.Streams), r => r.Streams);
+                Skip.IfBelow(muxer, RedisFeatures.v5_0_0);
 
                 RedisKey key = Me(), key2 = Me() + "2";
                 var db = muxer.GetDatabase();


### PR DESCRIPTION
This should again make PRs more straightforward by having 1 way to do things, and doesn't leave us appending kind of random surface area to `RedisFeatures`.

Also tidies up a few `RedisFeatures` versions to be what docs reflect.