### PR TITLE
Tests: normalize all the things

### DIFF
--- a/tests/StackExchange.Redis.Tests/AdhocTests.cs
+++ b/tests/StackExchange.Redis.Tests/AdhocTests.cs
@@ -1,34 +1,31 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class AdhocTests : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class AdhocTests : TestBase
+    public AdhocTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public void TestAdhocCommandsAPI()
     {
-        public AdhocTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
+        var db = conn.GetDatabase();
 
-        [Fact]
-        public void TestAdhocCommandsAPI()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
+        // needs explicit RedisKey type for key-based
+        // sharding to work; will still work with strings,
+        // but no key-based sharding support
+        RedisKey key = Me();
 
-                // needs explicit RedisKey type for key-based
-                // sharding to work; will still work with strings,
-                // but no key-based sharding support
-                RedisKey key = Me();
+        // note: if command renames are configured in
+        // the API, they will still work automatically 
+        db.Execute("del", key);
+        db.Execute("set", key, "12");
+        db.Execute("incrby", key, 4);
+        int i = (int)db.Execute("get", key);
 
-                // note: if command renames are configured in
-                // the API, they will still work automatically 
-                db.Execute("del", key);
-                db.Execute("set", key, "12");
-                db.Execute("incrby", key, 4);
-                int i = (int)db.Execute("get", key);
-
-                Assert.Equal(16, i);
-            }
-        }
+        Assert.Equal(16, i);
     }
 }

--- a/tests/StackExchange.Redis.Tests/AggresssiveTests.cs
+++ b/tests/StackExchange.Redis.Tests/AggresssiveTests.cs
@@ -3,321 +3,312 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class AggresssiveTests : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class AggresssiveTests : TestBase
+    public AggresssiveTests(ITestOutputHelper output) : base(output) { }
+
+    [FactLongRunning]
+    public async Task ParallelTransactionsWithConditions()
     {
-        public AggresssiveTests(ITestOutputHelper output) : base(output) { }
+        const int Muxers = 4, Workers = 20, PerThread = 250;
 
-        [FactLongRunning]
-        public async Task ParallelTransactionsWithConditions()
+        var muxers = new IConnectionMultiplexer[Muxers];
+        try
         {
-            const int Muxers = 4, Workers = 20, PerThread = 250;
+            for (int i = 0; i < Muxers; i++)
+                muxers[i] = Create();
 
-            var muxers = new IConnectionMultiplexer[Muxers];
-            try
+            RedisKey hits = Me(), trigger = Me() + "3";
+            int expectedSuccess = 0;
+
+            await muxers[0].GetDatabase().KeyDeleteAsync(new[] { hits, trigger }).ForAwait();
+
+            Task[] tasks = new Task[Workers];
+            for (int i = 0; i < tasks.Length; i++)
             {
-                for (int i = 0; i < Muxers; i++)
-                    muxers[i] = Create();
-
-                RedisKey hits = Me(), trigger = Me() + "3";
-                int expectedSuccess = 0;
-
-                await muxers[0].GetDatabase().KeyDeleteAsync(new[] { hits, trigger }).ForAwait();
-
-                Task[] tasks = new Task[Workers];
-                for (int i = 0; i < tasks.Length; i++)
+                var scopedDb = muxers[i % Muxers].GetDatabase();
+                tasks[i] = Task.Run(async () =>
                 {
-                    var scopedDb = muxers[i % Muxers].GetDatabase();
-                    tasks[i] = Task.Run(async () =>
+                    for (int j = 0; j < PerThread; j++)
                     {
-                        for (int j = 0; j < PerThread; j++)
+                        var oldVal = await scopedDb.StringGetAsync(trigger).ForAwait();
+                        var tran = scopedDb.CreateTransaction();
+                        tran.AddCondition(Condition.StringEqual(trigger, oldVal));
+                        var x = tran.StringIncrementAsync(trigger);
+                        var y = tran.StringIncrementAsync(hits);
+                        if (await tran.ExecuteAsync().ForAwait())
                         {
-                            var oldVal = await scopedDb.StringGetAsync(trigger).ForAwait();
-                            var tran = scopedDb.CreateTransaction();
-                            tran.AddCondition(Condition.StringEqual(trigger, oldVal));
-                            var x = tran.StringIncrementAsync(trigger);
-                            var y = tran.StringIncrementAsync(hits);
-                            if (await tran.ExecuteAsync().ForAwait())
-                            {
-                                Interlocked.Increment(ref expectedSuccess);
-                                await x;
-                                await y;
-                            }
-                            else
-                            {
-                                await Assert.ThrowsAsync<TaskCanceledException>(() => x).ForAwait();
-                                await Assert.ThrowsAsync<TaskCanceledException>(() => y).ForAwait();
-                            }
+                            Interlocked.Increment(ref expectedSuccess);
+                            await x;
+                            await y;
                         }
-                    });
-                }
-                for (int i = tasks.Length - 1; i >= 0; i--)
-                {
-                    await tasks[i];
-                }
-                var actual = (int)await muxers[0].GetDatabase().StringGetAsync(hits).ForAwait();
-                Assert.Equal(expectedSuccess, actual);
-                Writer.WriteLine($"success: {actual} out of {Workers * PerThread} attempts");
+                        else
+                        {
+                            await Assert.ThrowsAsync<TaskCanceledException>(() => x).ForAwait();
+                            await Assert.ThrowsAsync<TaskCanceledException>(() => y).ForAwait();
+                        }
+                    }
+                });
             }
-            finally
+            for (int i = tasks.Length - 1; i >= 0; i--)
             {
-                for (int i = 0; i < muxers.Length; i++)
-                {
-                    try { muxers[i]?.Dispose(); }
-                    catch { /* Don't care */ }
-                }
+                await tasks[i];
+            }
+            var actual = (int)await muxers[0].GetDatabase().StringGetAsync(hits).ForAwait();
+            Assert.Equal(expectedSuccess, actual);
+            Writer.WriteLine($"success: {actual} out of {Workers * PerThread} attempts");
+        }
+        finally
+        {
+            for (int i = 0; i < muxers.Length; i++)
+            {
+                try { muxers[i]?.Dispose(); }
+                catch { /* Don't care */ }
+            }
+        }
+    }
+
+    private const int IterationCount = 5000, InnerCount = 20;
+
+    [FactLongRunning]
+    public void RunCompetingBatchesOnSameMuxer()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+
+        Thread x = new Thread(state => BatchRunPings((IDatabase)state!))
+        {
+            Name = nameof(BatchRunPings)
+        };
+        Thread y = new Thread(state => BatchRunIntegers((IDatabase)state!))
+        {
+            Name = nameof(BatchRunIntegers)
+        };
+
+        x.Start(db);
+        y.Start(db);
+        x.Join();
+        y.Join();
+
+        Writer.WriteLine(conn.GetCounters().Interactive);
+    }
+
+    private void BatchRunIntegers(IDatabase db)
+    {
+        var key = Me();
+        db.KeyDelete(key);
+        db.StringSet(key, 1);
+        Task[] tasks = new Task[InnerCount];
+        for(int i = 0; i < IterationCount; i++)
+        {
+            var batch = db.CreateBatch();
+            for (int j = 0; j < tasks.Length; j++)
+            {
+                tasks[j] = batch.StringIncrementAsync(key);
+            }
+            batch.Execute();
+            db.Multiplexer.WaitAll(tasks);
+        }
+
+        var count = (long)db.StringGet(key);
+        Writer.WriteLine($"tally: {count}");
+    }
+
+    private static void BatchRunPings(IDatabase db)
+    {
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
+        {
+            var batch = db.CreateBatch();
+            for (int j = 0; j < tasks.Length; j++)
+            {
+                tasks[j] = batch.PingAsync();
+            }
+            batch.Execute();
+            db.Multiplexer.WaitAll(tasks);
+        }
+    }
+
+    [FactLongRunning]
+    public async Task RunCompetingBatchesOnSameMuxerAsync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+
+        var x = Task.Run(() => BatchRunPingsAsync(db));
+        var y = Task.Run(() => BatchRunIntegersAsync(db));
+
+        await x;
+        await y;
+
+        Writer.WriteLine(conn.GetCounters().Interactive);
+    }
+
+    private async Task BatchRunIntegersAsync(IDatabase db)
+    {
+        var key = Me();
+        await db.KeyDeleteAsync(key).ForAwait();
+        await db.StringSetAsync(key, 1).ForAwait();
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
+        {
+            var batch = db.CreateBatch();
+            for (int j = 0; j < tasks.Length; j++)
+            {
+                tasks[j] = batch.StringIncrementAsync(key);
+            }
+            batch.Execute();
+            for(int j = tasks.Length - 1; j >= 0;j--)
+            {
+                await tasks[j];
             }
         }
 
-        private const int IterationCount = 5000, InnerCount = 20;
+        var count = (long)await db.StringGetAsync(key).ForAwait();
+        Writer.WriteLine($"tally: {count}");
+    }
 
-        [FactLongRunning]
-        public void RunCompetingBatchesOnSameMuxer()
+    private static async Task BatchRunPingsAsync(IDatabase db)
+    {
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
         {
-            using (var muxer = Create())
+            var batch = db.CreateBatch();
+            for (int j = 0; j < tasks.Length; j++)
             {
-                var db = muxer.GetDatabase();
+                tasks[j] = batch.PingAsync();
+            }
+            batch.Execute();
+            for (int j = tasks.Length - 1; j >= 0; j--)
+            {
+                await tasks[j];
+            }
+        }
+    }
 
-                Thread x = new Thread(state => BatchRunPings((IDatabase)state!))
-                {
-                    Name = nameof(BatchRunPings)
-                };
-                Thread y = new Thread(state => BatchRunIntegers((IDatabase)state!))
-                {
-                    Name = nameof(BatchRunIntegers)
-                };
+    [FactLongRunning]
+    public void RunCompetingTransactionsOnSameMuxer()
+    {
+        using var conn = Create(logTransactionData: false);
+        var db = conn.GetDatabase();
 
-                x.Start(db);
-                y.Start(db);
-                x.Join();
-                y.Join();
+        Thread x = new Thread(state => TranRunPings((IDatabase)state!))
+        {
+            Name = nameof(BatchRunPings)
+        };
+        Thread y = new Thread(state => TranRunIntegers((IDatabase)state!))
+        {
+            Name = nameof(BatchRunIntegers)
+        };
 
-                Writer.WriteLine(muxer.GetCounters().Interactive);
+        x.Start(db);
+        y.Start(db);
+        x.Join();
+        y.Join();
+
+        Writer.WriteLine(conn.GetCounters().Interactive);
+    }
+
+    private void TranRunIntegers(IDatabase db)
+    {
+        var key = Me();
+        db.KeyDelete(key);
+        db.StringSet(key, 1);
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
+        {
+            var batch = db.CreateTransaction();
+            batch.AddCondition(Condition.KeyExists(key));
+            for (int j = 0; j < tasks.Length; j++)
+            {
+                tasks[j] = batch.StringIncrementAsync(key);
+            }
+            batch.Execute();
+            db.Multiplexer.WaitAll(tasks);
+        }
+
+        var count = (long)db.StringGet(key);
+        Writer.WriteLine($"tally: {count}");
+    }
+
+    private static void TranRunPings(IDatabase db)
+    {
+        var key = Me();
+        db.KeyDelete(key);
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
+        {
+            var batch = db.CreateTransaction();
+            batch.AddCondition(Condition.KeyNotExists(key));
+            for (int j = 0; j < tasks.Length; j++)
+            {
+                tasks[j] = batch.PingAsync();
+            }
+            batch.Execute();
+            db.Multiplexer.WaitAll(tasks);
+        }
+    }
+
+    [FactLongRunning]
+    public async Task RunCompetingTransactionsOnSameMuxerAsync()
+    {
+        using var conn = Create(logTransactionData: false);
+        var db = conn.GetDatabase();
+
+        var x = Task.Run(() => TranRunPingsAsync(db));
+        var y = Task.Run(() => TranRunIntegersAsync(db));
+
+        await x;
+        await y;
+
+        Writer.WriteLine(conn.GetCounters().Interactive);
+    }
+
+    private async Task TranRunIntegersAsync(IDatabase db)
+    {
+        var key = Me();
+        await db.KeyDeleteAsync(key).ForAwait();
+        await db.StringSetAsync(key, 1).ForAwait();
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
+        {
+            var batch = db.CreateTransaction();
+            batch.AddCondition(Condition.KeyExists(key));
+            for (int j = 0; j < tasks.Length; j++)
+            {
+                tasks[j] = batch.StringIncrementAsync(key);
+            }
+            await batch.ExecuteAsync().ForAwait();
+            for (int j = tasks.Length - 1; j >= 0; j--)
+            {
+                await tasks[j];
             }
         }
 
-        private void BatchRunIntegers(IDatabase db)
+        var count = (long)await db.StringGetAsync(key).ForAwait();
+        Writer.WriteLine($"tally: {count}");
+    }
+
+    private static async Task TranRunPingsAsync(IDatabase db)
+    {
+        var key = Me();
+        db.KeyDelete(key);
+        Task[] tasks = new Task[InnerCount];
+        for (int i = 0; i < IterationCount; i++)
         {
-            var key = Me();
-            db.KeyDelete(key);
-            db.StringSet(key, 1);
-            Task[] tasks = new Task[InnerCount];
-            for(int i = 0; i < IterationCount; i++)
+            var batch = db.CreateTransaction();
+            batch.AddCondition(Condition.KeyNotExists(key));
+            for (int j = 0; j < tasks.Length; j++)
             {
-                var batch = db.CreateBatch();
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.StringIncrementAsync(key);
-                }
-                batch.Execute();
-                db.Multiplexer.WaitAll(tasks);
+                tasks[j] = batch.PingAsync();
             }
-
-            var count = (long)db.StringGet(key);
-            Writer.WriteLine($"tally: {count}");
-        }
-
-        private static void BatchRunPings(IDatabase db)
-        {
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
+            await batch.ExecuteAsync().ForAwait();
+            for (int j = tasks.Length - 1; j >= 0; j--)
             {
-                var batch = db.CreateBatch();
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.PingAsync();
-                }
-                batch.Execute();
-                db.Multiplexer.WaitAll(tasks);
-            }
-        }
-
-        [FactLongRunning]
-        public async Task RunCompetingBatchesOnSameMuxerAsync()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-
-                var x = Task.Run(() => BatchRunPingsAsync(db));
-                var y = Task.Run(() => BatchRunIntegersAsync(db));
-
-                await x;
-                await y;
-
-                Writer.WriteLine(muxer.GetCounters().Interactive);
-            }
-        }
-
-        private async Task BatchRunIntegersAsync(IDatabase db)
-        {
-            var key = Me();
-            await db.KeyDeleteAsync(key).ForAwait();
-            await db.StringSetAsync(key, 1).ForAwait();
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
-            {
-                var batch = db.CreateBatch();
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.StringIncrementAsync(key);
-                }
-                batch.Execute();
-                for(int j = tasks.Length - 1; j >= 0;j--)
-                {
-                    await tasks[j];
-                }
-            }
-
-            var count = (long)await db.StringGetAsync(key).ForAwait();
-            Writer.WriteLine($"tally: {count}");
-        }
-
-        private static async Task BatchRunPingsAsync(IDatabase db)
-        {
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
-            {
-                var batch = db.CreateBatch();
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.PingAsync();
-                }
-                batch.Execute();
-                for (int j = tasks.Length - 1; j >= 0; j--)
-                {
-                    await tasks[j];
-                }
-            }
-        }
-
-        [FactLongRunning]
-        public void RunCompetingTransactionsOnSameMuxer()
-        {
-            using (var muxer = Create(logTransactionData: false))
-            {
-                var db = muxer.GetDatabase();
-
-                Thread x = new Thread(state => TranRunPings((IDatabase)state!))
-                {
-                    Name = nameof(BatchRunPings)
-                };
-                Thread y = new Thread(state => TranRunIntegers((IDatabase)state!))
-                {
-                    Name = nameof(BatchRunIntegers)
-                };
-
-                x.Start(db);
-                y.Start(db);
-                x.Join();
-                y.Join();
-
-                Writer.WriteLine(muxer.GetCounters().Interactive);
-            }
-        }
-
-        private void TranRunIntegers(IDatabase db)
-        {
-            var key = Me();
-            db.KeyDelete(key);
-            db.StringSet(key, 1);
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
-            {
-                var batch = db.CreateTransaction();
-                batch.AddCondition(Condition.KeyExists(key));
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.StringIncrementAsync(key);
-                }
-                batch.Execute();
-                db.Multiplexer.WaitAll(tasks);
-            }
-
-            var count = (long)db.StringGet(key);
-            Writer.WriteLine($"tally: {count}");
-        }
-
-        private static void TranRunPings(IDatabase db)
-        {
-            var key = Me();
-            db.KeyDelete(key);
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
-            {
-                var batch = db.CreateTransaction();
-                batch.AddCondition(Condition.KeyNotExists(key));
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.PingAsync();
-                }
-                batch.Execute();
-                db.Multiplexer.WaitAll(tasks);
-            }
-        }
-
-        [FactLongRunning]
-        public async Task RunCompetingTransactionsOnSameMuxerAsync()
-        {
-            using (var muxer = Create(logTransactionData: false))
-            {
-                var db = muxer.GetDatabase();
-
-                var x = Task.Run(() => TranRunPingsAsync(db));
-                var y = Task.Run(() => TranRunIntegersAsync(db));
-
-                await x;
-                await y;
-
-                Writer.WriteLine(muxer.GetCounters().Interactive);
-            }
-        }
-
-        private async Task TranRunIntegersAsync(IDatabase db)
-        {
-            var key = Me();
-            await db.KeyDeleteAsync(key).ForAwait();
-            await db.StringSetAsync(key, 1).ForAwait();
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
-            {
-                var batch = db.CreateTransaction();
-                batch.AddCondition(Condition.KeyExists(key));
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.StringIncrementAsync(key);
-                }
-                await batch.ExecuteAsync().ForAwait();
-                for (int j = tasks.Length - 1; j >= 0; j--)
-                {
-                    await tasks[j];
-                }
-            }
-
-            var count = (long)await db.StringGetAsync(key).ForAwait();
-            Writer.WriteLine($"tally: {count}");
-        }
-
-        private static async Task TranRunPingsAsync(IDatabase db)
-        {
-            var key = Me();
-            db.KeyDelete(key);
-            Task[] tasks = new Task[InnerCount];
-            for (int i = 0; i < IterationCount; i++)
-            {
-                var batch = db.CreateTransaction();
-                batch.AddCondition(Condition.KeyNotExists(key));
-                for (int j = 0; j < tasks.Length; j++)
-                {
-                    tasks[j] = batch.PingAsync();
-                }
-                await batch.ExecuteAsync().ForAwait();
-                for (int j = tasks.Length - 1; j >= 0; j--)
-                {
-                    await tasks[j];
-                }
+                await tasks[j];
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/AsyncTests.cs
+++ b/tests/StackExchange.Redis.Tests/AsyncTests.cs
@@ -5,82 +5,77 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class AsyncTests : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class AsyncTests : TestBase
+    public AsyncTests(ITestOutputHelper output) : base(output) { }
+
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+
+    [Fact]
+    public void AsyncTasksReportFailureIfServerUnavailable()
     {
-        public AsyncTests(ITestOutputHelper output) : base(output) { }
+        SetExpectedAmbientFailureCount(-1); // this will get messy
 
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+        using var conn = Create(allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast);
+        var server = conn.GetServer(TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort);
 
-        [Fact]
-        public void AsyncTasksReportFailureIfServerUnavailable()
-        {
-            SetExpectedAmbientFailureCount(-1); // this will get messy
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key);
+        var a = db.SetAddAsync(key, "a");
+        var b = db.SetAddAsync(key, "b");
 
-            using (var conn = Create(allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast))
-            {
-                var server = conn.GetServer(TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort);
+        Assert.True(conn.Wait(a));
+        Assert.True(conn.Wait(b));
 
-                RedisKey key = Me();
-                var db = conn.GetDatabase();
-                db.KeyDelete(key);
-                var a = db.SetAddAsync(key, "a");
-                var b = db.SetAddAsync(key, "b");
+        conn.AllowConnect = false;
+        server.SimulateConnectionFailure(SimulatedFailureType.All);
+        var c = db.SetAddAsync(key, "c");
 
-                Assert.True(conn.Wait(a));
-                Assert.True(conn.Wait(b));
+        Assert.True(c.IsFaulted, "faulted");
+        Assert.NotNull(c.Exception);
+        var ex = c.Exception.InnerExceptions.Single();
+        Assert.IsType<RedisConnectionException>(ex);
+        Assert.StartsWith("No connection is active/available to service this operation: SADD " + key.ToString(), ex.Message);
+    }
 
-                conn.AllowConnect = false;
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                var c = db.SetAddAsync(key, "c");
-
-                Assert.True(c.IsFaulted, "faulted");
-                Assert.NotNull(c.Exception);
-                var ex = c.Exception.InnerExceptions.Single();
-                Assert.IsType<RedisConnectionException>(ex);
-                Assert.StartsWith("No connection is active/available to service this operation: SADD " + key.ToString(), ex.Message);
-            }
+    [Fact]
+    public async Task AsyncTimeoutIsNoticed()
+    {
+        using var conn = Create(syncTimeout: 1000);
+        var opt = ConfigurationOptions.Parse(conn.Configuration);
+        if (!Debugger.IsAttached)
+        { // we max the timeouts if a degugger is detected
+            Assert.Equal(1000, opt.AsyncTimeout);
         }
 
-        [Fact]
-        public async Task AsyncTimeoutIsNoticed()
+        RedisKey key = Me();
+        var val = Guid.NewGuid().ToString();
+        var db = conn.GetDatabase();
+        db.StringSet(key, val);
+
+        Assert.Contains("; async timeouts: 0;", conn.GetStatus());
+
+        await db.ExecuteAsync("client", "pause", 4000).ForAwait(); // client pause returns immediately
+
+        var ms = Stopwatch.StartNew();
+        var ex = await Assert.ThrowsAsync<RedisTimeoutException>(async () =>
         {
-            using (var conn = Create(syncTimeout: 1000))
-            {
-                var opt = ConfigurationOptions.Parse(conn.Configuration);
-                if (!Debugger.IsAttached)
-                { // we max the timeouts if a degugger is detected
-                    Assert.Equal(1000, opt.AsyncTimeout);
-                }
-
-                RedisKey key = Me();
-                var val = Guid.NewGuid().ToString();
-                var db = conn.GetDatabase();
-                db.StringSet(key, val);
-
-                Assert.Contains("; async timeouts: 0;", conn.GetStatus());
-
-                await db.ExecuteAsync("client", "pause", 4000).ForAwait(); // client pause returns immediately
-
-                var ms = Stopwatch.StartNew();
-                var ex = await Assert.ThrowsAsync<RedisTimeoutException>(async () =>
-                {
-                    await db.StringGetAsync(key).ForAwait(); // but *subsequent* operations are paused
-                    ms.Stop();
-                    Writer.WriteLine($"Unexpectedly succeeded after {ms.ElapsedMilliseconds}ms");
-                }).ForAwait();
+            await db.StringGetAsync(key).ForAwait(); // but *subsequent* operations are paused
                 ms.Stop();
-                Writer.WriteLine($"Timed out after {ms.ElapsedMilliseconds}ms");
+            Writer.WriteLine($"Unexpectedly succeeded after {ms.ElapsedMilliseconds}ms");
+        }).ForAwait();
+        ms.Stop();
+        Writer.WriteLine($"Timed out after {ms.ElapsedMilliseconds}ms");
 
-                Assert.Contains("Timeout awaiting response", ex.Message);
-                Writer.WriteLine(ex.Message);
+        Assert.Contains("Timeout awaiting response", ex.Message);
+        Writer.WriteLine(ex.Message);
 
-                string status = conn.GetStatus();
-                Writer.WriteLine(status);
-                Assert.Contains("; async timeouts: 1;", status);
-            }
-        }
+        string status = conn.GetStatus();
+        Writer.WriteLine(status);
+        Assert.Contains("; async timeouts: 1;", status);
     }
 }

--- a/tests/StackExchange.Redis.Tests/AzureMaintenanceEventTests.cs
+++ b/tests/StackExchange.Redis.Tests/AzureMaintenanceEventTests.cs
@@ -5,49 +5,46 @@ using StackExchange.Redis.Maintenance;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class AzureMaintenanceEventTests : TestBase
 {
-    public class AzureMaintenanceEventTests : TestBase
+    public AzureMaintenanceEventTests(ITestOutputHelper output) : base(output) { }
+
+    [Theory]
+    [InlineData("NotificationType|NodeMaintenanceStarting|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress||SSLPort|15001|NonSSLPort|13001", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, null, 15001, 13001)]
+    [InlineData("NotificationType|NodeMaintenanceFailover|StartTimeInUTC||IsReplica|False|IPAddress||SSLPort|15001|NonSSLPort|13001", AzureNotificationType.NodeMaintenanceFailoverComplete, null, false, null, 15001, 13001)]
+    [InlineData("NotificationType|NodeMaintenanceFailover|StartTimeInUTC||IsReplica|True|IPAddress||SSLPort|15001|NonSSLPort|13001", AzureNotificationType.NodeMaintenanceFailoverComplete, null, true, null, 15001, 13001)]
+    [InlineData("NotificationType|NodeMaintenanceStarting|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|j|IPAddress||SSLPort|char|NonSSLPort|char", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, null, 0, 0)]
+    [InlineData("NotificationType|NodeMaintenanceStarting|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress||SSLPort|15999|NonSSLPort|139991", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, null, 15999, 139991)]
+    [InlineData("NotificationType|NodeMaintenanceStarting|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress|127.0.0.1|SSLPort|15999|NonSSLPort|139991", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, "127.0.0.1", 15999, 139991)]
+    [InlineData("NotificationType|NodeMaintenanceScaleComplete|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress|127.0.0.1|SSLPort|15999|NonSSLPort|139991", AzureNotificationType.NodeMaintenanceScaleComplete, "2021-03-02T23:26:57", false, "127.0.0.1", 15999, 139991)]
+    [InlineData("NotificationTypeNodeMaintenanceStartingsomejunkkeysomejunkvalueStartTimeInUTC2021-03-02T23:26:57IsReplicaFalseIPAddress127.0.0.1SSLPort15999NonSSLPort139991", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("NotificationType|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("NotificationType|NodeMaintenanceStarting1", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("1|2|3", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("StartTimeInUTC|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("IsReplica|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("SSLPort|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("NonSSLPort |", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData("StartTimeInUTC|thisisthestart", AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    [InlineData(null, AzureNotificationType.Unknown, null, false, null, 0, 0)]
+    public void TestAzureMaintenanceEventStrings(string message, AzureNotificationType expectedEventType, string expectedStart, bool expectedIsReplica, string expectedIP, int expectedSSLPort, int expectedNonSSLPort)
     {
-        public AzureMaintenanceEventTests(ITestOutputHelper output) : base(output)
+        DateTime? expectedStartTimeUtc = null;
+        if (expectedStart != null && DateTime.TryParseExact(expectedStart, "s", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime startTimeUtc))
         {
+            expectedStartTimeUtc = DateTime.SpecifyKind(startTimeUtc, DateTimeKind.Utc);
         }
+        _ = IPAddress.TryParse(expectedIP, out IPAddress? expectedIPAddress);
 
-        [Theory]
-        [InlineData("NotificationType|NodeMaintenanceStarting|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress||SSLPort|15001|NonSSLPort|13001", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, null, 15001, 13001)]
-        [InlineData("NotificationType|NodeMaintenanceFailover|StartTimeInUTC||IsReplica|False|IPAddress||SSLPort|15001|NonSSLPort|13001", AzureNotificationType.NodeMaintenanceFailoverComplete, null, false, null, 15001, 13001)]
-        [InlineData("NotificationType|NodeMaintenanceFailover|StartTimeInUTC||IsReplica|True|IPAddress||SSLPort|15001|NonSSLPort|13001", AzureNotificationType.NodeMaintenanceFailoverComplete, null, true, null, 15001, 13001)]
-        [InlineData("NotificationType|NodeMaintenanceStarting|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|j|IPAddress||SSLPort|char|NonSSLPort|char", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, null, 0, 0)]
-        [InlineData("NotificationType|NodeMaintenanceStarting|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress||SSLPort|15999|NonSSLPort|139991", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, null, 15999, 139991)]
-        [InlineData("NotificationType|NodeMaintenanceStarting|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress|127.0.0.1|SSLPort|15999|NonSSLPort|139991", AzureNotificationType.NodeMaintenanceStarting, "2021-03-02T23:26:57", false, "127.0.0.1", 15999, 139991)]
-        [InlineData("NotificationType|NodeMaintenanceScaleComplete|somejunkkey|somejunkvalue|StartTimeInUTC|2021-03-02T23:26:57|IsReplica|False|IPAddress|127.0.0.1|SSLPort|15999|NonSSLPort|139991", AzureNotificationType.NodeMaintenanceScaleComplete, "2021-03-02T23:26:57", false, "127.0.0.1", 15999, 139991)]
-        [InlineData("NotificationTypeNodeMaintenanceStartingsomejunkkeysomejunkvalueStartTimeInUTC2021-03-02T23:26:57IsReplicaFalseIPAddress127.0.0.1SSLPort15999NonSSLPort139991", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("NotificationType|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("NotificationType|NodeMaintenanceStarting1", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("1|2|3", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("StartTimeInUTC|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("IsReplica|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("SSLPort|", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("NonSSLPort |", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData("StartTimeInUTC|thisisthestart", AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        [InlineData(null, AzureNotificationType.Unknown, null, false, null, 0, 0)]
-        public void TestAzureMaintenanceEventStrings(string message, AzureNotificationType expectedEventType, string expectedStart, bool expectedIsReplica, string expectedIP, int expectedSSLPort, int expectedNonSSLPort)
-        {
-            DateTime? expectedStartTimeUtc = null;
-            if (expectedStart != null && DateTime.TryParseExact(expectedStart, "s", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime startTimeUtc))
-            {
-                expectedStartTimeUtc = DateTime.SpecifyKind(startTimeUtc, DateTimeKind.Utc);
-            }
-            _ = IPAddress.TryParse(expectedIP, out IPAddress? expectedIPAddress);
+        var azureMaintenance = new AzureMaintenanceEvent(message);
 
-            var azureMaintenance = new AzureMaintenanceEvent(message);
-
-            Assert.Equal(expectedEventType, azureMaintenance.NotificationType);
-            Assert.Equal(expectedStartTimeUtc, azureMaintenance.StartTimeUtc);
-            Assert.Equal(expectedIsReplica, azureMaintenance.IsReplica);
-            Assert.Equal(expectedIPAddress, azureMaintenance.IPAddress);
-            Assert.Equal(expectedSSLPort, azureMaintenance.SslPort);
-            Assert.Equal(expectedNonSSLPort, azureMaintenance.NonSslPort);
-        }
+        Assert.Equal(expectedEventType, azureMaintenance.NotificationType);
+        Assert.Equal(expectedStartTimeUtc, azureMaintenance.StartTimeUtc);
+        Assert.Equal(expectedIsReplica, azureMaintenance.IsReplica);
+        Assert.Equal(expectedIPAddress, azureMaintenance.IPAddress);
+        Assert.Equal(expectedSSLPort, azureMaintenance.SslPort);
+        Assert.Equal(expectedNonSSLPort, azureMaintenance.NonSslPort);
     }
 }

--- a/tests/StackExchange.Redis.Tests/BacklogTests.cs
+++ b/tests/StackExchange.Redis.Tests/BacklogTests.cs
@@ -1,405 +1,403 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class BacklogTests : TestBase
 {
-    public class BacklogTests : TestBase
+    public BacklogTests(ITestOutputHelper output) : base (output) { }
+
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
+
+    [Fact]
+    public async Task FailFast()
     {
-        public BacklogTests(ITestOutputHelper output) : base (output) { }
-
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
-
-        [Fact]
-        public async Task FailFast()
+        void PrintSnapshot(ConnectionMultiplexer muxer)
         {
-            void PrintSnapshot(ConnectionMultiplexer muxer)
+            Writer.WriteLine("Snapshot summary:");
+            foreach (var server in muxer.GetServerSnapshot())
             {
-                Writer.WriteLine("Snapshot summary:");
-                foreach (var server in muxer.GetServerSnapshot())
-                {
-                    Writer.WriteLine($"  {server.EndPoint}: ");
-                    Writer.WriteLine($"     Type: {server.ServerType}");
-                    Writer.WriteLine($"     IsConnected: {server.IsConnected}");
-                    Writer.WriteLine($"      IsConnecting: {server.IsConnecting}");
-                    Writer.WriteLine($"      IsSelectable(allowDisconnected: true): {server.IsSelectable(RedisCommand.PING, true)}");
-                    Writer.WriteLine($"      IsSelectable(allowDisconnected: false): {server.IsSelectable(RedisCommand.PING, false)}");
-                    Writer.WriteLine($"      UnselectableFlags: {server.GetUnselectableFlags()}");
-                    var bridge = server.GetBridge(RedisCommand.PING, create: false);
-                    Writer.WriteLine($"      GetBridge: {bridge}");
-                    Writer.WriteLine($"        IsConnected: {bridge?.IsConnected}");
-                    Writer.WriteLine($"        ConnectionState: {bridge?.ConnectionState}");
-                }
-            }
-
-            try
-            {
-                // Ensuring the FailFast policy errors immediate with no connection available exceptions
-                var options = new ConfigurationOptions()
-                {
-                    BacklogPolicy = BacklogPolicy.FailFast,
-                    AbortOnConnectFail = false,
-                    ConnectTimeout = 1000,
-                    ConnectRetry = 2,
-                    SyncTimeout = 10000,
-                    KeepAlive = 10000,
-                    AsyncTimeout = 5000,
-                    AllowAdmin = true,
-                };
-                options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
-
-                using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-
-                var db = muxer.GetDatabase();
-                Writer.WriteLine("Test: Initial (connected) ping");
-                await db.PingAsync();
-
-                var server = muxer.GetServerSnapshot()[0];
-                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
-
-                // Fail the connection
-                Writer.WriteLine("Test: Simulating failure");
-                muxer.AllowConnect = false;
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                Assert.False(muxer.IsConnected);
-
-                // Queue up some commands
-                Writer.WriteLine("Test: Disconnected pings");
-                await Assert.ThrowsAsync<RedisConnectionException>(() => db.PingAsync());
-
-                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.False(muxer.IsConnected);
-                Assert.Equal(0, disconnectedStats.BacklogMessagesPending);
-
-                Writer.WriteLine("Test: Allowing reconnect");
-                muxer.AllowConnect = true;
-                Writer.WriteLine("Test: Awaiting reconnect");
-                await UntilConditionAsync(TimeSpan.FromSeconds(3), () => muxer.IsConnected).ForAwait();
-
-                Writer.WriteLine("Test: Reconnecting");
-                Assert.True(muxer.IsConnected);
-                Assert.True(server.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
-
-                _ = db.PingAsync();
-                _ = db.PingAsync();
-                var lastPing = db.PingAsync();
-
-                // For debug, print out the snapshot and server states
-                PrintSnapshot(muxer);
-
-                Assert.NotNull(muxer.SelectServer(Message.Create(-1, CommandFlags.None, RedisCommand.PING)));
-
-                // We should see none queued
-                Assert.Equal(0, stats.BacklogMessagesPending);
-                await lastPing;
-            }
-            finally
-            {
-                ClearAmbientFailures();
+                Writer.WriteLine($"  {server.EndPoint}: ");
+                Writer.WriteLine($"     Type: {server.ServerType}");
+                Writer.WriteLine($"     IsConnected: {server.IsConnected}");
+                Writer.WriteLine($"      IsConnecting: {server.IsConnecting}");
+                Writer.WriteLine($"      IsSelectable(allowDisconnected: true): {server.IsSelectable(RedisCommand.PING, true)}");
+                Writer.WriteLine($"      IsSelectable(allowDisconnected: false): {server.IsSelectable(RedisCommand.PING, false)}");
+                Writer.WriteLine($"      UnselectableFlags: {server.GetUnselectableFlags()}");
+                var bridge = server.GetBridge(RedisCommand.PING, create: false);
+                Writer.WriteLine($"      GetBridge: {bridge}");
+                Writer.WriteLine($"        IsConnected: {bridge?.IsConnected}");
+                Writer.WriteLine($"        ConnectionState: {bridge?.ConnectionState}");
             }
         }
 
-        [Fact]
-        public async Task QueuesAndFlushesAfterReconnectingAsync()
+        try
         {
-            try
+            // Ensuring the FailFast policy errors immediate with no connection available exceptions
+            var options = new ConfigurationOptions()
             {
-                var options = new ConfigurationOptions()
-                {
-                    BacklogPolicy = BacklogPolicy.Default,
-                    AbortOnConnectFail = false,
-                    ConnectTimeout = 1000,
-                    ConnectRetry = 2,
-                    SyncTimeout = 10000,
-                    KeepAlive = 10000,
-                    AsyncTimeout = 5000,
-                    AllowAdmin = true,
-                    SocketManager = SocketManager.ThreadPool,
-                };
-                options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
+                BacklogPolicy = BacklogPolicy.FailFast,
+                AbortOnConnectFail = false,
+                ConnectTimeout = 1000,
+                ConnectRetry = 2,
+                SyncTimeout = 10000,
+                KeepAlive = 10000,
+                AsyncTimeout = 5000,
+                AllowAdmin = true,
+            };
+            options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
 
-                using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-                muxer.ErrorMessage += (s, e) => Log($"Error Message {e.EndPoint}: {e.Message}");
-                muxer.InternalError += (s, e) => Log($"Internal Error {e.EndPoint}: {e.Exception.Message}");
-                muxer.ConnectionFailed += (s, a) => Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
-                muxer.ConnectionRestored += (s, a) => Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
+            using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
 
-                var db = muxer.GetDatabase();
-                Writer.WriteLine("Test: Initial (connected) ping");
-                await db.PingAsync();
+            var db = conn.GetDatabase();
+            Writer.WriteLine("Test: Initial (connected) ping");
+            await db.PingAsync();
 
-                var server = muxer.GetServerSnapshot()[0];
-                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
+            var server = conn.GetServerSnapshot()[0];
+            var stats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
 
-                // Fail the connection
-                Writer.WriteLine("Test: Simulating failure");
-                muxer.AllowConnect = false;
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                Assert.False(muxer.IsConnected);
+            // Fail the connection
+            Writer.WriteLine("Test: Simulating failure");
+            conn.AllowConnect = false;
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(conn.IsConnected);
 
-                // Queue up some commands
-                Writer.WriteLine("Test: Disconnected pings");
-                var ignoredA = db.PingAsync();
-                var ignoredB = db.PingAsync();
-                var lastPing = db.PingAsync();
+            // Queue up some commands
+            Writer.WriteLine("Test: Disconnected pings");
+            await Assert.ThrowsAsync<RedisConnectionException>(() => db.PingAsync());
 
-                // TODO: Add specific server call
+            var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.False(conn.IsConnected);
+            Assert.Equal(0, disconnectedStats.BacklogMessagesPending);
 
-                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.False(muxer.IsConnected);
-                Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
+            Writer.WriteLine("Test: Allowing reconnect");
+            conn.AllowConnect = true;
+            Writer.WriteLine("Test: Awaiting reconnect");
+            await UntilConditionAsync(TimeSpan.FromSeconds(3), () => conn.IsConnected).ForAwait();
 
-                Writer.WriteLine("Test: Allowing reconnect");
-                muxer.AllowConnect = true;
-                Writer.WriteLine("Test: Awaiting reconnect");
-                await UntilConditionAsync(TimeSpan.FromSeconds(3), () => muxer.IsConnected).ForAwait();
+            Writer.WriteLine("Test: Reconnecting");
+            Assert.True(conn.IsConnected);
+            Assert.True(server.IsConnected);
+            var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
 
-                Writer.WriteLine("Test: Checking reconnected 1");
-                Assert.True(muxer.IsConnected);
+            _ = db.PingAsync();
+            _ = db.PingAsync();
+            var lastPing = db.PingAsync();
 
-                Writer.WriteLine("Test: ignoredA Status: " + ignoredA.Status);
-                Writer.WriteLine("Test: ignoredB Status: " + ignoredB.Status);
-                Writer.WriteLine("Test: lastPing Status: " + lastPing.Status);
-                var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
+            // For debug, print out the snapshot and server states
+            PrintSnapshot(conn);
 
-                Writer.WriteLine("Test: Awaiting lastPing 1");
-                await lastPing;
+            Assert.NotNull(conn.SelectServer(Message.Create(-1, CommandFlags.None, RedisCommand.PING)));
 
-                Writer.WriteLine("Test: Checking reconnected 2");
-                Assert.True(muxer.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
-
-                Writer.WriteLine("Test: Pinging again...");
-                _ = db.PingAsync();
-                _ = db.PingAsync();
-                Writer.WriteLine("Test: Last Ping issued");
-                lastPing = db.PingAsync();
-
-                // We should see none queued
-                Writer.WriteLine("Test: BacklogMessagesPending check");
-                Assert.Equal(0, stats.BacklogMessagesPending);
-                Writer.WriteLine("Test: Awaiting lastPing 2");
-                await lastPing;
-                Writer.WriteLine("Test: Done");
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            // We should see none queued
+            Assert.Equal(0, stats.BacklogMessagesPending);
+            await lastPing;
         }
-
-        [Fact]
-        public async Task QueuesAndFlushesAfterReconnecting()
+        finally
         {
-            try
-            {
-                var options = new ConfigurationOptions()
-                {
-                    BacklogPolicy = BacklogPolicy.Default,
-                    AbortOnConnectFail = false,
-                    ConnectTimeout = 1000,
-                    ConnectRetry = 2,
-                    SyncTimeout = 10000,
-                    KeepAlive = 10000,
-                    AsyncTimeout = 5000,
-                    AllowAdmin = true,
-                    SocketManager = SocketManager.ThreadPool,
-                };
-                options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
-
-                using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-                muxer.ErrorMessage += (s, e) => Log($"Error Message {e.EndPoint}: {e.Message}");
-                muxer.InternalError += (s, e) => Log($"Internal Error {e.EndPoint}: {e.Exception.Message}");
-                muxer.ConnectionFailed += (s, a) => Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
-                muxer.ConnectionRestored += (s, a) => Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
-
-                var db = muxer.GetDatabase();
-                Writer.WriteLine("Test: Initial (connected) ping");
-                await db.PingAsync();
-
-                var server = muxer.GetServerSnapshot()[0];
-                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
-
-                // Fail the connection
-                Writer.WriteLine("Test: Simulating failure");
-                muxer.AllowConnect = false;
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                Assert.False(muxer.IsConnected);
-
-                // Queue up some commands
-                Writer.WriteLine("Test: Disconnected pings");
-
-                Task[] pings = new Task[3];
-                pings[0] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(1));
-                pings[1] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(2));
-                pings[2] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(3));
-                void disconnectedPings(int id)
-                {
-                    // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
-                    Log($"Pinging (disconnected - {id})");
-                    var result = db.Ping();
-                    Log($"Pinging (disconnected - {id}) - result: " + result);
-                }
-                Writer.WriteLine("Test: Disconnected pings issued");
-
-                Assert.False(muxer.IsConnected);
-                // Give the tasks time to queue
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => server.GetBridgeStatus(ConnectionType.Interactive).BacklogMessagesPending >= 3);
-
-                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Log($"Test Stats: (BacklogMessagesPending: {disconnectedStats.BacklogMessagesPending}, TotalBacklogMessagesQueued: {disconnectedStats.TotalBacklogMessagesQueued})");
-                Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
-
-                Writer.WriteLine("Test: Allowing reconnect");
-                muxer.AllowConnect = true;
-                Writer.WriteLine("Test: Awaiting reconnect");
-                await UntilConditionAsync(TimeSpan.FromSeconds(3), () => muxer.IsConnected).ForAwait();
-
-                Writer.WriteLine("Test: Checking reconnected 1");
-                Assert.True(muxer.IsConnected);
-
-                var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
-
-                Writer.WriteLine("Test: Awaiting 3 pings");
-                await Task.WhenAll(pings);
-
-                Writer.WriteLine("Test: Checking reconnected 2");
-                Assert.True(muxer.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
-
-                Writer.WriteLine("Test: Pinging again...");
-                pings[0] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(4));
-                pings[1] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(5));
-                pings[2] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(6));
-                Writer.WriteLine("Test: Last Ping queued");
-
-                // We should see none queued
-                Writer.WriteLine("Test: BacklogMessagesPending check");
-                Assert.Equal(0, stats.BacklogMessagesPending);
-                Writer.WriteLine("Test: Awaiting 3 more pings");
-                await Task.WhenAll(pings);
-                Writer.WriteLine("Test: Done");
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            ClearAmbientFailures();
         }
+    }
 
-        [Fact]
-        public async Task QueuesAndFlushesAfterReconnectingClusterAsync()
+    [Fact]
+    public async Task QueuesAndFlushesAfterReconnectingAsync()
+    {
+        try
         {
-            try
+            var options = new ConfigurationOptions()
             {
-                var options = ConfigurationOptions.Parse(TestConfig.Current.ClusterServersAndPorts);
-                options.BacklogPolicy = BacklogPolicy.Default;
-                options.AbortOnConnectFail = false;
-                options.ConnectTimeout = 1000;
-                options.ConnectRetry = 2;
-                options.SyncTimeout = 10000;
-                options.KeepAlive = 10000;
-                options.AsyncTimeout = 5000;
-                options.AllowAdmin = true;
-                options.SocketManager = SocketManager.ThreadPool;
+                BacklogPolicy = BacklogPolicy.Default,
+                AbortOnConnectFail = false,
+                ConnectTimeout = 1000,
+                ConnectRetry = 2,
+                SyncTimeout = 10000,
+                KeepAlive = 10000,
+                AsyncTimeout = 5000,
+                AllowAdmin = true,
+                SocketManager = SocketManager.ThreadPool,
+            };
+            options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
 
-                using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-                muxer.ErrorMessage += (s, e) => Log($"Error Message {e.EndPoint}: {e.Message}");
-                muxer.InternalError += (s, e) => Log($"Internal Error {e.EndPoint}: {e.Exception.Message}");
-                muxer.ConnectionFailed += (s, a) => Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
-                muxer.ConnectionRestored += (s, a) => Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
+            using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
+            conn.ErrorMessage += (s, e) => Log($"Error Message {e.EndPoint}: {e.Message}");
+            conn.InternalError += (s, e) => Log($"Internal Error {e.EndPoint}: {e.Exception.Message}");
+            conn.ConnectionFailed += (s, a) => Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
+            conn.ConnectionRestored += (s, a) => Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
 
-                var db = muxer.GetDatabase();
-                Writer.WriteLine("Test: Initial (connected) ping");
-                await db.PingAsync();
+            var db = conn.GetDatabase();
+            Writer.WriteLine("Test: Initial (connected) ping");
+            await db.PingAsync();
 
-                RedisKey meKey = Me();
-                var getMsg = Message.Create(0, CommandFlags.None, RedisCommand.GET, meKey);
+            var server = conn.GetServerSnapshot()[0];
+            var stats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
 
-                ServerEndPoint? server = null; // Get the server specifically for this message's hash slot
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => (server = muxer.SelectServer(getMsg)) != null);
+            // Fail the connection
+            Writer.WriteLine("Test: Simulating failure");
+            conn.AllowConnect = false;
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(conn.IsConnected);
 
-                Assert.NotNull(server);
-                var stats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
+            // Queue up some commands
+            Writer.WriteLine("Test: Disconnected pings");
+            var ignoredA = db.PingAsync();
+            var ignoredB = db.PingAsync();
+            var lastPing = db.PingAsync();
 
-                static Task<TimeSpan> PingAsync(ServerEndPoint server, CommandFlags flags = CommandFlags.None)
-                {
-                    var message = ResultProcessor.TimingProcessor.CreateMessage(-1, flags, RedisCommand.PING);
+            // TODO: Add specific server call
 
-                    server.Multiplexer.CheckMessage(message);
-                    return server.Multiplexer.ExecuteAsyncImpl(message, ResultProcessor.ResponseTimer, null, server);
-                }
+            var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.False(conn.IsConnected);
+            Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
 
-                // Fail the connection
-                Writer.WriteLine("Test: Simulating failure");
-                muxer.AllowConnect = false;
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                Assert.False(server.IsConnected); // Server isn't connected
-                Assert.True(muxer.IsConnected); // ...but the multiplexer is
+            Writer.WriteLine("Test: Allowing reconnect");
+            conn.AllowConnect = true;
+            Writer.WriteLine("Test: Awaiting reconnect");
+            await UntilConditionAsync(TimeSpan.FromSeconds(3), () => conn.IsConnected).ForAwait();
 
-                // Queue up some commands
-                Writer.WriteLine("Test: Disconnected pings");
-                var ignoredA = PingAsync(server);
-                var ignoredB = PingAsync(server);
-                var lastPing = PingAsync(server);
+            Writer.WriteLine("Test: Checking reconnected 1");
+            Assert.True(conn.IsConnected);
 
-                var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.False(server.IsConnected);
-                Assert.True(muxer.IsConnected);
-                Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
+            Writer.WriteLine("Test: ignoredA Status: " + ignoredA.Status);
+            Writer.WriteLine("Test: ignoredB Status: " + ignoredB.Status);
+            Writer.WriteLine("Test: lastPing Status: " + lastPing.Status);
+            var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
 
-                Writer.WriteLine("Test: Allowing reconnect");
-                muxer.AllowConnect = true;
-                Writer.WriteLine("Test: Awaiting reconnect");
-                await UntilConditionAsync(TimeSpan.FromSeconds(3), () => server.IsConnected).ForAwait();
+            Writer.WriteLine("Test: Awaiting lastPing 1");
+            await lastPing;
 
-                Writer.WriteLine("Test: Checking reconnected 1");
-                Assert.True(server.IsConnected);
-                Assert.True(muxer.IsConnected);
+            Writer.WriteLine("Test: Checking reconnected 2");
+            Assert.True(conn.IsConnected);
+            var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
 
-                Writer.WriteLine("Test: ignoredA Status: " + ignoredA.Status);
-                Writer.WriteLine("Test: ignoredB Status: " + ignoredB.Status);
-                Writer.WriteLine("Test: lastPing Status: " + lastPing.Status);
-                var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
+            Writer.WriteLine("Test: Pinging again...");
+            _ = db.PingAsync();
+            _ = db.PingAsync();
+            Writer.WriteLine("Test: Last Ping issued");
+            lastPing = db.PingAsync();
 
-                Writer.WriteLine("Test: Awaiting lastPing 1");
-                await lastPing;
+            // We should see none queued
+            Writer.WriteLine("Test: BacklogMessagesPending check");
+            Assert.Equal(0, stats.BacklogMessagesPending);
+            Writer.WriteLine("Test: Awaiting lastPing 2");
+            await lastPing;
+            Writer.WriteLine("Test: Done");
+        }
+        finally
+        {
+            ClearAmbientFailures();
+        }
+    }
 
-                Writer.WriteLine("Test: Checking reconnected 2");
-                Assert.True(server.IsConnected);
-                Assert.True(muxer.IsConnected);
-                var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
-                Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
-
-                Writer.WriteLine("Test: Pinging again...");
-                _ = PingAsync(server);
-                _ = PingAsync(server);
-                Writer.WriteLine("Test: Last Ping issued");
-                lastPing = PingAsync(server);
-
-                // We should see none queued
-                Writer.WriteLine("Test: BacklogMessagesPending check");
-                Assert.Equal(0, stats.BacklogMessagesPending);
-                Writer.WriteLine("Test: Awaiting lastPing 2");
-                await lastPing;
-                Writer.WriteLine("Test: Done");
-            }
-            finally
+    [Fact]
+    public async Task QueuesAndFlushesAfterReconnecting()
+    {
+        try
+        {
+            var options = new ConfigurationOptions()
             {
-                ClearAmbientFailures();
+                BacklogPolicy = BacklogPolicy.Default,
+                AbortOnConnectFail = false,
+                ConnectTimeout = 1000,
+                ConnectRetry = 2,
+                SyncTimeout = 10000,
+                KeepAlive = 10000,
+                AsyncTimeout = 5000,
+                AllowAdmin = true,
+                SocketManager = SocketManager.ThreadPool,
+            };
+            options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
+
+            using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
+            conn.ErrorMessage += (s, e) => Log($"Error Message {e.EndPoint}: {e.Message}");
+            conn.InternalError += (s, e) => Log($"Internal Error {e.EndPoint}: {e.Exception.Message}");
+            conn.ConnectionFailed += (s, a) => Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
+            conn.ConnectionRestored += (s, a) => Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
+
+            var db = conn.GetDatabase();
+            Writer.WriteLine("Test: Initial (connected) ping");
+            await db.PingAsync();
+
+            var server = conn.GetServerSnapshot()[0];
+            var stats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
+
+            // Fail the connection
+            Writer.WriteLine("Test: Simulating failure");
+            conn.AllowConnect = false;
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(conn.IsConnected);
+
+            // Queue up some commands
+            Writer.WriteLine("Test: Disconnected pings");
+
+            Task[] pings = new Task[3];
+            pings[0] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(1));
+            pings[1] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(2));
+            pings[2] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(3));
+            void disconnectedPings(int id)
+            {
+                // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
+                Log($"Pinging (disconnected - {id})");
+                var result = db.Ping();
+                Log($"Pinging (disconnected - {id}) - result: " + result);
             }
+            Writer.WriteLine("Test: Disconnected pings issued");
+
+            Assert.False(conn.IsConnected);
+            // Give the tasks time to queue
+            await UntilConditionAsync(TimeSpan.FromSeconds(5), () => server.GetBridgeStatus(ConnectionType.Interactive).BacklogMessagesPending >= 3);
+
+            var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Log($"Test Stats: (BacklogMessagesPending: {disconnectedStats.BacklogMessagesPending}, TotalBacklogMessagesQueued: {disconnectedStats.TotalBacklogMessagesQueued})");
+            Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
+
+            Writer.WriteLine("Test: Allowing reconnect");
+            conn.AllowConnect = true;
+            Writer.WriteLine("Test: Awaiting reconnect");
+            await UntilConditionAsync(TimeSpan.FromSeconds(3), () => conn.IsConnected).ForAwait();
+
+            Writer.WriteLine("Test: Checking reconnected 1");
+            Assert.True(conn.IsConnected);
+
+            var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
+
+            Writer.WriteLine("Test: Awaiting 3 pings");
+            await Task.WhenAll(pings);
+
+            Writer.WriteLine("Test: Checking reconnected 2");
+            Assert.True(conn.IsConnected);
+            var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
+
+            Writer.WriteLine("Test: Pinging again...");
+            pings[0] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(4));
+            pings[1] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(5));
+            pings[2] = RunBlockingSynchronousWithExtraThreadAsync(() => disconnectedPings(6));
+            Writer.WriteLine("Test: Last Ping queued");
+
+            // We should see none queued
+            Writer.WriteLine("Test: BacklogMessagesPending check");
+            Assert.Equal(0, stats.BacklogMessagesPending);
+            Writer.WriteLine("Test: Awaiting 3 more pings");
+            await Task.WhenAll(pings);
+            Writer.WriteLine("Test: Done");
+        }
+        finally
+        {
+            ClearAmbientFailures();
+        }
+    }
+
+    [Fact]
+    public async Task QueuesAndFlushesAfterReconnectingClusterAsync()
+    {
+        try
+        {
+            var options = ConfigurationOptions.Parse(TestConfig.Current.ClusterServersAndPorts);
+            options.BacklogPolicy = BacklogPolicy.Default;
+            options.AbortOnConnectFail = false;
+            options.ConnectTimeout = 1000;
+            options.ConnectRetry = 2;
+            options.SyncTimeout = 10000;
+            options.KeepAlive = 10000;
+            options.AsyncTimeout = 5000;
+            options.AllowAdmin = true;
+            options.SocketManager = SocketManager.ThreadPool;
+
+            using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
+            conn.ErrorMessage += (s, e) => Log($"Error Message {e.EndPoint}: {e.Message}");
+            conn.InternalError += (s, e) => Log($"Internal Error {e.EndPoint}: {e.Exception.Message}");
+            conn.ConnectionFailed += (s, a) => Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
+            conn.ConnectionRestored += (s, a) => Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
+
+            var db = conn.GetDatabase();
+            Writer.WriteLine("Test: Initial (connected) ping");
+            await db.PingAsync();
+
+            RedisKey meKey = Me();
+            var getMsg = Message.Create(0, CommandFlags.None, RedisCommand.GET, meKey);
+
+            ServerEndPoint? server = null; // Get the server specifically for this message's hash slot
+            await UntilConditionAsync(TimeSpan.FromSeconds(10), () => (server = conn.SelectServer(getMsg)) != null);
+
+            Assert.NotNull(server);
+            var stats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, stats.BacklogMessagesPending); // Everything's normal
+
+            static Task<TimeSpan> PingAsync(ServerEndPoint server, CommandFlags flags = CommandFlags.None)
+            {
+                var message = ResultProcessor.TimingProcessor.CreateMessage(-1, flags, RedisCommand.PING);
+
+                server.Multiplexer.CheckMessage(message);
+                return server.Multiplexer.ExecuteAsyncImpl(message, ResultProcessor.ResponseTimer, null, server);
+            }
+
+            // Fail the connection
+            Writer.WriteLine("Test: Simulating failure");
+            conn.AllowConnect = false;
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(server.IsConnected); // Server isn't connected
+            Assert.True(conn.IsConnected); // ...but the multiplexer is
+
+            // Queue up some commands
+            Writer.WriteLine("Test: Disconnected pings");
+            var ignoredA = PingAsync(server);
+            var ignoredB = PingAsync(server);
+            var lastPing = PingAsync(server);
+
+            var disconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.False(server.IsConnected);
+            Assert.True(conn.IsConnected);
+            Assert.True(disconnectedStats.BacklogMessagesPending >= 3, $"Expected {nameof(disconnectedStats.BacklogMessagesPending)} > 3, got {disconnectedStats.BacklogMessagesPending}");
+
+            Writer.WriteLine("Test: Allowing reconnect");
+            conn.AllowConnect = true;
+            Writer.WriteLine("Test: Awaiting reconnect");
+            await UntilConditionAsync(TimeSpan.FromSeconds(3), () => server.IsConnected).ForAwait();
+
+            Writer.WriteLine("Test: Checking reconnected 1");
+            Assert.True(server.IsConnected);
+            Assert.True(conn.IsConnected);
+
+            Writer.WriteLine("Test: ignoredA Status: " + ignoredA.Status);
+            Writer.WriteLine("Test: ignoredB Status: " + ignoredB.Status);
+            Writer.WriteLine("Test: lastPing Status: " + lastPing.Status);
+            var afterConnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Writer.WriteLine($"Test: BacklogStatus: {afterConnectedStats.BacklogStatus}, BacklogMessagesPending: {afterConnectedStats.BacklogMessagesPending}, IsWriterActive: {afterConnectedStats.IsWriterActive}, MessagesSinceLastHeartbeat: {afterConnectedStats.MessagesSinceLastHeartbeat}, TotalBacklogMessagesQueued: {afterConnectedStats.TotalBacklogMessagesQueued}");
+
+            Writer.WriteLine("Test: Awaiting lastPing 1");
+            await lastPing;
+
+            Writer.WriteLine("Test: Checking reconnected 2");
+            Assert.True(server.IsConnected);
+            Assert.True(conn.IsConnected);
+            var reconnectedStats = server.GetBridgeStatus(ConnectionType.Interactive);
+            Assert.Equal(0, reconnectedStats.BacklogMessagesPending);
+
+            Writer.WriteLine("Test: Pinging again...");
+            _ = PingAsync(server);
+            _ = PingAsync(server);
+            Writer.WriteLine("Test: Last Ping issued");
+            lastPing = PingAsync(server);
+
+            // We should see none queued
+            Writer.WriteLine("Test: BacklogMessagesPending check");
+            Assert.Equal(0, stats.BacklogMessagesPending);
+            Writer.WriteLine("Test: Awaiting lastPing 2");
+            await lastPing;
+            Writer.WriteLine("Test: Done");
+        }
+        finally
+        {
+            ClearAmbientFailures();
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/BasicOps.cs
+++ b/tests/StackExchange.Redis.Tests/BasicOps.cs
@@ -5,523 +5,468 @@ using StackExchange.Redis.KeyspaceIsolation;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class BasicOpsTests : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class BasicOpsTests : TestBase
+    public BasicOpsTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public async Task PingOnce()
     {
-        public BasicOpsTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
+        var db = conn.GetDatabase();
 
-        [Fact]
-        public async Task PingOnce()
+        var duration = await db.PingAsync().ForAwait();
+        Log("Ping took: " + duration);
+        Assert.True(duration.TotalMilliseconds > 0);
+    }
+
+    [Fact]
+    public async Task RapidDispose()
+    {
+        using var primary = Create();
+        var db = primary.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        for (int i = 0; i < 10; i++)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
+            using var secondary = Create(fail: true, shared: false);
+            secondary.GetDatabase().StringIncrement(key, flags: CommandFlags.FireAndForget);
+        }
+        // Give it a moment to get through the pipe...they were fire and forget
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => 10 == (int)db.StringGet(key));
+        Assert.Equal(10, (int)db.StringGet(key));
+    }
 
-                var duration = await conn.PingAsync().ForAwait();
-                Log("Ping took: " + duration);
-                Assert.True(duration.TotalMilliseconds > 0);
+    [Fact]
+    public async Task PingMany()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var tasks = new Task<TimeSpan>[100];
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = db.PingAsync();
+        }
+        await Task.WhenAll(tasks).ForAwait();
+        Assert.True(tasks[0].Result.TotalMilliseconds > 0);
+        Assert.True(tasks[tasks.Length - 1].Result.TotalMilliseconds > 0);
+    }
+
+    [Fact]
+    public void GetWithNullKey()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        const string? key = null;
+        var ex = Assert.Throws<ArgumentException>(() => db.StringGet(key));
+        Assert.Equal("A null key is not valid in this context", ex.Message);
+    }
+
+    [Fact]
+    public void SetWithNullKey()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        const string? key = null, value = "abc";
+        var ex = Assert.Throws<ArgumentException>(() => db.StringSet(key!, value));
+        Assert.Equal("A null key is not valid in this context", ex.Message);
+    }
+
+    [Fact]
+    public void SetWithNullValue()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        string key = Me();
+        const string? value = null;
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        Assert.True(db.KeyExists(key));
+        db.StringSet(key, value, flags: CommandFlags.FireAndForget);
+
+        var actual = (string?)db.StringGet(key);
+        Assert.Null(actual);
+        Assert.False(db.KeyExists(key));
+    }
+
+    [Fact]
+    public void SetWithDefaultValue()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        string key = Me();
+        var value = default(RedisValue); // this is kinda 0... ish
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        Assert.True(db.KeyExists(key));
+        db.StringSet(key, value, flags: CommandFlags.FireAndForget);
+
+        var actual = (string?)db.StringGet(key);
+        Assert.Null(actual);
+        Assert.False(db.KeyExists(key));
+    }
+
+    [Fact]
+    public void SetWithZeroValue()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        string key = Me();
+        const long value = 0;
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        Assert.True(db.KeyExists(key));
+        db.StringSet(key, value, flags: CommandFlags.FireAndForget);
+
+        var actual = (string?)db.StringGet(key);
+        Assert.Equal("0", actual);
+        Assert.True(db.KeyExists(key));
+    }
+
+    [Fact]
+    public async Task GetSetAsync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+
+        RedisKey key = Me();
+        var d0 = db.KeyDeleteAsync(key);
+        var d1 = db.KeyDeleteAsync(key);
+        var g1 = db.StringGetAsync(key);
+        var s1 = db.StringSetAsync(key, "123");
+        var g2 = db.StringGetAsync(key);
+        var d2 = db.KeyDeleteAsync(key);
+
+        await d0;
+        Assert.False(await d1);
+        Assert.Null((string?)(await g1));
+        Assert.True((await g1).IsNull);
+        await s1;
+        Assert.Equal("123", await g2);
+        Assert.Equal(123, (int)(await g2));
+        Assert.False((await g2).IsNull);
+        Assert.True(await d2);
+    }
+
+    [Fact]
+    public void GetSetSync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var d1 = db.KeyDelete(key);
+        var g1 = db.StringGet(key);
+        db.StringSet(key, "123", flags: CommandFlags.FireAndForget);
+        var g2 = db.StringGet(key);
+        var d2 = db.KeyDelete(key);
+
+        Assert.False(d1);
+        Assert.Null((string?)g1);
+        Assert.True(g1.IsNull);
+
+        Assert.Equal("123", g2);
+        Assert.Equal(123, (int)g2);
+        Assert.False(g2.IsNull);
+        Assert.True(d2);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    public async Task GetWithExpiry(bool exists, bool hasExpiry)
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        if (exists)
+        {
+            if (hasExpiry)
+                db.StringSet(key, "val", TimeSpan.FromMinutes(5), flags: CommandFlags.FireAndForget);
+            else
+                db.StringSet(key, "val", flags: CommandFlags.FireAndForget);
+        }
+        var async = db.StringGetWithExpiryAsync(key);
+        var syncResult = db.StringGetWithExpiry(key);
+        var asyncResult = await async;
+
+        if (exists)
+        {
+            Assert.Equal("val", asyncResult.Value);
+            Assert.Equal(hasExpiry, asyncResult.Expiry.HasValue);
+            if (hasExpiry) Assert.True(asyncResult.Expiry!.Value.TotalMinutes >= 4.9 && asyncResult.Expiry.Value.TotalMinutes <= 5);
+            Assert.Equal("val", syncResult.Value);
+            Assert.Equal(hasExpiry, syncResult.Expiry.HasValue);
+            if (hasExpiry) Assert.True(syncResult.Expiry!.Value.TotalMinutes >= 4.9 && syncResult.Expiry.Value.TotalMinutes <= 5);
+        }
+        else
+        {
+            Assert.True(asyncResult.Value.IsNull);
+            Assert.False(asyncResult.Expiry.HasValue);
+            Assert.True(syncResult.Value.IsNull);
+            Assert.False(syncResult.Expiry.HasValue);
+        }
+    }
+
+    [Fact]
+    public async Task GetWithExpiryWrongTypeAsync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        _ = db.KeyDeleteAsync(key);
+        _ = db.SetAddAsync(key, "abc");
+        var ex = await Assert.ThrowsAsync<RedisServerException>(async () =>
+        {
+            try
+            {
+                Log("Key: " + (string?)key);
+                await db.StringGetWithExpiryAsync(key).ForAwait();
             }
-        }
-
-        [Fact]
-        public async Task RapidDispose()
-        {
-            RedisKey key = Me();
-            using (var primary = Create())
+            catch (AggregateException e)
             {
-                var conn = primary.GetDatabase();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                for (int i = 0; i < 10; i++)
-                {
-                    using (var secondary = Create(fail: true, shared: false))
-                    {
-                        secondary.GetDatabase().StringIncrement(key, flags: CommandFlags.FireAndForget);
-                    }
-                }
-                // Give it a moment to get through the pipe...they were fire and forget
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => 10 == (int)conn.StringGet(key));
-                Assert.Equal(10, (int)conn.StringGet(key));
+                throw e.InnerExceptions[0];
             }
-        }
+        }).ForAwait();
+        Assert.Equal("WRONGTYPE Operation against a key holding the wrong kind of value", ex.Message);
+    }
 
-        [Fact]
-        public async Task PingMany()
+    [Fact]
+    public void GetWithExpiryWrongTypeSync()
+    {
+        RedisKey key = Me();
+        var ex = Assert.Throws<RedisServerException>(() =>
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var tasks = new Task<TimeSpan>[100];
-                for (int i = 0; i < tasks.Length; i++)
-                {
-                    tasks[i] = conn.PingAsync();
-                }
-                await Task.WhenAll(tasks).ForAwait();
-                Assert.True(tasks[0].Result.TotalMilliseconds > 0);
-                Assert.True(tasks[tasks.Length - 1].Result.TotalMilliseconds > 0);
-            }
-        }
-
-        [Fact]
-        public void GetWithNullKey()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                const string? key = null;
-                var ex = Assert.Throws<ArgumentException>(() => db.StringGet(key));
-                Assert.Equal("A null key is not valid in this context", ex.Message);
-            }
-        }
-
-        [Fact]
-        public void SetWithNullKey()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                const string? key = null, value = "abc";
-                var ex = Assert.Throws<ArgumentException>(() => db.StringSet(key!, value));
-                Assert.Equal("A null key is not valid in this context", ex.Message);
-            }
-        }
-
-        [Fact]
-        public void SetWithNullValue()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                string key = Me();
-                const string? value = null;
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                Assert.True(db.KeyExists(key));
-                db.StringSet(key, value, flags: CommandFlags.FireAndForget);
-
-                var actual = (string?)db.StringGet(key);
-                Assert.Null(actual);
-                Assert.False(db.KeyExists(key));
-            }
-        }
-
-        [Fact]
-        public void SetWithDefaultValue()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                string key = Me();
-                var value = default(RedisValue); // this is kinda 0... ish
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                Assert.True(db.KeyExists(key));
-                db.StringSet(key, value, flags: CommandFlags.FireAndForget);
-
-                var actual = (string?)db.StringGet(key);
-                Assert.Null(actual);
-                Assert.False(db.KeyExists(key));
-            }
-        }
-
-        [Fact]
-        public void SetWithZeroValue()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                string key = Me();
-                const long value = 0;
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                Assert.True(db.KeyExists(key));
-                db.StringSet(key, value, flags: CommandFlags.FireAndForget);
-
-                var actual = (string?)db.StringGet(key);
-                Assert.Equal("0", actual);
-                Assert.True(db.KeyExists(key));
-            }
-        }
-
-        [Fact]
-        public async Task GetSetAsync()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-
-                RedisKey key = Me();
-                var d0 = conn.KeyDeleteAsync(key);
-                var d1 = conn.KeyDeleteAsync(key);
-                var g1 = conn.StringGetAsync(key);
-                var s1 = conn.StringSetAsync(key, "123");
-                var g2 = conn.StringGetAsync(key);
-                var d2 = conn.KeyDeleteAsync(key);
-
-                await d0;
-                Assert.False(await d1);
-                Assert.Null((string?)(await g1));
-                Assert.True((await g1).IsNull);
-                await s1;
-                Assert.Equal("123", await g2);
-                Assert.Equal(123, (int)(await g2));
-                Assert.False((await g2).IsNull);
-                Assert.True(await d2);
-            }
-        }
-
-        [Fact]
-        public void GetSetSync()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-
-                RedisKey key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var d1 = conn.KeyDelete(key);
-                var g1 = conn.StringGet(key);
-                conn.StringSet(key, "123", flags: CommandFlags.FireAndForget);
-                var g2 = conn.StringGet(key);
-                var d2 = conn.KeyDelete(key);
-
-                Assert.False(d1);
-                Assert.Null((string?)g1);
-                Assert.True(g1.IsNull);
-
-                Assert.Equal("123", g2);
-                Assert.Equal(123, (int)g2);
-                Assert.False(g2.IsNull);
-                Assert.True(d2);
-            }
-        }
-
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        public async Task GetWithExpiry(bool exists, bool hasExpiry)
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                if (exists)
-                {
-                    if (hasExpiry)
-                        db.StringSet(key, "val", TimeSpan.FromMinutes(5), flags: CommandFlags.FireAndForget);
-                    else
-                        db.StringSet(key, "val", flags: CommandFlags.FireAndForget);
-                }
-                var async = db.StringGetWithExpiryAsync(key);
-                var syncResult = db.StringGetWithExpiry(key);
-                var asyncResult = await async;
-
-                if (exists)
-                {
-                    Assert.Equal("val", asyncResult.Value);
-                    Assert.Equal(hasExpiry, asyncResult.Expiry.HasValue);
-                    if (hasExpiry) Assert.True(asyncResult.Expiry!.Value.TotalMinutes >= 4.9 && asyncResult.Expiry.Value.TotalMinutes <= 5);
-                    Assert.Equal("val", syncResult.Value);
-                    Assert.Equal(hasExpiry, syncResult.Expiry.HasValue);
-                    if (hasExpiry) Assert.True(syncResult.Expiry!.Value.TotalMinutes >= 4.9 && syncResult.Expiry.Value.TotalMinutes <= 5);
-                }
-                else
-                {
-                    Assert.True(asyncResult.Value.IsNull);
-                    Assert.False(asyncResult.Expiry.HasValue);
-                    Assert.True(syncResult.Value.IsNull);
-                    Assert.False(syncResult.Expiry.HasValue);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task GetWithExpiryWrongTypeAsync()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                _ = db.KeyDeleteAsync(key);
-                _ = db.SetAddAsync(key, "abc");
-                var ex = await Assert.ThrowsAsync<RedisServerException>(async () =>
-                {
-                    try
-                    {
-                        Log("Key: " + (string?)key);
-                        await db.StringGetWithExpiryAsync(key).ForAwait();
-                    }
-                    catch (AggregateException e)
-                    {
-                        throw e.InnerExceptions[0];
-                    }
-                }).ForAwait();
-                Assert.Equal("WRONGTYPE Operation against a key holding the wrong kind of value", ex.Message);
-            }
-        }
-
-        [Fact]
-        public void GetWithExpiryWrongTypeSync()
-        {
-            RedisKey key = Me();
-            var ex = Assert.Throws<RedisServerException>(() =>
-            {
-                using (var conn = Create())
-                {
-                    var db = conn.GetDatabase();
-                    db.KeyDelete(key, CommandFlags.FireAndForget);
-                    db.SetAdd(key, "abc", CommandFlags.FireAndForget);
-                    db.StringGetWithExpiry(key);
-                }
-            });
-            Assert.Equal("WRONGTYPE Operation against a key holding the wrong kind of value", ex.Message);
-        }
+            using var conn = Create();
+            var db = conn.GetDatabase();
+            db.KeyDelete(key, CommandFlags.FireAndForget);
+            db.SetAdd(key, "abc", CommandFlags.FireAndForget);
+            db.StringGetWithExpiry(key);
+        });
+        Assert.Equal("WRONGTYPE Operation against a key holding the wrong kind of value", ex.Message);
+    }
 
 #if DEBUG
-        [Fact]
-        public async Task TestSevered()
-        {
-            SetExpectedAmbientFailureCount(2);
-            using (var muxer = Create(allowAdmin: true, shared: false))
-            {
-                var db = muxer.GetDatabase();
-                string key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringSet(key, key, flags: CommandFlags.FireAndForget);
-                var server = GetServer(muxer);
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                var watch = Stopwatch.StartNew();
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => server.IsConnected);
-                watch.Stop();
-                Log("Time to re-establish: {0}ms (any order)", watch.ElapsedMilliseconds);
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => key == db.StringGet(key));
-                Debug.WriteLine("Pinging...");
-                Assert.Equal(key, db.StringGet(key));
-            }
-        }
+    [Fact]
+    public async Task TestSevered()
+    {
+        SetExpectedAmbientFailureCount(2);
+        using var conn = Create(allowAdmin: true, shared: false);
+        var db = conn.GetDatabase();
+        string key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, key, flags: CommandFlags.FireAndForget);
+        var server = GetServer(conn);
+        server.SimulateConnectionFailure(SimulatedFailureType.All);
+        var watch = Stopwatch.StartNew();
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => server.IsConnected);
+        watch.Stop();
+        Log("Time to re-establish: {0}ms (any order)", watch.ElapsedMilliseconds);
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => key == db.StringGet(key));
+        Debug.WriteLine("Pinging...");
+        Assert.Equal(key, db.StringGet(key));
+    }
 #endif
 
-        [Fact]
-        public async Task IncrAsync()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                RedisKey key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var nix = conn.KeyExistsAsync(key).ForAwait();
-                var a = conn.StringGetAsync(key).ForAwait();
-                var b = conn.StringIncrementAsync(key).ForAwait();
-                var c = conn.StringGetAsync(key).ForAwait();
-                var d = conn.StringIncrementAsync(key, 10).ForAwait();
-                var e = conn.StringGetAsync(key).ForAwait();
-                var f = conn.StringDecrementAsync(key, 11).ForAwait();
-                var g = conn.StringGetAsync(key).ForAwait();
-                var h = conn.KeyExistsAsync(key).ForAwait();
-                Assert.False(await nix);
-                Assert.True((await a).IsNull);
-                Assert.Equal(0, (long)(await a));
-                Assert.Equal(1, await b);
-                Assert.Equal(1, (long)(await c));
-                Assert.Equal(11, await d);
-                Assert.Equal(11, (long)(await e));
-                Assert.Equal(0, await f);
-                Assert.Equal(0, (long)(await g));
-                Assert.True(await h);
-            }
-        }
+    [Fact]
+    public async Task IncrAsync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var nix = db.KeyExistsAsync(key).ForAwait();
+        var a = db.StringGetAsync(key).ForAwait();
+        var b = db.StringIncrementAsync(key).ForAwait();
+        var c = db.StringGetAsync(key).ForAwait();
+        var d = db.StringIncrementAsync(key, 10).ForAwait();
+        var e = db.StringGetAsync(key).ForAwait();
+        var f = db.StringDecrementAsync(key, 11).ForAwait();
+        var g = db.StringGetAsync(key).ForAwait();
+        var h = db.KeyExistsAsync(key).ForAwait();
+        Assert.False(await nix);
+        Assert.True((await a).IsNull);
+        Assert.Equal(0, (long)(await a));
+        Assert.Equal(1, await b);
+        Assert.Equal(1, (long)(await c));
+        Assert.Equal(11, await d);
+        Assert.Equal(11, (long)(await e));
+        Assert.Equal(0, await f);
+        Assert.Equal(0, (long)(await g));
+        Assert.True(await h);
+    }
 
-        [Fact]
-        public void IncrSync()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                RedisKey key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var nix = conn.KeyExists(key);
-                var a = conn.StringGet(key);
-                var b = conn.StringIncrement(key);
-                var c = conn.StringGet(key);
-                var d = conn.StringIncrement(key, 10);
-                var e = conn.StringGet(key);
-                var f = conn.StringDecrement(key, 11);
-                var g = conn.StringGet(key);
-                var h = conn.KeyExists(key);
-                Assert.False(nix);
-                Assert.True(a.IsNull);
-                Assert.Equal(0, (long)a);
-                Assert.Equal(1, b);
-                Assert.Equal(1, (long)c);
-                Assert.Equal(11, d);
-                Assert.Equal(11, (long)e);
-                Assert.Equal(0, f);
-                Assert.Equal(0, (long)g);
-                Assert.True(h);
-            }
-        }
+    [Fact]
+    public void IncrSync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var nix = db.KeyExists(key);
+        var a = db.StringGet(key);
+        var b = db.StringIncrement(key);
+        var c = db.StringGet(key);
+        var d = db.StringIncrement(key, 10);
+        var e = db.StringGet(key);
+        var f = db.StringDecrement(key, 11);
+        var g = db.StringGet(key);
+        var h = db.KeyExists(key);
+        Assert.False(nix);
+        Assert.True(a.IsNull);
+        Assert.Equal(0, (long)a);
+        Assert.Equal(1, b);
+        Assert.Equal(1, (long)c);
+        Assert.Equal(11, d);
+        Assert.Equal(11, (long)e);
+        Assert.Equal(0, f);
+        Assert.Equal(0, (long)g);
+        Assert.True(h);
+    }
 
-        [Fact]
-        public void IncrDifferentSizes()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                int expected = 0;
-                Incr(db, key, -129019, ref expected);
-                Incr(db, key, -10023, ref expected);
-                Incr(db, key, -9933, ref expected);
-                Incr(db, key, -23, ref expected);
-                Incr(db, key, -7, ref expected);
-                Incr(db, key, -1, ref expected);
-                Incr(db, key, 0, ref expected);
-                Incr(db, key, 1, ref expected);
-                Incr(db, key, 9, ref expected);
-                Incr(db, key, 11, ref expected);
-                Incr(db, key, 345, ref expected);
-                Incr(db, key, 4982, ref expected);
-                Incr(db, key, 13091, ref expected);
-                Incr(db, key, 324092, ref expected);
-                Assert.NotEqual(0, expected);
-                var sum = (long)db.StringGet(key);
-                Assert.Equal(expected, sum);
-            }
-        }
+    [Fact]
+    public void IncrDifferentSizes()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        int expected = 0;
+        Incr(db, key, -129019, ref expected);
+        Incr(db, key, -10023, ref expected);
+        Incr(db, key, -9933, ref expected);
+        Incr(db, key, -23, ref expected);
+        Incr(db, key, -7, ref expected);
+        Incr(db, key, -1, ref expected);
+        Incr(db, key, 0, ref expected);
+        Incr(db, key, 1, ref expected);
+        Incr(db, key, 9, ref expected);
+        Incr(db, key, 11, ref expected);
+        Incr(db, key, 345, ref expected);
+        Incr(db, key, 4982, ref expected);
+        Incr(db, key, 13091, ref expected);
+        Incr(db, key, 324092, ref expected);
+        Assert.NotEqual(0, expected);
+        var sum = (long)db.StringGet(key);
+        Assert.Equal(expected, sum);
+    }
 
-        private static void Incr(IDatabase database, RedisKey key, int delta, ref int total)
-        {
-            database.StringIncrement(key, delta, CommandFlags.FireAndForget);
-            total += delta;
-        }
+    private static void Incr(IDatabase database, RedisKey key, int delta, ref int total)
+    {
+        database.StringIncrement(key, delta, CommandFlags.FireAndForget);
+        total += delta;
+    }
 
-        [Fact]
-        public void ShouldUseSharedMuxer()
+    [Fact]
+    public void ShouldUseSharedMuxer()
+    {
+        Writer.WriteLine($"Shared: {SharedFixtureAvailable}");
+        if (SharedFixtureAvailable)
         {
-            Writer.WriteLine($"Shared: {SharedFixtureAvailable}");
-            if (SharedFixtureAvailable)
-            {
-                using (var a = Create())
-                {
-                    Assert.IsNotType<ConnectionMultiplexer>(a);
-                    using (var b = Create())
-                    {
-                        Assert.Same(a, b);
-                    }
-                }
-            }
-            else
-            {
-                using (var a = Create())
-                {
-                    Assert.IsType<ConnectionMultiplexer>(a);
-                    using (var b = Create())
-                    {
-                        Assert.NotSame(a, b);
-                    }
-                }
-            }
+            using var a = Create();
+            Assert.IsNotType<ConnectionMultiplexer>(a);
+            using var b = Create();
+            Assert.Same(a, b);
         }
-
-        [Fact]
-        public async Task Delete()
+        else
         {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                var key = Me();
-                _ = db.StringSetAsync(key, "Heyyyyy");
-                var ke1 = db.KeyExistsAsync(key).ForAwait();
-                var ku1 = db.KeyDelete(key);
-                var ke2 = db.KeyExistsAsync(key).ForAwait();
-                Assert.True(await ke1);
-                Assert.True(ku1);
-                Assert.False(await ke2);
-            }
+            using var a = Create();
+            Assert.IsType<ConnectionMultiplexer>(a);
+            using var b = Create();
+            Assert.NotSame(a, b);
         }
+    }
 
-        [Fact]
-        public async Task DeleteAsync()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                var key = Me();
-                _ = db.StringSetAsync(key, "Heyyyyy");
-                var ke1 = db.KeyExistsAsync(key).ForAwait();
-                var ku1 = db.KeyDeleteAsync(key).ForAwait();
-                var ke2 = db.KeyExistsAsync(key).ForAwait();
-                Assert.True(await ke1);
-                Assert.True(await ku1);
-                Assert.False(await ke2);
-            }
-        }
+    [Fact]
+    public async Task Delete()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var key = Me();
+        _ = db.StringSetAsync(key, "Heyyyyy");
+        var ke1 = db.KeyExistsAsync(key).ForAwait();
+        var ku1 = db.KeyDelete(key);
+        var ke2 = db.KeyExistsAsync(key).ForAwait();
+        Assert.True(await ke1);
+        Assert.True(ku1);
+        Assert.False(await ke2);
+    }
 
-        [Fact]
-        public async Task DeleteMany()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                var key1 = Me();
-                var key2 = Me() + "2";
-                var key3 = Me() + "3";
-                _ = db.StringSetAsync(key1, "Heyyyyy");
-                _ = db.StringSetAsync(key2, "Heyyyyy");
-                // key 3 not set
-                var ku1 = db.KeyDelete(new RedisKey[] { key1, key2, key3 });
-                var ke1 = db.KeyExistsAsync(key1).ForAwait();
-                var ke2 = db.KeyExistsAsync(key2).ForAwait();
-                Assert.Equal(2, ku1);
-                Assert.False(await ke1);
-                Assert.False(await ke2);
-            }
-        }
+    [Fact]
+    public async Task DeleteAsync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var key = Me();
+        _ = db.StringSetAsync(key, "Heyyyyy");
+        var ke1 = db.KeyExistsAsync(key).ForAwait();
+        var ku1 = db.KeyDeleteAsync(key).ForAwait();
+        var ke2 = db.KeyExistsAsync(key).ForAwait();
+        Assert.True(await ke1);
+        Assert.True(await ku1);
+        Assert.False(await ke2);
+    }
 
-        [Fact]
-        public async Task DeleteManyAsync()
-        {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                var key1 = Me();
-                var key2 = Me() + "2";
-                var key3 = Me() + "3";
-                _ = db.StringSetAsync(key1, "Heyyyyy");
-                _ = db.StringSetAsync(key2, "Heyyyyy");
-                // key 3 not set
-                var ku1 = db.KeyDeleteAsync(new RedisKey[] { key1, key2, key3 }).ForAwait();
-                var ke1 = db.KeyExistsAsync(key1).ForAwait();
-                var ke2 = db.KeyExistsAsync(key2).ForAwait();
-                Assert.Equal(2, await ku1);
-                Assert.False(await ke1);
-                Assert.False(await ke2);
-            }
-        }
+    [Fact]
+    public async Task DeleteMany()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        var key2 = Me() + "2";
+        var key3 = Me() + "3";
+        _ = db.StringSetAsync(key1, "Heyyyyy");
+        _ = db.StringSetAsync(key2, "Heyyyyy");
+        // key 3 not set
+        var ku1 = db.KeyDelete(new RedisKey[] { key1, key2, key3 });
+        var ke1 = db.KeyExistsAsync(key1).ForAwait();
+        var ke2 = db.KeyExistsAsync(key2).ForAwait();
+        Assert.Equal(2, ku1);
+        Assert.False(await ke1);
+        Assert.False(await ke2);
+    }
 
-        [Fact]
-        public void WrappedDatabasePrefixIntegration()
-        {
-            var key = Me();
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase().WithKeyPrefix("abc");
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                db.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                db.StringIncrement(key, flags: CommandFlags.FireAndForget);
+    [Fact]
+    public async Task DeleteManyAsync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        var key2 = Me() + "2";
+        var key3 = Me() + "3";
+        _ = db.StringSetAsync(key1, "Heyyyyy");
+        _ = db.StringSetAsync(key2, "Heyyyyy");
+        // key 3 not set
+        var ku1 = db.KeyDeleteAsync(new RedisKey[] { key1, key2, key3 }).ForAwait();
+        var ke1 = db.KeyExistsAsync(key1).ForAwait();
+        var ke2 = db.KeyExistsAsync(key2).ForAwait();
+        Assert.Equal(2, await ku1);
+        Assert.False(await ke1);
+        Assert.False(await ke2);
+    }
 
-                int count = (int)conn.GetDatabase().StringGet("abc" + key);
-                Assert.Equal(3, count);
-            }
-        }
+    [Fact]
+    public void WrappedDatabasePrefixIntegration()
+    {
+        var key = Me();
+        using var conn = Create();
+        var db = conn.GetDatabase().WithKeyPrefix("abc");
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringIncrement(key, flags: CommandFlags.FireAndForget);
+        db.StringIncrement(key, flags: CommandFlags.FireAndForget);
+        db.StringIncrement(key, flags: CommandFlags.FireAndForget);
+
+        int count = (int)conn.GetDatabase().StringGet("abc" + key);
+        Assert.Equal(3, count);
     }
 }

--- a/tests/StackExchange.Redis.Tests/BatchWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/BatchWrapperTests.cs
@@ -3,25 +3,24 @@ using StackExchange.Redis.KeyspaceIsolation;
 using System.Text;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(nameof(MoqDependentCollection))]
+public sealed class BatchWrapperTests
 {
-    [Collection(nameof(MoqDependentCollection))]
-    public sealed class BatchWrapperTests
+    private readonly Mock<IBatch> mock;
+    private readonly BatchWrapper wrapper;
+
+    public BatchWrapperTests()
     {
-        private readonly Mock<IBatch> mock;
-        private readonly BatchWrapper wrapper;
+        mock = new Mock<IBatch>();
+        wrapper = new BatchWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+    }
 
-        public BatchWrapperTests()
-        {
-            mock = new Mock<IBatch>();
-            wrapper = new BatchWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
-        }
-
-        [Fact]
-        public void Execute()
-        {
-            wrapper.Execute();
-            mock.Verify(_ => _.Execute(), Times.Once());
-        }
+    [Fact]
+    public void Execute()
+    {
+        wrapper.Execute();
+        mock.Verify(_ => _.Execute(), Times.Once());
     }
 }

--- a/tests/StackExchange.Redis.Tests/Batches.cs
+++ b/tests/StackExchange.Redis.Tests/Batches.cs
@@ -4,61 +4,56 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Batches : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Batches : TestBase
+    public Batches(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void TestBatchNotSent()
     {
-        public Batches(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDeleteAsync(key);
+        db.StringSetAsync(key, "batch-not-sent");
+        var batch = db.CreateBatch();
 
-        [Fact]
-        public void TestBatchNotSent()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDeleteAsync(key);
-                conn.StringSetAsync(key, "batch-not-sent");
-                var batch = conn.CreateBatch();
+        batch.KeyDeleteAsync(key);
+        batch.SetAddAsync(key, "a");
+        batch.SetAddAsync(key, "b");
+        batch.SetAddAsync(key, "c");
 
-                batch.KeyDeleteAsync(key);
-                batch.SetAddAsync(key, "a");
-                batch.SetAddAsync(key, "b");
-                batch.SetAddAsync(key, "c");
+        Assert.Equal("batch-not-sent", db.StringGet(key));
+    }
 
-                Assert.Equal("batch-not-sent", conn.StringGet(key));
-            }
-        }
+    [Fact]
+    public void TestBatchSent()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDeleteAsync(key);
+        db.StringSetAsync(key, "batch-sent");
+        var tasks = new List<Task>();
+        var batch = db.CreateBatch();
+        tasks.Add(batch.KeyDeleteAsync(key));
+        tasks.Add(batch.SetAddAsync(key, "a"));
+        tasks.Add(batch.SetAddAsync(key, "b"));
+        tasks.Add(batch.SetAddAsync(key, "c"));
+        batch.Execute();
 
-        [Fact]
-        public void TestBatchSent()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDeleteAsync(key);
-                conn.StringSetAsync(key, "batch-sent");
-                var tasks = new List<Task>();
-                var batch = conn.CreateBatch();
-                tasks.Add(batch.KeyDeleteAsync(key));
-                tasks.Add(batch.SetAddAsync(key, "a"));
-                tasks.Add(batch.SetAddAsync(key, "b"));
-                tasks.Add(batch.SetAddAsync(key, "c"));
-                batch.Execute();
+        var result = db.SetMembersAsync(key);
+        tasks.Add(result);
+        Task.WhenAll(tasks.ToArray());
 
-                var result = conn.SetMembersAsync(key);
-                tasks.Add(result);
-                Task.WhenAll(tasks.ToArray());
-
-                var arr = result.Result;
-                Array.Sort(arr, (x, y) => string.Compare(x, y));
-                Assert.Equal(3, arr.Length);
-                Assert.Equal("a", arr[0]);
-                Assert.Equal("b", arr[1]);
-                Assert.Equal("c", arr[2]);
-            }
-        }
+        var arr = result.Result;
+        Array.Sort(arr, (x, y) => string.Compare(x, y));
+        Assert.Equal(3, arr.Length);
+        Assert.Equal("a", arr[0]);
+        Assert.Equal("b", arr[1]);
+        Assert.Equal("c", arr[2]);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Bits.cs
+++ b/tests/StackExchange.Redis.Tests/Bits.cs
@@ -1,26 +1,23 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Bits : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Bits : TestBase
+    public Bits(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public void BasicOps()
     {
-        public Bits(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
 
-        [Fact]
-        public void BasicOps()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringSetBit(key, 10, true);
-                Assert.True(db.StringGetBit(key, 10));
-                Assert.False(db.StringGetBit(key, 11));
-            }
-        }
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSetBit(key, 10, true);
+        Assert.True(db.StringGetBit(key, 10));
+        Assert.False(db.StringGetBit(key, 11));
     }
 }

--- a/tests/StackExchange.Redis.Tests/BoxUnbox.cs
+++ b/tests/StackExchange.Redis.Tests/BoxUnbox.cs
@@ -3,167 +3,166 @@ using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class BoxUnboxTests
 {
-    public class BoxUnboxTests
+    [Theory]
+    [MemberData(nameof(RoundTripValues))]
+    public void RoundTripRedisValue(RedisValue value)
     {
-        [Theory]
-        [MemberData(nameof(RoundTripValues))]
-        public void RoundTripRedisValue(RedisValue value)
-        {
-            var boxed = value.Box();
-            var unboxed = RedisValue.Unbox(boxed);
-            AssertEqualGiveOrTakeNaN(value, unboxed);
-        }
+        var boxed = value.Box();
+        var unboxed = RedisValue.Unbox(boxed);
+        AssertEqualGiveOrTakeNaN(value, unboxed);
+    }
 
-        [Theory]
-        [MemberData(nameof(UnboxValues))]
-        public void UnboxCommonValues(object value, RedisValue expected)
-        {
-            var unboxed = RedisValue.Unbox(value);
-            AssertEqualGiveOrTakeNaN(expected, unboxed);
-        }
+    [Theory]
+    [MemberData(nameof(UnboxValues))]
+    public void UnboxCommonValues(object value, RedisValue expected)
+    {
+        var unboxed = RedisValue.Unbox(value);
+        AssertEqualGiveOrTakeNaN(expected, unboxed);
+    }
 
-        [Theory]
-        [MemberData(nameof(InternedValues))]
-        public void ReturnInternedBoxesForCommonValues(RedisValue value, bool expectSameReference)
-        {
-            object? x = value.Box(), y = value.Box();
-            Assert.Equal(expectSameReference, ReferenceEquals(x, y));
-            // check we got the right values!
-            AssertEqualGiveOrTakeNaN(value, RedisValue.Unbox(x));
-            AssertEqualGiveOrTakeNaN(value, RedisValue.Unbox(y));
-        }
+    [Theory]
+    [MemberData(nameof(InternedValues))]
+    public void ReturnInternedBoxesForCommonValues(RedisValue value, bool expectSameReference)
+    {
+        object? x = value.Box(), y = value.Box();
+        Assert.Equal(expectSameReference, ReferenceEquals(x, y));
+        // check we got the right values!
+        AssertEqualGiveOrTakeNaN(value, RedisValue.Unbox(x));
+        AssertEqualGiveOrTakeNaN(value, RedisValue.Unbox(y));
+    }
 
-        private static void AssertEqualGiveOrTakeNaN(RedisValue expected, RedisValue actual)
+    private static void AssertEqualGiveOrTakeNaN(RedisValue expected, RedisValue actual)
+    {
+        if (expected.Type == RedisValue.StorageType.Double && actual.Type == expected.Type)
         {
-            if (expected.Type == RedisValue.StorageType.Double && actual.Type == expected.Type)
+            // because NaN != NaN, we need to special-case this scenario
+            bool enan = double.IsNaN((double)expected), anan = double.IsNaN((double)actual);
+            if (enan | anan)
             {
-                // because NaN != NaN, we need to special-case this scenario
-                bool enan = double.IsNaN((double)expected), anan = double.IsNaN((double)actual);
-                if (enan | anan)
-                {
-                    Assert.Equal(enan, anan);
-                    return; // and that's all
-                }
+                Assert.Equal(enan, anan);
+                return; // and that's all
             }
-            Assert.Equal(expected, actual);
         }
+        Assert.Equal(expected, actual);
+    }
 
-        private static readonly byte[] s_abc = Encoding.UTF8.GetBytes("abc");
-        public static IEnumerable<object[]> RoundTripValues
-            => new []
-            {
-                new object[] { RedisValue.Null },
-                new object[] { RedisValue.EmptyString },
-                new object[] { (RedisValue)0L },
-                new object[] { (RedisValue)1L },
-                new object[] { (RedisValue)18L },
-                new object[] { (RedisValue)19L },
-                new object[] { (RedisValue)20L },
-                new object[] { (RedisValue)21L },
-                new object[] { (RedisValue)22L },
-                new object[] { (RedisValue)(-1L) },
-                new object[] { (RedisValue)0 },
-                new object[] { (RedisValue)1 },
-                new object[] { (RedisValue)18 },
-                new object[] { (RedisValue)19 },
-                new object[] { (RedisValue)20 },
-                new object[] { (RedisValue)21 },
-                new object[] { (RedisValue)22 },
-                new object[] { (RedisValue)(-1) },
-                new object[] { (RedisValue)0F },
-                new object[] { (RedisValue)1F },
-                new object[] { (RedisValue)(-1F) },
-                new object[] { (RedisValue)0D },
-                new object[] { (RedisValue)1D },
-                new object[] { (RedisValue)(-1D) },
-                new object[] { (RedisValue)float.PositiveInfinity },
-                new object[] { (RedisValue)float.NegativeInfinity },
-                new object[] { (RedisValue)float.NaN },
-                new object[] { (RedisValue)double.PositiveInfinity },
-                new object[] { (RedisValue)double.NegativeInfinity },
-                new object[] { (RedisValue)double.NaN },
-                new object[] { (RedisValue)true },
-                new object[] { (RedisValue)false },
-                new object[] { (RedisValue)(string?)null },
-                new object[] { (RedisValue)"abc" },
-                new object[] { (RedisValue)s_abc },
-                new object[] { (RedisValue)new Memory<byte>(s_abc) },
-                new object[] { (RedisValue)new ReadOnlyMemory<byte>(s_abc) },
-            };
-
-        public static IEnumerable<object?[]> UnboxValues
-            => new []
-            {
-                new object?[] { null, RedisValue.Null },
-                new object[] { "", RedisValue.EmptyString },
-                new object[] { 0, (RedisValue)0 },
-                new object[] { 1, (RedisValue)1 },
-                new object[] { 18, (RedisValue)18 },
-                new object[] { 19, (RedisValue)19 },
-                new object[] { 20, (RedisValue)20 },
-                new object[] { 21, (RedisValue)21 },
-                new object[] { 22, (RedisValue)22 },
-                new object[] { -1, (RedisValue)(-1) },
-                new object[] { 18L, (RedisValue)18 },
-                new object[] { 19L, (RedisValue)19 },
-                new object[] { 20L, (RedisValue)20 },
-                new object[] { 21L, (RedisValue)21 },
-                new object[] { 22L, (RedisValue)22 },
-                new object[] { -1L, (RedisValue)(-1) },
-                new object[] { 0F, (RedisValue)0 },
-                new object[] { 1F, (RedisValue)1 },
-                new object[] { -1F, (RedisValue)(-1) },
-                new object[] { 0D, (RedisValue)0 },
-                new object[] { 1D, (RedisValue)1 },
-                new object[] { -1D, (RedisValue)(-1) },
-                new object[] { float.PositiveInfinity, (RedisValue)double.PositiveInfinity },
-                new object[] { float.NegativeInfinity, (RedisValue)double.NegativeInfinity },
-                new object[] { float.NaN, (RedisValue)double.NaN },
-                new object[] { double.PositiveInfinity, (RedisValue)double.PositiveInfinity },
-                new object[] { double.NegativeInfinity, (RedisValue)double.NegativeInfinity },
-                new object[] { double.NaN, (RedisValue)double.NaN },
-                new object[] { true, (RedisValue)true },
-                new object[] { false, (RedisValue)false},
-                new object[] { "abc", (RedisValue)"abc" },
-                new object[] { s_abc, (RedisValue)s_abc },
-                new object[] { new Memory<byte>(s_abc), (RedisValue)s_abc },
-                new object[] { new ReadOnlyMemory<byte>(s_abc), (RedisValue)s_abc },
-                new object[] { (RedisValue)1234, (RedisValue)1234 },
-            };
-
-        public static IEnumerable<object[]> InternedValues()
+    private static readonly byte[] s_abc = Encoding.UTF8.GetBytes("abc");
+    public static IEnumerable<object[]> RoundTripValues
+        => new []
         {
-            for(int i = -20; i <= 40; i++)
-            {
-                bool expectInterned = i >= -1 & i <= 20;
-                yield return new object[] { (RedisValue)i, expectInterned };
-                yield return new object[] { (RedisValue)(long)i, expectInterned };
-                yield return new object[] { (RedisValue)(float)i, expectInterned };
-                yield return new object[] { (RedisValue)(double)i, expectInterned };
-            }
+            new object[] { RedisValue.Null },
+            new object[] { RedisValue.EmptyString },
+            new object[] { (RedisValue)0L },
+            new object[] { (RedisValue)1L },
+            new object[] { (RedisValue)18L },
+            new object[] { (RedisValue)19L },
+            new object[] { (RedisValue)20L },
+            new object[] { (RedisValue)21L },
+            new object[] { (RedisValue)22L },
+            new object[] { (RedisValue)(-1L) },
+            new object[] { (RedisValue)0 },
+            new object[] { (RedisValue)1 },
+            new object[] { (RedisValue)18 },
+            new object[] { (RedisValue)19 },
+            new object[] { (RedisValue)20 },
+            new object[] { (RedisValue)21 },
+            new object[] { (RedisValue)22 },
+            new object[] { (RedisValue)(-1) },
+            new object[] { (RedisValue)0F },
+            new object[] { (RedisValue)1F },
+            new object[] { (RedisValue)(-1F) },
+            new object[] { (RedisValue)0D },
+            new object[] { (RedisValue)1D },
+            new object[] { (RedisValue)(-1D) },
+            new object[] { (RedisValue)float.PositiveInfinity },
+            new object[] { (RedisValue)float.NegativeInfinity },
+            new object[] { (RedisValue)float.NaN },
+            new object[] { (RedisValue)double.PositiveInfinity },
+            new object[] { (RedisValue)double.NegativeInfinity },
+            new object[] { (RedisValue)double.NaN },
+            new object[] { (RedisValue)true },
+            new object[] { (RedisValue)false },
+            new object[] { (RedisValue)(string?)null },
+            new object[] { (RedisValue)"abc" },
+            new object[] { (RedisValue)s_abc },
+            new object[] { (RedisValue)new Memory<byte>(s_abc) },
+            new object[] { (RedisValue)new ReadOnlyMemory<byte>(s_abc) },
+        };
 
-            yield return new object[] { (RedisValue)float.NegativeInfinity, true };
-            yield return new object[] { (RedisValue)(-0.5F), false };
-            yield return new object[] { (RedisValue)(0.5F), false };
-            yield return new object[] { (RedisValue)float.PositiveInfinity, true };
-            yield return new object[] { (RedisValue)float.NaN, true };
+    public static IEnumerable<object?[]> UnboxValues
+        => new []
+        {
+            new object?[] { null, RedisValue.Null },
+            new object[] { "", RedisValue.EmptyString },
+            new object[] { 0, (RedisValue)0 },
+            new object[] { 1, (RedisValue)1 },
+            new object[] { 18, (RedisValue)18 },
+            new object[] { 19, (RedisValue)19 },
+            new object[] { 20, (RedisValue)20 },
+            new object[] { 21, (RedisValue)21 },
+            new object[] { 22, (RedisValue)22 },
+            new object[] { -1, (RedisValue)(-1) },
+            new object[] { 18L, (RedisValue)18 },
+            new object[] { 19L, (RedisValue)19 },
+            new object[] { 20L, (RedisValue)20 },
+            new object[] { 21L, (RedisValue)21 },
+            new object[] { 22L, (RedisValue)22 },
+            new object[] { -1L, (RedisValue)(-1) },
+            new object[] { 0F, (RedisValue)0 },
+            new object[] { 1F, (RedisValue)1 },
+            new object[] { -1F, (RedisValue)(-1) },
+            new object[] { 0D, (RedisValue)0 },
+            new object[] { 1D, (RedisValue)1 },
+            new object[] { -1D, (RedisValue)(-1) },
+            new object[] { float.PositiveInfinity, (RedisValue)double.PositiveInfinity },
+            new object[] { float.NegativeInfinity, (RedisValue)double.NegativeInfinity },
+            new object[] { float.NaN, (RedisValue)double.NaN },
+            new object[] { double.PositiveInfinity, (RedisValue)double.PositiveInfinity },
+            new object[] { double.NegativeInfinity, (RedisValue)double.NegativeInfinity },
+            new object[] { double.NaN, (RedisValue)double.NaN },
+            new object[] { true, (RedisValue)true },
+            new object[] { false, (RedisValue)false},
+            new object[] { "abc", (RedisValue)"abc" },
+            new object[] { s_abc, (RedisValue)s_abc },
+            new object[] { new Memory<byte>(s_abc), (RedisValue)s_abc },
+            new object[] { new ReadOnlyMemory<byte>(s_abc), (RedisValue)s_abc },
+            new object[] { (RedisValue)1234, (RedisValue)1234 },
+        };
 
-            yield return new object[] { (RedisValue)double.NegativeInfinity, true };
-            yield return new object[] { (RedisValue)(-0.5D), false };
-            yield return new object[] { (RedisValue)(0.5D), false };
-            yield return new object[] { (RedisValue)double.PositiveInfinity, true };
-            yield return new object[] { (RedisValue)double.NaN, true };
-
-            yield return new object[] { (RedisValue)true, true };
-            yield return new object[] { (RedisValue)false, true };
-            yield return new object[] { RedisValue.Null, true };
-            yield return new object[] { RedisValue.EmptyString, true };
-            yield return new object[] { (RedisValue)"abc", true };
-            yield return new object[] { (RedisValue)s_abc, true };
-            yield return new object[] { (RedisValue)new Memory<byte>(s_abc), false };
-            yield return new object[] { (RedisValue)new ReadOnlyMemory<byte>(s_abc), false };
+    public static IEnumerable<object[]> InternedValues()
+    {
+        for(int i = -20; i <= 40; i++)
+        {
+            bool expectInterned = i >= -1 & i <= 20;
+            yield return new object[] { (RedisValue)i, expectInterned };
+            yield return new object[] { (RedisValue)(long)i, expectInterned };
+            yield return new object[] { (RedisValue)(float)i, expectInterned };
+            yield return new object[] { (RedisValue)(double)i, expectInterned };
         }
+
+        yield return new object[] { (RedisValue)float.NegativeInfinity, true };
+        yield return new object[] { (RedisValue)(-0.5F), false };
+        yield return new object[] { (RedisValue)(0.5F), false };
+        yield return new object[] { (RedisValue)float.PositiveInfinity, true };
+        yield return new object[] { (RedisValue)float.NaN, true };
+
+        yield return new object[] { (RedisValue)double.NegativeInfinity, true };
+        yield return new object[] { (RedisValue)(-0.5D), false };
+        yield return new object[] { (RedisValue)(0.5D), false };
+        yield return new object[] { (RedisValue)double.PositiveInfinity, true };
+        yield return new object[] { (RedisValue)double.NaN, true };
+
+        yield return new object[] { (RedisValue)true, true };
+        yield return new object[] { (RedisValue)false, true };
+        yield return new object[] { RedisValue.Null, true };
+        yield return new object[] { RedisValue.EmptyString, true };
+        yield return new object[] { (RedisValue)"abc", true };
+        yield return new object[] { (RedisValue)s_abc, true };
+        yield return new object[] { (RedisValue)new Memory<byte>(s_abc), false };
+        yield return new object[] { (RedisValue)new ReadOnlyMemory<byte>(s_abc), false };
     }
 }

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -9,739 +9,722 @@ using StackExchange.Redis.Profiling;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Cluster : TestBase
 {
-    public class Cluster : TestBase
+    public Cluster(ITestOutputHelper output) : base (output) { }
+    protected override string GetConfiguration() => TestConfig.Current.ClusterServersAndPorts + ",connectTimeout=10000";
+
+    [Fact]
+    public void ExportConfiguration()
     {
-        public Cluster(ITestOutputHelper output) : base (output) { }
-        protected override string GetConfiguration() => TestConfig.Current.ClusterServersAndPorts + ",connectTimeout=10000";
-
-        [Fact]
-        public void ExportConfiguration()
+        if (File.Exists("cluster.zip")) File.Delete("cluster.zip");
+        Assert.False(File.Exists("cluster.zip"));
+        using (var muxer = Create(allowAdmin: true))
+        using (var file = File.Create("cluster.zip"))
         {
-            if (File.Exists("cluster.zip")) File.Delete("cluster.zip");
-            Assert.False(File.Exists("cluster.zip"));
-            using (var muxer = Create(allowAdmin: true))
-            using (var file = File.Create("cluster.zip"))
-            {
-                muxer.ExportConfiguration(file);
-            }
-            Assert.True(File.Exists("cluster.zip"));
+            muxer.ExportConfiguration(file);
         }
+        Assert.True(File.Exists("cluster.zip"));
+    }
 
-        [Fact]
-        public void ConnectUsesSingleSocket()
+    [Fact]
+    public void ConnectUsesSingleSocket()
+    {
+        for (int i = 0; i < 5; i++)
         {
-            for (int i = 0; i < 5; i++)
+            using var conn = Create(failMessage: i + ": ", log: Writer);
+
+            foreach (var ep in conn.GetEndPoints())
             {
-                using (var muxer = Create(failMessage: i + ": ", log: Writer))
-                {
-                    foreach (var ep in muxer.GetEndPoints())
-                    {
-                        var srv = muxer.GetServer(ep);
-                        var counters = srv.GetCounters();
-                        Log($"{i}; interactive, {ep}, count: {counters.Interactive.SocketCount}");
-                        Log($"{i}; subscription, {ep}, count: {counters.Subscription.SocketCount}");
-                    }
-                    foreach (var ep in muxer.GetEndPoints())
-                    {
-                        var srv = muxer.GetServer(ep);
-                        var counters = srv.GetCounters();
-                        Assert.Equal(1, counters.Interactive.SocketCount);
-                        Assert.Equal(1, counters.Subscription.SocketCount);
-                    }
-                }
+                var srv = conn.GetServer(ep);
+                var counters = srv.GetCounters();
+                Log($"{i}; interactive, {ep}, count: {counters.Interactive.SocketCount}");
+                Log($"{i}; subscription, {ep}, count: {counters.Subscription.SocketCount}");
+            }
+            foreach (var ep in conn.GetEndPoints())
+            {
+                var srv = conn.GetServer(ep);
+                var counters = srv.GetCounters();
+                Assert.Equal(1, counters.Interactive.SocketCount);
+                Assert.Equal(1, counters.Subscription.SocketCount);
             }
         }
+    }
 
-        [Fact]
-        public void CanGetTotalStats()
+    [Fact]
+    public void CanGetTotalStats()
+    {
+        using var conn = Create();
+
+        var counters = conn.GetCounters();
+        Log(counters.ToString());
+    }
+
+    private void PrintEndpoints(EndPoint[] endpoints)
+    {
+        Log($"Endpoints Expected: {TestConfig.Current.ClusterStartPort}+{TestConfig.Current.ClusterServerCount}");
+        Log("Endpoints Found:");
+        foreach (var endpoint in endpoints)
         {
-            using (var muxer = Create())
+            Log("  Endpoint: " + endpoint);
+        }
+    }
+
+    [Fact]
+    public void Connect()
+    {
+        using var conn = Create(log: Writer);
+
+        var expectedPorts = new HashSet<int>(Enumerable.Range(TestConfig.Current.ClusterStartPort, TestConfig.Current.ClusterServerCount));
+        var endpoints = conn.GetEndPoints();
+        if (TestConfig.Current.ClusterServerCount != endpoints.Length)
+        {
+            PrintEndpoints(endpoints);
+        }
+
+        Assert.Equal(TestConfig.Current.ClusterServerCount, endpoints.Length);
+        int primaries = 0, replicas = 0;
+        var failed = new List<EndPoint>();
+        foreach (var endpoint in endpoints)
+        {
+            var server = conn.GetServer(endpoint);
+            if (!server.IsConnected)
             {
-                var counters = muxer.GetCounters();
-                Log(counters.ToString());
+                failed.Add(endpoint);
             }
-        }
+            Log("endpoint:" + endpoint);
+            Assert.Equal(endpoint, server.EndPoint);
 
-        private void PrintEndpoints(EndPoint[] endpoints)
+            Log("endpoint-type:" + endpoint);
+            Assert.IsType<IPEndPoint>(endpoint);
+
+            Log("port:" + endpoint);
+            Assert.True(expectedPorts.Remove(((IPEndPoint)endpoint).Port));
+
+            Log("server-type:" + endpoint);
+            Assert.Equal(ServerType.Cluster, server.ServerType);
+
+            if (server.IsReplica) replicas++;
+            else primaries++;
+        }
+        if (failed.Count != 0)
         {
-            Log($"Endpoints Expected: {TestConfig.Current.ClusterStartPort}+{TestConfig.Current.ClusterServerCount}");
-            Log("Endpoints Found:");
-            foreach (var endpoint in endpoints)
+            Log("{0} failues", failed.Count);
+            foreach (var fail in failed)
             {
-                Log("  Endpoint: " + endpoint);
+                Log(fail.ToString());
             }
+            Assert.True(false, "not all servers connected");
         }
 
-        [Fact]
-        public void Connect()
+        Assert.Equal(TestConfig.Current.ClusterServerCount / 2, replicas);
+        Assert.Equal(TestConfig.Current.ClusterServerCount / 2, primaries);
+    }
+
+    [Fact]
+    public void TestIdentity()
+    {
+        using var conn = Create();
+
+        RedisKey key = Guid.NewGuid().ToByteArray();
+        var ep = conn.GetDatabase().IdentifyEndpoint(key);
+        Assert.NotNull(ep);
+        Assert.Equal(ep, conn.GetServer(ep).ClusterConfiguration?.GetBySlot(key)?.EndPoint);
+    }
+
+    [Fact]
+    public void IntentionalWrongServer()
+    {
+        static string? StringGet(IServer server, RedisKey key, CommandFlags flags = CommandFlags.None)
+            => (string?)server.Execute("GET", new object[] { key }, flags);
+
+        using var conn = Create();
+
+        var endpoints = conn.GetEndPoints();
+        var servers = endpoints.Select(e => conn.GetServer(e)).ToList();
+
+        var key = Me();
+        const string value = "abc";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, value, flags: CommandFlags.FireAndForget);
+        servers[0].Ping();
+        var config = servers[0].ClusterConfiguration;
+        Assert.NotNull(config);
+        int slot = conn.HashSlot(key);
+        var rightPrimaryNode = config.GetBySlot(key);
+        Assert.NotNull(rightPrimaryNode);
+        Log("Right Primary: {0} {1}", rightPrimaryNode.EndPoint, rightPrimaryNode.NodeId);
+
+        Assert.NotNull(rightPrimaryNode.EndPoint);
+        string? a = StringGet(conn.GetServer(rightPrimaryNode.EndPoint), key);
+        Assert.Equal(value, a); // right primary
+
+        var node = config.Nodes.FirstOrDefault(x => !x.IsReplica && x.NodeId != rightPrimaryNode.NodeId);
+        Assert.NotNull(node);
+        Log("Using Primary: {0}", node.EndPoint, node.NodeId);
         {
-            var expectedPorts = new HashSet<int>(Enumerable.Range(TestConfig.Current.ClusterStartPort, TestConfig.Current.ClusterServerCount));
-            using (var muxer = Create(log: Writer))
-            {
-                var endpoints = muxer.GetEndPoints();
-                if (TestConfig.Current.ClusterServerCount != endpoints.Length)
-                {
-                    PrintEndpoints(endpoints);
-                }
+            Assert.NotNull(node.EndPoint);
+            string? b = StringGet(conn.GetServer(node.EndPoint), key);
+            Assert.Equal(value, b); // wrong primary, allow redirect
 
-                Assert.Equal(TestConfig.Current.ClusterServerCount, endpoints.Length);
-                int primaries = 0, replicas = 0;
-                var failed = new List<EndPoint>();
-                foreach (var endpoint in endpoints)
-                {
-                    var server = muxer.GetServer(endpoint);
-                    if (!server.IsConnected)
-                    {
-                        failed.Add(endpoint);
-                    }
-                    Log("endpoint:" + endpoint);
-                    Assert.Equal(endpoint, server.EndPoint);
-
-                    Log("endpoint-type:" + endpoint);
-                    Assert.IsType<IPEndPoint>(endpoint);
-
-                    Log("port:" + endpoint);
-                    Assert.True(expectedPorts.Remove(((IPEndPoint)endpoint).Port));
-
-                    Log("server-type:" + endpoint);
-                    Assert.Equal(ServerType.Cluster, server.ServerType);
-
-                    if (server.IsReplica) replicas++;
-                    else primaries++;
-                }
-                if (failed.Count != 0)
-                {
-                    Log("{0} failues", failed.Count);
-                    foreach (var fail in failed)
-                    {
-                        Log(fail.ToString());
-                    }
-                    Assert.True(false, "not all servers connected");
-                }
-
-                Assert.Equal(TestConfig.Current.ClusterServerCount / 2, replicas);
-                Assert.Equal(TestConfig.Current.ClusterServerCount / 2, primaries);
-            }
+            var ex = Assert.Throws<RedisServerException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
+            Assert.StartsWith($"Key has MOVED to Endpoint {rightPrimaryNode.EndPoint} and hashslot {slot}", ex.Message);
         }
 
-        [Fact]
-        public void TestIdentity()
+        node = config.Nodes.FirstOrDefault(x => x.IsReplica && x.ParentNodeId == rightPrimaryNode.NodeId);
+        Assert.NotNull(node);
         {
-            using (var conn = Create())
-            {
-                RedisKey key = Guid.NewGuid().ToByteArray();
-                var ep = conn.GetDatabase().IdentifyEndpoint(key);
-                Assert.NotNull(ep);
-                Assert.Equal(ep, conn.GetServer(ep).ClusterConfiguration?.GetBySlot(key)?.EndPoint);
-            }
+            Assert.NotNull(node.EndPoint);
+            string? d = StringGet(conn.GetServer(node.EndPoint), key);
+            Assert.Equal(value, d); // right replica
         }
 
-        [Fact]
-        public void IntentionalWrongServer()
+        node = config.Nodes.FirstOrDefault(x => x.IsReplica && x.ParentNodeId != rightPrimaryNode.NodeId);
+        Assert.NotNull(node);
         {
-            static string? StringGet(IServer server, RedisKey key, CommandFlags flags = CommandFlags.None)
-                => (string?)server.Execute("GET", new object[] { key }, flags);
+            Assert.NotNull(node.EndPoint);
+            string? e = StringGet(conn.GetServer(node.EndPoint), key);
+            Assert.Equal(value, e); // wrong replica, allow redirect
 
-            using (var conn = Create())
+            var ex = Assert.Throws<RedisServerException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
+            Assert.StartsWith($"Key has MOVED to Endpoint {rightPrimaryNode.EndPoint} and hashslot {slot}", ex.Message);
+        }
+    }
+
+    [Fact]
+    public void TransactionWithMultiServerKeys()
+    {
+        var ex = Assert.Throws<RedisCommandException>(() =>
+        {
+            using var conn = Create();
+
+            // connect
+            var cluster = conn.GetDatabase();
+            var anyServer = conn.GetServer(conn.GetEndPoints()[0]);
+            anyServer.Ping();
+            Assert.Equal(ServerType.Cluster, anyServer.ServerType);
+            var config = anyServer.ClusterConfiguration;
+            Assert.NotNull(config);
+
+            // invent 2 keys that we believe are served by different nodes
+            string x = Guid.NewGuid().ToString(), y;
+            var xNode = config.GetBySlot(x);
+            Assert.NotNull(xNode);
+            int abort = 1000;
+            do
             {
-                var endpoints = conn.GetEndPoints();
-                var servers = endpoints.Select(e => conn.GetServer(e)).ToList();
+                y = Guid.NewGuid().ToString();
+            } while (--abort > 0 && config.GetBySlot(y) == xNode);
+            if (abort == 0) Skip.Inconclusive("failed to find a different node to use");
+            var yNode = config.GetBySlot(y);
+            Assert.NotNull(yNode);
+            Log("x={0}, served by {1}", x, xNode.NodeId);
+            Log("y={0}, served by {1}", y, yNode.NodeId);
+            Assert.NotEqual(xNode.NodeId, yNode.NodeId);
 
-                var key = Me();
-                const string value = "abc";
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringSet(key, value, flags: CommandFlags.FireAndForget);
-                servers[0].Ping();
-                var config = servers[0].ClusterConfiguration;
-                Assert.NotNull(config);
-                int slot = conn.HashSlot(key);
-                var rightPrimaryNode = config.GetBySlot(key);
-                Assert.NotNull(rightPrimaryNode);
-                Log("Right Primary: {0} {1}", rightPrimaryNode.EndPoint, rightPrimaryNode.NodeId);
+            // wipe those keys
+            cluster.KeyDelete(x, CommandFlags.FireAndForget);
+            cluster.KeyDelete(y, CommandFlags.FireAndForget);
 
-                Assert.NotNull(rightPrimaryNode.EndPoint);
-                string? a = StringGet(conn.GetServer(rightPrimaryNode.EndPoint), key);
-                Assert.Equal(value, a); // right primary
+            // create a transaction that attempts to assign both keys
+            var tran = cluster.CreateTransaction();
+            tran.AddCondition(Condition.KeyNotExists(x));
+            tran.AddCondition(Condition.KeyNotExists(y));
+            _ = tran.StringSetAsync(x, "x-val");
+            _ = tran.StringSetAsync(y, "y-val");
+            tran.Execute();
 
-                var node = config.Nodes.FirstOrDefault(x => !x.IsReplica && x.NodeId != rightPrimaryNode.NodeId);
-                Assert.NotNull(node);
-                Log("Using Primary: {0}", node.EndPoint, node.NodeId);
-                {
-                    Assert.NotNull(node.EndPoint);
-                    string? b = StringGet(conn.GetServer(node.EndPoint), key);
-                    Assert.Equal(value, b); // wrong primary, allow redirect
+            Assert.True(false, "Expected single-slot rules to apply");
+            // the rest no longer applies while we are following single-slot rules
 
-                    var ex = Assert.Throws<RedisServerException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
-                    Assert.StartsWith($"Key has MOVED to Endpoint {rightPrimaryNode.EndPoint} and hashslot {slot}", ex.Message);
-                }
+            //// check that everything was aborted
+            //Assert.False(success, "tran aborted");
+            //Assert.True(setX.IsCanceled, "set x cancelled");
+            //Assert.True(setY.IsCanceled, "set y cancelled");
+            //var existsX = cluster.KeyExistsAsync(x);
+            //var existsY = cluster.KeyExistsAsync(y);
+            //Assert.False(cluster.Wait(existsX), "x exists");
+            //Assert.False(cluster.Wait(existsY), "y exists");
+        });
+        Assert.Equal("Multi-key operations must involve a single slot; keys can use 'hash tags' to help this, i.e. '{/users/12345}/account' and '{/users/12345}/contacts' will always be in the same slot", ex.Message);
+    }
 
-                node = config.Nodes.FirstOrDefault(x => x.IsReplica && x.ParentNodeId == rightPrimaryNode.NodeId);
-                Assert.NotNull(node);
-                {
-                    Assert.NotNull(node.EndPoint);
-                    string? d = StringGet(conn.GetServer(node.EndPoint), key);
-                    Assert.Equal(value, d); // right replica
-                }
+    [Fact]
+    public void TransactionWithSameServerKeys()
+    {
+        var ex = Assert.Throws<RedisCommandException>(() =>
+        {
+            using var conn = Create();
 
-                node = config.Nodes.FirstOrDefault(x => x.IsReplica && x.ParentNodeId != rightPrimaryNode.NodeId);
-                Assert.NotNull(node);
-                {
-                    Assert.NotNull(node.EndPoint);
-                    string? e = StringGet(conn.GetServer(node.EndPoint), key);
-                    Assert.Equal(value, e); // wrong replica, allow redirect
+            // connect
+            var cluster = conn.GetDatabase();
+            var anyServer = conn.GetServer(conn.GetEndPoints()[0]);
+            anyServer.Ping();
+            var config = anyServer.ClusterConfiguration;
+            Assert.NotNull(config);
 
-                    var ex = Assert.Throws<RedisServerException>(() => StringGet(conn.GetServer(node.EndPoint), key, CommandFlags.NoRedirect));
-                    Assert.StartsWith($"Key has MOVED to Endpoint {rightPrimaryNode.EndPoint} and hashslot {slot}", ex.Message);
-                }
-            }
+            // invent 2 keys that we believe are served by different nodes
+            string x = Guid.NewGuid().ToString(), y;
+            var xNode = config.GetBySlot(x);
+            int abort = 1000;
+            do
+            {
+                y = Guid.NewGuid().ToString();
+            } while (--abort > 0 && config.GetBySlot(y) != xNode);
+            if (abort == 0) Skip.Inconclusive("failed to find a key with the same node to use");
+            var yNode = config.GetBySlot(y);
+            Assert.NotNull(xNode);
+            Log("x={0}, served by {1}", x, xNode.NodeId);
+            Assert.NotNull(yNode);
+            Log("y={0}, served by {1}", y, yNode.NodeId);
+            Assert.Equal(xNode.NodeId, yNode.NodeId);
+
+            // wipe those keys
+            cluster.KeyDelete(x, CommandFlags.FireAndForget);
+            cluster.KeyDelete(y, CommandFlags.FireAndForget);
+
+            // create a transaction that attempts to assign both keys
+            var tran = cluster.CreateTransaction();
+            tran.AddCondition(Condition.KeyNotExists(x));
+            tran.AddCondition(Condition.KeyNotExists(y));
+            _ = tran.StringSetAsync(x, "x-val");
+            _ = tran.StringSetAsync(y, "y-val");
+            tran.Execute();
+
+            Assert.True(false, "Expected single-slot rules to apply");
+            // the rest no longer applies while we are following single-slot rules
+
+            //// check that everything was aborted
+            //Assert.True(success, "tran aborted");
+            //Assert.False(setX.IsCanceled, "set x cancelled");
+            //Assert.False(setY.IsCanceled, "set y cancelled");
+            //var existsX = cluster.KeyExistsAsync(x);
+            //var existsY = cluster.KeyExistsAsync(y);
+            //Assert.True(cluster.Wait(existsX), "x exists");
+            //Assert.True(cluster.Wait(existsY), "y exists");
+        });
+        Assert.Equal("Multi-key operations must involve a single slot; keys can use 'hash tags' to help this, i.e. '{/users/12345}/account' and '{/users/12345}/contacts' will always be in the same slot", ex.Message);
+    }
+
+    [Fact]
+    public void TransactionWithSameSlotKeys()
+    {
+        using var conn = Create();
+
+        // connect
+        var cluster = conn.GetDatabase();
+        var anyServer = conn.GetServer(conn.GetEndPoints()[0]);
+        anyServer.Ping();
+        var config = anyServer.ClusterConfiguration;
+        Assert.NotNull(config);
+
+        // invent 2 keys that we believe are in the same slot
+        var guid = Guid.NewGuid().ToString();
+        string x = "/{" + guid + "}/foo", y = "/{" + guid + "}/bar";
+
+        Assert.Equal(conn.HashSlot(x), conn.HashSlot(y));
+        var xNode = config.GetBySlot(x);
+        var yNode = config.GetBySlot(y);
+        Assert.NotNull(xNode);
+        Log("x={0}, served by {1}", x, xNode.NodeId);
+        Assert.NotNull(yNode);
+        Log("y={0}, served by {1}", y, yNode.NodeId);
+        Assert.Equal(xNode.NodeId, yNode.NodeId);
+
+        // wipe those keys
+        cluster.KeyDelete(x, CommandFlags.FireAndForget);
+        cluster.KeyDelete(y, CommandFlags.FireAndForget);
+
+        // create a transaction that attempts to assign both keys
+        var tran = cluster.CreateTransaction();
+        tran.AddCondition(Condition.KeyNotExists(x));
+        tran.AddCondition(Condition.KeyNotExists(y));
+        var setX = tran.StringSetAsync(x, "x-val");
+        var setY = tran.StringSetAsync(y, "y-val");
+        bool success = tran.Execute();
+
+        // check that everything was aborted
+        Assert.True(success, "tran aborted");
+        Assert.False(setX.IsCanceled, "set x cancelled");
+        Assert.False(setY.IsCanceled, "set y cancelled");
+        var existsX = cluster.KeyExistsAsync(x);
+        var existsY = cluster.KeyExistsAsync(y);
+        Assert.True(cluster.Wait(existsX), "x exists");
+        Assert.True(cluster.Wait(existsY), "y exists");
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Because.")]
+    [Theory (Skip = "FlushAllDatabases")]
+    [InlineData(null, 10)]
+    [InlineData(null, 100)]
+    [InlineData("abc", 10)]
+    [InlineData("abc", 100)]
+    public void Keys(string pattern, int pageSize)
+    {
+        using var conn = Create(allowAdmin: true);
+
+        _ = conn.GetDatabase();
+        var server = conn.GetEndPoints().Select(x => conn.GetServer(x)).First(x => !x.IsReplica);
+        server.FlushAllDatabases();
+        try
+        {
+            Assert.False(server.Keys(pattern: pattern, pageSize: pageSize).Any());
+            Log("Complete: '{0}' / {1}", pattern, pageSize);
+        }
+        catch
+        {
+            Log("Failed: '{0}' / {1}", pattern, pageSize);
+            throw;
+        }
+    }
+
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("abc", 7638)]
+    [InlineData("{abc}", 7638)]
+    [InlineData("abcdef", 15101)]
+    [InlineData("abc{abc}def", 7638)]
+    [InlineData("c", 7365)]
+    [InlineData("g", 7233)]
+    [InlineData("d", 11298)]
+
+    [InlineData("user1000", 3443)]
+    [InlineData("{user1000}", 3443)]
+    [InlineData("abc{user1000}", 3443)]
+    [InlineData("abc{user1000}def", 3443)]
+    [InlineData("{user1000}.following", 3443)]
+    [InlineData("{user1000}.followers", 3443)]
+
+    [InlineData("foo{}{bar}", 8363)]
+
+    [InlineData("foo{{bar}}zap", 4015)]
+    [InlineData("{bar", 4015)]
+
+    [InlineData("foo{bar}{zap}", 5061)]
+    [InlineData("bar", 5061)]
+
+    public void HashSlots(string key, int slot)
+    {
+        using var conn = Create(connectTimeout: 5000);
+
+        Assert.Equal(slot, conn.HashSlot(key));
+    }
+
+    [Fact]
+    public void SScan()
+    {
+        using var conn = Create();
+
+        RedisKey key = "a";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        int totalUnfiltered = 0, totalFiltered = 0;
+        for (int i = 0; i < 1000; i++)
+        {
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
+            totalUnfiltered += i;
+            if (i.ToString().Contains('3')) totalFiltered += i;
+        }
+        var unfilteredActual = db.SetScan(key).Select(x => (int)x).Sum();
+        var filteredActual = db.SetScan(key, "*3*").Select(x => (int)x).Sum();
+        Assert.Equal(totalUnfiltered, unfilteredActual);
+        Assert.Equal(totalFiltered, filteredActual);
+    }
+
+    [Fact]
+    public void GetConfig()
+    {
+        using var conn = Create(allowAdmin: true, log: Writer);
+
+        var endpoints = conn.GetEndPoints();
+        var server = conn.GetServer(endpoints[0]);
+        var nodes = server.ClusterNodes();
+        Assert.NotNull(nodes);
+
+        Log("Endpoints:");
+        foreach (var endpoint in endpoints)
+        {
+            Log(endpoint.ToString());
+        }
+        Log("Nodes:");
+        foreach (var node in nodes.Nodes.OrderBy(x => x))
+        {
+            Log(node.ToString());
         }
 
-        [Fact]
-        public void TransactionWithMultiServerKeys()
+        Assert.Equal(TestConfig.Current.ClusterServerCount, endpoints.Length);
+        Assert.Equal(TestConfig.Current.ClusterServerCount, nodes.Nodes.Count);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1004:Test methods should not be skipped", Justification = "Because.")]
+    [Fact(Skip = "FlushAllDatabases")]
+    public void AccessRandomKeys()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var cluster = conn.GetDatabase();
+        int slotMovedCount = 0;
+        conn.HashSlotMoved += (s, a) =>
         {
-            var ex = Assert.Throws<RedisCommandException>(() =>
-            {
-                using (var muxer = Create())
-                {
-                    // connect
-                    var cluster = muxer.GetDatabase();
-                    var anyServer = muxer.GetServer(muxer.GetEndPoints()[0]);
-                    anyServer.Ping();
-                    Assert.Equal(ServerType.Cluster, anyServer.ServerType);
-                    var config = anyServer.ClusterConfiguration;
-                    Assert.NotNull(config);
+            Assert.NotNull(a.OldEndPoint);
+            Log("{0} moved from {1} to {2}", a.HashSlot, Describe(a.OldEndPoint), Describe(a.NewEndPoint));
+            Interlocked.Increment(ref slotMovedCount);
+        };
+        var pairs = new Dictionary<string, string>();
+        const int COUNT = 500;
+        int index = 0;
 
-                    // invent 2 keys that we believe are served by different nodes
-                    string x = Guid.NewGuid().ToString(), y;
-                    var xNode = config.GetBySlot(x);
-                    Assert.NotNull(xNode);
-                    int abort = 1000;
-                    do
-                    {
-                        y = Guid.NewGuid().ToString();
-                    } while (--abort > 0 && config.GetBySlot(y) == xNode);
-                    if (abort == 0) Skip.Inconclusive("failed to find a different node to use");
-                    var yNode = config.GetBySlot(y);
-                    Assert.NotNull(yNode);
-                    Log("x={0}, served by {1}", x, xNode.NodeId);
-                    Log("y={0}, served by {1}", y, yNode.NodeId);
-                    Assert.NotEqual(xNode.NodeId, yNode.NodeId);
-
-                    // wipe those keys
-                    cluster.KeyDelete(x, CommandFlags.FireAndForget);
-                    cluster.KeyDelete(y, CommandFlags.FireAndForget);
-
-                    // create a transaction that attempts to assign both keys
-                    var tran = cluster.CreateTransaction();
-                    tran.AddCondition(Condition.KeyNotExists(x));
-                    tran.AddCondition(Condition.KeyNotExists(y));
-                    _ = tran.StringSetAsync(x, "x-val");
-                    _ = tran.StringSetAsync(y, "y-val");
-                    tran.Execute();
-
-                    Assert.True(false, "Expected single-slot rules to apply");
-                    // the rest no longer applies while we are following single-slot rules
-
-                    //// check that everything was aborted
-                    //Assert.False(success, "tran aborted");
-                    //Assert.True(setX.IsCanceled, "set x cancelled");
-                    //Assert.True(setY.IsCanceled, "set y cancelled");
-                    //var existsX = cluster.KeyExistsAsync(x);
-                    //var existsY = cluster.KeyExistsAsync(y);
-                    //Assert.False(cluster.Wait(existsX), "x exists");
-                    //Assert.False(cluster.Wait(existsY), "y exists");
-                }
-            });
-            Assert.Equal("Multi-key operations must involve a single slot; keys can use 'hash tags' to help this, i.e. '{/users/12345}/account' and '{/users/12345}/contacts' will always be in the same slot", ex.Message);
-        }
-
-        [Fact]
-        public void TransactionWithSameServerKeys()
+        var servers = conn.GetEndPoints().Select(x => conn.GetServer(x)).ToList();
+        foreach (var server in servers)
         {
-            var ex = Assert.Throws<RedisCommandException>(() =>
+            if (!server.IsReplica)
             {
-                using (var muxer = Create())
-                {
-                    // connect
-                    var cluster = muxer.GetDatabase();
-                    var anyServer = muxer.GetServer(muxer.GetEndPoints()[0]);
-                    anyServer.Ping();
-                    var config = anyServer.ClusterConfiguration;
-                    Assert.NotNull(config);
-
-                    // invent 2 keys that we believe are served by different nodes
-                    string x = Guid.NewGuid().ToString(), y;
-                    var xNode = config.GetBySlot(x);
-                    int abort = 1000;
-                    do
-                    {
-                        y = Guid.NewGuid().ToString();
-                    } while (--abort > 0 && config.GetBySlot(y) != xNode);
-                    if (abort == 0) Skip.Inconclusive("failed to find a key with the same node to use");
-                    var yNode = config.GetBySlot(y);
-                    Assert.NotNull(xNode);
-                    Log("x={0}, served by {1}", x, xNode.NodeId);
-                    Assert.NotNull(yNode);
-                    Log("y={0}, served by {1}", y, yNode.NodeId);
-                    Assert.Equal(xNode.NodeId, yNode.NodeId);
-
-                    // wipe those keys
-                    cluster.KeyDelete(x, CommandFlags.FireAndForget);
-                    cluster.KeyDelete(y, CommandFlags.FireAndForget);
-
-                    // create a transaction that attempts to assign both keys
-                    var tran = cluster.CreateTransaction();
-                    tran.AddCondition(Condition.KeyNotExists(x));
-                    tran.AddCondition(Condition.KeyNotExists(y));
-                    _ = tran.StringSetAsync(x, "x-val");
-                    _ = tran.StringSetAsync(y, "y-val");
-                    tran.Execute();
-
-                    Assert.True(false, "Expected single-slot rules to apply");
-                    // the rest no longer applies while we are following single-slot rules
-
-                    //// check that everything was aborted
-                    //Assert.True(success, "tran aborted");
-                    //Assert.False(setX.IsCanceled, "set x cancelled");
-                    //Assert.False(setY.IsCanceled, "set y cancelled");
-                    //var existsX = cluster.KeyExistsAsync(x);
-                    //var existsY = cluster.KeyExistsAsync(y);
-                    //Assert.True(cluster.Wait(existsX), "x exists");
-                    //Assert.True(cluster.Wait(existsY), "y exists");
-                }
-            });
-            Assert.Equal("Multi-key operations must involve a single slot; keys can use 'hash tags' to help this, i.e. '{/users/12345}/account' and '{/users/12345}/contacts' will always be in the same slot", ex.Message);
-        }
-
-        [Fact]
-        public void TransactionWithSameSlotKeys()
-        {
-            using (var muxer = Create())
-            {
-                // connect
-                var cluster = muxer.GetDatabase();
-                var anyServer = muxer.GetServer(muxer.GetEndPoints()[0]);
-                anyServer.Ping();
-                var config = anyServer.ClusterConfiguration;
-                Assert.NotNull(config);
-
-                // invent 2 keys that we believe are in the same slot
-                var guid = Guid.NewGuid().ToString();
-                string x = "/{" + guid + "}/foo", y = "/{" + guid + "}/bar";
-
-                Assert.Equal(muxer.HashSlot(x), muxer.HashSlot(y));
-                var xNode = config.GetBySlot(x);
-                var yNode = config.GetBySlot(y);
-                Assert.NotNull(xNode);
-                Log("x={0}, served by {1}", x, xNode.NodeId);
-                Assert.NotNull(yNode);
-                Log("y={0}, served by {1}", y, yNode.NodeId);
-                Assert.Equal(xNode.NodeId, yNode.NodeId);
-
-                // wipe those keys
-                cluster.KeyDelete(x, CommandFlags.FireAndForget);
-                cluster.KeyDelete(y, CommandFlags.FireAndForget);
-
-                // create a transaction that attempts to assign both keys
-                var tran = cluster.CreateTransaction();
-                tran.AddCondition(Condition.KeyNotExists(x));
-                tran.AddCondition(Condition.KeyNotExists(y));
-                var setX = tran.StringSetAsync(x, "x-val");
-                var setY = tran.StringSetAsync(y, "y-val");
-                bool success = tran.Execute();
-
-                // check that everything was aborted
-                Assert.True(success, "tran aborted");
-                Assert.False(setX.IsCanceled, "set x cancelled");
-                Assert.False(setY.IsCanceled, "set y cancelled");
-                var existsX = cluster.KeyExistsAsync(x);
-                var existsY = cluster.KeyExistsAsync(y);
-                Assert.True(cluster.Wait(existsX), "x exists");
-                Assert.True(cluster.Wait(existsY), "y exists");
-            }
-        }
-
-        [Theory]
-        [InlineData(null, 10)]
-        [InlineData(null, 100)]
-        [InlineData("abc", 10)]
-        [InlineData("abc", 100)]
-
-        public void Keys(string pattern, int pageSize)
-        {
-            using (var conn = Create(allowAdmin: true))
-            {
-                _ = conn.GetDatabase();
-                var server = conn.GetEndPoints().Select(x => conn.GetServer(x)).First(x => !x.IsReplica);
+                server.Ping();
                 server.FlushAllDatabases();
-                try
-                {
-                    Assert.False(server.Keys(pattern: pattern, pageSize: pageSize).Any());
-                    Log("Complete: '{0}' / {1}", pattern, pageSize);
-                }
-                catch
-                {
-                    Log("Failed: '{0}' / {1}", pattern, pageSize);
-                    throw;
-                }
             }
         }
 
-        [Theory]
-        [InlineData("", 0)]
-        [InlineData("abc", 7638)]
-        [InlineData("{abc}", 7638)]
-        [InlineData("abcdef", 15101)]
-        [InlineData("abc{abc}def", 7638)]
-        [InlineData("c", 7365)]
-        [InlineData("g", 7233)]
-        [InlineData("d", 11298)]
-
-        [InlineData("user1000", 3443)]
-        [InlineData("{user1000}", 3443)]
-        [InlineData("abc{user1000}", 3443)]
-        [InlineData("abc{user1000}def", 3443)]
-        [InlineData("{user1000}.following", 3443)]
-        [InlineData("{user1000}.followers", 3443)]
-
-        [InlineData("foo{}{bar}", 8363)]
-
-        [InlineData("foo{{bar}}zap", 4015)]
-        [InlineData("{bar", 4015)]
-
-        [InlineData("foo{bar}{zap}", 5061)]
-        [InlineData("bar", 5061)]
-
-        public void HashSlots(string key, int slot)
+        for (int i = 0; i < COUNT; i++)
         {
-            using (var muxer = Create(connectTimeout: 5000))
-            {
-                Assert.Equal(slot, muxer.HashSlot(key));
-            }
+            var key = Guid.NewGuid().ToString();
+            var value = Guid.NewGuid().ToString();
+            pairs.Add(key, value);
+            cluster.StringSet(key, value, flags: CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public void SScan()
+        var expected = new string[COUNT];
+        var actual = new Task<RedisValue>[COUNT];
+        index = 0;
+        foreach (var pair in pairs)
         {
-            using (var conn = Create())
-            {
-                RedisKey key = "a";
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                int totalUnfiltered = 0, totalFiltered = 0;
-                for (int i = 0; i < 1000; i++)
-                {
-                    db.SetAdd(key, i, CommandFlags.FireAndForget);
-                    totalUnfiltered += i;
-                    if (i.ToString().Contains('3')) totalFiltered += i;
-                }
-                var unfilteredActual = db.SetScan(key).Select(x => (int)x).Sum();
-                var filteredActual = db.SetScan(key, "*3*").Select(x => (int)x).Sum();
-                Assert.Equal(totalUnfiltered, unfilteredActual);
-                Assert.Equal(totalFiltered, filteredActual);
-            }
+            expected[index] = pair.Value;
+            actual[index] = cluster.StringGetAsync(pair.Key);
+            index++;
+        }
+        cluster.WaitAll(actual);
+        for (int i = 0; i < COUNT; i++)
+        {
+            Assert.Equal(expected[i], actual[i].Result);
         }
 
-        [Fact]
-        public void GetConfig()
+        int total = 0;
+        Parallel.ForEach(servers, server =>
         {
-            using (var muxer = Create(allowAdmin: true, log: Writer))
+            if (!server.IsReplica)
             {
-                var endpoints = muxer.GetEndPoints();
-                var server = muxer.GetServer(endpoints[0]);
-                var nodes = server.ClusterNodes();
-                Assert.NotNull(nodes);
-
-                Log("Endpoints:");
-                foreach (var endpoint in endpoints)
-                {
-                    Log(endpoint.ToString());
-                }
-                Log("Nodes:");
-                foreach (var node in nodes.Nodes.OrderBy(x => x))
-                {
-                    Log(node.ToString());
-                }
-
-                Assert.Equal(TestConfig.Current.ClusterServerCount, endpoints.Length);
-                Assert.Equal(TestConfig.Current.ClusterServerCount, nodes.Nodes.Count);
+                int count = server.Keys(pageSize: 100).Count();
+                Log("{0} has {1} keys", server.EndPoint, count);
+                Interlocked.Add(ref total, count);
             }
+        });
+
+        foreach (var server in servers)
+        {
+            var counters = server.GetCounters();
+            Log(counters.ToString());
+        }
+        int final = Interlocked.CompareExchange(ref total, 0, 0);
+        Assert.Equal(COUNT, final);
+        Assert.Equal(0, Interlocked.CompareExchange(ref slotMovedCount, 0, 0));
+    }
+
+    [Theory]
+    [InlineData(CommandFlags.DemandMaster, false)]
+    [InlineData(CommandFlags.DemandReplica, true)]
+    [InlineData(CommandFlags.PreferMaster, false)]
+    [InlineData(CommandFlags.PreferReplica, true)]
+    public void GetFromRightNodeBasedOnFlags(CommandFlags flags, bool isReplica)
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var db = conn.GetDatabase();
+        for (int i = 0; i < 1000; i++)
+        {
+            var key = Guid.NewGuid().ToString();
+            var endpoint = db.IdentifyEndpoint(key, flags);
+            Assert.NotNull(endpoint);
+            var server = conn.GetServer(endpoint);
+            Assert.Equal(isReplica, server.IsReplica);
+        }
+    }
+
+    private static string Describe(EndPoint endpoint) => endpoint?.ToString() ?? "(unknown)";
+
+    [Fact]
+    public void SimpleProfiling()
+    {
+        using var conn = Create(log: Writer);
+
+        var profiler = new ProfilingSession();
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        conn.RegisterProfiler(() => profiler);
+        db.StringSet(key, "world");
+        var val = db.StringGet(key);
+        Assert.Equal("world", val);
+
+        var msgs = profiler.FinishProfiling().Where(m => m.Command == "GET" || m.Command == "SET").ToList();
+        foreach (var msg in msgs)
+        {
+            Log("Profiler Message: " + Environment.NewLine + msg);
+        }
+        Log("Checking GET...");
+        Assert.Contains(msgs, m => m.Command == "GET");
+        Log("Checking SET...");
+        Assert.Contains(msgs, m => m.Command == "SET");
+        Assert.Equal(2, msgs.Count(m => m.RetransmissionOf is null));
+
+        var arr = msgs.Where(m => m.RetransmissionOf is null).ToArray();
+        Assert.Equal("SET", arr[0].Command);
+        Assert.Equal("GET", arr[1].Command);
+    }
+
+    [Fact]
+    public void MultiKeyQueryFails()
+    {
+        var keys = InventKeys(); // note the rules expected of this data are enforced in GroupedQueriesWork
+
+        using var conn = Create();
+
+        var ex = Assert.Throws<RedisCommandException>(() => conn.GetDatabase(0).StringGet(keys));
+        Assert.Contains("Multi-key operations must involve a single slot", ex.Message);
+    }
+
+    private static RedisKey[] InventKeys()
+    {
+        RedisKey[] keys = new RedisKey[256];
+        Random rand = new Random(12324);
+        string InventString()
+        {
+            const string alphabet = "abcdefghijklmnopqrstuvwxyz012345689";
+            var len = rand.Next(10, 50);
+            char[] chars = new char[len];
+            for (int i = 0; i < len; i++)
+                chars[i] = alphabet[rand.Next(alphabet.Length)];
+            return new string(chars);
         }
 
-        [Fact]
-        public void AccessRandomKeys()
+        for (int i = 0; i < keys.Length; i++)
         {
-            using (var conn = Create(allowAdmin: true))
-            {
-                var cluster = conn.GetDatabase();
-                int slotMovedCount = 0;
-                conn.HashSlotMoved += (s, a) =>
-                {
-                    Assert.NotNull(a.OldEndPoint);
-                    Log("{0} moved from {1} to {2}", a.HashSlot, Describe(a.OldEndPoint), Describe(a.NewEndPoint));
-                    Interlocked.Increment(ref slotMovedCount);
-                };
-                var pairs = new Dictionary<string, string>();
-                const int COUNT = 500;
-                int index = 0;
+            keys[i] = InventString();
+        }
+        return keys;
+    }
 
-                var servers = conn.GetEndPoints().Select(x => conn.GetServer(x)).ToList();
-                foreach (var server in servers)
-                {
-                    if (!server.IsReplica)
-                    {
-                        server.Ping();
-                        server.FlushAllDatabases();
-                    }
-                }
+    [Fact]
+    public void GroupedQueriesWork()
+    {
+        // note it doesn't matter that the data doesn't exist for this;
+        // the point here is that the entire thing *won't work* otherwise,
+        // as per above test
 
-                for (int i = 0; i < COUNT; i++)
-                {
-                    var key = Guid.NewGuid().ToString();
-                    var value = Guid.NewGuid().ToString();
-                    pairs.Add(key, value);
-                    cluster.StringSet(key, value, flags: CommandFlags.FireAndForget);
-                }
+        var keys = InventKeys();
+        using var conn = Create();
 
-                var expected = new string[COUNT];
-                var actual = new Task<RedisValue>[COUNT];
-                index = 0;
-                foreach (var pair in pairs)
-                {
-                    expected[index] = pair.Value;
-                    actual[index] = cluster.StringGetAsync(pair.Key);
-                    index++;
-                }
-                cluster.WaitAll(actual);
-                for (int i = 0; i < COUNT; i++)
-                {
-                    Assert.Equal(expected[i], actual[i].Result);
-                }
+        var grouped = keys.GroupBy(key => conn.GetHashSlot(key)).ToList();
+        Assert.True(grouped.Count > 1); // check not all a super-group
+        Assert.True(grouped.Count < keys.Length); // check not all singleton groups
+        Assert.Equal(keys.Length, grouped.Sum(x => x.Count())); // check they're all there
+        Assert.Contains(grouped, x => x.Count() > 1); // check at least one group with multiple items (redundant from above, but... meh)
 
-                int total = 0;
-                Parallel.ForEach(servers, server =>
-                {
-                    if (!server.IsReplica)
-                    {
-                        int count = server.Keys(pageSize: 100).Count();
-                        Log("{0} has {1} keys", server.EndPoint, count);
-                        Interlocked.Add(ref total, count);
-                    }
-                });
+        Log($"{grouped.Count} groups, min: {grouped.Min(x => x.Count())}, max: {grouped.Max(x => x.Count())}, avg: {grouped.Average(x => x.Count())}");
 
-                foreach (var server in servers)
-                {
-                    var counters = server.GetCounters();
-                    Log(counters.ToString());
-                }
-                int final = Interlocked.CompareExchange(ref total, 0, 0);
-                Assert.Equal(COUNT, final);
-                Assert.Equal(0, Interlocked.CompareExchange(ref slotMovedCount, 0, 0));
-            }
+        var db = conn.GetDatabase(0);
+        var all = grouped.SelectMany(grp =>
+        {
+            var grpKeys = grp.ToArray();
+            var values = db.StringGet(grpKeys);
+            return grpKeys.Zip(values, (key, val) => new { key, val });
+        }).ToDictionary(x => x.key, x => x.val);
+
+        Assert.Equal(keys.Length, all.Count);
+    }
+
+    [Fact]
+    public void MovedProfiling()
+    {
+        var Key = Me();
+        const string Value = "redirected-value";
+
+        var profiler = new Profiling.PerThreadProfiler();
+
+        using var conn = Create();
+
+        conn.RegisterProfiler(profiler.GetSession);
+
+        var endpoints = conn.GetEndPoints();
+        var servers = endpoints.Select(e => conn.GetServer(e));
+
+        var db = conn.GetDatabase();
+        db.KeyDelete(Key);
+        db.StringSet(Key, Value);
+        var config = servers.First().ClusterConfiguration;
+        Assert.NotNull(config);
+
+        //int slot = conn.HashSlot(Key);
+        var rightPrimaryNode = config.GetBySlot(Key);
+        Assert.NotNull(rightPrimaryNode);
+
+        Assert.NotNull(rightPrimaryNode.EndPoint);
+        string? a = (string?)conn.GetServer(rightPrimaryNode.EndPoint).Execute("GET", Key);
+        Assert.Equal(Value, a); // right primary
+
+        var wrongPrimaryNode = config.Nodes.FirstOrDefault(x => !x.IsReplica && x.NodeId != rightPrimaryNode.NodeId);
+        Assert.NotNull(wrongPrimaryNode);
+
+        Assert.NotNull(wrongPrimaryNode.EndPoint);
+        string? b = (string?)conn.GetServer(wrongPrimaryNode.EndPoint).Execute("GET", Key);
+        Assert.Equal(Value, b); // wrong primary, allow redirect
+
+        var msgs = profiler.GetSession().FinishProfiling().ToList();
+
+        // verify that things actually got recorded properly, and the retransmission profilings are connected as expected
+        {
+            // expect 1 DEL, 1 SET, 1 GET (to right primary), 1 GET (to wrong primary) that was responded to by an ASK, and 1 GET (to right primary or a replica of it)
+            Assert.Equal(5, msgs.Count);
+            Assert.Equal(1, msgs.Count(c => c.Command == "DEL" || c.Command == "UNLINK"));
+            Assert.Equal(1, msgs.Count(c => c.Command == "SET"));
+            Assert.Equal(3, msgs.Count(c => c.Command == "GET"));
+
+            var toRightPrimaryNotRetransmission = msgs.Where(m => m.Command == "GET" && m.EndPoint.Equals(rightPrimaryNode.EndPoint) && m.RetransmissionOf == null);
+            Assert.Single(toRightPrimaryNotRetransmission);
+
+            var toWrongPrimaryWithoutRetransmission = msgs.Where(m => m.Command == "GET" && m.EndPoint.Equals(wrongPrimaryNode.EndPoint) && m.RetransmissionOf == null).ToList();
+            Assert.Single(toWrongPrimaryWithoutRetransmission);
+
+            var toRightPrimaryOrReplicaAsRetransmission = msgs.Where(m => m.Command == "GET" && (m.EndPoint.Equals(rightPrimaryNode.EndPoint) || rightPrimaryNode.Children.Any(c => m.EndPoint.Equals(c.EndPoint))) && m.RetransmissionOf != null).ToList();
+            Assert.Single(toRightPrimaryOrReplicaAsRetransmission);
+
+            var originalWrongPrimary = toWrongPrimaryWithoutRetransmission.Single();
+            var retransmissionToRight = toRightPrimaryOrReplicaAsRetransmission.Single();
+
+            Assert.True(ReferenceEquals(originalWrongPrimary, retransmissionToRight.RetransmissionOf));
         }
 
-        [Theory]
-        [InlineData(CommandFlags.DemandMaster, false)]
-        [InlineData(CommandFlags.DemandReplica, true)]
-        [InlineData(CommandFlags.PreferMaster, false)]
-        [InlineData(CommandFlags.PreferReplica, true)]
-        public void GetFromRightNodeBasedOnFlags(CommandFlags flags, bool isReplica)
+        foreach (var msg in msgs)
         {
-            using (var muxer = Create(allowAdmin: true))
+            Assert.True(msg.CommandCreated != default(DateTime));
+            Assert.True(msg.CreationToEnqueued > TimeSpan.Zero);
+            Assert.True(msg.EnqueuedToSending > TimeSpan.Zero);
+            Assert.True(msg.SentToResponse > TimeSpan.Zero);
+            Assert.True(msg.ResponseToCompletion >= TimeSpan.Zero); // this can be immeasurably fast
+            Assert.True(msg.ElapsedTime > TimeSpan.Zero);
+
+            if (msg.RetransmissionOf != null)
             {
-                var db = muxer.GetDatabase();
-                for (int i = 0; i < 1000; i++)
-                {
-                    var key = Guid.NewGuid().ToString();
-                    var endpoint = db.IdentifyEndpoint(key, flags);
-                    Assert.NotNull(endpoint);
-                    var server = muxer.GetServer(endpoint);
-                    Assert.Equal(isReplica, server.IsReplica);
-                }
+                // imprecision of DateTime.UtcNow makes this pretty approximate
+                Assert.True(msg.RetransmissionOf.CommandCreated <= msg.CommandCreated);
+                Assert.Equal(RetransmissionReasonType.Moved, msg.RetransmissionReason);
             }
-        }
-
-        private static string Describe(EndPoint endpoint) => endpoint?.ToString() ?? "(unknown)";
-
-        [Fact]
-        public void SimpleProfiling()
-        {
-            using (var conn = Create(log: Writer))
+            else
             {
-                var profiler = new ProfilingSession();
-                var key = Me();
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.RegisterProfiler(() => profiler);
-                db.StringSet(key, "world");
-                var val = db.StringGet(key);
-                Assert.Equal("world", val);
-
-                var msgs = profiler.FinishProfiling().Where(m => m.Command == "GET" || m.Command == "SET").ToList();
-                foreach (var msg in msgs)
-                {
-                    Log("Profiler Message: " + Environment.NewLine + msg);
-                }
-                Log("Checking GET...");
-                Assert.Contains(msgs, m => m.Command == "GET");
-                Log("Checking SET...");
-                Assert.Contains(msgs, m => m.Command == "SET");
-                Assert.Equal(2, msgs.Count(m => m.RetransmissionOf is null));
-
-                var arr = msgs.Where(m => m.RetransmissionOf is null).ToArray();
-                Assert.Equal("SET", arr[0].Command);
-                Assert.Equal("GET", arr[1].Command);
-            }
-        }
-
-        [Fact]
-        public void MultiKeyQueryFails()
-        {
-            var keys = InventKeys(); // note the rules expected of this data are enforced in GroupedQueriesWork
-
-            using (var conn = Create())
-            {
-                var ex = Assert.Throws<RedisCommandException>(() => conn.GetDatabase(0).StringGet(keys));
-                Assert.Contains("Multi-key operations must involve a single slot", ex.Message);
-            }
-        }
-
-        private static RedisKey[] InventKeys()
-        {
-            RedisKey[] keys = new RedisKey[256];
-            Random rand = new Random(12324);
-            string InventString()
-            {
-                const string alphabet = "abcdefghijklmnopqrstuvwxyz012345689";
-                var len = rand.Next(10, 50);
-                char[] chars = new char[len];
-                for (int i = 0; i < len; i++)
-                    chars[i] = alphabet[rand.Next(alphabet.Length)];
-                return new string(chars);
-            }
-
-            for (int i = 0; i < keys.Length; i++)
-            {
-                keys[i] = InventString();
-            }
-            return keys;
-        }
-
-        [Fact]
-        public void GroupedQueriesWork()
-        {
-            // note it doesn't matter that the data doesn't exist for this;
-            // the point here is that the entire thing *won't work* otherwise,
-            // as per above test
-
-            var keys = InventKeys();
-            using (var conn = Create())
-            {
-                var grouped = keys.GroupBy(key => conn.GetHashSlot(key)).ToList();
-                Assert.True(grouped.Count > 1); // check not all a super-group
-                Assert.True(grouped.Count < keys.Length); // check not all singleton groups
-                Assert.Equal(keys.Length, grouped.Sum(x => x.Count())); // check they're all there
-                Assert.Contains(grouped, x => x.Count() > 1); // check at least one group with multiple items (redundant from above, but... meh)
-
-                Log($"{grouped.Count} groups, min: {grouped.Min(x => x.Count())}, max: {grouped.Max(x => x.Count())}, avg: {grouped.Average(x => x.Count())}");
-
-                var db = conn.GetDatabase(0);
-                var all = grouped.SelectMany(grp => {
-                    var grpKeys = grp.ToArray();
-                    var values = db.StringGet(grpKeys);
-                    return grpKeys.Zip(values, (key, val) => new { key, val });
-                }).ToDictionary(x => x.key, x => x.val);
-
-                Assert.Equal(keys.Length, all.Count);
-            }
-        }
-
-        [Fact]
-        public void MovedProfiling()
-        {
-            var Key = Me();
-            const string Value = "redirected-value";
-
-            var profiler = new Profiling.PerThreadProfiler();
-
-            using (var conn = Create())
-            {
-                conn.RegisterProfiler(profiler.GetSession);
-
-                var endpoints = conn.GetEndPoints();
-                var servers = endpoints.Select(e => conn.GetServer(e));
-
-                var db = conn.GetDatabase();
-                db.KeyDelete(Key);
-                db.StringSet(Key, Value);
-                var config = servers.First().ClusterConfiguration;
-                Assert.NotNull(config);
-
-                //int slot = conn.HashSlot(Key);
-                var rightPrimaryNode = config.GetBySlot(Key);
-                Assert.NotNull(rightPrimaryNode);
-
-                Assert.NotNull(rightPrimaryNode.EndPoint);
-                string? a = (string?)conn.GetServer(rightPrimaryNode.EndPoint).Execute("GET", Key);
-                Assert.Equal(Value, a); // right primary
-
-                var wrongPrimaryNode = config.Nodes.FirstOrDefault(x => !x.IsReplica && x.NodeId != rightPrimaryNode.NodeId);
-                Assert.NotNull(wrongPrimaryNode);
-
-                Assert.NotNull(wrongPrimaryNode.EndPoint);
-                string? b = (string?)conn.GetServer(wrongPrimaryNode.EndPoint).Execute("GET", Key);
-                Assert.Equal(Value, b); // wrong primary, allow redirect
-
-                var msgs = profiler.GetSession().FinishProfiling().ToList();
-
-                // verify that things actually got recorded properly, and the retransmission profilings are connected as expected
-                {
-                    // expect 1 DEL, 1 SET, 1 GET (to right primary), 1 GET (to wrong primary) that was responded to by an ASK, and 1 GET (to right primary or a replica of it)
-                    Assert.Equal(5, msgs.Count);
-                    Assert.Equal(1, msgs.Count(c => c.Command == "DEL" || c.Command == "UNLINK"));
-                    Assert.Equal(1, msgs.Count(c => c.Command == "SET"));
-                    Assert.Equal(3, msgs.Count(c => c.Command == "GET"));
-
-                    var toRightPrimaryNotRetransmission = msgs.Where(m => m.Command == "GET" && m.EndPoint.Equals(rightPrimaryNode.EndPoint) && m.RetransmissionOf == null);
-                    Assert.Single(toRightPrimaryNotRetransmission);
-
-                    var toWrongPrimaryWithoutRetransmission = msgs.Where(m => m.Command == "GET" && m.EndPoint.Equals(wrongPrimaryNode.EndPoint) && m.RetransmissionOf == null).ToList();
-                    Assert.Single(toWrongPrimaryWithoutRetransmission);
-
-                    var toRightPrimaryOrReplicaAsRetransmission = msgs.Where(m => m.Command == "GET" && (m.EndPoint.Equals(rightPrimaryNode.EndPoint) || rightPrimaryNode.Children.Any(c => m.EndPoint.Equals(c.EndPoint))) && m.RetransmissionOf != null).ToList();
-                    Assert.Single(toRightPrimaryOrReplicaAsRetransmission);
-
-                    var originalWrongPrimary = toWrongPrimaryWithoutRetransmission.Single();
-                    var retransmissionToRight = toRightPrimaryOrReplicaAsRetransmission.Single();
-
-                    Assert.True(ReferenceEquals(originalWrongPrimary, retransmissionToRight.RetransmissionOf));
-                }
-
-                foreach (var msg in msgs)
-                {
-                    Assert.True(msg.CommandCreated != default(DateTime));
-                    Assert.True(msg.CreationToEnqueued > TimeSpan.Zero);
-                    Assert.True(msg.EnqueuedToSending > TimeSpan.Zero);
-                    Assert.True(msg.SentToResponse > TimeSpan.Zero);
-                    Assert.True(msg.ResponseToCompletion >= TimeSpan.Zero); // this can be immeasurably fast
-                    Assert.True(msg.ElapsedTime > TimeSpan.Zero);
-
-                    if (msg.RetransmissionOf != null)
-                    {
-                        // imprecision of DateTime.UtcNow makes this pretty approximate
-                        Assert.True(msg.RetransmissionOf.CommandCreated <= msg.CommandCreated);
-                        Assert.Equal(RetransmissionReasonType.Moved, msg.RetransmissionReason);
-                    }
-                    else
-                    {
-                        Assert.False(msg.RetransmissionReason.HasValue);
-                    }
-                }
+                Assert.False(msg.RetransmissionReason.HasValue);
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/Cluster.cs
+++ b/tests/StackExchange.Redis.Tests/Cluster.cs
@@ -21,10 +21,10 @@ public class Cluster : TestBase
     {
         if (File.Exists("cluster.zip")) File.Delete("cluster.zip");
         Assert.False(File.Exists("cluster.zip"));
-        using (var muxer = Create(allowAdmin: true))
+        using (var conn = Create(allowAdmin: true))
         using (var file = File.Create("cluster.zip"))
         {
-            muxer.ExportConfiguration(file);
+            conn.ExportConfiguration(file);
         }
         Assert.True(File.Exists("cluster.zip"));
     }

--- a/tests/StackExchange.Redis.Tests/Commands.cs
+++ b/tests/StackExchange.Redis.Tests/Commands.cs
@@ -1,58 +1,56 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Commands
 {
-    public class Commands
+    [Fact]
+    public void CommandByteLength()
     {
-        [Fact]
-        public void CommandByteLength()
+        Assert.Equal(31, CommandBytes.MaxLength);
+    }
+
+    [Fact]
+    public void CheckCommandContents()
+    {
+        for (int len = 0; len <= CommandBytes.MaxLength; len++)
         {
-            Assert.Equal(31, CommandBytes.MaxLength);
+            var s = new string('A', len);
+            CommandBytes b = s;
+            Assert.Equal(len, b.Length);
+
+            var t = b.ToString();
+            Assert.Equal(s, t);
+
+            CommandBytes b2 = t;
+            Assert.Equal(b, b2);
+
+            Assert.Equal(len == 0, ReferenceEquals(s, t));
         }
+    }
 
-        [Fact]
-        public void CheckCommandContents()
-        {
-            for (int len = 0; len <= CommandBytes.MaxLength; len++)
-            {
-                var s = new string('A', len);
-                CommandBytes b = s;
-                Assert.Equal(len, b.Length);
+    [Fact]
+    public void Basic()
+    {
+        var config = ConfigurationOptions.Parse(".,$PING=p");
+        Assert.Single(config.EndPoints);
+        config.SetDefaultPorts();
+        Assert.Contains(new DnsEndPoint(".", 6379), config.EndPoints);
+        var map = config.CommandMap;
+        Assert.Equal("$PING=P", map.ToString());
+        Assert.Equal(".:6379,$PING=P", config.ToString());
+    }
 
-                var t = b.ToString();
-                Assert.Equal(s, t);
+    [Theory]
+    [InlineData("redisql.CREATE_STATEMENT")]
+    [InlineData("INSERTINTOTABLE1STMT")]
+    public void CanHandleNonTrivialCommands(string command)
+    {
+        var cmd = new CommandBytes(command);
+        Assert.Equal(command.Length, cmd.Length);
+        Assert.Equal(command.ToUpperInvariant(), cmd.ToString());
 
-                CommandBytes b2 = t;
-                Assert.Equal(b, b2);
-
-                Assert.Equal(len == 0, ReferenceEquals(s, t));
-            }
-        }
-
-        [Fact]
-        public void Basic()
-        {
-            var config = ConfigurationOptions.Parse(".,$PING=p");
-            Assert.Single(config.EndPoints);
-            config.SetDefaultPorts();
-            Assert.Contains(new DnsEndPoint(".", 6379), config.EndPoints);
-            var map = config.CommandMap;
-            Assert.Equal("$PING=P", map.ToString());
-            Assert.Equal(".:6379,$PING=P", config.ToString());
-        }
-
-        [Theory]
-        [InlineData("redisql.CREATE_STATEMENT")]
-        [InlineData("INSERTINTOTABLE1STMT")]
-        public void CanHandleNonTrivialCommands(string command)
-        {
-            var cmd = new CommandBytes(command);
-            Assert.Equal(command.Length, cmd.Length);
-            Assert.Equal(command.ToUpperInvariant(), cmd.ToString());
-
-            Assert.Equal(31, CommandBytes.MaxLength);
-        }
+        Assert.Equal(31, CommandBytes.MaxLength);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -12,617 +12,603 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Config : TestBase
 {
-    public class Config : TestBase
+    public Version DefaultVersion = new (3, 0, 0);
+    public Version DefaultAzureVersion = new (4, 0, 0);
+
+    public Config(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void SslProtocols_SingleValue()
     {
-        public Version DefaultVersion = new (3, 0, 0);
-        public Version DefaultAzureVersion = new (4, 0, 0);
+        var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11");
+        Assert.Equal(SslProtocols.Tls11, options.SslProtocols.GetValueOrDefault());
+    }
 
-        public Config(ITestOutputHelper output) : base(output) { }
+    [Fact]
+    public void SslProtocols_MultipleValues()
+    {
+        var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11|Tls12");
+        Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
+    }
 
-        [Fact]
-        public void SslProtocols_SingleValue()
-        {
-            var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11");
-            Assert.Equal(SslProtocols.Tls11, options.SslProtocols.GetValueOrDefault());
-        }
+    [Theory]
+    [InlineData("checkCertificateRevocation=false", false)]
+    [InlineData("checkCertificateRevocation=true", true)]
+    [InlineData("", true)]
+    public void ConfigurationOption_CheckCertificateRevocation(string conString, bool expectedValue)
+    {
+        var options = ConfigurationOptions.Parse($"host,{conString}");
+        Assert.Equal(expectedValue, options.CheckCertificateRevocation);
+        var toString = options.ToString();
+        Assert.Contains(conString, toString, StringComparison.CurrentCultureIgnoreCase);
+    }
 
-        [Fact]
-        public void SslProtocols_MultipleValues()
-        {
-            var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls11|Tls12");
-            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
-        }
+    [Fact]
+    public void SslProtocols_UsingIntegerValue()
+    {
+        // The below scenario is for cases where the *targeted*
+        // .NET framework version (e.g. .NET 4.0) doesn't define an enum value (e.g. Tls11)
+        // but the OS has been patched with support
+        const int integerValue = (int)(SslProtocols.Tls11 | SslProtocols.Tls12);
+        var options = ConfigurationOptions.Parse("myhost,sslProtocols=" + integerValue);
+        Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
+    }
 
-        [Theory]
-        [InlineData("checkCertificateRevocation=false", false)]
-        [InlineData("checkCertificateRevocation=true", true)]
-        [InlineData("", true)]
-        public void ConfigurationOption_CheckCertificateRevocation(string conString, bool expectedValue)
-        {
-            var options = ConfigurationOptions.Parse($"host,{conString}");
-            Assert.Equal(expectedValue, options.CheckCertificateRevocation);
-            var toString = options.ToString();
-            Assert.Contains(conString, toString, StringComparison.CurrentCultureIgnoreCase);
-        }
+    [Fact]
+    public void SslProtocols_InvalidValue()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse("myhost,sslProtocols=InvalidSslProtocol"));
+    }
 
-        [Fact]
-        public void SslProtocols_UsingIntegerValue()
-        {
-            // The below scenario is for cases where the *targeted*
-            // .NET framework version (e.g. .NET 4.0) doesn't define an enum value (e.g. Tls11)
-            // but the OS has been patched with support
-            const int integerValue = (int)(SslProtocols.Tls11 | SslProtocols.Tls12);
-            var options = ConfigurationOptions.Parse("myhost,sslProtocols=" + integerValue);
-            Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, options.SslProtocols.GetValueOrDefault());
-        }
+    [Fact]
+    public void ConfigurationOptionsDefaultForAzure()
+    {
+        var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net");
+        Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
+        Assert.False(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void SslProtocols_InvalidValue()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse("myhost,sslProtocols=InvalidSslProtocol"));
-        }
+    [Fact]
+    public void ConfigurationOptionsForAzureWhenSpecified()
+    {
+        var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net,abortConnect=true, version=2.1.1");
+        Assert.True(options.DefaultVersion.Equals(new Version(2, 1, 1)));
+        Assert.True(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsDefaultForAzure()
-        {
-            var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net");
-            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
-            Assert.False(options.AbortOnConnectFail);
-        }
+    [Fact]
+    public void ConfigurationOptionsDefaultForAzureChina()
+    {
+        // added a few upper case chars to validate comparison
+        var options = ConfigurationOptions.Parse("contoso.REDIS.CACHE.chinacloudapi.cn");
+        Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
+        Assert.False(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsForAzureWhenSpecified()
-        {
-            var options = ConfigurationOptions.Parse("contoso.redis.cache.windows.net,abortConnect=true, version=2.1.1");
-            Assert.True(options.DefaultVersion.Equals(new Version(2, 1, 1)));
-            Assert.True(options.AbortOnConnectFail);
-        }
+    [Fact]
+    public void ConfigurationOptionsDefaultForAzureGermany()
+    {
+        var options = ConfigurationOptions.Parse("contoso.redis.cache.cloudapi.de");
+        Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
+        Assert.False(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsDefaultForAzureChina()
-        {
-            // added a few upper case chars to validate comparison
-            var options = ConfigurationOptions.Parse("contoso.REDIS.CACHE.chinacloudapi.cn");
-            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
-            Assert.False(options.AbortOnConnectFail);
-        }
+    [Fact]
+    public void ConfigurationOptionsDefaultForAzureUSGov()
+    {
+        var options = ConfigurationOptions.Parse("contoso.redis.cache.usgovcloudapi.net");
+        Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
+        Assert.False(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsDefaultForAzureGermany()
-        {
-            var options = ConfigurationOptions.Parse("contoso.redis.cache.cloudapi.de");
-            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
-            Assert.False(options.AbortOnConnectFail);
-        }
+    [Fact]
+    public void ConfigurationOptionsDefaultForNonAzure()
+    {
+        var options = ConfigurationOptions.Parse("redis.contoso.com");
+        Assert.True(options.DefaultVersion.Equals(DefaultVersion));
+        Assert.True(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsDefaultForAzureUSGov()
-        {
-            var options = ConfigurationOptions.Parse("contoso.redis.cache.usgovcloudapi.net");
-            Assert.True(options.DefaultVersion.Equals(DefaultAzureVersion));
-            Assert.False(options.AbortOnConnectFail);
-        }
+    [Fact]
+    public void ConfigurationOptionsDefaultWhenNoEndpointsSpecifiedYet()
+    {
+        var options = new ConfigurationOptions();
+        Assert.True(options.DefaultVersion.Equals(DefaultVersion));
+        Assert.True(options.AbortOnConnectFail);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsDefaultForNonAzure()
-        {
-            var options = ConfigurationOptions.Parse("redis.contoso.com");
-            Assert.True(options.DefaultVersion.Equals(DefaultVersion));
-            Assert.True(options.AbortOnConnectFail);
-        }
+    [Fact]
+    public void ConfigurationOptionsSyncTimeout()
+    {
+        // Default check
+        var options = new ConfigurationOptions();
+        Assert.Equal(5000, options.SyncTimeout);
 
-        [Fact]
-        public void ConfigurationOptionsDefaultWhenNoEndpointsSpecifiedYet()
-        {
-            var options = new ConfigurationOptions();
-            Assert.True(options.DefaultVersion.Equals(DefaultVersion));
-            Assert.True(options.AbortOnConnectFail);
-        }
+        options = ConfigurationOptions.Parse("syncTimeout=20");
+        Assert.Equal(20, options.SyncTimeout);
+    }
 
-        [Fact]
-        public void ConfigurationOptionsSyncTimeout()
-        {
-            // Default check
-            var options = new ConfigurationOptions();
-            Assert.Equal(5000, options.SyncTimeout);
+    [Theory]
+    [InlineData("127.1:6379", AddressFamily.InterNetwork, "127.0.0.1", 6379)]
+    [InlineData("127.0.0.1:6379", AddressFamily.InterNetwork, "127.0.0.1", 6379)]
+    [InlineData("2a01:9820:1:24::1:1:6379", AddressFamily.InterNetworkV6, "2a01:9820:1:24:0:1:1:6379", 0)]
+    [InlineData("[2a01:9820:1:24::1:1]:6379", AddressFamily.InterNetworkV6, "2a01:9820:1:24::1:1", 6379)]
+    public void ConfigurationOptionsIPv6Parsing(string configString, AddressFamily family, string address, int port)
+    {
+        var options = ConfigurationOptions.Parse(configString);
+        Assert.Single(options.EndPoints);
+        var ep = Assert.IsType<IPEndPoint>(options.EndPoints[0]);
+        Assert.Equal(family, ep.AddressFamily);
+        Assert.Equal(address, ep.Address.ToString());
+        Assert.Equal(port, ep.Port);
+    }
 
-            options = ConfigurationOptions.Parse("syncTimeout=20");
-            Assert.Equal(20, options.SyncTimeout);
-        }
-
-        [Theory]
-        [InlineData("127.1:6379", AddressFamily.InterNetwork, "127.0.0.1", 6379)]
-        [InlineData("127.0.0.1:6379", AddressFamily.InterNetwork, "127.0.0.1", 6379)]
-        [InlineData("2a01:9820:1:24::1:1:6379", AddressFamily.InterNetworkV6, "2a01:9820:1:24:0:1:1:6379", 0)]
-        [InlineData("[2a01:9820:1:24::1:1]:6379", AddressFamily.InterNetworkV6, "2a01:9820:1:24::1:1", 6379)]
-        public void ConfigurationOptionsIPv6Parsing(string configString, AddressFamily family, string address, int port)
-        {
-            var options = ConfigurationOptions.Parse(configString);
-            Assert.Single(options.EndPoints);
-            var ep = Assert.IsType<IPEndPoint>(options.EndPoints[0]);
-            Assert.Equal(family, ep.AddressFamily);
-            Assert.Equal(address, ep.Address.ToString());
-            Assert.Equal(port, ep.Port);
-        }
-
-        [Fact]
-        public void CanParseAndFormatUnixDomainSocket()
-        {
-            const string ConfigString = "!/some/path,allowAdmin=True";
+    [Fact]
+    public void CanParseAndFormatUnixDomainSocket()
+    {
+        const string ConfigString = "!/some/path,allowAdmin=True";
 #if NET472
-            var ex = Assert.Throws<PlatformNotSupportedException>(() => ConfigurationOptions.Parse(ConfigString));
-            Assert.Equal("Unix domain sockets require .NET Core 3 or above", ex.Message);
+        var ex = Assert.Throws<PlatformNotSupportedException>(() => ConfigurationOptions.Parse(ConfigString));
+        Assert.Equal("Unix domain sockets require .NET Core 3 or above", ex.Message);
 #else
-            var config = ConfigurationOptions.Parse(ConfigString);
-            Assert.True(config.AllowAdmin);
-            var ep = Assert.IsType<UnixDomainSocketEndPoint>(Assert.Single(config.EndPoints));
-            Assert.Equal("/some/path", ep.ToString());
-            Assert.Equal(ConfigString, config.ToString());
+        var config = ConfigurationOptions.Parse(ConfigString);
+        Assert.True(config.AllowAdmin);
+        var ep = Assert.IsType<UnixDomainSocketEndPoint>(Assert.Single(config.EndPoints));
+        Assert.Equal("/some/path", ep.ToString());
+        Assert.Equal(ConfigString, config.ToString());
 #endif
+    }
+
+    [Fact]
+    public void TalkToNonsenseServer()
+    {
+        var config = new ConfigurationOptions
+        {
+            AbortOnConnectFail = false,
+            EndPoints =
+            {
+                { "127.0.0.1:1234" }
+            },
+            ConnectTimeout = 200
+        };
+        var log = new StringWriter();
+        using (var conn = ConnectionMultiplexer.Connect(config, log))
+        {
+            Log(log.ToString());
+            Assert.False(conn.IsConnected);
+        }
+    }
+
+    [Fact]
+    public async Task TestManaulHeartbeat()
+    {
+        using var conn = Create(keepAlive: 2);
+
+        var db = conn.GetDatabase();
+        db.Ping();
+
+        var before = conn.OperationCount;
+
+        Log("sleeping to test heartbeat...");
+        await Task.Delay(5000).ForAwait();
+
+        var after = conn.OperationCount;
+
+        Assert.True(after >= before + 2, $"after: {after}, before: {before}");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(200)]
+    public void GetSlowlog(int count)
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var rows = GetAnyPrimary(conn).SlowlogGet(count);
+        Assert.NotNull(rows);
+    }
+
+    [Fact]
+    public void ClearSlowlog()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        GetAnyPrimary(conn).SlowlogReset();
+    }
+
+    [Fact]
+    public void ClientName()
+    {
+        using var conn = Create(clientName: "Test Rig", allowAdmin: true);
+
+        Assert.Equal("Test Rig", conn.ClientName);
+
+        var db = conn.GetDatabase();
+        db.Ping();
+
+        var name = (string?)GetAnyPrimary(conn).Execute("CLIENT", "GETNAME");
+        Assert.Equal("TestRig", name);
+    }
+
+    [Fact]
+    public void DefaultClientName()
+    {
+        using var conn = Create(allowAdmin: true, caller: null); // force default naming to kick in
+
+        Assert.Equal($"{Environment.MachineName}(SE.Redis-v{Utils.GetLibVersion()})", conn.ClientName);
+        var db = conn.GetDatabase();
+        db.Ping();
+
+        var name = (string?)GetAnyPrimary(conn).Execute("CLIENT", "GETNAME");
+        Assert.Equal($"{Environment.MachineName}(SE.Redis-v{Utils.GetLibVersion()})", name);
+    }
+
+    [Fact]
+    public void ReadConfigWithConfigDisabled()
+    {
+        using var conn = Create(allowAdmin: true, disabledCommands: new[] { "config", "info" });
+
+        var server = GetAnyPrimary(conn);
+        var ex = Assert.Throws<RedisCommandException>(() => server.ConfigGet());
+        Assert.Equal("This operation has been disabled in the command-map and cannot be used: CONFIG", ex.Message);
+    }
+
+    [Fact]
+    public void ConnectWithSubscribeDisabled()
+    {
+        using var conn = Create(allowAdmin: true, disabledCommands: new[] { "subscribe" });
+
+        Assert.True(conn.IsConnected);
+        var servers = conn.GetServerSnapshot();
+        Assert.True(servers[0].IsConnected);
+        Assert.False(servers[0].IsSubscriberConnected);
+
+        var ex = Assert.Throws<RedisCommandException>(() => conn.GetSubscriber().Subscribe(Me(), (_, _) => GC.KeepAlive(this)));
+        Assert.Equal("This operation has been disabled in the command-map and cannot be used: SUBSCRIBE", ex.Message);
+    }
+
+    [Fact]
+    public void ReadConfig()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        Log("about to get config");
+        var server = GetAnyPrimary(conn);
+        var all = server.ConfigGet();
+        Assert.True(all.Length > 0, "any");
+
+        var pairs = all.ToDictionary(x => (string)x.Key, x => (string)x.Value, StringComparer.InvariantCultureIgnoreCase);
+
+        Assert.Equal(all.Length, pairs.Count);
+        Assert.True(pairs.ContainsKey("timeout"), "timeout");
+        var val = int.Parse(pairs["timeout"]);
+
+        Assert.True(pairs.ContainsKey("port"), "port");
+        val = int.Parse(pairs["port"]);
+        Assert.Equal(TestConfig.Current.PrimaryPort, val);
+    }
+
+    [Fact]
+    public void GetTime()
+    {
+        using var conn = Create();
+
+        var server = GetAnyPrimary(conn);
+        var serverTime = server.Time();
+        var localTime = DateTime.UtcNow;
+        Log("Server: " + serverTime.ToString(CultureInfo.InvariantCulture));
+        Log("Local: " + localTime.ToString(CultureInfo.InvariantCulture));
+        Assert.Equal(localTime, serverTime, TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public void DebugObject()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringIncrement(key, flags: CommandFlags.FireAndForget);
+        var debug = (string?)db.DebugObject(key);
+        Assert.NotNull(debug);
+        Assert.Contains("encoding:int serializedlength:2", debug);
+    }
+
+    [Fact]
+    public void GetInfo()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var server = GetAnyPrimary(conn);
+        var info1 = server.Info();
+        Assert.True(info1.Length > 5);
+        Log("All sections");
+        foreach (var group in info1)
+        {
+            Log(group.Key);
+        }
+        var first = info1[0];
+        Log("Full info for: " + first.Key);
+        foreach (var setting in first)
+        {
+            Log("{0}  ==>  {1}", setting.Key, setting.Value);
         }
 
-        [Fact]
-        public void TalkToNonsenseServer()
+        var info2 = server.Info("cpu");
+        Assert.Single(info2);
+        var cpu = info2.Single();
+        var cpuCount = cpu.Count();
+        Assert.True(cpuCount > 2);
+        Assert.Equal("CPU", cpu.Key);
+        Assert.Contains(cpu, x => x.Key == "used_cpu_sys");
+        Assert.Contains(cpu, x => x.Key == "used_cpu_user");
+    }
+
+    [Fact]
+    public void GetInfoRaw()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var server = GetAnyPrimary(conn);
+        var info = server.InfoRaw();
+        Assert.Contains("used_cpu_sys", info);
+        Assert.Contains("used_cpu_user", info);
+    }
+
+    [Fact]
+    public void GetClients()
+    {
+        var name = Guid.NewGuid().ToString();
+        using var conn = Create(clientName: name, allowAdmin: true);
+
+        var server = GetAnyPrimary(conn);
+        var clients = server.ClientList();
+        Assert.True(clients.Length > 0, "no clients"); // ourselves!
+        Assert.True(clients.Any(x => x.Name == name), "expected: " + name);
+    }
+
+    [Fact]
+    public void SlowLog()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var server = GetAnyPrimary(conn);
+        server.SlowlogGet();
+        server.SlowlogReset();
+    }
+
+    [Fact]
+    public async Task TestAutomaticHeartbeat()
+    {
+        RedisValue oldTimeout = RedisValue.Null;
+        using var configConn = Create(allowAdmin: true);
+
+        try
         {
-            var config = new ConfigurationOptions
+            configConn.GetDatabase();
+            var srv = GetAnyPrimary(configConn);
+            oldTimeout = srv.ConfigGet("timeout")[0].Value;
+            srv.ConfigSet("timeout", 5);
+
+            using var innerConn = Create();
+            var innerDb = innerConn.GetDatabase();
+            innerDb.Ping(); // need to wait to pick up configuration etc
+
+            var before = innerConn.OperationCount;
+
+            Log("sleeping to test heartbeat...");
+            await Task.Delay(8000).ForAwait();
+
+            var after = innerConn.OperationCount;
+            Assert.True(after >= before + 2, $"after: {after}, before: {before}");
+        }
+        finally
+        {
+            if (!oldTimeout.IsNull)
             {
-                AbortOnConnectFail = false,
-                EndPoints =
-                {
-                    { "127.0.0.1:1234" }
-                },
-                ConnectTimeout = 200
-            };
-            var log = new StringWriter();
-            using (var conn = ConnectionMultiplexer.Connect(config, log))
-            {
-                Log(log.ToString());
-                Assert.False(conn.IsConnected);
+                var srv = GetAnyPrimary(configConn);
+                srv.ConfigSet("timeout", oldTimeout);
             }
         }
+    }
 
-        [Fact]
-        public async Task TestManaulHeartbeat()
+    [Fact]
+    public void EndpointIteratorIsReliableOverChanges()
+    {
+        var eps = new EndPointCollection
         {
-            using (var muxer = Create(keepAlive: 2))
-            {
-                var conn = muxer.GetDatabase();
-                conn.Ping();
+            { IPAddress.Loopback, 7999 },
+            { IPAddress.Loopback, 8000 },
+        };
 
-                var before = muxer.OperationCount;
+        using var iter = eps.GetEnumerator();
+        Assert.True(iter.MoveNext());
+        Assert.Equal(7999, ((IPEndPoint)iter.Current).Port);
+        eps[1] = new IPEndPoint(IPAddress.Loopback, 8001); // boom
+        Assert.True(iter.MoveNext());
+        Assert.Equal(8001, ((IPEndPoint)iter.Current).Port);
+        Assert.False(iter.MoveNext());
+    }
 
-                Log("sleeping to test heartbeat...");
-                await Task.Delay(5000).ForAwait();
-
-                var after = muxer.OperationCount;
-
-                Assert.True(after >= before + 2, $"after: {after}, before: {before}");
-            }
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(10)]
-        [InlineData(100)]
-        [InlineData(200)]
-        public void GetSlowlog(int count)
+    [Fact]
+    public void ThreadPoolManagerIsDetected()
+    {
+        var config = new ConfigurationOptions
         {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                var rows = GetAnyPrimary(muxer).SlowlogGet(count);
-                Assert.NotNull(rows);
-            }
-        }
+            EndPoints = { { IPAddress.Loopback, 6379 } },
+            SocketManager = SocketManager.ThreadPool
+        };
 
-        [Fact]
-        public void ClearSlowlog()
+        using var conn = ConnectionMultiplexer.Connect(config);
+
+        Assert.Same(PipeScheduler.ThreadPool, conn.SocketManager?.Scheduler);
+    }
+
+    [Fact]
+    public void DefaultThreadPoolManagerIsDetected()
+    {
+        var config = new ConfigurationOptions
         {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                GetAnyPrimary(muxer).SlowlogReset();
-            }
-        }
+            EndPoints = { { IPAddress.Loopback, 6379 } },
+        };
 
-        [Fact]
-        public void ClientName()
-        {
-            using (var muxer = Create(clientName: "Test Rig", allowAdmin: true))
-            {
-                Assert.Equal("Test Rig", muxer.ClientName);
+        using var conn = ConnectionMultiplexer.Connect(config);
 
-                var conn = muxer.GetDatabase();
-                conn.Ping();
+        Assert.Same(ConnectionMultiplexer.GetDefaultSocketManager().Scheduler, conn.SocketManager?.Scheduler);
+    }
 
-                var name = (string?)GetAnyPrimary(muxer).Execute("CLIENT", "GETNAME");
-                Assert.Equal("TestRig", name);
-            }
-        }
-
-        [Fact]
-        public void DefaultClientName()
-        {
-            using (var muxer = Create(allowAdmin: true, caller: null)) // force default naming to kick in
-            {
-                Assert.Equal($"{Environment.MachineName}(SE.Redis-v{Utils.GetLibVersion()})", muxer.ClientName);
-                var conn = muxer.GetDatabase();
-                conn.Ping();
-
-                var name = (string?)GetAnyPrimary(muxer).Execute("CLIENT", "GETNAME");
-                Assert.Equal($"{Environment.MachineName}(SE.Redis-v{Utils.GetLibVersion()})", name);
-            }
-        }
-
-        [Fact]
-        public void ReadConfigWithConfigDisabled()
-        {
-            using (var muxer = Create(allowAdmin: true, disabledCommands: new[] { "config", "info" }))
-            {
-                var conn = GetAnyPrimary(muxer);
-                var ex = Assert.Throws<RedisCommandException>(() => conn.ConfigGet());
-                Assert.Equal("This operation has been disabled in the command-map and cannot be used: CONFIG", ex.Message);
-            }
-        }
-
-        [Fact]
-        public void ConnectWithSubscribeDisabled()
-        {
-            using (var muxer = Create(allowAdmin: true, disabledCommands: new[] { "subscribe" }))
-            {
-                Assert.True(muxer.IsConnected);
-                var servers = muxer.GetServerSnapshot();
-                Assert.True(servers[0].IsConnected);
-                Assert.False(servers[0].IsSubscriberConnected);
-
-                var ex = Assert.Throws<RedisCommandException>(() => muxer.GetSubscriber().Subscribe(Me(), (_, _) => GC.KeepAlive(this)));
-                Assert.Equal("This operation has been disabled in the command-map and cannot be used: SUBSCRIBE", ex.Message);
-            }
-        }
-
-        [Fact]
-        public void ReadConfig()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                Log("about to get config");
-                var conn = GetAnyPrimary(muxer);
-                var all = conn.ConfigGet();
-                Assert.True(all.Length > 0, "any");
-
-                var pairs = all.ToDictionary(x => (string)x.Key, x => (string)x.Value, StringComparer.InvariantCultureIgnoreCase);
-
-                Assert.Equal(all.Length, pairs.Count);
-                Assert.True(pairs.ContainsKey("timeout"), "timeout");
-                var val = int.Parse(pairs["timeout"]);
-
-                Assert.True(pairs.ContainsKey("port"), "port");
-                val = int.Parse(pairs["port"]);
-                Assert.Equal(TestConfig.Current.PrimaryPort, val);
-            }
-        }
-
-        [Fact]
-        public void GetTime()
-        {
-            using (var muxer = Create())
-            {
-                var server = GetAnyPrimary(muxer);
-                var serverTime = server.Time();
-                var localTime = DateTime.UtcNow;
-                Log("Server: " + serverTime.ToString(CultureInfo.InvariantCulture));
-                Log("Local: " + localTime.ToString(CultureInfo.InvariantCulture));
-                Assert.Equal(localTime, serverTime, TimeSpan.FromSeconds(10));
-            }
-        }
-
-        [Fact]
-        public void DebugObject()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                var db = muxer.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                var debug = (string?)db.DebugObject(key);
-                Assert.NotNull(debug);
-                Assert.Contains("encoding:int serializedlength:2", debug);
-            }
-        }
-
-        [Fact]
-        public void GetInfo()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                var server = GetAnyPrimary(muxer);
-                var info1 = server.Info();
-                Assert.True(info1.Length > 5);
-                Log("All sections");
-                foreach (var group in info1)
-                {
-                    Log(group.Key);
-                }
-                var first = info1[0];
-                Log("Full info for: " + first.Key);
-                foreach (var setting in first)
-                {
-                    Log("{0}  ==>  {1}", setting.Key, setting.Value);
-                }
-
-                var info2 = server.Info("cpu");
-                Assert.Single(info2);
-                var cpu = info2.Single();
-                var cpuCount = cpu.Count();
-                Assert.True(cpuCount > 2);
-                Assert.Equal("CPU", cpu.Key);
-                Assert.Contains(cpu, x => x.Key == "used_cpu_sys");
-                Assert.Contains(cpu, x => x.Key == "used_cpu_user");
-            }
-        }
-
-        [Fact]
-        public void GetInfoRaw()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                var server = GetAnyPrimary(muxer);
-                var info = server.InfoRaw();
-                Assert.Contains("used_cpu_sys", info);
-                Assert.Contains("used_cpu_user", info);
-            }
-        }
-
-        [Fact]
-        public void GetClients()
-        {
-            var name = Guid.NewGuid().ToString();
-            using (var muxer = Create(clientName: name, allowAdmin: true))
-            {
-                var server = GetAnyPrimary(muxer);
-                var clients = server.ClientList();
-                Assert.True(clients.Length > 0, "no clients"); // ourselves!
-                Assert.True(clients.Any(x => x.Name == name), "expected: " + name);
-            }
-        }
-
-        [Fact]
-        public void SlowLog()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                var server = GetAnyPrimary(muxer);
-                server.SlowlogGet();
-                server.SlowlogReset();
-            }
-        }
-
-        [Fact]
-        public async Task TestAutomaticHeartbeat()
-        {
-            RedisValue oldTimeout = RedisValue.Null;
-            using (var configMuxer = Create(allowAdmin: true))
-            {
-                try
-                {
-                    configMuxer.GetDatabase();
-                    var srv = GetAnyPrimary(configMuxer);
-                    oldTimeout = srv.ConfigGet("timeout")[0].Value;
-                    srv.ConfigSet("timeout", 5);
-
-                    using (var innerMuxer = Create())
-                    {
-                        var innerConn = innerMuxer.GetDatabase();
-                        innerConn.Ping(); // need to wait to pick up configuration etc
-
-                        var before = innerMuxer.OperationCount;
-
-                        Log("sleeping to test heartbeat...");
-                        await Task.Delay(8000).ForAwait();
-
-                        var after = innerMuxer.OperationCount;
-                        Assert.True(after >= before + 2, $"after: {after}, before: {before}");
-                    }
-                }
-                finally
-                {
-                    if (!oldTimeout.IsNull)
-                    {
-                        var srv = GetAnyPrimary(configMuxer);
-                        srv.ConfigSet("timeout", oldTimeout);
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void EndpointIteratorIsReliableOverChanges()
-        {
-            var eps = new EndPointCollection
-            {
-                { IPAddress.Loopback, 7999 },
-                { IPAddress.Loopback, 8000 },
-            };
-
-            using var iter = eps.GetEnumerator();
-            Assert.True(iter.MoveNext());
-            Assert.Equal(7999, ((IPEndPoint)iter.Current).Port);
-            eps[1] = new IPEndPoint(IPAddress.Loopback, 8001); // boom
-            Assert.True(iter.MoveNext());
-            Assert.Equal(8001, ((IPEndPoint)iter.Current).Port);
-            Assert.False(iter.MoveNext());
-        }
-
-        [Fact]
-        public void ThreadPoolManagerIsDetected()
-        {
-            var config = new ConfigurationOptions
-            {
-                EndPoints = { { IPAddress.Loopback, 6379 } },
-                SocketManager = SocketManager.ThreadPool
-            };
-            using var muxer = ConnectionMultiplexer.Connect(config);
-            Assert.Same(PipeScheduler.ThreadPool, muxer.SocketManager?.Scheduler);
-        }
-
-        [Fact]
-        public void DefaultThreadPoolManagerIsDetected()
-        {
-            var config = new ConfigurationOptions
-            {
-                EndPoints = { { IPAddress.Loopback, 6379 } },
-            };
-            using var muxer = ConnectionMultiplexer.Connect(config);
-            Assert.Same(ConnectionMultiplexer.GetDefaultSocketManager().Scheduler, muxer.SocketManager?.Scheduler);
-        }
-
-        [Theory]
-        [InlineData("myDNS:myPort,password=myPassword,connectRetry=3,connectTimeout=15000,syncTimeout=15000,defaultDatabase=0,abortConnect=false,ssl=true,sslProtocols=Tls12", SslProtocols.Tls12)]
-        [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Tls12", SslProtocols.Tls12)]
+    [Theory]
+    [InlineData("myDNS:myPort,password=myPassword,connectRetry=3,connectTimeout=15000,syncTimeout=15000,defaultDatabase=0,abortConnect=false,ssl=true,sslProtocols=Tls12", SslProtocols.Tls12)]
+    [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Tls12", SslProtocols.Tls12)]
 #pragma warning disable CS0618 // Type or member is obsolete
-        [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Ssl3", SslProtocols.Ssl3)]
+    [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Ssl3", SslProtocols.Ssl3)]
 #pragma warning restore CS0618
-        [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Tls12 ", SslProtocols.Tls12)]
-        public void ParseTlsWithoutTrailingComma(string configString, SslProtocols expected)
+    [InlineData("myDNS:myPort,password=myPassword,abortConnect=false,ssl=true,sslProtocols=Tls12 ", SslProtocols.Tls12)]
+    public void ParseTlsWithoutTrailingComma(string configString, SslProtocols expected)
+    {
+        var config = ConfigurationOptions.Parse(configString);
+        Assert.Equal(expected, config.SslProtocols);
+    }
+
+    [Theory]
+    [InlineData("foo,sslProtocols=NotAThing", "Keyword 'sslProtocols' requires an SslProtocol value (multiple values separated by '|'); the value 'NotAThing' is not recognised.", "sslProtocols")]
+    [InlineData("foo,SyncTimeout=ten", "Keyword 'SyncTimeout' requires an integer value; the value 'ten' is not recognised.", "SyncTimeout")]
+    [InlineData("foo,syncTimeout=-42", "Keyword 'syncTimeout' has a minimum value of '1'; the value '-42' is not permitted.", "syncTimeout")]
+    [InlineData("foo,AllowAdmin=maybe", "Keyword 'AllowAdmin' requires a boolean value; the value 'maybe' is not recognised.", "AllowAdmin")]
+    [InlineData("foo,Version=current", "Keyword 'Version' requires a version value; the value 'current' is not recognised.", "Version")]
+    [InlineData("foo,proxy=epoxy", "Keyword 'proxy' requires a proxy value; the value 'epoxy' is not recognised.", "proxy")]
+    public void ConfigStringErrorsGiveMeaningfulMessages(string configString, string expected, string paramName)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse(configString));
+        Assert.StartsWith(expected, ex.Message); // param name gets concatenated sometimes
+        Assert.Equal(paramName, ex.ParamName); // param name gets concatenated sometimes
+    }
+
+    [Fact]
+    public void ConfigStringInvalidOptionErrorGiveMeaningfulMessages()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ConfigurationOptions.Parse("foo,flibble=value"));
+        Assert.StartsWith("Keyword 'flibble' is not supported.", ex.Message); // param name gets concatenated sometimes
+        Assert.Equal("flibble", ex.ParamName);
+    }
+
+    [Fact]
+    public void NullApply()
+    {
+        var options = ConfigurationOptions.Parse("127.0.0.1,name=FooApply");
+        Assert.Equal("FooApply", options.ClientName);
+
+        // Doesn't go boom
+        var result = options.Apply(null!);
+        Assert.Equal("FooApply", options.ClientName);
+        Assert.Equal(result, options);
+    }
+
+    [Fact]
+    public void Apply()
+    {
+        var options = ConfigurationOptions.Parse("127.0.0.1,name=FooApply");
+        Assert.Equal("FooApply", options.ClientName);
+
+        var randomName = Guid.NewGuid().ToString();
+        var result = options.Apply(options => options.ClientName = randomName);
+
+        Assert.Equal(randomName, options.ClientName);
+        Assert.Equal(randomName, result.ClientName);
+        Assert.Equal(result, options);
+    }
+
+    [Fact]
+    public void BeforeSocketConnect()
+    {
+        var options = ConfigurationOptions.Parse(TestConfig.Current.PrimaryServerAndPort);
+        int count = 0;
+        options.BeforeSocketConnect = (endpoint, connType, socket) =>
         {
-            var config = ConfigurationOptions.Parse(configString);
-            Assert.Equal(expected, config.SslProtocols);
-        }
+            Interlocked.Increment(ref count);
+            Log($"Endpoint: {endpoint}, ConnType: {connType}, Socket: {socket}");
+            socket.DontFragment = true;
+            socket.Ttl = (short)(connType == ConnectionType.Interactive ? 12 : 123);
+        };
+        var muxer = ConnectionMultiplexer.Connect(options);
+        Assert.True(muxer.IsConnected);
+        Assert.Equal(2, count);
 
-        [Theory]
-        [InlineData("foo,sslProtocols=NotAThing", "Keyword 'sslProtocols' requires an SslProtocol value (multiple values separated by '|'); the value 'NotAThing' is not recognised.", "sslProtocols")]
-        [InlineData("foo,SyncTimeout=ten", "Keyword 'SyncTimeout' requires an integer value; the value 'ten' is not recognised.", "SyncTimeout")]
-        [InlineData("foo,syncTimeout=-42", "Keyword 'syncTimeout' has a minimum value of '1'; the value '-42' is not permitted.", "syncTimeout")]
-        [InlineData("foo,AllowAdmin=maybe", "Keyword 'AllowAdmin' requires a boolean value; the value 'maybe' is not recognised.", "AllowAdmin")]
-        [InlineData("foo,Version=current", "Keyword 'Version' requires a version value; the value 'current' is not recognised.", "Version")]
-        [InlineData("foo,proxy=epoxy", "Keyword 'proxy' requires a proxy value; the value 'epoxy' is not recognised.", "proxy")]
-        public void ConfigStringErrorsGiveMeaningfulMessages(string configString, string expected, string paramName)
-        {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ConfigurationOptions.Parse(configString));
-            Assert.StartsWith(expected, ex.Message); // param name gets concatenated sometimes
-            Assert.Equal(paramName, ex.ParamName); // param name gets concatenated sometimes
-        }
+        var endpoint = muxer.GetServerSnapshot()[0];
+        var interactivePhysical = endpoint.GetBridge(ConnectionType.Interactive)?.TryConnect(null);
+        var subscriptionPhysical = endpoint.GetBridge(ConnectionType.Subscription)?.TryConnect(null);
+        Assert.NotNull(interactivePhysical);
+        Assert.NotNull(subscriptionPhysical);
 
-        [Fact]
-        public void ConfigStringInvalidOptionErrorGiveMeaningfulMessages()
-        {
-            var ex = Assert.Throws<ArgumentException>(() => ConfigurationOptions.Parse("foo,flibble=value"));
-            Assert.StartsWith("Keyword 'flibble' is not supported.", ex.Message); // param name gets concatenated sometimes
-            Assert.Equal("flibble", ex.ParamName);
-        }
+        var interactiveSocket = interactivePhysical.VolatileSocket;
+        var subscriptionSocket = subscriptionPhysical.VolatileSocket;
+        Assert.NotNull(interactiveSocket);
+        Assert.NotNull(subscriptionSocket);
 
-        [Fact]
-        public void NullApply()
-        {
-            var options = ConfigurationOptions.Parse("127.0.0.1,name=FooApply");
-            Assert.Equal("FooApply", options.ClientName);
+        Assert.Equal(12, interactiveSocket.Ttl);
+        Assert.Equal(123, subscriptionSocket.Ttl);
+        Assert.True(interactiveSocket.DontFragment);
+        Assert.True(subscriptionSocket.DontFragment);
+    }
 
-            // Doesn't go boom
-            var result = options.Apply(null!);
-            Assert.Equal("FooApply", options.ClientName);
-            Assert.Equal(result, options);
-        }
+    [Fact]
+    public async Task MutableOptions()
+    {
+        var options = ConfigurationOptions.Parse(TestConfig.Current.PrimaryServerAndPort + ",name=Details");
+        var originalConfigChannel = options.ConfigurationChannel = "originalConfig";
+        var originalUser = options.User = "originalUser";
+        var originalPassword = options.Password = "originalPassword";
+        Assert.Equal("Details", options.ClientName);
+        using var conn = await ConnectionMultiplexer.ConnectAsync(options);
 
-        [Fact]
-        public void Apply()
-        {
-            var options = ConfigurationOptions.Parse("127.0.0.1,name=FooApply");
-            Assert.Equal("FooApply", options.ClientName);
+        // Same instance
+        Assert.Same(options, conn.RawConfig);
+        // Copies
+        Assert.NotSame(options.EndPoints, conn.EndPoints);
 
-            var randomName = Guid.NewGuid().ToString();
-            var result = options.Apply(options => options.ClientName = randomName);
-
-            Assert.Equal(randomName, options.ClientName);
-            Assert.Equal(randomName, result.ClientName);
-            Assert.Equal(result, options);
-        }
-
-        [Fact]
-        public void BeforeSocketConnect()
-        {
-            var options = ConfigurationOptions.Parse(TestConfig.Current.PrimaryServerAndPort);
-            int count = 0;
-            options.BeforeSocketConnect = (endpoint, connType, socket) =>
-            {
-                Interlocked.Increment(ref count);
-                Log($"Endpoint: {endpoint}, ConnType: {connType}, Socket: {socket}");
-                socket.DontFragment = true;
-                socket.Ttl = (short)(connType == ConnectionType.Interactive ? 12 : 123);
-            };
-            var muxer = ConnectionMultiplexer.Connect(options);
-            Assert.True(muxer.IsConnected);
-            Assert.Equal(2, count);
-
-            var endpoint = muxer.GetServerSnapshot()[0];
-            var interactivePhysical = endpoint.GetBridge(ConnectionType.Interactive)?.TryConnect(null);
-            var subscriptionPhysical = endpoint.GetBridge(ConnectionType.Subscription)?.TryConnect(null);
-            Assert.NotNull(interactivePhysical);
-            Assert.NotNull(subscriptionPhysical);
-
-            var interactiveSocket = interactivePhysical.VolatileSocket;
-            var subscriptionSocket = subscriptionPhysical.VolatileSocket;
-            Assert.NotNull(interactiveSocket);
-            Assert.NotNull(subscriptionSocket);
-
-            Assert.Equal(12, interactiveSocket.Ttl);
-            Assert.Equal(123, subscriptionSocket.Ttl);
-            Assert.True(interactiveSocket.DontFragment);
-            Assert.True(subscriptionSocket.DontFragment);
-        }
-
-        [Fact]
-        public async Task MutableOptions()
-        {
-            var options = ConfigurationOptions.Parse(TestConfig.Current.PrimaryServerAndPort + ",name=Details");
-            var originalConfigChannel = options.ConfigurationChannel = "originalConfig";
-            var originalUser = options.User = "originalUser";
-            var originalPassword = options.Password = "originalPassword";
-            Assert.Equal("Details", options.ClientName);
-            using var muxer = await ConnectionMultiplexer.ConnectAsync(options);
-
-            // Same instance
-            Assert.Same(options, muxer.RawConfig);
-            // Copies
-            Assert.NotSame(options.EndPoints, muxer.EndPoints);
-
-            // Same until forked - it's not cloned
-            Assert.Same(options.CommandMap, muxer.CommandMap);
-            options.CommandMap = CommandMap.Envoyproxy;
-            Assert.NotSame(options.CommandMap, muxer.CommandMap);
+        // Same until forked - it's not cloned
+        Assert.Same(options.CommandMap, conn.CommandMap);
+        options.CommandMap = CommandMap.Envoyproxy;
+        Assert.NotSame(options.CommandMap, conn.CommandMap);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            // Defaults true
-            Assert.True(options.IncludeDetailInExceptions);
-            Assert.True(muxer.IncludeDetailInExceptions);
-            options.IncludeDetailInExceptions = false;
-            Assert.False(options.IncludeDetailInExceptions);
-            Assert.False(muxer.IncludeDetailInExceptions);
+        // Defaults true
+        Assert.True(options.IncludeDetailInExceptions);
+        Assert.True(conn.IncludeDetailInExceptions);
+        options.IncludeDetailInExceptions = false;
+        Assert.False(options.IncludeDetailInExceptions);
+        Assert.False(conn.IncludeDetailInExceptions);
 
-            // Defaults false
-            Assert.False(options.IncludePerformanceCountersInExceptions);
-            Assert.False(muxer.IncludePerformanceCountersInExceptions);
-            options.IncludePerformanceCountersInExceptions = true;
-            Assert.True(options.IncludePerformanceCountersInExceptions);
-            Assert.True(muxer.IncludePerformanceCountersInExceptions);
+        // Defaults false
+        Assert.False(options.IncludePerformanceCountersInExceptions);
+        Assert.False(conn.IncludePerformanceCountersInExceptions);
+        options.IncludePerformanceCountersInExceptions = true;
+        Assert.True(options.IncludePerformanceCountersInExceptions);
+        Assert.True(conn.IncludePerformanceCountersInExceptions);
 #pragma warning restore CS0618
 
-            var newName = Guid.NewGuid().ToString();
-            options.ClientName = newName;
-            Assert.Equal(newName, muxer.ClientName);
+        var newName = Guid.NewGuid().ToString();
+        options.ClientName = newName;
+        Assert.Equal(newName, conn.ClientName);
 
-            // TODO: This forks due to memoization of the byte[] for efficiency
-            // If we could cheaply detect change it'd be good to let this change
-            const string newConfigChannel = "newConfig";
-            options.ConfigurationChannel = newConfigChannel;
-            Assert.Equal(newConfigChannel, options.ConfigurationChannel);
-            Assert.NotNull(muxer.ConfigurationChangedChannel);
-            Assert.Equal(Encoding.UTF8.GetString(muxer.ConfigurationChangedChannel), originalConfigChannel);
+        // TODO: This forks due to memoization of the byte[] for efficiency
+        // If we could cheaply detect change it'd be good to let this change
+        const string newConfigChannel = "newConfig";
+        options.ConfigurationChannel = newConfigChannel;
+        Assert.Equal(newConfigChannel, options.ConfigurationChannel);
+        Assert.NotNull(conn.ConfigurationChangedChannel);
+        Assert.Equal(Encoding.UTF8.GetString(conn.ConfigurationChangedChannel), originalConfigChannel);
 
-            Assert.Equal(originalUser, muxer.RawConfig.User);
-            Assert.Equal(originalPassword, muxer.RawConfig.Password);
-            var newPass = options.Password = "newPassword";
-            Assert.Equal(newPass, muxer.RawConfig.Password);
-        }
+        Assert.Equal(originalUser, conn.RawConfig.User);
+        Assert.Equal(originalPassword, conn.RawConfig.Password);
+        var newPass = options.Password = "newPassword";
+        Assert.Equal(newPass, conn.RawConfig.Password);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -537,11 +537,11 @@ public class Config : TestBase
             socket.DontFragment = true;
             socket.Ttl = (short)(connType == ConnectionType.Interactive ? 12 : 123);
         };
-        var muxer = ConnectionMultiplexer.Connect(options);
-        Assert.True(muxer.IsConnected);
+        using var conn = ConnectionMultiplexer.Connect(options);
+        Assert.True(conn.IsConnected);
         Assert.Equal(2, count);
 
-        var endpoint = muxer.GetServerSnapshot()[0];
+        var endpoint = conn.GetServerSnapshot()[0];
         var interactivePhysical = endpoint.GetBridge(ConnectionType.Interactive)?.TryConnect(null);
         var subscriptionPhysical = endpoint.GetBridge(ConnectionType.Subscription)?.TryConnect(null);
         Assert.NotNull(interactivePhysical);

--- a/tests/StackExchange.Redis.Tests/ConnectByIP.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectByIP.cs
@@ -5,104 +5,101 @@ using System.Net.Sockets;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ConnectByIP : TestBase
 {
-    public class ConnectByIP : TestBase
+    public ConnectByIP(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void ParseEndpoints()
     {
-        public ConnectByIP(ITestOutputHelper output) : base (output) { }
-
-        [Fact]
-        public void ParseEndpoints()
+        var eps = new EndPointCollection
         {
-            var eps = new EndPointCollection
-            {
-                { "127.0.0.1", 1000 },
-                { "::1", 1001 },
-                { "localhost", 1002 }
-            };
+            { "127.0.0.1", 1000 },
+            { "::1", 1001 },
+            { "localhost", 1002 }
+        };
 
-            Assert.Equal(AddressFamily.InterNetwork, eps[0].AddressFamily);
-            Assert.Equal(AddressFamily.InterNetworkV6, eps[1].AddressFamily);
-            Assert.Equal(AddressFamily.Unspecified, eps[2].AddressFamily);
+        Assert.Equal(AddressFamily.InterNetwork, eps[0].AddressFamily);
+        Assert.Equal(AddressFamily.InterNetworkV6, eps[1].AddressFamily);
+        Assert.Equal(AddressFamily.Unspecified, eps[2].AddressFamily);
 
-            Assert.Equal("127.0.0.1:1000", eps[0].ToString());
-            Assert.Equal("[::1]:1001", eps[1].ToString());
-            Assert.Equal("Unspecified/localhost:1002", eps[2].ToString());
-        }
+        Assert.Equal("127.0.0.1:1000", eps[0].ToString());
+        Assert.Equal("[::1]:1001", eps[1].ToString());
+        Assert.Equal("Unspecified/localhost:1002", eps[2].ToString());
+    }
 
-        [Fact]
-        public void IPv4Connection()
+    [Fact]
+    public void IPv4Connection()
+    {
+        var config = new ConfigurationOptions
         {
-            var config = new ConfigurationOptions
-            {
-                EndPoints = { { TestConfig.Current.IPv4Server, TestConfig.Current.IPv4Port } }
-            };
+            EndPoints = { { TestConfig.Current.IPv4Server, TestConfig.Current.IPv4Port } }
+        };
+        using var conn = ConnectionMultiplexer.Connect(config);
+
+        var server = conn.GetServer(config.EndPoints[0]);
+        Assert.Equal(AddressFamily.InterNetwork, server.EndPoint.AddressFamily);
+        server.Ping();
+    }
+
+    [Fact]
+    public void IPv6Connection()
+    {
+        var config = new ConfigurationOptions
+        {
+            EndPoints = { { TestConfig.Current.IPv6Server, TestConfig.Current.IPv6Port } }
+        };
+        using var conn = ConnectionMultiplexer.Connect(config);
+
+        var server = conn.GetServer(config.EndPoints[0]);
+        Assert.Equal(AddressFamily.InterNetworkV6, server.EndPoint.AddressFamily);
+        server.Ping();
+    }
+
+    [Theory]
+    [MemberData(nameof(ConnectByVariousEndpointsData))]
+    public void ConnectByVariousEndpoints(EndPoint ep, AddressFamily expectedFamily)
+    {
+        Assert.Equal(expectedFamily, ep.AddressFamily);
+        var config = new ConfigurationOptions
+        {
+            EndPoints = { ep }
+        };
+        if (ep.AddressFamily != AddressFamily.InterNetworkV6) // I don't have IPv6 servers
+        {
             using (var conn = ConnectionMultiplexer.Connect(config))
             {
-                var server = conn.GetServer(config.EndPoints[0]);
-                Assert.Equal(AddressFamily.InterNetwork, server.EndPoint.AddressFamily);
+                var actual = conn.GetEndPoints().Single();
+                var server = conn.GetServer(actual);
                 server.Ping();
             }
         }
+    }
 
-        [Fact]
-        public void IPv6Connection()
-        {
-            var config = new ConfigurationOptions
-            {
-                EndPoints = { { TestConfig.Current.IPv6Server, TestConfig.Current.IPv6Port } }
-            };
-            using (var conn = ConnectionMultiplexer.Connect(config))
-            {
-                var server = conn.GetServer(config.EndPoints[0]);
-                Assert.Equal(AddressFamily.InterNetworkV6, server.EndPoint.AddressFamily);
-                server.Ping();
-            }
-        }
+    public static IEnumerable<object[]> ConnectByVariousEndpointsData()
+    {
+        yield return new object[] { new IPEndPoint(IPAddress.Loopback, 6379), AddressFamily.InterNetwork };
 
-        [Theory]
-        [MemberData(nameof(ConnectByVariousEndpointsData))]
-        public void ConnectByVariousEndpoints(EndPoint ep, AddressFamily expectedFamily)
-        {
-            Assert.Equal(expectedFamily, ep.AddressFamily);
-            var config = new ConfigurationOptions
-            {
-                EndPoints = { ep }
-            };
-            if (ep.AddressFamily != AddressFamily.InterNetworkV6) // I don't have IPv6 servers
-            {
-                using (var conn = ConnectionMultiplexer.Connect(config))
-                {
-                    var actual = conn.GetEndPoints().Single();
-                    var server = conn.GetServer(actual);
-                    server.Ping();
-                }
-            }
-        }
+        yield return new object[] { new IPEndPoint(IPAddress.IPv6Loopback, 6379), AddressFamily.InterNetworkV6 };
 
-        public static IEnumerable<object[]> ConnectByVariousEndpointsData()
-        {
-            yield return new object[] { new IPEndPoint(IPAddress.Loopback, 6379), AddressFamily.InterNetwork };
+        yield return new object[] { new DnsEndPoint("localhost", 6379), AddressFamily.Unspecified };
 
-            yield return new object[] { new IPEndPoint(IPAddress.IPv6Loopback, 6379), AddressFamily.InterNetworkV6 };
+        yield return new object[] { new DnsEndPoint("localhost", 6379, AddressFamily.InterNetwork), AddressFamily.InterNetwork };
 
-            yield return new object[] { new DnsEndPoint("localhost", 6379), AddressFamily.Unspecified };
+        yield return new object[] { new DnsEndPoint("localhost", 6379, AddressFamily.InterNetworkV6), AddressFamily.InterNetworkV6 };
 
-            yield return new object[] { new DnsEndPoint("localhost", 6379, AddressFamily.InterNetwork), AddressFamily.InterNetwork };
+        yield return new object[] { ConfigurationOptions.Parse("localhost:6379").EndPoints.Single(), AddressFamily.Unspecified };
 
-            yield return new object[] { new DnsEndPoint("localhost", 6379, AddressFamily.InterNetworkV6), AddressFamily.InterNetworkV6 };
+        yield return new object[] { ConfigurationOptions.Parse("localhost").EndPoints.Single(), AddressFamily.Unspecified };
 
-            yield return new object[] { ConfigurationOptions.Parse("localhost:6379").EndPoints.Single(), AddressFamily.Unspecified };
+        yield return new object[] { ConfigurationOptions.Parse("127.0.0.1:6379").EndPoints.Single(), AddressFamily.InterNetwork };
 
-            yield return new object[] { ConfigurationOptions.Parse("localhost").EndPoints.Single(), AddressFamily.Unspecified };
+        yield return new object[] { ConfigurationOptions.Parse("127.0.0.1").EndPoints.Single(), AddressFamily.InterNetwork };
 
-            yield return new object[] { ConfigurationOptions.Parse("127.0.0.1:6379").EndPoints.Single(), AddressFamily.InterNetwork };
+        yield return new object[] { ConfigurationOptions.Parse("[::1]").EndPoints.Single(), AddressFamily.InterNetworkV6 };
 
-            yield return new object[] { ConfigurationOptions.Parse("127.0.0.1").EndPoints.Single(), AddressFamily.InterNetwork };
-
-            yield return new object[] { ConfigurationOptions.Parse("[::1]").EndPoints.Single(), AddressFamily.InterNetworkV6 };
-
-            yield return new object[] { ConfigurationOptions.Parse("[::1]:6379").EndPoints.Single(), AddressFamily.InterNetworkV6 };
-        }
+        yield return new object[] { ConfigurationOptions.Parse("[::1]:6379").EndPoints.Single(), AddressFamily.InterNetworkV6 };
     }
 }

--- a/tests/StackExchange.Redis.Tests/ConnectCustomConfig.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectCustomConfig.cs
@@ -75,9 +75,9 @@ public class ConnectCustomConfig : TestBase
     public void TiebreakerIncorrectType()
     {
         var tiebreakerKey = Me();
-        using var fubarMuxer = Create(allowAdmin: true, log: Writer);
+        using var fubarConn = Create(allowAdmin: true, log: Writer);
         // Store something nonsensical in the tiebreaker key:
-        fubarMuxer.GetDatabase().HashSet(tiebreakerKey, "foo", "bar");
+        fubarConn.GetDatabase().HashSet(tiebreakerKey, "foo", "bar");
 
         // Ensure the next connection getting an invalid type still connects
         using var conn = Create(allowAdmin: true, tieBreaker: tiebreakerKey, log: Writer);

--- a/tests/StackExchange.Redis.Tests/ConnectCustomConfig.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectCustomConfig.cs
@@ -1,95 +1,92 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ConnectCustomConfig : TestBase
 {
-    public class ConnectCustomConfig : TestBase
+    public ConnectCustomConfig(ITestOutputHelper output) : base (output) { }
+
+    // So we're triggering tiebreakers here
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
+
+    [Theory]
+    [InlineData("config")]
+    [InlineData("info")]
+    [InlineData("get")]
+    [InlineData("config,get")]
+    [InlineData("info,get")]
+    [InlineData("config,info,get")]
+    public void DisabledCommandsStillConnect(string disabledCommands)
     {
-        public ConnectCustomConfig(ITestOutputHelper output) : base (output) { }
+        using var conn = Create(allowAdmin: true, disabledCommands: disabledCommands.Split(','), log: Writer);
 
-        // So we're triggering tiebreakers here
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
+        var db = conn.GetDatabase();
+        db.Ping();
+        Assert.True(db.IsConnected(default(RedisKey)));
+    }
 
-        [Theory]
-        [InlineData("config")]
-        [InlineData("info")]
-        [InlineData("get")]
-        [InlineData("config,get")]
-        [InlineData("info,get")]
-        [InlineData("config,info,get")]
-        public void DisabledCommandsStillConnect(string disabledCommands)
+    [Theory]
+    [InlineData("config")]
+    [InlineData("info")]
+    [InlineData("get")]
+    [InlineData("cluster")]
+    [InlineData("config,get")]
+    [InlineData("info,get")]
+    [InlineData("config,info,get")]
+    [InlineData("config,info,get,cluster")]
+    public void DisabledCommandsStillConnectCluster(string disabledCommands)
+    {
+        using var conn = Create(allowAdmin: true, configuration: TestConfig.Current.ClusterServersAndPorts, disabledCommands: disabledCommands.Split(','), log: Writer);
+
+        var db = conn.GetDatabase();
+        db.Ping();
+        Assert.True(db.IsConnected(default(RedisKey)));
+    }
+
+    [Fact]
+    public void TieBreakerIntact()
+    {
+        using var conn = (Create(allowAdmin: true, log: Writer) as ConnectionMultiplexer)!;
+
+        var tiebreaker = conn.GetDatabase().StringGet(conn.RawConfig.TieBreaker);
+        Log($"Tiebreaker: {tiebreaker}");
+
+        foreach (var server in conn.GetServerSnapshot())
         {
-            using var muxer = Create(allowAdmin: true, disabledCommands: disabledCommands.Split(','), log: Writer);
-
-            var db = muxer.GetDatabase();
-            db.Ping();
-            Assert.True(db.IsConnected(default(RedisKey)));
+            Assert.Equal(tiebreaker, server.TieBreakerResult);
         }
+    }
 
-        [Theory]
-        [InlineData("config")]
-        [InlineData("info")]
-        [InlineData("get")]
-        [InlineData("cluster")]
-        [InlineData("config,get")]
-        [InlineData("info,get")]
-        [InlineData("config,info,get")]
-        [InlineData("config,info,get,cluster")]
-        public void DisabledCommandsStillConnectCluster(string disabledCommands)
+    [Fact]
+    public void TieBreakerSkips()
+    {
+        using var conn = (Create(allowAdmin: true, disabledCommands: new[] { "get" }, log: Writer) as ConnectionMultiplexer)!;
+        Assert.Throws<RedisCommandException>(() => conn.GetDatabase().StringGet(conn.RawConfig.TieBreaker));
+
+        foreach (var server in conn.GetServerSnapshot())
         {
-            using var muxer = Create(allowAdmin: true, configuration: TestConfig.Current.ClusterServersAndPorts, disabledCommands: disabledCommands.Split(','), log: Writer);
-
-            var db = muxer.GetDatabase();
-            db.Ping();
-            Assert.True(db.IsConnected(default(RedisKey)));
+            Assert.True(server.IsConnected);
+            Assert.Null(server.TieBreakerResult);
         }
+    }
 
-        [Fact]
-        public void TieBreakerIntact()
-        {
-            using var muxer = (Create(allowAdmin: true, log: Writer) as ConnectionMultiplexer)!;
+    [Fact]
+    public void TiebreakerIncorrectType()
+    {
+        var tiebreakerKey = Me();
+        using var fubarMuxer = Create(allowAdmin: true, log: Writer);
+        // Store something nonsensical in the tiebreaker key:
+        fubarMuxer.GetDatabase().HashSet(tiebreakerKey, "foo", "bar");
 
-            var tiebreaker = muxer.GetDatabase().StringGet(muxer.RawConfig.TieBreaker);
-            Log($"Tiebreaker: {tiebreaker}");
+        // Ensure the next connection getting an invalid type still connects
+        using var conn = Create(allowAdmin: true, tieBreaker: tiebreakerKey, log: Writer);
 
-            var snapshot = muxer.GetServerSnapshot();
-            foreach (var server in snapshot)
-            {
-                Assert.Equal(tiebreaker, server.TieBreakerResult);
-            }
-        }
+        var db = conn.GetDatabase();
+        db.Ping();
+        Assert.True(db.IsConnected(default(RedisKey)));
 
-        [Fact]
-        public void TieBreakerSkips()
-        {
-            using var muxer = (Create(allowAdmin: true, disabledCommands: new[] { "get" }, log: Writer) as ConnectionMultiplexer)!;
-            Assert.Throws<RedisCommandException>(() => muxer.GetDatabase().StringGet(muxer.RawConfig.TieBreaker));
-
-            var snapshot = muxer.GetServerSnapshot();
-            foreach (var server in snapshot)
-            {
-                Assert.True(server.IsConnected);
-                Assert.Null(server.TieBreakerResult);
-            }
-        }
-
-        [Fact]
-        public void TiebreakerIncorrectType()
-        {
-            var tiebreakerKey = Me();
-            using var fubarMuxer = Create(allowAdmin: true, log: Writer);
-            // Store something nonsensical in the tiebreaker key:
-            fubarMuxer.GetDatabase().HashSet(tiebreakerKey, "foo", "bar");
-
-            // Ensure the next connection getting an invalid type still connects
-            using var muxer = Create(allowAdmin: true, tieBreaker: tiebreakerKey, log: Writer);
-
-            var db = muxer.GetDatabase();
-            db.Ping();
-            Assert.True(db.IsConnected(default(RedisKey)));
-
-            var ex = Assert.Throws<RedisServerException>(() => db.StringGet(tiebreakerKey));
-            Assert.Contains("WRONGTYPE", ex.Message);
-        }
+        var ex = Assert.Throws<RedisServerException>(() => db.StringGet(tiebreakerKey));
+        Assert.Contains("WRONGTYPE", ex.Message);
     }
 }

--- a/tests/StackExchange.Redis.Tests/ConnectFailTimeout.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectFailTimeout.cs
@@ -3,47 +3,45 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ConnectFailTimeout : TestBase
 {
-    public class ConnectFailTimeout : TestBase
+    public ConnectFailTimeout(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public async Task NoticesConnectFail()
     {
-        public ConnectFailTimeout(ITestOutputHelper output) : base (output) { }
+        SetExpectedAmbientFailureCount(-1);
+        using var conn = Create(allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast);
 
-        [Fact]
-        public async Task NoticesConnectFail()
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
         {
-            SetExpectedAmbientFailureCount(-1);
-            using (var conn = Create(allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast))
-            {
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
+            conn.ConnectionFailed += (s, a) =>
+                Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
+            conn.ConnectionRestored += (s, a) =>
+                Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
 
-                await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-                void innerScenario()
-                {
-                    conn.ConnectionFailed += (s, a) =>
-                        Log("Disconnected: " + EndPointCollection.ToString(a.EndPoint));
-                    conn.ConnectionRestored += (s, a) =>
-                        Log("Reconnected: " + EndPointCollection.ToString(a.EndPoint));
-
-                    // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
-                    conn.IgnoreConnect = true;
-                    Log("simulating failure");
-                    server.SimulateConnectionFailure(SimulatedFailureType.All);
-                    Log("simulated failure");
-                    conn.IgnoreConnect = false;
-                    Log("pinging - expect failure");
-                    Assert.Throws<RedisConnectionException>(() => server.Ping());
-                    Log("pinged");
-                }
-
-                // Heartbeat should reconnect by now
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => server.IsConnected);
-
-                Log("pinging - expect success");
-                var time = server.Ping();
-                Log("pinged");
-                Log(time.ToString());
-            }
+            // No need to delay, we're going to try a disconnected connection immediately so it'll fail...
+            conn.IgnoreConnect = true;
+            Log("simulating failure");
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Log("simulated failure");
+            conn.IgnoreConnect = false;
+            Log("pinging - expect failure");
+            Assert.Throws<RedisConnectionException>(() => server.Ping());
+            Log("pinged");
         }
+
+        // Heartbeat should reconnect by now
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => server.IsConnected);
+
+        Log("pinging - expect success");
+        var time = server.Ping();
+        Log("pinged");
+        Log(time.ToString());
     }
 }

--- a/tests/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectToUnexistingHost.cs
@@ -5,90 +5,89 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ConnectToUnexistingHost : TestBase
 {
-    public class ConnectToUnexistingHost : TestBase
+    public ConnectToUnexistingHost(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public async Task FailsWithinTimeout()
     {
-        public ConnectToUnexistingHost(ITestOutputHelper output) : base (output) { }
-
-        [Fact]
-        public async Task FailsWithinTimeout()
+        const int timeout = 1000;
+        var sw = Stopwatch.StartNew();
+        try
         {
-            const int timeout = 1000;
-            var sw = Stopwatch.StartNew();
-            try
+            var config = new ConfigurationOptions
             {
-                var config = new ConfigurationOptions
-                {
-                    EndPoints = { { "invalid", 1234 } },
-                    ConnectTimeout = timeout
-                };
+                EndPoints = { { "invalid", 1234 } },
+                ConnectTimeout = timeout
+            };
 
-                using (ConnectionMultiplexer.Connect(config, Writer))
-                {
-                    await Task.Delay(10000).ForAwait();
-                }
-
-                Assert.True(false, "Connect should fail with RedisConnectionException exception");
-            }
-            catch (RedisConnectionException)
+            using (ConnectionMultiplexer.Connect(config, Writer))
             {
-                var elapsed = sw.ElapsedMilliseconds;
-                Log("Elapsed time: " + elapsed);
-                Log("Timeout: " + timeout);
-                Assert.True(elapsed < 9000, "Connect should fail within ConnectTimeout, ElapsedMs: " + elapsed);
+                await Task.Delay(10000).ForAwait();
             }
+
+            Assert.True(false, "Connect should fail with RedisConnectionException exception");
         }
-
-        [Fact]
-        public async Task CanNotOpenNonsenseConnection_IP()
+        catch (RedisConnectionException)
         {
-            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-            void innerScenario()
-            {
-                var ex = Assert.Throws<RedisConnectionException>(() =>
-                {
-                    using (ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServer + ":6500,connectTimeout=1000,connectRetry=0", Writer)) { }
-                });
-                Log(ex.ToString());
-            }
+            var elapsed = sw.ElapsedMilliseconds;
+            Log("Elapsed time: " + elapsed);
+            Log("Timeout: " + timeout);
+            Assert.True(elapsed < 9000, "Connect should fail within ConnectTimeout, ElapsedMs: " + elapsed);
         }
+    }
 
-        [Fact]
-        public async Task CanNotOpenNonsenseConnection_DNS()
+    [Fact]
+    public async Task CanNotOpenNonsenseConnection_IP()
+    {
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
         {
-            var ex = await Assert.ThrowsAsync<RedisConnectionException>(async () =>
+            var ex = Assert.Throws<RedisConnectionException>(() =>
             {
-                using (await ConnectionMultiplexer.ConnectAsync($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,connectTimeout=1000,connectRetry=0", Writer).ForAwait()) { }
-            }).ForAwait();
+                using (ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServer + ":6500,connectTimeout=1000,connectRetry=0", Writer)) { }
+            });
             Log(ex.ToString());
         }
+    }
 
-        [Fact]
-        public async Task CreateDisconnectedNonsenseConnection_IP()
+    [Fact]
+    public async Task CanNotOpenNonsenseConnection_DNS()
+    {
+        var ex = await Assert.ThrowsAsync<RedisConnectionException>(async () =>
         {
-            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-            void innerScenario()
+            using (await ConnectionMultiplexer.ConnectAsync($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,connectTimeout=1000,connectRetry=0", Writer).ForAwait()) { }
+        }).ForAwait();
+        Log(ex.ToString());
+    }
+
+    [Fact]
+    public async Task CreateDisconnectedNonsenseConnection_IP()
+    {
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
+        {
+            using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServer + ":6500,abortConnect=false,connectTimeout=1000,connectRetry=0", Writer))
             {
-                using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServer + ":6500,abortConnect=false,connectTimeout=1000,connectRetry=0", Writer))
-                {
-                    Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
-                    Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
-                }
+                Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
+                Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
             }
         }
+    }
 
-        [Fact]
-        public async Task CreateDisconnectedNonsenseConnection_DNS()
+    [Fact]
+    public async Task CreateDisconnectedNonsenseConnection_DNS()
+    {
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
         {
-            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-            void innerScenario()
+            using (var conn = ConnectionMultiplexer.Connect($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,abortConnect=false,connectTimeout=1000,connectRetry=0", Writer))
             {
-                using (var conn = ConnectionMultiplexer.Connect($"doesnot.exist.ds.{Guid.NewGuid():N}.com:6500,abortConnect=false,connectTimeout=1000,connectRetry=0", Writer))
-                {
-                    Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
-                    Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
-                }
+                Assert.False(conn.GetServer(conn.GetEndPoints().Single()).IsConnected);
+                Assert.False(conn.GetDatabase().IsConnected(default(RedisKey)));
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetection.cs
@@ -4,156 +4,151 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ConnectingFailDetection : TestBase
 {
-    public class ConnectingFailDetection : TestBase
+    public ConnectingFailDetection(ITestOutputHelper output) : base (output) { }
+
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
+
+    [Fact]
+    public async Task FastNoticesFailOnConnectingSyncCompletion()
     {
-        public ConnectingFailDetection(ITestOutputHelper output) : base (output) { }
-
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
-
-        [Fact]
-        public async Task FastNoticesFailOnConnectingSyncCompletion()
+        try
         {
-            try
-            {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false))
-                {
-                    var conn = muxer.GetDatabase();
-                    conn.Ping();
+            using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false);
 
-                    var server = muxer.GetServer(muxer.GetEndPoints()[0]);
-                    var server2 = muxer.GetServer(muxer.GetEndPoints()[1]);
+            var db = conn.GetDatabase();
+            db.Ping();
 
-                    muxer.AllowConnect = false;
+            var server = conn.GetServer(conn.GetEndPoints()[0]);
+            var server2 = conn.GetServer(conn.GetEndPoints()[1]);
 
-                    // muxer.IsConnected is true of *any* are connected, simulate failure for all cases.
-                    server.SimulateConnectionFailure(SimulatedFailureType.All);
-                    Assert.False(server.IsConnected);
-                    Assert.True(server2.IsConnected);
-                    Assert.True(muxer.IsConnected);
+            conn.AllowConnect = false;
 
-                    server2.SimulateConnectionFailure(SimulatedFailureType.All);
-                    Assert.False(server.IsConnected);
-                    Assert.False(server2.IsConnected);
-                    Assert.False(muxer.IsConnected);
+            // muxer.IsConnected is true of *any* are connected, simulate failure for all cases.
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(server.IsConnected);
+            Assert.True(server2.IsConnected);
+            Assert.True(conn.IsConnected);
 
-                    // should reconnect within 1 keepalive interval
-                    muxer.AllowConnect = true;
-                    Log("Waiting for reconnect");
-                    await UntilConditionAsync(TimeSpan.FromSeconds(2), () => muxer.IsConnected).ForAwait();
+            server2.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(server.IsConnected);
+            Assert.False(server2.IsConnected);
+            Assert.False(conn.IsConnected);
 
-                    Assert.True(muxer.IsConnected);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            // should reconnect within 1 keepalive interval
+            conn.AllowConnect = true;
+            Log("Waiting for reconnect");
+            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => conn.IsConnected).ForAwait();
+
+            Assert.True(conn.IsConnected);
         }
-
-        [Fact]
-        public async Task FastNoticesFailOnConnectingAsyncCompletion()
+        finally
         {
-            try
-            {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false))
-                {
-                    var conn = muxer.GetDatabase();
-                    conn.Ping();
-
-                    var server = muxer.GetServer(muxer.GetEndPoints()[0]);
-                    var server2 = muxer.GetServer(muxer.GetEndPoints()[1]);
-
-                    muxer.AllowConnect = false;
-
-                    // muxer.IsConnected is true of *any* are connected, simulate failure for all cases.
-                    server.SimulateConnectionFailure(SimulatedFailureType.All);
-                    Assert.False(server.IsConnected);
-                    Assert.True(server2.IsConnected);
-                    Assert.True(muxer.IsConnected);
-
-                    server2.SimulateConnectionFailure(SimulatedFailureType.All);
-                    Assert.False(server.IsConnected);
-                    Assert.False(server2.IsConnected);
-                    Assert.False(muxer.IsConnected);
-
-                    // should reconnect within 1 keepalive interval
-                    muxer.AllowConnect = true;
-                    Log("Waiting for reconnect");
-                    await UntilConditionAsync(TimeSpan.FromSeconds(2), () => muxer.IsConnected).ForAwait();
-
-                    Assert.True(muxer.IsConnected);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            ClearAmbientFailures();
         }
+    }
 
-        [Fact]
-        public async Task Issue922_ReconnectRaised()
+    [Fact]
+    public async Task FastNoticesFailOnConnectingAsyncCompletion()
+    {
+        try
         {
-            var config = ConfigurationOptions.Parse(TestConfig.Current.PrimaryServerAndPort);
-            config.AbortOnConnectFail = true;
-            config.KeepAlive = 1;
-            config.SyncTimeout = 1000;
-            config.AsyncTimeout = 1000;
-            config.ReconnectRetryPolicy = new ExponentialRetry(5000);
-            config.AllowAdmin = true;
-            config.BacklogPolicy = BacklogPolicy.FailFast;
+            using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false);
 
-            int failCount = 0, restoreCount = 0;
+            var db = conn.GetDatabase();
+            db.Ping();
 
-            using (var muxer = ConnectionMultiplexer.Connect(config))
-            {
-                muxer.ConnectionFailed += (s, e) =>
-                {
-                    Interlocked.Increment(ref failCount);
-                    Log($"Connection Failed ({e.ConnectionType}, {e.FailureType}): {e.Exception}");
-                };
-                muxer.ConnectionRestored += (s, e) =>
-                {
-                    Interlocked.Increment(ref restoreCount);
-                    Log($"Connection Restored ({e.ConnectionType}, {e.FailureType})");
-                };
+            var server = conn.GetServer(conn.GetEndPoints()[0]);
+            var server2 = conn.GetServer(conn.GetEndPoints()[1]);
 
-                muxer.GetDatabase();
-                Assert.Equal(0, Volatile.Read(ref failCount));
-                Assert.Equal(0, Volatile.Read(ref restoreCount));
+            conn.AllowConnect = false;
 
-                var server = muxer.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
+            // muxer.IsConnected is true of *any* are connected, simulate failure for all cases.
+            server.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(server.IsConnected);
+            Assert.True(server2.IsConnected);
+            Assert.True(conn.IsConnected);
 
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => Volatile.Read(ref failCount) >= 2 && Volatile.Read(ref restoreCount) >= 2);
+            server2.SimulateConnectionFailure(SimulatedFailureType.All);
+            Assert.False(server.IsConnected);
+            Assert.False(server2.IsConnected);
+            Assert.False(conn.IsConnected);
 
-                // interactive+subscriber = 2
-                var failCountSnapshot = Volatile.Read(ref failCount);
-                Assert.True(failCountSnapshot >= 2, $"failCount {failCountSnapshot} >= 2");
+            // should reconnect within 1 keepalive interval
+            conn.AllowConnect = true;
+            Log("Waiting for reconnect");
+            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => conn.IsConnected).ForAwait();
 
-                var restoreCountSnapshot = Volatile.Read(ref restoreCount);
-                Assert.True(restoreCountSnapshot >= 2, $"restoreCount ({restoreCountSnapshot}) >= 2");
-            }
+            Assert.True(conn.IsConnected);
         }
-
-        [Fact]
-        public void ConnectsWhenBeginConnectCompletesSynchronously()
+        finally
         {
-            try
-            {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 3000))
-                {
-                    var conn = muxer.GetDatabase();
-                    conn.Ping();
+            ClearAmbientFailures();
+        }
+    }
 
-                    Assert.True(muxer.IsConnected);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+    [Fact]
+    public async Task Issue922_ReconnectRaised()
+    {
+        var config = ConfigurationOptions.Parse(TestConfig.Current.PrimaryServerAndPort);
+        config.AbortOnConnectFail = true;
+        config.KeepAlive = 1;
+        config.SyncTimeout = 1000;
+        config.AsyncTimeout = 1000;
+        config.ReconnectRetryPolicy = new ExponentialRetry(5000);
+        config.AllowAdmin = true;
+        config.BacklogPolicy = BacklogPolicy.FailFast;
+
+        int failCount = 0, restoreCount = 0;
+
+        using var conn = ConnectionMultiplexer.Connect(config);
+
+        conn.ConnectionFailed += (s, e) =>
+        {
+            Interlocked.Increment(ref failCount);
+            Log($"Connection Failed ({e.ConnectionType}, {e.FailureType}): {e.Exception}");
+        };
+        conn.ConnectionRestored += (s, e) =>
+        {
+            Interlocked.Increment(ref restoreCount);
+            Log($"Connection Restored ({e.ConnectionType}, {e.FailureType})");
+        };
+
+        conn.GetDatabase();
+        Assert.Equal(0, Volatile.Read(ref failCount));
+        Assert.Equal(0, Volatile.Read(ref restoreCount));
+
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.SimulateConnectionFailure(SimulatedFailureType.All);
+
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => Volatile.Read(ref failCount) >= 2 && Volatile.Read(ref restoreCount) >= 2);
+
+        // interactive+subscriber = 2
+        var failCountSnapshot = Volatile.Read(ref failCount);
+        Assert.True(failCountSnapshot >= 2, $"failCount {failCountSnapshot} >= 2");
+
+        var restoreCountSnapshot = Volatile.Read(ref restoreCount);
+        Assert.True(restoreCountSnapshot >= 2, $"restoreCount ({restoreCountSnapshot}) >= 2");
+    }
+
+    [Fact]
+    public void ConnectsWhenBeginConnectCompletesSynchronously()
+    {
+        try
+        {
+            using var conn = Create(keepAlive: 1, connectTimeout: 3000);
+
+            var db = conn.GetDatabase();
+            db.Ping();
+
+            Assert.True(conn.IsConnected);
+        }
+        finally
+        {
+            ClearAmbientFailures();
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionFailedErrors.cs
@@ -6,16 +6,146 @@ using StackExchange.Redis.Configuration;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
-{
-    public class ConnectionFailedErrors : TestBase
-    {
-        public ConnectionFailedErrors(ITestOutputHelper output) : base (output) { }
+namespace StackExchange.Redis.Tests;
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task SSLCertificateValidationError(bool isCertValidationSucceeded)
+public class ConnectionFailedErrors : TestBase
+{
+    public ConnectionFailedErrors(ITestOutputHelper output) : base (output) { }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SSLCertificateValidationError(bool isCertValidationSucceeded)
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
+
+        var options = new ConfigurationOptions();
+        options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
+        options.Ssl = true;
+        options.Password = TestConfig.Current.AzureCachePassword;
+        options.CertificateValidation += (sender, cert, chain, errors) => isCertValidationSucceeded;
+        options.AbortOnConnectFail = false;
+
+        using var conn = ConnectionMultiplexer.Connect(options);
+
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
+        {
+            conn.ConnectionFailed += (sender, e) =>
+                Assert.Equal(ConnectionFailureType.AuthenticationFailure, e.FailureType);
+            if (!isCertValidationSucceeded)
+            {
+                //validate that in this case it throws an certificatevalidation exception
+                var outer = Assert.Throws<RedisConnectionException>(() => conn.GetDatabase().Ping());
+                Assert.Equal(ConnectionFailureType.UnableToResolvePhysicalConnection, outer.FailureType);
+
+                Assert.NotNull(outer.InnerException);
+                var inner = Assert.IsType<RedisConnectionException>(outer.InnerException);
+                Assert.Equal(ConnectionFailureType.AuthenticationFailure, inner.FailureType);
+
+                Assert.NotNull(inner.InnerException);
+                var innerMost = Assert.IsType<AuthenticationException>(inner.InnerException);
+                Assert.Equal("The remote certificate is invalid according to the validation procedure.", innerMost.Message);
+            }
+            else
+            {
+                conn.GetDatabase().Ping();
+            }
+        }
+
+        // wait for a second for connectionfailed event to fire
+        await Task.Delay(1000).ForAwait();
+    }
+
+    [Fact]
+    public async Task AuthenticationFailureError()
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
+
+        var options = new ConfigurationOptions();
+        options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
+        options.Ssl = true;
+        options.Password = "";
+        options.AbortOnConnectFail = false;
+        options.CertificateValidation += SSL.ShowCertFailures(Writer);
+
+        using var conn = ConnectionMultiplexer.Connect(options);
+
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
+        {
+            conn.ConnectionFailed += (sender, e) =>
+            {
+                if (e.FailureType == ConnectionFailureType.SocketFailure) Skip.Inconclusive("socket fail"); // this is OK too
+                    Assert.Equal(ConnectionFailureType.AuthenticationFailure, e.FailureType);
+            };
+            var ex = Assert.Throws<RedisConnectionException>(() => conn.GetDatabase().Ping());
+
+            Assert.NotNull(ex.InnerException);
+            var rde = Assert.IsType<RedisConnectionException>(ex.InnerException);
+            Assert.Equal(CommandStatus.WaitingToBeSent, ex.CommandStatus);
+            Assert.Equal(ConnectionFailureType.AuthenticationFailure, rde.FailureType);
+            Assert.NotNull(rde.InnerException);
+            Assert.Equal("Error: NOAUTH Authentication required. Verify if the Redis password provided is correct.", rde.InnerException.Message);
+        }
+
+        //wait for a second  for connectionfailed event to fire
+        await Task.Delay(1000).ForAwait();
+    }
+
+    [Fact]
+    public async Task SocketFailureError()
+    {
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
+        {
+            var options = new ConfigurationOptions();
+            options.EndPoints.Add($"{Guid.NewGuid():N}.redis.cache.windows.net");
+            options.Ssl = true;
+            options.Password = "";
+            options.AbortOnConnectFail = false;
+            options.ConnectTimeout = 1000;
+            options.BacklogPolicy = BacklogPolicy.FailFast;
+            var outer = Assert.Throws<RedisConnectionException>(() =>
+            {
+                using var conn = ConnectionMultiplexer.Connect(options);
+
+                conn.GetDatabase().Ping();
+            });
+            Assert.Equal(ConnectionFailureType.UnableToResolvePhysicalConnection, outer.FailureType);
+
+            Assert.NotNull(outer.InnerException);
+            if (outer.InnerException is RedisConnectionException rce)
+            {
+                Assert.Equal(ConnectionFailureType.UnableToConnect, rce.FailureType);
+            }
+            else if (outer.InnerException is AggregateException ae
+                && ae.InnerExceptions.Any(e => e is RedisConnectionException rce2
+                && rce2.FailureType == ConnectionFailureType.UnableToConnect))
+            {
+                // fine; at least *one* of them is the one we were hoping to see
+            }
+            else
+            {
+                Writer.WriteLine(outer.InnerException.ToString());
+                if (outer.InnerException is AggregateException inner)
+                {
+                    foreach (var ex in inner.InnerExceptions)
+                    {
+                        Writer.WriteLine(ex.ToString());
+                    }
+                }
+                Assert.False(true); // force fail
+            }
+        }
+    }
+
+    [Fact]
+    public async Task AbortOnConnectFailFalseConnectTimeoutError()
+    {
+        await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+        void innerScenario()
         {
             Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
             Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
@@ -23,189 +153,55 @@ namespace StackExchange.Redis.Tests
             var options = new ConfigurationOptions();
             options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
             options.Ssl = true;
+            options.ConnectTimeout = 0;
             options.Password = TestConfig.Current.AzureCachePassword;
-            options.CertificateValidation += (sender, cert, chain, errors) => isCertValidationSucceeded;
-            options.AbortOnConnectFail = false;
 
-            using (var connection = ConnectionMultiplexer.Connect(options))
-            {
-                await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-                void innerScenario()
-                {
-                    connection.ConnectionFailed += (sender, e) =>
-                        Assert.Equal(ConnectionFailureType.AuthenticationFailure, e.FailureType);
-                    if (!isCertValidationSucceeded)
-                    {
-                        //validate that in this case it throws an certificatevalidation exception
-                        var outer = Assert.Throws<RedisConnectionException>(() => connection.GetDatabase().Ping());
-                        Assert.Equal(ConnectionFailureType.UnableToResolvePhysicalConnection, outer.FailureType);
+            using var conn = ConnectionMultiplexer.Connect(options);
 
-                        Assert.NotNull(outer.InnerException);
-                        var inner = Assert.IsType<RedisConnectionException>(outer.InnerException);
-                        Assert.Equal(ConnectionFailureType.AuthenticationFailure, inner.FailureType);
-
-                        Assert.NotNull(inner.InnerException);
-                        var innerMost = Assert.IsType<AuthenticationException>(inner.InnerException);
-                        Assert.Equal("The remote certificate is invalid according to the validation procedure.", innerMost.Message);
-                    }
-                    else
-                    {
-                        connection.GetDatabase().Ping();
-                    }
-                }
-
-                // wait for a second for connectionfailed event to fire
-                await Task.Delay(1000).ForAwait();
-            }
+            var ex = Assert.Throws<RedisConnectionException>(() => conn.GetDatabase().Ping());
+            Assert.Contains("ConnectTimeout", ex.Message);
         }
+    }
 
-        [Fact]
-        public async Task AuthenticationFailureError()
-        {
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
-
-            var options = new ConfigurationOptions();
-            options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
-            options.Ssl = true;
-            options.Password = "";
-            options.AbortOnConnectFail = false;
-            options.CertificateValidation += SSL.ShowCertFailures(Writer);
-            using (var muxer = ConnectionMultiplexer.Connect(options))
-            {
-                await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-                void innerScenario()
-                {
-                    muxer.ConnectionFailed += (sender, e) =>
-                    {
-                        if (e.FailureType == ConnectionFailureType.SocketFailure) Skip.Inconclusive("socket fail"); // this is OK too
-                        Assert.Equal(ConnectionFailureType.AuthenticationFailure, e.FailureType);
-                    };
-                    var ex = Assert.Throws<RedisConnectionException>(() => muxer.GetDatabase().Ping());
-
-                    Assert.NotNull(ex.InnerException);
-                    var rde = Assert.IsType<RedisConnectionException>(ex.InnerException);
-                    Assert.Equal(CommandStatus.WaitingToBeSent, ex.CommandStatus);
-                    Assert.Equal(ConnectionFailureType.AuthenticationFailure, rde.FailureType);
-                    Assert.NotNull(rde.InnerException);
-                    Assert.Equal("Error: NOAUTH Authentication required. Verify if the Redis password provided is correct.", rde.InnerException.Message);
-                }
-
-                //wait for a second  for connectionfailed event to fire
-                await Task.Delay(1000).ForAwait();
-            }
-        }
-
-        [Fact]
-        public async Task SocketFailureError()
-        {
-            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-            void innerScenario()
-            {
-                var options = new ConfigurationOptions();
-                options.EndPoints.Add($"{Guid.NewGuid():N}.redis.cache.windows.net");
-                options.Ssl = true;
-                options.Password = "";
-                options.AbortOnConnectFail = false;
-                options.ConnectTimeout = 1000;
-                options.BacklogPolicy = BacklogPolicy.FailFast;
-                var outer = Assert.Throws<RedisConnectionException>(() =>
-                {
-                    using (var muxer = ConnectionMultiplexer.Connect(options))
-                    {
-                        muxer.GetDatabase().Ping();
-                    }
-                });
-                Assert.Equal(ConnectionFailureType.UnableToResolvePhysicalConnection, outer.FailureType);
-
-                Assert.NotNull(outer.InnerException);
-                if (outer.InnerException is RedisConnectionException rce)
-                {
-                    Assert.Equal(ConnectionFailureType.UnableToConnect, rce.FailureType);
-                }
-                else if (outer.InnerException is AggregateException ae
-                    && ae.InnerExceptions.Any(e => e is RedisConnectionException rce2
-                    && rce2.FailureType == ConnectionFailureType.UnableToConnect))
-                {
-                    // fine; at least *one* of them is the one we were hoping to see
-                }
-                else
-                {
-                    Writer.WriteLine(outer.InnerException.ToString());
-                    if (outer.InnerException is AggregateException inner)
-                    {
-                        foreach (var ex in inner.InnerExceptions)
-                        {
-                            Writer.WriteLine(ex.ToString());
-                        }
-                    }
-                    Assert.False(true); // force fail
-                }
-            }
-        }
-
-        [Fact]
-        public async Task AbortOnConnectFailFalseConnectTimeoutError()
-        {
-            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-            void innerScenario()
-            {
-                Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
-                Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
-
-                var options = new ConfigurationOptions();
-                options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
-                options.Ssl = true;
-                options.ConnectTimeout = 0;
-                options.Password = TestConfig.Current.AzureCachePassword;
-                using (var muxer = ConnectionMultiplexer.Connect(options))
-                {
-                    var ex = Assert.Throws<RedisConnectionException>(() => muxer.GetDatabase().Ping());
-                    Assert.Contains("ConnectTimeout", ex.Message);
-                }
-            }
-        }
-
-        [Fact]
-        public void TryGetAzureRoleInstanceIdNoThrow()
-        {
-            Assert.Null(DefaultOptionsProvider.TryGetAzureRoleInstanceIdNoThrow());
-        }
+    [Fact]
+    public void TryGetAzureRoleInstanceIdNoThrow()
+    {
+        Assert.Null(DefaultOptionsProvider.TryGetAzureRoleInstanceIdNoThrow());
+    }
 
 #if DEBUG
-        [Fact]
-        public async Task CheckFailureRecovered()
+    [Fact]
+    public async Task CheckFailureRecovered()
+    {
+        try
         {
-            try
+            using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, log: Writer, shared: false);
+
+            await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
+            void innerScenario()
             {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, log: Writer, shared: false))
-                {
-                    await RunBlockingSynchronousWithExtraThreadAsync(innerScenario).ForAwait();
-                    void innerScenario()
-                    {
-                        muxer.GetDatabase();
-                        var server = muxer.GetServer(muxer.GetEndPoints()[0]);
+                conn.GetDatabase();
+                var server = conn.GetServer(conn.GetEndPoints()[0]);
 
-                        muxer.AllowConnect = false;
+                conn.AllowConnect = false;
 
-                        server.SimulateConnectionFailure(SimulatedFailureType.All);
+                server.SimulateConnectionFailure(SimulatedFailureType.All);
 
-                        var lastFailure = ((RedisConnectionException?)muxer.GetServerSnapshot()[0].LastException)!.FailureType;
-                        // Depending on heartbat races, the last exception will be a socket failure or an internal (follow-up) failure
-                        Assert.Contains(lastFailure, new[] { ConnectionFailureType.SocketFailure, ConnectionFailureType.InternalFailure });
+                var lastFailure = ((RedisConnectionException?)conn.GetServerSnapshot()[0].LastException)!.FailureType;
+                // Depending on heartbeat races, the last exception will be a socket failure or an internal (follow-up) failure
+                Assert.Contains(lastFailure, new[] { ConnectionFailureType.SocketFailure, ConnectionFailureType.InternalFailure });
 
-                        // should reconnect within 1 keepalive interval
-                        muxer.AllowConnect = true;
-                    }
-                    await Task.Delay(2000).ForAwait();
-
-                    Assert.Null(muxer.GetServerSnapshot()[0].LastException);
-                }
+                // should reconnect within 1 keepalive interval
+                conn.AllowConnect = true;
             }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            await Task.Delay(2000).ForAwait();
+
+            Assert.Null(conn.GetServerSnapshot()[0].LastException);
         }
-#endif
+        finally
+        {
+            ClearAmbientFailures();
+        }
     }
+#endif
 }

--- a/tests/StackExchange.Redis.Tests/ConnectionReconnectRetryPolicyTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionReconnectRetryPolicyTests.cs
@@ -2,52 +2,51 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class TransientErrorTests : TestBase
 {
-    public class TransientErrorTests : TestBase
+    public TransientErrorTests(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void TestExponentialRetry()
     {
-        public TransientErrorTests(ITestOutputHelper output) : base (output) { }
+        IReconnectRetryPolicy exponentialRetry = new ExponentialRetry(5000);
+        Assert.False(exponentialRetry.ShouldRetry(0, 0));
+        Assert.True(exponentialRetry.ShouldRetry(1, 5600));
+        Assert.True(exponentialRetry.ShouldRetry(2, 6050));
+        Assert.False(exponentialRetry.ShouldRetry(2, 4050));
+    }
 
-        [Fact]
-        public void TestExponentialRetry()
-        {
-            IReconnectRetryPolicy exponentialRetry = new ExponentialRetry(5000);
-            Assert.False(exponentialRetry.ShouldRetry(0, 0));
-            Assert.True(exponentialRetry.ShouldRetry(1, 5600));
-            Assert.True(exponentialRetry.ShouldRetry(2, 6050));
-            Assert.False(exponentialRetry.ShouldRetry(2, 4050));
-        }
+    [Fact]
+    public void TestExponentialMaxRetry()
+    {
+        IReconnectRetryPolicy exponentialRetry = new ExponentialRetry(5000);
+        Assert.True(exponentialRetry.ShouldRetry(long.MaxValue, (int)TimeSpan.FromSeconds(30).TotalMilliseconds));
+    }
 
-        [Fact]
-        public void TestExponentialMaxRetry()
-        {
-            IReconnectRetryPolicy exponentialRetry = new ExponentialRetry(5000);
-            Assert.True(exponentialRetry.ShouldRetry(long.MaxValue, (int)TimeSpan.FromSeconds(30).TotalMilliseconds));
-        }
+    [Fact]
+    public void TestExponentialRetryArgs()
+    {
+        _ = new ExponentialRetry(5000);
+        _ = new ExponentialRetry(5000, 10000);
 
-        [Fact]
-        public void TestExponentialRetryArgs()
-        {
-            _ = new ExponentialRetry(5000);
-            _ = new ExponentialRetry(5000, 10000);
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialRetry(-1));
+        Assert.Equal("deltaBackOffMilliseconds", ex.ParamName);
 
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialRetry(-1));
-            Assert.Equal("deltaBackOffMilliseconds", ex.ParamName);
+        ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialRetry(5000, -1));
+        Assert.Equal("maxDeltaBackOffMilliseconds", ex.ParamName);
 
-            ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialRetry(5000, -1));
-            Assert.Equal("maxDeltaBackOffMilliseconds", ex.ParamName);
+        ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialRetry(10000, 5000));
+        Assert.Equal("maxDeltaBackOffMilliseconds", ex.ParamName);
+    }
 
-            ex = Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialRetry(10000, 5000));
-            Assert.Equal("maxDeltaBackOffMilliseconds", ex.ParamName);
-        }
-
-        [Fact]
-        public void TestLinearRetry()
-        {
-            IReconnectRetryPolicy linearRetry = new LinearRetry(5000);
-            Assert.False(linearRetry.ShouldRetry(0, 0));
-            Assert.False(linearRetry.ShouldRetry(2, 4999));
-            Assert.True(linearRetry.ShouldRetry(1, 5000));
-        }
+    [Fact]
+    public void TestLinearRetry()
+    {
+        IReconnectRetryPolicy linearRetry = new LinearRetry(5000);
+        Assert.False(linearRetry.ShouldRetry(0, 0));
+        Assert.False(linearRetry.ShouldRetry(2, 4999));
+        Assert.True(linearRetry.ShouldRetry(1, 5000));
     }
 }

--- a/tests/StackExchange.Redis.Tests/ConnectionShutdown.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectionShutdown.cs
@@ -4,53 +4,51 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ConnectionShutdown : TestBase
 {
-    public class ConnectionShutdown : TestBase
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+    public ConnectionShutdown(ITestOutputHelper output) : base(output) { }
+
+    [Fact(Skip = "Unfriendly")]
+    public async Task ShutdownRaisesConnectionFailedAndRestore()
     {
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
-        public ConnectionShutdown(ITestOutputHelper output) : base(output) { }
+        using var conn = Create(allowAdmin: true, shared: false);
 
-        [Fact(Skip = "Unfriendly")]
-        public async Task ShutdownRaisesConnectionFailedAndRestore()
+        int failed = 0, restored = 0;
+        Stopwatch watch = Stopwatch.StartNew();
+        conn.ConnectionFailed += (sender, args) =>
         {
-            using (var conn = Create(allowAdmin: true, shared: false))
-            {
-                int failed = 0, restored = 0;
-                Stopwatch watch = Stopwatch.StartNew();
-                conn.ConnectionFailed += (sender, args) =>
-                {
-                    Log(watch.Elapsed + ": failed: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args);
-                    Interlocked.Increment(ref failed);
-                };
-                conn.ConnectionRestored += (sender, args) =>
-                {
-                    Log(watch.Elapsed + ": restored: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args);
-                    Interlocked.Increment(ref restored);
-                };
-                var db = conn.GetDatabase();
-                db.Ping();
-                Assert.Equal(0, Interlocked.CompareExchange(ref failed, 0, 0));
-                Assert.Equal(0, Interlocked.CompareExchange(ref restored, 0, 0));
-                await Task.Delay(1).ForAwait(); // To make compiler happy in Release
+            Log(watch.Elapsed + ": failed: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args);
+            Interlocked.Increment(ref failed);
+        };
+        conn.ConnectionRestored += (sender, args) =>
+        {
+            Log(watch.Elapsed + ": restored: " + EndPointCollection.ToString(args.EndPoint) + "/" + args.ConnectionType + ": " + args);
+            Interlocked.Increment(ref restored);
+        };
+        var db = conn.GetDatabase();
+        db.Ping();
+        Assert.Equal(0, Interlocked.CompareExchange(ref failed, 0, 0));
+        Assert.Equal(0, Interlocked.CompareExchange(ref restored, 0, 0));
+        await Task.Delay(1).ForAwait(); // To make compiler happy in Release
 
-                conn.AllowConnect = false;
-                var server = conn.GetServer(TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort);
+        conn.AllowConnect = false;
+        var server = conn.GetServer(TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort);
 
-                SetExpectedAmbientFailureCount(2);
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
+        SetExpectedAmbientFailureCount(2);
+        server.SimulateConnectionFailure(SimulatedFailureType.All);
 
-                db.Ping(CommandFlags.FireAndForget);
-                await Task.Delay(250).ForAwait();
-                Assert.Equal(2, Interlocked.CompareExchange(ref failed, 0, 0));
-                Assert.Equal(0, Interlocked.CompareExchange(ref restored, 0, 0));
-                conn.AllowConnect = true;
-                db.Ping(CommandFlags.FireAndForget);
-                await Task.Delay(1500).ForAwait();
-                Assert.Equal(2, Interlocked.CompareExchange(ref failed, 0, 0));
-                Assert.Equal(2, Interlocked.CompareExchange(ref restored, 0, 0));
-                watch.Stop();
-            }
-        }
+        db.Ping(CommandFlags.FireAndForget);
+        await Task.Delay(250).ForAwait();
+        Assert.Equal(2, Interlocked.CompareExchange(ref failed, 0, 0));
+        Assert.Equal(0, Interlocked.CompareExchange(ref restored, 0, 0));
+        conn.AllowConnect = true;
+        db.Ping(CommandFlags.FireAndForget);
+        await Task.Delay(1500).ForAwait();
+        Assert.Equal(2, Interlocked.CompareExchange(ref failed, 0, 0));
+        Assert.Equal(2, Interlocked.CompareExchange(ref restored, 0, 0));
+        watch.Stop();
     }
 }

--- a/tests/StackExchange.Redis.Tests/Constraints.cs
+++ b/tests/StackExchange.Redis.Tests/Constraints.cs
@@ -2,49 +2,47 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Constraints : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Constraints : TestBase
+    public Constraints(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void ValueEquals()
     {
-        public Constraints(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        RedisValue x = 1, y = "1";
+        Assert.True(x.Equals(y), "equals");
+        Assert.True(x == y, "operator");
+    }
 
-        [Fact]
-        public void ValueEquals()
+    [Fact]
+    public async Task TestManualIncr()
+    {
+        using var conn = Create(syncTimeout: 120000); // big timeout while debugging
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        for (int i = 0; i < 10; i++)
         {
-            RedisValue x = 1, y = "1";
-            Assert.True(x.Equals(y), "equals");
-            Assert.True(x == y, "operator");
+            db.KeyDelete(key, CommandFlags.FireAndForget);
+            Assert.Equal(1, await ManualIncrAsync(db, key).ForAwait());
+            Assert.Equal(2, await ManualIncrAsync(db, key).ForAwait());
+            Assert.Equal(2, (long)db.StringGet(key));
         }
+    }
 
-        [Fact]
-        public async Task TestManualIncr()
-        {
-            using (var muxer = Create(syncTimeout: 120000)) // big timeout while debugging
-            {
-                var key = Me();
-                var conn = muxer.GetDatabase();
-                for (int i = 0; i < 10; i++)
-                {
-                    conn.KeyDelete(key, CommandFlags.FireAndForget);
-                    Assert.Equal(1, await ManualIncrAsync(conn, key).ForAwait());
-                    Assert.Equal(2, await ManualIncrAsync(conn, key).ForAwait());
-                    Assert.Equal(2, (long)conn.StringGet(key));
-                }
-            }
-        }
-
-        public static async Task<long?> ManualIncrAsync(IDatabase connection, RedisKey key)
-        {
-            var oldVal = (long?)await connection.StringGetAsync(key).ForAwait();
-            var newVal = (oldVal ?? 0) + 1;
-            var tran = connection.CreateTransaction();
-            { // check hasn't changed
-                tran.AddCondition(Condition.StringEqual(key, oldVal));
-                _ = tran.StringSetAsync(key, newVal);
-                if (!await tran.ExecuteAsync().ForAwait()) return null; // aborted
-                return newVal;
-            }
+    public static async Task<long?> ManualIncrAsync(IDatabase connection, RedisKey key)
+    {
+        var oldVal = (long?)await connection.StringGetAsync(key).ForAwait();
+        var newVal = (oldVal ?? 0) + 1;
+        var tran = connection.CreateTransaction();
+        { // check hasn't changed
+            tran.AddCondition(Condition.StringEqual(key, oldVal));
+            _ = tran.StringSetAsync(key, newVal);
+            if (!await tran.ExecuteAsync().ForAwait()) return null; // aborted
+            return newVal;
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/Copy.cs
+++ b/tests/StackExchange.Redis.Tests/Copy.cs
@@ -3,71 +3,67 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Copy : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Copy : TestBase
+    public Copy(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public async Task Basic()
     {
-        public Copy(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create(require: RedisFeatures.v6_2_0);
 
-        [Fact]
-        public async Task Basic()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
+        var db = conn.GetDatabase();
+        var src = Me();
+        var dest = Me() + "2";
+        _ = db.KeyDelete(dest);
 
-            var db = muxer.GetDatabase();
-            var src = Me();
-            var dest = Me() + "2";
-            _ = db.KeyDelete(dest);
+        _ = db.StringSetAsync(src, "Heyyyyy");
+        var ke1 = db.KeyCopyAsync(src, dest).ForAwait();
+        var ku1 = db.StringGet(dest);
+        Assert.True(await ke1);
+        Assert.True(ku1.Equals("Heyyyyy"));
+    }
 
-            _ = db.StringSetAsync(src, "Heyyyyy");
-            var ke1 = db.KeyCopyAsync(src, dest).ForAwait();
-            var ku1 = db.StringGet(dest);
-            Assert.True(await ke1);
-            Assert.True(ku1.Equals("Heyyyyy"));
-        }
+    [Fact]
+    public async Task CrossDB()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
 
-        [Fact]
-        public async Task CrossDB()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
+        var db = conn.GetDatabase();
+        var dbDestId = TestConfig.GetDedicatedDB(conn);
+        var dbDest = conn.GetDatabase(dbDestId);
 
-            var db = muxer.GetDatabase();
-            var dbDestId = TestConfig.GetDedicatedDB(muxer);
-            var dbDest = muxer.GetDatabase(dbDestId);
+        var src = Me();
+        var dest = Me() + "2";
+        dbDest.KeyDelete(dest);
 
-            var src = Me();
-            var dest = Me() + "2";
-            dbDest.KeyDelete(dest);
+        _ = db.StringSetAsync(src, "Heyyyyy");
+        var ke1 = db.KeyCopyAsync(src, dest, dbDestId).ForAwait();
+        var ku1 = dbDest.StringGet(dest);
+        Assert.True(await ke1);
+        Assert.True(ku1.Equals("Heyyyyy"));
 
-            _ = db.StringSetAsync(src, "Heyyyyy");
-            var ke1 = db.KeyCopyAsync(src, dest, dbDestId).ForAwait();
-            var ku1 = dbDest.StringGet(dest);
-            Assert.True(await ke1);
-            Assert.True(ku1.Equals("Heyyyyy"));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => db.KeyCopyAsync(src, dest, destinationDatabase: -10));
+    }
 
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => db.KeyCopyAsync(src, dest, destinationDatabase: -10));
-        }
+    [Fact]
+    public async Task WithReplace()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
 
-        [Fact]
-        public async Task WithReplace()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var db = muxer.GetDatabase();
-            var src = Me();
-            var dest = Me() + "2";
-            _ = db.StringSetAsync(src, "foo1");
-            _ = db.StringSetAsync(dest, "foo2");
-            var ke1 = db.KeyCopyAsync(src, dest).ForAwait();
-            var ke2 = db.KeyCopyAsync(src, dest, replace: true).ForAwait();
-            var ku1 = db.StringGet(dest);
-            Assert.False(await ke1); // Should fail when not using replace and destination key exist
-            Assert.True(await ke2);
-            Assert.True(ku1.Equals("foo1"));
-        }
+        var db = conn.GetDatabase();
+        var src = Me();
+        var dest = Me() + "2";
+        _ = db.StringSetAsync(src, "foo1");
+        _ = db.StringSetAsync(dest, "foo2");
+        var ke1 = db.KeyCopyAsync(src, dest).ForAwait();
+        var ke2 = db.KeyCopyAsync(src, dest, replace: true).ForAwait();
+        var ku1 = db.StringGet(dest);
+        Assert.False(await ke1); // Should fail when not using replace and destination key exist
+        Assert.True(await ke2);
+        Assert.True(ku1.Equals("foo1"));
     }
 }

--- a/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/DatabaseWrapperTests.cs
@@ -7,1307 +7,1306 @@ using Moq;
 using StackExchange.Redis.KeyspaceIsolation;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[CollectionDefinition(nameof(MoqDependentCollection), DisableParallelization = true)]
+public class MoqDependentCollection { }
+
+[Collection(nameof(MoqDependentCollection))]
+public sealed class DatabaseWrapperTests
 {
-    [CollectionDefinition(nameof(MoqDependentCollection), DisableParallelization = true)]
-    public class MoqDependentCollection { }
+    private readonly Mock<IDatabase> mock;
+    private readonly IDatabase wrapper;
 
-    [Collection(nameof(MoqDependentCollection))]
-    public sealed class DatabaseWrapperTests
+    public DatabaseWrapperTests()
     {
-        private readonly Mock<IDatabase> mock;
-        private readonly IDatabase wrapper;
-
-        public DatabaseWrapperTests()
-        {
-            mock = new Mock<IDatabase>();
-            wrapper = new DatabaseWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
-        }
-
-        [Fact]
-        public void CreateBatch()
-        {
-            object asyncState = new();
-            IBatch innerBatch = new Mock<IBatch>().Object;
-            mock.Setup(_ => _.CreateBatch(asyncState)).Returns(innerBatch);
-            IBatch wrappedBatch = wrapper.CreateBatch(asyncState);
-            mock.Verify(_ => _.CreateBatch(asyncState));
-            Assert.IsType<BatchWrapper>(wrappedBatch);
-            Assert.Same(innerBatch, ((BatchWrapper)wrappedBatch).Inner);
-        }
-
-        [Fact]
-        public void CreateTransaction()
-        {
-            object asyncState = new();
-            ITransaction innerTransaction = new Mock<ITransaction>().Object;
-            mock.Setup(_ => _.CreateTransaction(asyncState)).Returns(innerTransaction);
-            ITransaction wrappedTransaction = wrapper.CreateTransaction(asyncState);
-            mock.Verify(_ => _.CreateTransaction(asyncState));
-            Assert.IsType<TransactionWrapper>(wrappedTransaction);
-            Assert.Same(innerTransaction, ((TransactionWrapper)wrappedTransaction).Inner);
-        }
-
-        [Fact]
-        public void DebugObject()
-        {
-            wrapper.DebugObject("key", CommandFlags.None);
-            mock.Verify(_ => _.DebugObject("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void Get_Database()
-        {
-            mock.SetupGet(_ => _.Database).Returns(123);
-            Assert.Equal(123, wrapper.Database);
-        }
-
-        [Fact]
-        public void HashDecrement_1()
-        {
-            wrapper.HashDecrement("key", "hashField", 123, CommandFlags.None);
-            mock.Verify(_ => _.HashDecrement("prefix:key", "hashField", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashDecrement_2()
-        {
-            wrapper.HashDecrement("key", "hashField", 1.23, CommandFlags.None);
-            mock.Verify(_ => _.HashDecrement("prefix:key", "hashField", 1.23, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashDelete_1()
-        {
-            wrapper.HashDelete("key", "hashField", CommandFlags.None);
-            mock.Verify(_ => _.HashDelete("prefix:key", "hashField", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashDelete_2()
-        {
-            RedisValue[] hashFields = Array.Empty<RedisValue>();
-            wrapper.HashDelete("key", hashFields, CommandFlags.None);
-            mock.Verify(_ => _.HashDelete("prefix:key", hashFields, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashExists()
-        {
-            wrapper.HashExists("key", "hashField", CommandFlags.None);
-            mock.Verify(_ => _.HashExists("prefix:key", "hashField", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashGet_1()
-        {
-            wrapper.HashGet("key", "hashField", CommandFlags.None);
-            mock.Verify(_ => _.HashGet("prefix:key", "hashField", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashGet_2()
-        {
-            RedisValue[] hashFields = Array.Empty<RedisValue>();
-            wrapper.HashGet("key", hashFields, CommandFlags.None);
-            mock.Verify(_ => _.HashGet("prefix:key", hashFields, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashGetAll()
-        {
-            wrapper.HashGetAll("key", CommandFlags.None);
-            mock.Verify(_ => _.HashGetAll("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashIncrement_1()
-        {
-            wrapper.HashIncrement("key", "hashField", 123, CommandFlags.None);
-            mock.Verify(_ => _.HashIncrement("prefix:key", "hashField", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashIncrement_2()
-        {
-            wrapper.HashIncrement("key", "hashField", 1.23, CommandFlags.None);
-            mock.Verify(_ => _.HashIncrement("prefix:key", "hashField", 1.23, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashKeys()
-        {
-            wrapper.HashKeys("key", CommandFlags.None);
-            mock.Verify(_ => _.HashKeys("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashLength()
-        {
-            wrapper.HashLength("key", CommandFlags.None);
-            mock.Verify(_ => _.HashLength("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashScan()
-        {
-            wrapper.HashScan("key", "pattern", 123, flags: CommandFlags.None);
-            mock.Verify(_ => _.HashScan("prefix:key", "pattern", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashScan_Full()
-        {
-            wrapper.HashScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
-            mock.Verify(_ => _.HashScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashSet_1()
-        {
-            HashEntry[] hashFields = Array.Empty<HashEntry>();
-            wrapper.HashSet("key", hashFields, CommandFlags.None);
-            mock.Verify(_ => _.HashSet("prefix:key", hashFields, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashSet_2()
-        {
-            wrapper.HashSet("key", "hashField", "value", When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.HashSet("prefix:key", "hashField", "value", When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashStringLength()
-        {
-            wrapper.HashStringLength("key","field", CommandFlags.None);
-            mock.Verify(_ => _.HashStringLength("prefix:key", "field", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HashValues()
-        {
-            wrapper.HashValues("key", CommandFlags.None);
-            mock.Verify(_ => _.HashValues("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HyperLogLogAdd_1()
-        {
-            wrapper.HyperLogLogAdd("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.HyperLogLogAdd("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HyperLogLogAdd_2()
-        {
-            RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.HyperLogLogAdd("key", values, CommandFlags.None);
-            mock.Verify(_ => _.HyperLogLogAdd("prefix:key", values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void HyperLogLogLength()
-        {
-            wrapper.HyperLogLogLength("key", CommandFlags.None);
-            mock.Verify(_ => _.HyperLogLogLength("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HyperLogLogMerge_1()
-        {
-            wrapper.HyperLogLogMerge("destination", "first", "second", CommandFlags.None);
-            mock.Verify(_ => _.HyperLogLogMerge("prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
-        }
-
-        [Fact]
-        public void HyperLogLogMerge_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.HyperLogLogMerge("destination", keys, CommandFlags.None);
-            mock.Verify(_ => _.HyperLogLogMerge("prefix:destination", It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void IdentifyEndpoint()
-        {
-            wrapper.IdentifyEndpoint("key", CommandFlags.None);
-            mock.Verify(_ => _.IdentifyEndpoint("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyCopy()
-        {
-            wrapper.KeyCopy("key", "destination", flags: CommandFlags.None);
-            mock.Verify(_ => _.KeyCopy("prefix:key", "prefix:destination", -1, false, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyDelete_1()
-        {
-            wrapper.KeyDelete("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyDelete("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyDelete_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.KeyDelete(keys, CommandFlags.None);
-            mock.Verify(_ => _.KeyDelete(It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyDump()
-        {
-            wrapper.KeyDump("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyDump("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyEncoding()
-        {
-            wrapper.KeyEncoding("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyEncoding("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyExists()
-        {
-            wrapper.KeyExists("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyExists("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyExpire_1()
-        {
-            TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.KeyExpire("key", expiry, CommandFlags.None);
-            mock.Verify(_ => _.KeyExpire("prefix:key", expiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyExpire_2()
-        {
-            DateTime expiry = DateTime.Now;
-            wrapper.KeyExpire("key", expiry, CommandFlags.None);
-            mock.Verify(_ => _.KeyExpire("prefix:key", expiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyExpire_3()
-        {
-            TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
-            mock.Verify(_ => _.KeyExpire("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyExpire_4()
-        {
-            DateTime expiry = DateTime.Now;
-            wrapper.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
-            mock.Verify(_ => _.KeyExpire("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyExpireTime()
-        {
-            wrapper.KeyExpireTime("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyExpireTime("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyMigrate()
-        {
-            EndPoint toServer = new IPEndPoint(IPAddress.Loopback, 123);
-            wrapper.KeyMigrate("key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None);
-            mock.Verify(_ => _.KeyMigrate("prefix:key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyMove()
-        {
-            wrapper.KeyMove("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.KeyMove("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyPersist()
-        {
-            wrapper.KeyPersist("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyPersist("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyRandom()
-        {
-            Assert.Throws<NotSupportedException>(() => wrapper.KeyRandom());
-        }
-
-        [Fact]
-        public void KeyRefCount()
-        {
-            wrapper.KeyRefCount("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyRefCount("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyRename()
-        {
-            wrapper.KeyRename("key", "newKey", When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.KeyRename("prefix:key", "prefix:newKey", When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyRestore()
-        {
-            byte[] value = Array.Empty<byte>();
-            TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.KeyRestore("key", value, expiry, CommandFlags.None);
-            mock.Verify(_ => _.KeyRestore("prefix:key", value, expiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyTimeToLive()
-        {
-            wrapper.KeyTimeToLive("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyTimeToLive("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void KeyType()
-        {
-            wrapper.KeyType("key", CommandFlags.None);
-            mock.Verify(_ => _.KeyType("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListGetByIndex()
-        {
-            wrapper.ListGetByIndex("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.ListGetByIndex("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListInsertAfter()
-        {
-            wrapper.ListInsertAfter("key", "pivot", "value", CommandFlags.None);
-            mock.Verify(_ => _.ListInsertAfter("prefix:key", "pivot", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListInsertBefore()
-        {
-            wrapper.ListInsertBefore("key", "pivot", "value", CommandFlags.None);
-            mock.Verify(_ => _.ListInsertBefore("prefix:key", "pivot", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListLeftPop()
-        {
-            wrapper.ListLeftPop("key", CommandFlags.None);
-            mock.Verify(_ => _.ListLeftPop("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListLeftPop_1()
-        {
-            wrapper.ListLeftPop("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.ListLeftPop("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListLeftPush_1()
-        {
-            wrapper.ListLeftPush("key", "value", When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.ListLeftPush("prefix:key", "value", When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListLeftPush_2()
-        {
-            RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.ListLeftPush("key", values, CommandFlags.None);
-            mock.Verify(_ => _.ListLeftPush("prefix:key", values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListLeftPush_3()
-        {
-            RedisValue[] values = new RedisValue[] { "value1", "value2" };
-            wrapper.ListLeftPush("key", values, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.ListLeftPush("prefix:key", values, When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListLength()
-        {
-            wrapper.ListLength("key", CommandFlags.None);
-            mock.Verify(_ => _.ListLength("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListMove()
-        {
-            wrapper.ListMove("key", "destination", ListSide.Left, ListSide.Right, CommandFlags.None);
-            mock.Verify(_ => _.ListMove("prefix:key", "prefix:destination", ListSide.Left, ListSide.Right, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRange()
-        {
-            wrapper.ListRange("key", 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.ListRange("prefix:key", 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRemove()
-        {
-            wrapper.ListRemove("key", "value", 123, CommandFlags.None);
-            mock.Verify(_ => _.ListRemove("prefix:key", "value", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRightPop()
-        {
-            wrapper.ListRightPop("key", CommandFlags.None);
-            mock.Verify(_ => _.ListRightPop("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRightPop_1()
-        {
-            wrapper.ListRightPop("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.ListRightPop("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRightPopLeftPush()
-        {
-            wrapper.ListRightPopLeftPush("source", "destination", CommandFlags.None);
-            mock.Verify(_ => _.ListRightPopLeftPush("prefix:source", "prefix:destination", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRightPush_1()
-        {
-            wrapper.ListRightPush("key", "value", When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.ListRightPush("prefix:key", "value", When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRightPush_2()
-        {
-            RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.ListRightPush("key", values, CommandFlags.None);
-            mock.Verify(_ => _.ListRightPush("prefix:key", values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListRightPush_3()
-        {
-            RedisValue[] values = new RedisValue[] { "value1", "value2" };
-            wrapper.ListRightPush("key", values, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.ListRightPush("prefix:key", values, When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListSetByIndex()
-        {
-            wrapper.ListSetByIndex("key", 123, "value", CommandFlags.None);
-            mock.Verify(_ => _.ListSetByIndex("prefix:key", 123, "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ListTrim()
-        {
-            wrapper.ListTrim("key", 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.ListTrim("prefix:key", 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void LockExtend()
-        {
-            TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.LockExtend("key", "value", expiry, CommandFlags.None);
-            mock.Verify(_ => _.LockExtend("prefix:key", "value", expiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void LockQuery()
-        {
-            wrapper.LockQuery("key", CommandFlags.None);
-            mock.Verify(_ => _.LockQuery("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void LockRelease()
-        {
-            wrapper.LockRelease("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.LockRelease("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void LockTake()
-        {
-            TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.LockTake("key", "value", expiry, CommandFlags.None);
-            mock.Verify(_ => _.LockTake("prefix:key", "value", expiry, CommandFlags.None));
-        }
-
-        [Fact]
-        public void Publish()
-        {
-            wrapper.Publish("channel", "message", CommandFlags.None);
-            mock.Verify(_ => _.Publish("prefix:channel", "message", CommandFlags.None));
-        }
-
-        [Fact]
-        public void ScriptEvaluate_1()
-        {
-            byte[] hash = Array.Empty<byte>();
-            RedisValue[] values = Array.Empty<RedisValue>();
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.ScriptEvaluate(hash, keys, values, CommandFlags.None);
-            mock.Verify(_ => _.ScriptEvaluate(hash, It.Is(valid), values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void ScriptEvaluate_2()
-        {
-            RedisValue[] values = Array.Empty<RedisValue>();
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.ScriptEvaluate("script", keys, values, CommandFlags.None);
-            mock.Verify(_ => _.ScriptEvaluate("script", It.Is(valid), values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetAdd_1()
-        {
-            wrapper.SetAdd("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.SetAdd("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetAdd_2()
-        {
-            RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.SetAdd("key", values, CommandFlags.None);
-            mock.Verify(_ => _.SetAdd("prefix:key", values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetCombine_1()
-        {
-            wrapper.SetCombine(SetOperation.Intersect, "first", "second", CommandFlags.None);
-            mock.Verify(_ => _.SetCombine(SetOperation.Intersect, "prefix:first", "prefix:second", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetCombine_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.SetCombine(SetOperation.Intersect, keys, CommandFlags.None);
-            mock.Verify(_ => _.SetCombine(SetOperation.Intersect, It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetCombineAndStore_1()
-        {
-            wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", CommandFlags.None);
-            mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetCombineAndStore_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
-            mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetContains()
-        {
-            wrapper.SetContains("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.SetContains("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetContains_2()
-        {
-            RedisValue[] values = new RedisValue[] { "value1", "value2" };
-            wrapper.SetContains("key", values, CommandFlags.None);
-            mock.Verify(_ => _.SetContains("prefix:key", values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetIntersectionLength()
-        {
-            var keys = new RedisKey[] { "key1", "key2" };
-            wrapper.SetIntersectionLength(keys);
-            mock.Verify(_ => _.SetIntersectionLength(keys, 0, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetLength()
-        {
-            wrapper.SetLength("key", CommandFlags.None);
-            mock.Verify(_ => _.SetLength("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetMembers()
-        {
-            wrapper.SetMembers("key", CommandFlags.None);
-            mock.Verify(_ => _.SetMembers("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetMove()
-        {
-            wrapper.SetMove("source", "destination", "value", CommandFlags.None);
-            mock.Verify(_ => _.SetMove("prefix:source", "prefix:destination", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetPop_1()
-        {
-            wrapper.SetPop("key", CommandFlags.None);
-            mock.Verify(_ => _.SetPop("prefix:key", CommandFlags.None));
-
-            wrapper.SetPop("key", 5, CommandFlags.None);
-            mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetPop_2()
-        {
-            wrapper.SetPop("key", 5, CommandFlags.None);
-            mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetRandomMember()
-        {
-            wrapper.SetRandomMember("key", CommandFlags.None);
-            mock.Verify(_ => _.SetRandomMember("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetRandomMembers()
-        {
-            wrapper.SetRandomMembers("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.SetRandomMembers("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetRemove_1()
-        {
-            wrapper.SetRemove("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.SetRemove("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetRemove_2()
-        {
-            RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.SetRemove("key", values, CommandFlags.None);
-            mock.Verify(_ => _.SetRemove("prefix:key", values, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetScan()
-        {
-            wrapper.SetScan("key", "pattern", 123, flags: CommandFlags.None);
-            mock.Verify(_ => _.SetScan("prefix:key", "pattern", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SetScan_Full()
-        {
-            wrapper.SetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
-            mock.Verify(_ => _.SetScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
-        }
-
-        [Fact]
-        public void Sort()
-        {
-            RedisValue[] get = new RedisValue[] { "a", "#" };
-            Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
-
-            wrapper.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
-            wrapper.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
-
-            mock.Verify(_ => _.Sort("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
-            mock.Verify(_ => _.Sort("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortAndStore()
-        {
-            RedisValue[] get = new RedisValue[] { "a", "#" };
-            Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
-
-            wrapper.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
-            wrapper.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
-
-            mock.Verify(_ => _.SortAndStore("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
-            mock.Verify(_ => _.SortAndStore("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetAdd_1()
-        {
-            wrapper.SortedSetAdd("key", "member", 1.23, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetAdd("prefix:key", "member", 1.23, When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetAdd_2()
-        {
-            SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-            wrapper.SortedSetAdd("key", values, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetAdd("prefix:key", values, When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetCombine()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            wrapper.SortedSetCombine(SetOperation.Intersect, keys);
-            mock.Verify(_ => _.SortedSetCombine(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetCombineWithScores()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            wrapper.SortedSetCombineWithScores(SetOperation.Intersect, keys);
-            mock.Verify(_ => _.SortedSetCombineWithScores(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetCombineAndStore_1()
-        {
-            wrapper.SortedSetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", Aggregate.Max, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetCombineAndStore(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", Aggregate.Max, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetCombineAndStore_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
-            mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetDecrement()
-        {
-            wrapper.SortedSetDecrement("key", "member", 1.23, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetDecrement("prefix:key", "member", 1.23, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetIncrement()
-        {
-            wrapper.SortedSetIncrement("key", "member", 1.23, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetIncrement("prefix:key", "member", 1.23, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetIntersectionLength()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            wrapper.SortedSetIntersectionLength(keys, 1, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetIntersectionLength(keys, 1, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetLength()
-        {
-            wrapper.SortedSetLength("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetLength("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRandomMember()
-        {
-            wrapper.SortedSetRandomMember("key", CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRandomMember("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRandomMembers()
-        {
-            wrapper.SortedSetRandomMembers("key", 2, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRandomMembers("prefix:key", 2, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRandomMembersWithScores()
-        {
-            wrapper.SortedSetRandomMembersWithScores("key", 2, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRandomMembersWithScores("prefix:key", 2, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetLengthByValue()
-        {
-            wrapper.SortedSetLengthByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetLengthByValue("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRangeByRank()
-        {
-            wrapper.SortedSetRangeByRank("key", 123, 456, Order.Descending, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRangeByRank("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRangeByRankWithScores()
-        {
-            wrapper.SortedSetRangeByRankWithScores("key", 123, 456, Order.Descending, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRangeByRankWithScores("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRangeByScore()
-        {
-            wrapper.SortedSetRangeByScore("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRangeByScore("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRangeByScoreWithScores()
-        {
-            wrapper.SortedSetRangeByScoreWithScores("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRangeByScoreWithScores("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRangeByValue()
-        {
-            wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, Order.Ascending, 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRangeByValueDesc()
-        {
-            wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRank()
-        {
-            wrapper.SortedSetRank("key", "member", Order.Descending, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRank("prefix:key", "member", Order.Descending, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRemove_1()
-        {
-            wrapper.SortedSetRemove("key", "member", CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRemove("prefix:key", "member", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRemove_2()
-        {
-            RedisValue[] members = Array.Empty<RedisValue>();
-            wrapper.SortedSetRemove("key", members, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRemove("prefix:key", members, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRemoveRangeByRank()
-        {
-            wrapper.SortedSetRemoveRangeByRank("key", 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRemoveRangeByRank("prefix:key", 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRemoveRangeByScore()
-        {
-            wrapper.SortedSetRemoveRangeByScore("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRemoveRangeByScore("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetRemoveRangeByValue()
-        {
-            wrapper.SortedSetRemoveRangeByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetRemoveRangeByValue("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetScan()
-        {
-            wrapper.SortedSetScan("key", "pattern", 123, flags: CommandFlags.None);
-            mock.Verify(_ => _.SortedSetScan("prefix:key", "pattern", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetScan_Full()
-        {
-            wrapper.SortedSetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
-            mock.Verify(_ => _.SortedSetScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetScore()
-        {
-            wrapper.SortedSetScore("key", "member", CommandFlags.None);
-            mock.Verify(_ => _.SortedSetScore("prefix:key", "member", CommandFlags.None));
-        }
-
-        [Fact]
-        public void SortedSetScore_Multiple()
-        {
-            wrapper.SortedSetScores("key", new RedisValue[] { "member1", "member2" }, CommandFlags.None);
-            mock.Verify(_ => _.SortedSetScores("prefix:key", new RedisValue[] { "member1", "member2" }, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamAcknowledge_1()
-        {
-            wrapper.StreamAcknowledge("key", "group", "0-0", CommandFlags.None);
-            mock.Verify(_ => _.StreamAcknowledge("prefix:key", "group", "0-0", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamAcknowledge_2()
-        {
-            var messageIds = new RedisValue[] { "0-0", "0-1", "0-2" };
-            wrapper.StreamAcknowledge("key", "group", messageIds, CommandFlags.None);
-            mock.Verify(_ => _.StreamAcknowledge("prefix:key", "group", messageIds, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamAdd_1()
-        {
-            wrapper.StreamAdd("key", "field1", "value1", "*", 1000, true, CommandFlags.None);
-            mock.Verify(_ => _.StreamAdd("prefix:key", "field1", "value1", "*", 1000, true, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamAdd_2()
-        {
-            var fields = Array.Empty<NameValueEntry>();
-            wrapper.StreamAdd("key", fields, "*", 1000, true, CommandFlags.None);
-            mock.Verify(_ => _.StreamAdd("prefix:key", fields, "*", 1000, true, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamClaimMessages()
-        {
-            var messageIds = Array.Empty<RedisValue>();
-            wrapper.StreamClaim("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
-            mock.Verify(_ => _.StreamClaim("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamClaimMessagesReturningIds()
-        {
-            var messageIds = Array.Empty<RedisValue>();
-            wrapper.StreamClaimIdsOnly("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
-            mock.Verify(_ => _.StreamClaimIdsOnly("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamConsumerGroupSetPosition()
-        {
-            wrapper.StreamConsumerGroupSetPosition("key", "group", StreamPosition.Beginning, CommandFlags.None);
-            mock.Verify(_ => _.StreamConsumerGroupSetPosition("prefix:key", "group", StreamPosition.Beginning, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamConsumerInfoGet()
-        {
-            wrapper.StreamConsumerInfo("key", "group", CommandFlags.None);
-            mock.Verify(_ => _.StreamConsumerInfo("prefix:key", "group", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamCreateConsumerGroup()
-        {
-            wrapper.StreamCreateConsumerGroup("key", "group", StreamPosition.Beginning, false, CommandFlags.None);
-            mock.Verify(_ => _.StreamCreateConsumerGroup("prefix:key", "group", StreamPosition.Beginning, false, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamGroupInfoGet()
-        {
-            wrapper.StreamGroupInfo("key", CommandFlags.None);
-            mock.Verify(_ => _.StreamGroupInfo("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamInfoGet()
-        {
-            wrapper.StreamInfo("key", CommandFlags.None);
-            mock.Verify(_ => _.StreamInfo("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamLength()
-        {
-            wrapper.StreamLength("key", CommandFlags.None);
-            mock.Verify(_ => _.StreamLength("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamMessagesDelete()
-        {
-            var messageIds = Array.Empty<RedisValue>();
-            wrapper.StreamDelete("key", messageIds, CommandFlags.None);
-            mock.Verify(_ => _.StreamDelete("prefix:key", messageIds, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamDeleteConsumer()
-        {
-            wrapper.StreamDeleteConsumer("key", "group", "consumer", CommandFlags.None);
-            mock.Verify(_ => _.StreamDeleteConsumer("prefix:key", "group", "consumer", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamDeleteConsumerGroup()
-        {
-            wrapper.StreamDeleteConsumerGroup("key", "group", CommandFlags.None);
-            mock.Verify(_ => _.StreamDeleteConsumerGroup("prefix:key", "group", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamPendingInfoGet()
-        {
-            wrapper.StreamPending("key", "group", CommandFlags.None);
-            mock.Verify(_ => _.StreamPending("prefix:key", "group", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamPendingMessageInfoGet()
-        {
-            wrapper.StreamPendingMessages("key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None);
-            mock.Verify(_ => _.StreamPendingMessages("prefix:key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamRange()
-        {
-            wrapper.StreamRange("key", "-", "+", null, Order.Ascending, CommandFlags.None);
-            mock.Verify(_ => _.StreamRange("prefix:key", "-", "+", null, Order.Ascending, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamRead_1()
-        {
-            var streamPositions = Array.Empty<StreamPosition>();
-            wrapper.StreamRead(streamPositions, null, CommandFlags.None);
-            mock.Verify(_ => _.StreamRead(streamPositions, null, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamRead_2()
-        {
-            wrapper.StreamRead("key", "0-0", null, CommandFlags.None);
-            mock.Verify(_ => _.StreamRead("prefix:key", "0-0", null, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamStreamReadGroup_1()
-        {
-            wrapper.StreamReadGroup("key", "group", "consumer", "0-0", 10, false, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadGroup("prefix:key", "group", "consumer", "0-0", 10, false, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamStreamReadGroup_2()
-        {
-            var streamPositions = Array.Empty<StreamPosition>();
-            wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
-            mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StreamTrim()
-        {
-            wrapper.StreamTrim("key", 1000, true, CommandFlags.None);
-            mock.Verify(_ => _.StreamTrim("prefix:key", 1000, true, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringAppend()
-        {
-            wrapper.StringAppend("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.StringAppend("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringBitCount()
-        {
-            wrapper.StringBitCount("key", 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.StringBitCount("prefix:key", 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringBitOperation_1()
-        {
-            wrapper.StringBitOperation(Bitwise.Xor, "destination", "first", "second", CommandFlags.None);
-            mock.Verify(_ => _.StringBitOperation(Bitwise.Xor, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringBitOperation_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.StringBitOperation(Bitwise.Xor, "destination", keys, CommandFlags.None);
-            mock.Verify(_ => _.StringBitOperation(Bitwise.Xor, "prefix:destination", It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringBitPosition()
-        {
-            wrapper.StringBitPosition("key", true, 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.StringBitPosition("prefix:key", true, 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringDecrement_1()
-        {
-            wrapper.StringDecrement("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.StringDecrement("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringDecrement_2()
-        {
-            wrapper.StringDecrement("key", 1.23, CommandFlags.None);
-            mock.Verify(_ => _.StringDecrement("prefix:key", 1.23, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGet_1()
-        {
-            wrapper.StringGet("key", CommandFlags.None);
-            mock.Verify(_ => _.StringGet("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGet_2()
-        {
-            RedisKey[] keys = new RedisKey[] { "a", "b" };
-            Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.StringGet(keys, CommandFlags.None);
-            mock.Verify(_ => _.StringGet(It.Is(valid), CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGetBit()
-        {
-            wrapper.StringGetBit("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.StringGetBit("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGetRange()
-        {
-            wrapper.StringGetRange("key", 123, 456, CommandFlags.None);
-            mock.Verify(_ => _.StringGetRange("prefix:key", 123, 456, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGetSet()
-        {
-            wrapper.StringGetSet("key", "value", CommandFlags.None);
-            mock.Verify(_ => _.StringGetSet("prefix:key", "value", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGetDelete()
-        {
-            wrapper.StringGetDelete("key", CommandFlags.None);
-            mock.Verify(_ => _.StringGetDelete("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringGetWithExpiry()
-        {
-            wrapper.StringGetWithExpiry("key", CommandFlags.None);
-            mock.Verify(_ => _.StringGetWithExpiry("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringIncrement_1()
-        {
-            wrapper.StringIncrement("key", 123, CommandFlags.None);
-            mock.Verify(_ => _.StringIncrement("prefix:key", 123, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringIncrement_2()
-        {
-            wrapper.StringIncrement("key", 1.23, CommandFlags.None);
-            mock.Verify(_ => _.StringIncrement("prefix:key", 1.23, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringLength()
-        {
-            wrapper.StringLength("key", CommandFlags.None);
-            mock.Verify(_ => _.StringLength("prefix:key", CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringSet_1()
-        {
-            TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.StringSet("key", "value", expiry, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringSet_2()
-        {
-            TimeSpan? expiry = null;
-            wrapper.StringSet("key", "value", expiry, true, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, true, When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringSet_3()
-        {
-            KeyValuePair<RedisKey, RedisValue>[] values = new KeyValuePair<RedisKey, RedisValue>[] { new KeyValuePair<RedisKey, RedisValue>("a", "x"), new KeyValuePair<RedisKey, RedisValue>("b", "y") };
-            Expression<Func<KeyValuePair<RedisKey, RedisValue>[], bool>> valid = _ => _.Length == 2 && _[0].Key == "prefix:a" && _[0].Value == "x" && _[1].Key == "prefix:b" && _[1].Value == "y";
-            wrapper.StringSet(values, When.Exists, CommandFlags.None);
-            mock.Verify(_ => _.StringSet(It.Is(valid), When.Exists, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringSetBit()
-        {
-            wrapper.StringSetBit("key", 123, true, CommandFlags.None);
-            mock.Verify(_ => _.StringSetBit("prefix:key", 123, true, CommandFlags.None));
-        }
-
-        [Fact]
-        public void StringSetRange()
-        {
-            wrapper.StringSetRange("key", 123, "value", CommandFlags.None);
-            mock.Verify(_ => _.StringSetRange("prefix:key", 123, "value", CommandFlags.None));
-        }
+        mock = new Mock<IDatabase>();
+        wrapper = new DatabaseWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+    }
+
+    [Fact]
+    public void CreateBatch()
+    {
+        object asyncState = new();
+        IBatch innerBatch = new Mock<IBatch>().Object;
+        mock.Setup(_ => _.CreateBatch(asyncState)).Returns(innerBatch);
+        IBatch wrappedBatch = wrapper.CreateBatch(asyncState);
+        mock.Verify(_ => _.CreateBatch(asyncState));
+        Assert.IsType<BatchWrapper>(wrappedBatch);
+        Assert.Same(innerBatch, ((BatchWrapper)wrappedBatch).Inner);
+    }
+
+    [Fact]
+    public void CreateTransaction()
+    {
+        object asyncState = new();
+        ITransaction innerTransaction = new Mock<ITransaction>().Object;
+        mock.Setup(_ => _.CreateTransaction(asyncState)).Returns(innerTransaction);
+        ITransaction wrappedTransaction = wrapper.CreateTransaction(asyncState);
+        mock.Verify(_ => _.CreateTransaction(asyncState));
+        Assert.IsType<TransactionWrapper>(wrappedTransaction);
+        Assert.Same(innerTransaction, ((TransactionWrapper)wrappedTransaction).Inner);
+    }
+
+    [Fact]
+    public void DebugObject()
+    {
+        wrapper.DebugObject("key", CommandFlags.None);
+        mock.Verify(_ => _.DebugObject("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void Get_Database()
+    {
+        mock.SetupGet(_ => _.Database).Returns(123);
+        Assert.Equal(123, wrapper.Database);
+    }
+
+    [Fact]
+    public void HashDecrement_1()
+    {
+        wrapper.HashDecrement("key", "hashField", 123, CommandFlags.None);
+        mock.Verify(_ => _.HashDecrement("prefix:key", "hashField", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashDecrement_2()
+    {
+        wrapper.HashDecrement("key", "hashField", 1.23, CommandFlags.None);
+        mock.Verify(_ => _.HashDecrement("prefix:key", "hashField", 1.23, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashDelete_1()
+    {
+        wrapper.HashDelete("key", "hashField", CommandFlags.None);
+        mock.Verify(_ => _.HashDelete("prefix:key", "hashField", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashDelete_2()
+    {
+        RedisValue[] hashFields = Array.Empty<RedisValue>();
+        wrapper.HashDelete("key", hashFields, CommandFlags.None);
+        mock.Verify(_ => _.HashDelete("prefix:key", hashFields, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashExists()
+    {
+        wrapper.HashExists("key", "hashField", CommandFlags.None);
+        mock.Verify(_ => _.HashExists("prefix:key", "hashField", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashGet_1()
+    {
+        wrapper.HashGet("key", "hashField", CommandFlags.None);
+        mock.Verify(_ => _.HashGet("prefix:key", "hashField", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashGet_2()
+    {
+        RedisValue[] hashFields = Array.Empty<RedisValue>();
+        wrapper.HashGet("key", hashFields, CommandFlags.None);
+        mock.Verify(_ => _.HashGet("prefix:key", hashFields, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashGetAll()
+    {
+        wrapper.HashGetAll("key", CommandFlags.None);
+        mock.Verify(_ => _.HashGetAll("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashIncrement_1()
+    {
+        wrapper.HashIncrement("key", "hashField", 123, CommandFlags.None);
+        mock.Verify(_ => _.HashIncrement("prefix:key", "hashField", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashIncrement_2()
+    {
+        wrapper.HashIncrement("key", "hashField", 1.23, CommandFlags.None);
+        mock.Verify(_ => _.HashIncrement("prefix:key", "hashField", 1.23, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashKeys()
+    {
+        wrapper.HashKeys("key", CommandFlags.None);
+        mock.Verify(_ => _.HashKeys("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashLength()
+    {
+        wrapper.HashLength("key", CommandFlags.None);
+        mock.Verify(_ => _.HashLength("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashScan()
+    {
+        wrapper.HashScan("key", "pattern", 123, flags: CommandFlags.None);
+        mock.Verify(_ => _.HashScan("prefix:key", "pattern", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashScan_Full()
+    {
+        wrapper.HashScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
+        mock.Verify(_ => _.HashScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashSet_1()
+    {
+        HashEntry[] hashFields = Array.Empty<HashEntry>();
+        wrapper.HashSet("key", hashFields, CommandFlags.None);
+        mock.Verify(_ => _.HashSet("prefix:key", hashFields, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashSet_2()
+    {
+        wrapper.HashSet("key", "hashField", "value", When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.HashSet("prefix:key", "hashField", "value", When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashStringLength()
+    {
+        wrapper.HashStringLength("key", "field", CommandFlags.None);
+        mock.Verify(_ => _.HashStringLength("prefix:key", "field", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HashValues()
+    {
+        wrapper.HashValues("key", CommandFlags.None);
+        mock.Verify(_ => _.HashValues("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HyperLogLogAdd_1()
+    {
+        wrapper.HyperLogLogAdd("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.HyperLogLogAdd("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HyperLogLogAdd_2()
+    {
+        RedisValue[] values = Array.Empty<RedisValue>();
+        wrapper.HyperLogLogAdd("key", values, CommandFlags.None);
+        mock.Verify(_ => _.HyperLogLogAdd("prefix:key", values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void HyperLogLogLength()
+    {
+        wrapper.HyperLogLogLength("key", CommandFlags.None);
+        mock.Verify(_ => _.HyperLogLogLength("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HyperLogLogMerge_1()
+    {
+        wrapper.HyperLogLogMerge("destination", "first", "second", CommandFlags.None);
+        mock.Verify(_ => _.HyperLogLogMerge("prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
+    }
+
+    [Fact]
+    public void HyperLogLogMerge_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.HyperLogLogMerge("destination", keys, CommandFlags.None);
+        mock.Verify(_ => _.HyperLogLogMerge("prefix:destination", It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void IdentifyEndpoint()
+    {
+        wrapper.IdentifyEndpoint("key", CommandFlags.None);
+        mock.Verify(_ => _.IdentifyEndpoint("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyCopy()
+    {
+        wrapper.KeyCopy("key", "destination", flags: CommandFlags.None);
+        mock.Verify(_ => _.KeyCopy("prefix:key", "prefix:destination", -1, false, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyDelete_1()
+    {
+        wrapper.KeyDelete("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyDelete("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyDelete_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.KeyDelete(keys, CommandFlags.None);
+        mock.Verify(_ => _.KeyDelete(It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyDump()
+    {
+        wrapper.KeyDump("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyDump("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyEncoding()
+    {
+        wrapper.KeyEncoding("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyEncoding("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyExists()
+    {
+        wrapper.KeyExists("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyExists("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyExpire_1()
+    {
+        TimeSpan expiry = TimeSpan.FromSeconds(123);
+        wrapper.KeyExpire("key", expiry, CommandFlags.None);
+        mock.Verify(_ => _.KeyExpire("prefix:key", expiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyExpire_2()
+    {
+        DateTime expiry = DateTime.Now;
+        wrapper.KeyExpire("key", expiry, CommandFlags.None);
+        mock.Verify(_ => _.KeyExpire("prefix:key", expiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyExpire_3()
+    {
+        TimeSpan expiry = TimeSpan.FromSeconds(123);
+        wrapper.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
+        mock.Verify(_ => _.KeyExpire("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyExpire_4()
+    {
+        DateTime expiry = DateTime.Now;
+        wrapper.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
+        mock.Verify(_ => _.KeyExpire("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyExpireTime()
+    {
+        wrapper.KeyExpireTime("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyExpireTime("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyMigrate()
+    {
+        EndPoint toServer = new IPEndPoint(IPAddress.Loopback, 123);
+        wrapper.KeyMigrate("key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None);
+        mock.Verify(_ => _.KeyMigrate("prefix:key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyMove()
+    {
+        wrapper.KeyMove("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.KeyMove("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyPersist()
+    {
+        wrapper.KeyPersist("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyPersist("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyRandom()
+    {
+        Assert.Throws<NotSupportedException>(() => wrapper.KeyRandom());
+    }
+
+    [Fact]
+    public void KeyRefCount()
+    {
+        wrapper.KeyRefCount("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyRefCount("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyRename()
+    {
+        wrapper.KeyRename("key", "newKey", When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.KeyRename("prefix:key", "prefix:newKey", When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyRestore()
+    {
+        byte[] value = Array.Empty<byte>();
+        TimeSpan expiry = TimeSpan.FromSeconds(123);
+        wrapper.KeyRestore("key", value, expiry, CommandFlags.None);
+        mock.Verify(_ => _.KeyRestore("prefix:key", value, expiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyTimeToLive()
+    {
+        wrapper.KeyTimeToLive("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyTimeToLive("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void KeyType()
+    {
+        wrapper.KeyType("key", CommandFlags.None);
+        mock.Verify(_ => _.KeyType("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListGetByIndex()
+    {
+        wrapper.ListGetByIndex("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.ListGetByIndex("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListInsertAfter()
+    {
+        wrapper.ListInsertAfter("key", "pivot", "value", CommandFlags.None);
+        mock.Verify(_ => _.ListInsertAfter("prefix:key", "pivot", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListInsertBefore()
+    {
+        wrapper.ListInsertBefore("key", "pivot", "value", CommandFlags.None);
+        mock.Verify(_ => _.ListInsertBefore("prefix:key", "pivot", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListLeftPop()
+    {
+        wrapper.ListLeftPop("key", CommandFlags.None);
+        mock.Verify(_ => _.ListLeftPop("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListLeftPop_1()
+    {
+        wrapper.ListLeftPop("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.ListLeftPop("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListLeftPush_1()
+    {
+        wrapper.ListLeftPush("key", "value", When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.ListLeftPush("prefix:key", "value", When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListLeftPush_2()
+    {
+        RedisValue[] values = Array.Empty<RedisValue>();
+        wrapper.ListLeftPush("key", values, CommandFlags.None);
+        mock.Verify(_ => _.ListLeftPush("prefix:key", values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListLeftPush_3()
+    {
+        RedisValue[] values = new RedisValue[] { "value1", "value2" };
+        wrapper.ListLeftPush("key", values, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.ListLeftPush("prefix:key", values, When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListLength()
+    {
+        wrapper.ListLength("key", CommandFlags.None);
+        mock.Verify(_ => _.ListLength("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListMove()
+    {
+        wrapper.ListMove("key", "destination", ListSide.Left, ListSide.Right, CommandFlags.None);
+        mock.Verify(_ => _.ListMove("prefix:key", "prefix:destination", ListSide.Left, ListSide.Right, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRange()
+    {
+        wrapper.ListRange("key", 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.ListRange("prefix:key", 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRemove()
+    {
+        wrapper.ListRemove("key", "value", 123, CommandFlags.None);
+        mock.Verify(_ => _.ListRemove("prefix:key", "value", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRightPop()
+    {
+        wrapper.ListRightPop("key", CommandFlags.None);
+        mock.Verify(_ => _.ListRightPop("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRightPop_1()
+    {
+        wrapper.ListRightPop("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.ListRightPop("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRightPopLeftPush()
+    {
+        wrapper.ListRightPopLeftPush("source", "destination", CommandFlags.None);
+        mock.Verify(_ => _.ListRightPopLeftPush("prefix:source", "prefix:destination", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRightPush_1()
+    {
+        wrapper.ListRightPush("key", "value", When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.ListRightPush("prefix:key", "value", When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRightPush_2()
+    {
+        RedisValue[] values = Array.Empty<RedisValue>();
+        wrapper.ListRightPush("key", values, CommandFlags.None);
+        mock.Verify(_ => _.ListRightPush("prefix:key", values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListRightPush_3()
+    {
+        RedisValue[] values = new RedisValue[] { "value1", "value2" };
+        wrapper.ListRightPush("key", values, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.ListRightPush("prefix:key", values, When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListSetByIndex()
+    {
+        wrapper.ListSetByIndex("key", 123, "value", CommandFlags.None);
+        mock.Verify(_ => _.ListSetByIndex("prefix:key", 123, "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ListTrim()
+    {
+        wrapper.ListTrim("key", 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.ListTrim("prefix:key", 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void LockExtend()
+    {
+        TimeSpan expiry = TimeSpan.FromSeconds(123);
+        wrapper.LockExtend("key", "value", expiry, CommandFlags.None);
+        mock.Verify(_ => _.LockExtend("prefix:key", "value", expiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void LockQuery()
+    {
+        wrapper.LockQuery("key", CommandFlags.None);
+        mock.Verify(_ => _.LockQuery("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void LockRelease()
+    {
+        wrapper.LockRelease("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.LockRelease("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void LockTake()
+    {
+        TimeSpan expiry = TimeSpan.FromSeconds(123);
+        wrapper.LockTake("key", "value", expiry, CommandFlags.None);
+        mock.Verify(_ => _.LockTake("prefix:key", "value", expiry, CommandFlags.None));
+    }
+
+    [Fact]
+    public void Publish()
+    {
+        wrapper.Publish("channel", "message", CommandFlags.None);
+        mock.Verify(_ => _.Publish("prefix:channel", "message", CommandFlags.None));
+    }
+
+    [Fact]
+    public void ScriptEvaluate_1()
+    {
+        byte[] hash = Array.Empty<byte>();
+        RedisValue[] values = Array.Empty<RedisValue>();
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.ScriptEvaluate(hash, keys, values, CommandFlags.None);
+        mock.Verify(_ => _.ScriptEvaluate(hash, It.Is(valid), values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void ScriptEvaluate_2()
+    {
+        RedisValue[] values = Array.Empty<RedisValue>();
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.ScriptEvaluate("script", keys, values, CommandFlags.None);
+        mock.Verify(_ => _.ScriptEvaluate("script", It.Is(valid), values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetAdd_1()
+    {
+        wrapper.SetAdd("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.SetAdd("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetAdd_2()
+    {
+        RedisValue[] values = Array.Empty<RedisValue>();
+        wrapper.SetAdd("key", values, CommandFlags.None);
+        mock.Verify(_ => _.SetAdd("prefix:key", values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetCombine_1()
+    {
+        wrapper.SetCombine(SetOperation.Intersect, "first", "second", CommandFlags.None);
+        mock.Verify(_ => _.SetCombine(SetOperation.Intersect, "prefix:first", "prefix:second", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetCombine_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.SetCombine(SetOperation.Intersect, keys, CommandFlags.None);
+        mock.Verify(_ => _.SetCombine(SetOperation.Intersect, It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetCombineAndStore_1()
+    {
+        wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", CommandFlags.None);
+        mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetCombineAndStore_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
+        mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetContains()
+    {
+        wrapper.SetContains("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.SetContains("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetContains_2()
+    {
+        RedisValue[] values = new RedisValue[] { "value1", "value2" };
+        wrapper.SetContains("key", values, CommandFlags.None);
+        mock.Verify(_ => _.SetContains("prefix:key", values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetIntersectionLength()
+    {
+        var keys = new RedisKey[] { "key1", "key2" };
+        wrapper.SetIntersectionLength(keys);
+        mock.Verify(_ => _.SetIntersectionLength(keys, 0, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetLength()
+    {
+        wrapper.SetLength("key", CommandFlags.None);
+        mock.Verify(_ => _.SetLength("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetMembers()
+    {
+        wrapper.SetMembers("key", CommandFlags.None);
+        mock.Verify(_ => _.SetMembers("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetMove()
+    {
+        wrapper.SetMove("source", "destination", "value", CommandFlags.None);
+        mock.Verify(_ => _.SetMove("prefix:source", "prefix:destination", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetPop_1()
+    {
+        wrapper.SetPop("key", CommandFlags.None);
+        mock.Verify(_ => _.SetPop("prefix:key", CommandFlags.None));
+
+        wrapper.SetPop("key", 5, CommandFlags.None);
+        mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetPop_2()
+    {
+        wrapper.SetPop("key", 5, CommandFlags.None);
+        mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetRandomMember()
+    {
+        wrapper.SetRandomMember("key", CommandFlags.None);
+        mock.Verify(_ => _.SetRandomMember("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetRandomMembers()
+    {
+        wrapper.SetRandomMembers("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.SetRandomMembers("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetRemove_1()
+    {
+        wrapper.SetRemove("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.SetRemove("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetRemove_2()
+    {
+        RedisValue[] values = Array.Empty<RedisValue>();
+        wrapper.SetRemove("key", values, CommandFlags.None);
+        mock.Verify(_ => _.SetRemove("prefix:key", values, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetScan()
+    {
+        wrapper.SetScan("key", "pattern", 123, flags: CommandFlags.None);
+        mock.Verify(_ => _.SetScan("prefix:key", "pattern", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SetScan_Full()
+    {
+        wrapper.SetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
+        mock.Verify(_ => _.SetScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
+    }
+
+    [Fact]
+    public void Sort()
+    {
+        RedisValue[] get = new RedisValue[] { "a", "#" };
+        Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
+
+        wrapper.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
+        wrapper.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
+
+        mock.Verify(_ => _.Sort("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
+        mock.Verify(_ => _.Sort("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortAndStore()
+    {
+        RedisValue[] get = new RedisValue[] { "a", "#" };
+        Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
+
+        wrapper.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
+        wrapper.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
+
+        mock.Verify(_ => _.SortAndStore("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
+        mock.Verify(_ => _.SortAndStore("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetAdd_1()
+    {
+        wrapper.SortedSetAdd("key", "member", 1.23, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetAdd("prefix:key", "member", 1.23, When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetAdd_2()
+    {
+        SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
+        wrapper.SortedSetAdd("key", values, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetAdd("prefix:key", values, When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetCombine()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        wrapper.SortedSetCombine(SetOperation.Intersect, keys);
+        mock.Verify(_ => _.SortedSetCombine(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetCombineWithScores()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        wrapper.SortedSetCombineWithScores(SetOperation.Intersect, keys);
+        mock.Verify(_ => _.SortedSetCombineWithScores(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetCombineAndStore_1()
+    {
+        wrapper.SortedSetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", Aggregate.Max, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetCombineAndStore(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", Aggregate.Max, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetCombineAndStore_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
+        mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetDecrement()
+    {
+        wrapper.SortedSetDecrement("key", "member", 1.23, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetDecrement("prefix:key", "member", 1.23, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetIncrement()
+    {
+        wrapper.SortedSetIncrement("key", "member", 1.23, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetIncrement("prefix:key", "member", 1.23, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetIntersectionLength()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        wrapper.SortedSetIntersectionLength(keys, 1, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetIntersectionLength(keys, 1, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetLength()
+    {
+        wrapper.SortedSetLength("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetLength("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRandomMember()
+    {
+        wrapper.SortedSetRandomMember("key", CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRandomMember("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRandomMembers()
+    {
+        wrapper.SortedSetRandomMembers("key", 2, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRandomMembers("prefix:key", 2, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRandomMembersWithScores()
+    {
+        wrapper.SortedSetRandomMembersWithScores("key", 2, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRandomMembersWithScores("prefix:key", 2, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetLengthByValue()
+    {
+        wrapper.SortedSetLengthByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetLengthByValue("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRangeByRank()
+    {
+        wrapper.SortedSetRangeByRank("key", 123, 456, Order.Descending, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRangeByRank("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRangeByRankWithScores()
+    {
+        wrapper.SortedSetRangeByRankWithScores("key", 123, 456, Order.Descending, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRangeByRankWithScores("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRangeByScore()
+    {
+        wrapper.SortedSetRangeByScore("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRangeByScore("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRangeByScoreWithScores()
+    {
+        wrapper.SortedSetRangeByScoreWithScores("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRangeByScoreWithScores("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRangeByValue()
+    {
+        wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, Order.Ascending, 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRangeByValueDesc()
+    {
+        wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRank()
+    {
+        wrapper.SortedSetRank("key", "member", Order.Descending, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRank("prefix:key", "member", Order.Descending, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRemove_1()
+    {
+        wrapper.SortedSetRemove("key", "member", CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRemove("prefix:key", "member", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRemove_2()
+    {
+        RedisValue[] members = Array.Empty<RedisValue>();
+        wrapper.SortedSetRemove("key", members, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRemove("prefix:key", members, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRemoveRangeByRank()
+    {
+        wrapper.SortedSetRemoveRangeByRank("key", 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRemoveRangeByRank("prefix:key", 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRemoveRangeByScore()
+    {
+        wrapper.SortedSetRemoveRangeByScore("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRemoveRangeByScore("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetRemoveRangeByValue()
+    {
+        wrapper.SortedSetRemoveRangeByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetRemoveRangeByValue("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetScan()
+    {
+        wrapper.SortedSetScan("key", "pattern", 123, flags: CommandFlags.None);
+        mock.Verify(_ => _.SortedSetScan("prefix:key", "pattern", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetScan_Full()
+    {
+        wrapper.SortedSetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
+        mock.Verify(_ => _.SortedSetScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetScore()
+    {
+        wrapper.SortedSetScore("key", "member", CommandFlags.None);
+        mock.Verify(_ => _.SortedSetScore("prefix:key", "member", CommandFlags.None));
+    }
+
+    [Fact]
+    public void SortedSetScore_Multiple()
+    {
+        wrapper.SortedSetScores("key", new RedisValue[] { "member1", "member2" }, CommandFlags.None);
+        mock.Verify(_ => _.SortedSetScores("prefix:key", new RedisValue[] { "member1", "member2" }, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamAcknowledge_1()
+    {
+        wrapper.StreamAcknowledge("key", "group", "0-0", CommandFlags.None);
+        mock.Verify(_ => _.StreamAcknowledge("prefix:key", "group", "0-0", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamAcknowledge_2()
+    {
+        var messageIds = new RedisValue[] { "0-0", "0-1", "0-2" };
+        wrapper.StreamAcknowledge("key", "group", messageIds, CommandFlags.None);
+        mock.Verify(_ => _.StreamAcknowledge("prefix:key", "group", messageIds, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamAdd_1()
+    {
+        wrapper.StreamAdd("key", "field1", "value1", "*", 1000, true, CommandFlags.None);
+        mock.Verify(_ => _.StreamAdd("prefix:key", "field1", "value1", "*", 1000, true, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamAdd_2()
+    {
+        var fields = Array.Empty<NameValueEntry>();
+        wrapper.StreamAdd("key", fields, "*", 1000, true, CommandFlags.None);
+        mock.Verify(_ => _.StreamAdd("prefix:key", fields, "*", 1000, true, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamClaimMessages()
+    {
+        var messageIds = Array.Empty<RedisValue>();
+        wrapper.StreamClaim("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
+        mock.Verify(_ => _.StreamClaim("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamClaimMessagesReturningIds()
+    {
+        var messageIds = Array.Empty<RedisValue>();
+        wrapper.StreamClaimIdsOnly("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
+        mock.Verify(_ => _.StreamClaimIdsOnly("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamConsumerGroupSetPosition()
+    {
+        wrapper.StreamConsumerGroupSetPosition("key", "group", StreamPosition.Beginning, CommandFlags.None);
+        mock.Verify(_ => _.StreamConsumerGroupSetPosition("prefix:key", "group", StreamPosition.Beginning, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamConsumerInfoGet()
+    {
+        wrapper.StreamConsumerInfo("key", "group", CommandFlags.None);
+        mock.Verify(_ => _.StreamConsumerInfo("prefix:key", "group", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamCreateConsumerGroup()
+    {
+        wrapper.StreamCreateConsumerGroup("key", "group", StreamPosition.Beginning, false, CommandFlags.None);
+        mock.Verify(_ => _.StreamCreateConsumerGroup("prefix:key", "group", StreamPosition.Beginning, false, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamGroupInfoGet()
+    {
+        wrapper.StreamGroupInfo("key", CommandFlags.None);
+        mock.Verify(_ => _.StreamGroupInfo("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamInfoGet()
+    {
+        wrapper.StreamInfo("key", CommandFlags.None);
+        mock.Verify(_ => _.StreamInfo("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamLength()
+    {
+        wrapper.StreamLength("key", CommandFlags.None);
+        mock.Verify(_ => _.StreamLength("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamMessagesDelete()
+    {
+        var messageIds = Array.Empty<RedisValue>();
+        wrapper.StreamDelete("key", messageIds, CommandFlags.None);
+        mock.Verify(_ => _.StreamDelete("prefix:key", messageIds, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamDeleteConsumer()
+    {
+        wrapper.StreamDeleteConsumer("key", "group", "consumer", CommandFlags.None);
+        mock.Verify(_ => _.StreamDeleteConsumer("prefix:key", "group", "consumer", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamDeleteConsumerGroup()
+    {
+        wrapper.StreamDeleteConsumerGroup("key", "group", CommandFlags.None);
+        mock.Verify(_ => _.StreamDeleteConsumerGroup("prefix:key", "group", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamPendingInfoGet()
+    {
+        wrapper.StreamPending("key", "group", CommandFlags.None);
+        mock.Verify(_ => _.StreamPending("prefix:key", "group", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamPendingMessageInfoGet()
+    {
+        wrapper.StreamPendingMessages("key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None);
+        mock.Verify(_ => _.StreamPendingMessages("prefix:key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamRange()
+    {
+        wrapper.StreamRange("key", "-", "+", null, Order.Ascending, CommandFlags.None);
+        mock.Verify(_ => _.StreamRange("prefix:key", "-", "+", null, Order.Ascending, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamRead_1()
+    {
+        var streamPositions = Array.Empty<StreamPosition>();
+        wrapper.StreamRead(streamPositions, null, CommandFlags.None);
+        mock.Verify(_ => _.StreamRead(streamPositions, null, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamRead_2()
+    {
+        wrapper.StreamRead("key", "0-0", null, CommandFlags.None);
+        mock.Verify(_ => _.StreamRead("prefix:key", "0-0", null, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamStreamReadGroup_1()
+    {
+        wrapper.StreamReadGroup("key", "group", "consumer", "0-0", 10, false, CommandFlags.None);
+        mock.Verify(_ => _.StreamReadGroup("prefix:key", "group", "consumer", "0-0", 10, false, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamStreamReadGroup_2()
+    {
+        var streamPositions = Array.Empty<StreamPosition>();
+        wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
+        mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StreamTrim()
+    {
+        wrapper.StreamTrim("key", 1000, true, CommandFlags.None);
+        mock.Verify(_ => _.StreamTrim("prefix:key", 1000, true, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringAppend()
+    {
+        wrapper.StringAppend("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.StringAppend("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringBitCount()
+    {
+        wrapper.StringBitCount("key", 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.StringBitCount("prefix:key", 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringBitOperation_1()
+    {
+        wrapper.StringBitOperation(Bitwise.Xor, "destination", "first", "second", CommandFlags.None);
+        mock.Verify(_ => _.StringBitOperation(Bitwise.Xor, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringBitOperation_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.StringBitOperation(Bitwise.Xor, "destination", keys, CommandFlags.None);
+        mock.Verify(_ => _.StringBitOperation(Bitwise.Xor, "prefix:destination", It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringBitPosition()
+    {
+        wrapper.StringBitPosition("key", true, 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.StringBitPosition("prefix:key", true, 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringDecrement_1()
+    {
+        wrapper.StringDecrement("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.StringDecrement("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringDecrement_2()
+    {
+        wrapper.StringDecrement("key", 1.23, CommandFlags.None);
+        mock.Verify(_ => _.StringDecrement("prefix:key", 1.23, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGet_1()
+    {
+        wrapper.StringGet("key", CommandFlags.None);
+        mock.Verify(_ => _.StringGet("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGet_2()
+    {
+        RedisKey[] keys = new RedisKey[] { "a", "b" };
+        Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
+        wrapper.StringGet(keys, CommandFlags.None);
+        mock.Verify(_ => _.StringGet(It.Is(valid), CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGetBit()
+    {
+        wrapper.StringGetBit("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.StringGetBit("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGetRange()
+    {
+        wrapper.StringGetRange("key", 123, 456, CommandFlags.None);
+        mock.Verify(_ => _.StringGetRange("prefix:key", 123, 456, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGetSet()
+    {
+        wrapper.StringGetSet("key", "value", CommandFlags.None);
+        mock.Verify(_ => _.StringGetSet("prefix:key", "value", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGetDelete()
+    {
+        wrapper.StringGetDelete("key", CommandFlags.None);
+        mock.Verify(_ => _.StringGetDelete("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringGetWithExpiry()
+    {
+        wrapper.StringGetWithExpiry("key", CommandFlags.None);
+        mock.Verify(_ => _.StringGetWithExpiry("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringIncrement_1()
+    {
+        wrapper.StringIncrement("key", 123, CommandFlags.None);
+        mock.Verify(_ => _.StringIncrement("prefix:key", 123, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringIncrement_2()
+    {
+        wrapper.StringIncrement("key", 1.23, CommandFlags.None);
+        mock.Verify(_ => _.StringIncrement("prefix:key", 1.23, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringLength()
+    {
+        wrapper.StringLength("key", CommandFlags.None);
+        mock.Verify(_ => _.StringLength("prefix:key", CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringSet_1()
+    {
+        TimeSpan expiry = TimeSpan.FromSeconds(123);
+        wrapper.StringSet("key", "value", expiry, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringSet_2()
+    {
+        TimeSpan? expiry = null;
+        wrapper.StringSet("key", "value", expiry, true, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, true, When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringSet_3()
+    {
+        KeyValuePair<RedisKey, RedisValue>[] values = new KeyValuePair<RedisKey, RedisValue>[] { new KeyValuePair<RedisKey, RedisValue>("a", "x"), new KeyValuePair<RedisKey, RedisValue>("b", "y") };
+        Expression<Func<KeyValuePair<RedisKey, RedisValue>[], bool>> valid = _ => _.Length == 2 && _[0].Key == "prefix:a" && _[0].Value == "x" && _[1].Key == "prefix:b" && _[1].Value == "y";
+        wrapper.StringSet(values, When.Exists, CommandFlags.None);
+        mock.Verify(_ => _.StringSet(It.Is(valid), When.Exists, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringSetBit()
+    {
+        wrapper.StringSetBit("key", 123, true, CommandFlags.None);
+        mock.Verify(_ => _.StringSetBit("prefix:key", 123, true, CommandFlags.None));
+    }
+
+    [Fact]
+    public void StringSetRange()
+    {
+        wrapper.StringSetRange("key", 123, "value", CommandFlags.None);
+        mock.Verify(_ => _.StringSetRange("prefix:key", 123, "value", CommandFlags.None));
     }
 }

--- a/tests/StackExchange.Redis.Tests/Databases.cs
+++ b/tests/StackExchange.Redis.Tests/Databases.cs
@@ -2,160 +2,151 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Databases : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Databases : TestBase
+    public Databases(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public async Task CountKeys()
     {
-        public Databases(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
-
-        [Fact]
-        public async Task CountKeys()
+        var db1Id = TestConfig.GetDedicatedDB();
+        var db2Id = TestConfig.GetDedicatedDB();
+        using (var conn = Create(allowAdmin: true))
         {
-            var db1Id = TestConfig.GetDedicatedDB();
-            var db2Id = TestConfig.GetDedicatedDB();
-            using (var muxer = Create(allowAdmin: true))
-            {
-                Skip.IfMissingDatabase(muxer, db1Id);
-                Skip.IfMissingDatabase(muxer, db2Id);
-                var server = GetAnyPrimary(muxer);
-                server.FlushDatabase(db1Id, CommandFlags.FireAndForget);
-                server.FlushDatabase(db2Id, CommandFlags.FireAndForget);
-            }
-            using (var muxer = Create(defaultDatabase: db2Id))
-            {
-                Skip.IfMissingDatabase(muxer, db1Id);
-                Skip.IfMissingDatabase(muxer, db2Id);
-                RedisKey key = Me();
-                var dba = muxer.GetDatabase(db1Id);
-                var dbb = muxer.GetDatabase(db2Id);
-                dba.StringSet("abc", "def", flags: CommandFlags.FireAndForget);
-                dba.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                dbb.StringIncrement(key, flags: CommandFlags.FireAndForget);
-
-                var server = GetAnyPrimary(muxer);
-                var c0 = server.DatabaseSizeAsync(db1Id);
-                var c1 = server.DatabaseSizeAsync(db2Id);
-                var c2 = server.DatabaseSizeAsync(); // using default DB, which is db2Id
-
-                Assert.Equal(2, await c0);
-                Assert.Equal(1, await c1);
-                Assert.Equal(1, await c2);
-            }
+            Skip.IfMissingDatabase(conn, db1Id);
+            Skip.IfMissingDatabase(conn, db2Id);
+            var server = GetAnyPrimary(conn);
+            server.FlushDatabase(db1Id, CommandFlags.FireAndForget);
+            server.FlushDatabase(db2Id, CommandFlags.FireAndForget);
         }
-
-        [Fact]
-        public void DatabaseCount()
+        using (var conn = Create(defaultDatabase: db2Id))
         {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                var server = GetAnyPrimary(muxer);
-                var count = server.DatabaseCount;
-                Log("Count: " + count);
-                var configVal = server.ConfigGet("databases")[0].Value;
-                Log("Config databases: " + configVal);
-                Assert.Equal(int.Parse(configVal), count);
-            }
+            Skip.IfMissingDatabase(conn, db1Id);
+            Skip.IfMissingDatabase(conn, db2Id);
+            RedisKey key = Me();
+            var dba = conn.GetDatabase(db1Id);
+            var dbb = conn.GetDatabase(db2Id);
+            dba.StringSet("abc", "def", flags: CommandFlags.FireAndForget);
+            dba.StringIncrement(key, flags: CommandFlags.FireAndForget);
+            dbb.StringIncrement(key, flags: CommandFlags.FireAndForget);
+
+            var server = GetAnyPrimary(conn);
+            var c0 = server.DatabaseSizeAsync(db1Id);
+            var c1 = server.DatabaseSizeAsync(db2Id);
+            var c2 = server.DatabaseSizeAsync(); // using default DB, which is db2Id
+
+            Assert.Equal(2, await c0);
+            Assert.Equal(1, await c1);
+            Assert.Equal(1, await c2);
         }
+    }
 
-        [Fact]
-        public async Task MultiDatabases()
-        {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me();
-                var db0 = muxer.GetDatabase(TestConfig.GetDedicatedDB(muxer));
-                var db1 = muxer.GetDatabase(TestConfig.GetDedicatedDB(muxer));
-                var db2 = muxer.GetDatabase(TestConfig.GetDedicatedDB(muxer));
+    [Fact]
+    public void DatabaseCount()
+    {
+        using var conn = Create(allowAdmin: true);
 
-                db0.KeyDelete(key, CommandFlags.FireAndForget);
-                db1.KeyDelete(key, CommandFlags.FireAndForget);
-                db2.KeyDelete(key, CommandFlags.FireAndForget);
+        var server = GetAnyPrimary(conn);
+        var count = server.DatabaseCount;
+        Log("Count: " + count);
+        var configVal = server.ConfigGet("databases")[0].Value;
+        Log("Config databases: " + configVal);
+        Assert.Equal(int.Parse(configVal), count);
+    }
 
-                db0.StringSet(key, "a", flags: CommandFlags.FireAndForget);
-                db1.StringSet(key, "b", flags: CommandFlags.FireAndForget);
-                db2.StringSet(key, "c", flags: CommandFlags.FireAndForget);
+    [Fact]
+    public async Task MultiDatabases()
+    {
+        using var conn = Create();
 
-                var a = db0.StringGetAsync(key);
-                var b = db1.StringGetAsync(key);
-                var c = db2.StringGetAsync(key);
+        RedisKey key = Me();
+        var db0 = conn.GetDatabase(TestConfig.GetDedicatedDB(conn));
+        var db1 = conn.GetDatabase(TestConfig.GetDedicatedDB(conn));
+        var db2 = conn.GetDatabase(TestConfig.GetDedicatedDB(conn));
 
-                Assert.Equal("a", await a); // db:0
-                Assert.Equal("b", await b); // db:1
-                Assert.Equal("c", await c); // db:2
-            }
-        }
+        db0.KeyDelete(key, CommandFlags.FireAndForget);
+        db1.KeyDelete(key, CommandFlags.FireAndForget);
+        db2.KeyDelete(key, CommandFlags.FireAndForget);
 
-        [Fact]
-        public async Task SwapDatabases()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v4_0_0);
+        db0.StringSet(key, "a", flags: CommandFlags.FireAndForget);
+        db1.StringSet(key, "b", flags: CommandFlags.FireAndForget);
+        db2.StringSet(key, "c", flags: CommandFlags.FireAndForget);
 
-                RedisKey key = Me();
-                var db0id = TestConfig.GetDedicatedDB(muxer);
-                var db0 = muxer.GetDatabase(db0id);
-                var db1id = TestConfig.GetDedicatedDB(muxer);
-                var db1 = muxer.GetDatabase(db1id);
+        var a = db0.StringGetAsync(key);
+        var b = db1.StringGetAsync(key);
+        var c = db2.StringGetAsync(key);
 
-                db0.KeyDelete(key, CommandFlags.FireAndForget);
-                db1.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.Equal("a", await a); // db:0
+        Assert.Equal("b", await b); // db:1
+        Assert.Equal("c", await c); // db:2
+    }
 
-                db0.StringSet(key, "a", flags: CommandFlags.FireAndForget);
-                db1.StringSet(key, "b", flags: CommandFlags.FireAndForget);
+    [Fact]
+    public async Task SwapDatabases()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v4_0_0);
 
-                var a = db0.StringGetAsync(key);
-                var b = db1.StringGetAsync(key);
+        RedisKey key = Me();
+        var db0id = TestConfig.GetDedicatedDB(conn);
+        var db0 = conn.GetDatabase(db0id);
+        var db1id = TestConfig.GetDedicatedDB(conn);
+        var db1 = conn.GetDatabase(db1id);
 
-                Assert.Equal("a", await a); // db:0
-                Assert.Equal("b", await b); // db:1
+        db0.KeyDelete(key, CommandFlags.FireAndForget);
+        db1.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var server = GetServer(muxer);
-                server.SwapDatabases(db0id, db1id);
+        db0.StringSet(key, "a", flags: CommandFlags.FireAndForget);
+        db1.StringSet(key, "b", flags: CommandFlags.FireAndForget);
 
-                var aNew = db1.StringGetAsync(key);
-                var bNew = db0.StringGetAsync(key);
+        var a = db0.StringGetAsync(key);
+        var b = db1.StringGetAsync(key);
 
-                Assert.Equal("a", await aNew); // db:1
-                Assert.Equal("b", await bNew); // db:0
-            }
-        }
+        Assert.Equal("a", await a); // db:0
+        Assert.Equal("b", await b); // db:1
 
-        [Fact]
-        public async Task SwapDatabasesAsync()
-        {
-            using (var muxer = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v4_0_0);
+        var server = GetServer(conn);
+        server.SwapDatabases(db0id, db1id);
 
-                RedisKey key = Me();
-                var db0id = TestConfig.GetDedicatedDB(muxer);
-                var db0 = muxer.GetDatabase(db0id);
-                var db1id = TestConfig.GetDedicatedDB(muxer);
-                var db1 = muxer.GetDatabase(db1id);
+        var aNew = db1.StringGetAsync(key);
+        var bNew = db0.StringGetAsync(key);
 
-                db0.KeyDelete(key, CommandFlags.FireAndForget);
-                db1.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.Equal("a", await aNew); // db:1
+        Assert.Equal("b", await bNew); // db:0
+    }
 
-                db0.StringSet(key, "a", flags: CommandFlags.FireAndForget);
-                db1.StringSet(key, "b", flags: CommandFlags.FireAndForget);
+    [Fact]
+    public async Task SwapDatabasesAsync()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v4_0_0);
 
-                var a = db0.StringGetAsync(key);
-                var b = db1.StringGetAsync(key);
+        RedisKey key = Me();
+        var db0id = TestConfig.GetDedicatedDB(conn);
+        var db0 = conn.GetDatabase(db0id);
+        var db1id = TestConfig.GetDedicatedDB(conn);
+        var db1 = conn.GetDatabase(db1id);
 
-                Assert.Equal("a", await a); // db:0
-                Assert.Equal("b", await b); // db:1
+        db0.KeyDelete(key, CommandFlags.FireAndForget);
+        db1.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var server = GetServer(muxer);
-                _ = server.SwapDatabasesAsync(db0id, db1id).ForAwait();
+        db0.StringSet(key, "a", flags: CommandFlags.FireAndForget);
+        db1.StringSet(key, "b", flags: CommandFlags.FireAndForget);
 
-                var aNew = db1.StringGetAsync(key);
-                var bNew = db0.StringGetAsync(key);
+        var a = db0.StringGetAsync(key);
+        var b = db1.StringGetAsync(key);
 
-                Assert.Equal("a", await aNew); // db:1
-                Assert.Equal("b", await bNew); // db:0
-            }
-        }
+        Assert.Equal("a", await a); // db:0
+        Assert.Equal("b", await b); // db:1
+
+        var server = GetServer(conn);
+        _ = server.SwapDatabasesAsync(db0id, db1id).ForAwait();
+
+        var aNew = db1.StringGetAsync(key);
+        var bNew = db0.StringGetAsync(key);
+
+        Assert.Equal("a", await aNew); // db:1
+        Assert.Equal("b", await bNew); // db:0
     }
 }

--- a/tests/StackExchange.Redis.Tests/DefaultOptions.cs
+++ b/tests/StackExchange.Redis.Tests/DefaultOptions.cs
@@ -120,9 +120,9 @@ public class DefaultOptions : TestBase
         var provider = new TestAfterConnectOptionsProvider();
         options.Defaults = provider;
 
-        using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
+        using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
 
-        Assert.True(muxer.IsConnected);
+        Assert.True(conn.IsConnected);
         Assert.Equal(1, provider.Calls);
     }
 

--- a/tests/StackExchange.Redis.Tests/DefaultOptions.cs
+++ b/tests/StackExchange.Redis.Tests/DefaultOptions.cs
@@ -7,152 +7,151 @@ using StackExchange.Redis.Configuration;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class DefaultOptions : TestBase
 {
-    public class DefaultOptions : TestBase
+    public DefaultOptions(ITestOutputHelper output) : base(output) { }
+
+    public class TestOptionsProvider : DefaultOptionsProvider
     {
-        public DefaultOptions(ITestOutputHelper output) : base(output) { }
+        private readonly string _domainSuffix;
+        public TestOptionsProvider(string domainSuffix) => _domainSuffix = domainSuffix;
 
-        public class TestOptionsProvider : DefaultOptionsProvider
+        public override bool AbortOnConnectFail => true;
+        public override TimeSpan? ConnectTimeout => TimeSpan.FromSeconds(123);
+        public override bool AllowAdmin => true;
+        public override BacklogPolicy BacklogPolicy => BacklogPolicy.FailFast;
+        public override bool CheckCertificateRevocation => true;
+        public override CommandMap CommandMap => CommandMap.Create(new HashSet<string>() { "SELECT" });
+        public override TimeSpan ConfigCheckInterval => TimeSpan.FromSeconds(124);
+        public override string ConfigurationChannel => "TestConfigChannel";
+        public override int ConnectRetry => 123;
+        public override Version DefaultVersion => new Version(1, 2, 3, 4);
+        protected override string GetDefaultClientName() => "TestPrefix-" + base.GetDefaultClientName();
+        public override bool IsMatch(EndPoint endpoint) => endpoint is DnsEndPoint dnsep && dnsep.Host.EndsWith(_domainSuffix);
+        public override TimeSpan KeepAliveInterval => TimeSpan.FromSeconds(125);
+        public override Proxy Proxy => Proxy.Twemproxy;
+        public override IReconnectRetryPolicy ReconnectRetryPolicy => new TestRetryPolicy();
+        public override bool ResolveDns => true;
+        public override TimeSpan SyncTimeout => TimeSpan.FromSeconds(126);
+        public override string TieBreaker => "TestTiebreaker";
+    }
+
+    public class TestRetryPolicy : IReconnectRetryPolicy
+    {
+        public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry) => false;
+    }
+
+    [Fact]
+    public void IsMatchOnDomain()
+    {
+        DefaultOptionsProvider.AddProvider(new TestOptionsProvider(".testdomain"));
+
+        var epc = new EndPointCollection(new List<EndPoint>() { new DnsEndPoint("local.testdomain", 0) });
+        var provider = DefaultOptionsProvider.GetForEndpoints(epc);
+        Assert.IsType<TestOptionsProvider>(provider);
+
+        epc = new EndPointCollection(new List<EndPoint>() { new DnsEndPoint("local.nottestdomain", 0) });
+        provider = DefaultOptionsProvider.GetForEndpoints(epc);
+        Assert.IsType<DefaultOptionsProvider>(provider);
+    }
+
+    [Fact]
+    public void AllOverridesFromDefaultsProp()
+    {
+        var options = ConfigurationOptions.Parse("localhost");
+        Assert.IsType<DefaultOptionsProvider>(options.Defaults);
+        options.Defaults = new TestOptionsProvider("");
+        Assert.IsType<TestOptionsProvider>(options.Defaults);
+        AssertAllOverrides(options);
+    }
+
+    [Fact]
+    public void AllOverridesFromEndpointsParse()
+    {
+        DefaultOptionsProvider.AddProvider(new TestOptionsProvider(".parse"));
+        var options = ConfigurationOptions.Parse("localhost.parse:6379");
+        Assert.IsType<TestOptionsProvider>(options.Defaults);
+        AssertAllOverrides(options);
+    }
+
+    private static void AssertAllOverrides(ConfigurationOptions options)
+    {
+        Assert.True(options.AbortOnConnectFail);
+        Assert.Equal(TimeSpan.FromSeconds(123), TimeSpan.FromMilliseconds(options.ConnectTimeout));
+
+        Assert.True(options.AllowAdmin);
+        Assert.Equal(BacklogPolicy.FailFast, options.BacklogPolicy);
+        Assert.True(options.CheckCertificateRevocation);
+
+        Assert.True(options.CommandMap.IsAvailable(RedisCommand.SELECT));
+        Assert.False(options.CommandMap.IsAvailable(RedisCommand.GET));
+
+        Assert.Equal(TimeSpan.FromSeconds(124), TimeSpan.FromSeconds(options.ConfigCheckSeconds));
+        Assert.Equal("TestConfigChannel", options.ConfigurationChannel);
+        Assert.Equal(123, options.ConnectRetry);
+        Assert.Equal(new Version(1, 2, 3, 4), options.DefaultVersion);
+
+        Assert.Equal(TimeSpan.FromSeconds(125), TimeSpan.FromSeconds(options.KeepAlive));
+        Assert.Equal(Proxy.Twemproxy, options.Proxy);
+        Assert.IsType<TestRetryPolicy>(options.ReconnectRetryPolicy);
+        Assert.True(options.ResolveDns);
+        Assert.Equal(TimeSpan.FromSeconds(126), TimeSpan.FromMilliseconds(options.SyncTimeout));
+        Assert.Equal("TestTiebreaker", options.TieBreaker);
+    }
+
+    public class TestAfterConnectOptionsProvider : DefaultOptionsProvider
+    {
+        public int Calls;
+
+        public override Task AfterConnectAsync(ConnectionMultiplexer muxer, Action<string> log)
         {
-            private readonly string _domainSuffix;
-            public TestOptionsProvider(string domainSuffix) => _domainSuffix = domainSuffix;
-
-            public override bool AbortOnConnectFail => true;
-            public override TimeSpan? ConnectTimeout => TimeSpan.FromSeconds(123);
-            public override bool AllowAdmin => true;
-            public override BacklogPolicy BacklogPolicy => BacklogPolicy.FailFast;
-            public override bool CheckCertificateRevocation => true;
-            public override CommandMap CommandMap => CommandMap.Create(new HashSet<string>() { "SELECT" });
-            public override TimeSpan ConfigCheckInterval => TimeSpan.FromSeconds(124);
-            public override string ConfigurationChannel => "TestConfigChannel";
-            public override int ConnectRetry => 123;
-            public override Version DefaultVersion => new Version(1, 2, 3, 4);
-            protected override string GetDefaultClientName() => "TestPrefix-" + base.GetDefaultClientName();
-            public override bool IsMatch(EndPoint endpoint) => endpoint is DnsEndPoint dnsep && dnsep.Host.EndsWith(_domainSuffix);
-            public override TimeSpan KeepAliveInterval => TimeSpan.FromSeconds(125);
-            public override Proxy Proxy => Proxy.Twemproxy;
-            public override IReconnectRetryPolicy ReconnectRetryPolicy => new TestRetryPolicy();
-            public override bool ResolveDns => true;
-            public override TimeSpan SyncTimeout => TimeSpan.FromSeconds(126);
-            public override string TieBreaker => "TestTiebreaker";
+            Interlocked.Increment(ref Calls);
+            log("TestAfterConnectOptionsProvider.AfterConnectAsync!");
+            return Task.CompletedTask;
         }
+    }
 
-        public class TestRetryPolicy : IReconnectRetryPolicy
-        {
-            public bool ShouldRetry(long currentRetryCount, int timeElapsedMillisecondsSinceLastRetry) => false;
-        }
+    [Fact]
+    public async Task AfterConnectAsyncHandler()
+    {
+        var options = ConfigurationOptions.Parse(GetConfiguration());
+        var provider = new TestAfterConnectOptionsProvider();
+        options.Defaults = provider;
 
-        [Fact]
-        public void IsMatchOnDomain()
-        {
-            DefaultOptionsProvider.AddProvider(new TestOptionsProvider(".testdomain"));
+        using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
 
-            var epc = new EndPointCollection(new List<EndPoint>() { new DnsEndPoint("local.testdomain", 0) });
-            var provider = DefaultOptionsProvider.GetForEndpoints(epc);
-            Assert.IsType<TestOptionsProvider>(provider);
+        Assert.True(muxer.IsConnected);
+        Assert.Equal(1, provider.Calls);
+    }
 
-            epc = new EndPointCollection(new List<EndPoint>() { new DnsEndPoint("local.nottestdomain", 0) });
-            provider = DefaultOptionsProvider.GetForEndpoints(epc);
-            Assert.IsType<DefaultOptionsProvider>(provider);
-        }
+    public class TestClientNameOptionsProvider : DefaultOptionsProvider
+    {
+        protected override string GetDefaultClientName() => "Hey there";
+    }
 
-        [Fact]
-        public void AllOverridesFromDefaultsProp()
-        {
-            var options = ConfigurationOptions.Parse("localhost");
-            Assert.IsType<DefaultOptionsProvider>(options.Defaults);
-            options.Defaults = new TestOptionsProvider("");
-            Assert.IsType<TestOptionsProvider>(options.Defaults);
-            AssertAllOverrides(options);
-        }
+    [Fact]
+    public async Task ClientNameOverride()
+    {
+        var options = ConfigurationOptions.Parse(GetConfiguration());
+        options.Defaults = new TestClientNameOptionsProvider();
 
-        [Fact]
-        public void AllOverridesFromEndpointsParse()
-        {
-            DefaultOptionsProvider.AddProvider(new TestOptionsProvider(".parse"));
-            var options = ConfigurationOptions.Parse("localhost.parse:6379");
-            Assert.IsType<TestOptionsProvider>(options.Defaults);
-            AssertAllOverrides(options);
-        }
+        using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
 
-        private static void AssertAllOverrides(ConfigurationOptions options)
-        {
-            Assert.True(options.AbortOnConnectFail);
-            Assert.Equal(TimeSpan.FromSeconds(123), TimeSpan.FromMilliseconds(options.ConnectTimeout));
+        Assert.True(conn.IsConnected);
+        Assert.Equal("Hey there", conn.ClientName);
+    }
 
-            Assert.True(options.AllowAdmin);
-            Assert.Equal(BacklogPolicy.FailFast, options.BacklogPolicy);
-            Assert.True(options.CheckCertificateRevocation);
+    [Fact]
+    public async Task ClientNameExplicitWins()
+    {
+        var options = ConfigurationOptions.Parse(GetConfiguration() + ",name=FooBar");
+        options.Defaults = new TestClientNameOptionsProvider();
 
-            Assert.True(options.CommandMap.IsAvailable(RedisCommand.SELECT));
-            Assert.False(options.CommandMap.IsAvailable(RedisCommand.GET));
+        using var conn = await ConnectionMultiplexer.ConnectAsync(options, Writer);
 
-            Assert.Equal(TimeSpan.FromSeconds(124), TimeSpan.FromSeconds(options.ConfigCheckSeconds));
-            Assert.Equal("TestConfigChannel", options.ConfigurationChannel);
-            Assert.Equal(123, options.ConnectRetry);
-            Assert.Equal(new Version(1, 2, 3, 4), options.DefaultVersion);
-
-            Assert.Equal(TimeSpan.FromSeconds(125), TimeSpan.FromSeconds(options.KeepAlive));
-            Assert.Equal(Proxy.Twemproxy, options.Proxy);
-            Assert.IsType<TestRetryPolicy>(options.ReconnectRetryPolicy);
-            Assert.True(options.ResolveDns);
-            Assert.Equal(TimeSpan.FromSeconds(126), TimeSpan.FromMilliseconds(options.SyncTimeout));
-            Assert.Equal("TestTiebreaker", options.TieBreaker);
-        }
-
-        public class TestAfterConnectOptionsProvider : DefaultOptionsProvider
-        {
-            public int Calls;
-
-            public override Task AfterConnectAsync(ConnectionMultiplexer muxer, Action<string> log)
-            {
-                Interlocked.Increment(ref Calls);
-                log("TestAfterConnectOptionsProvider.AfterConnectAsync!");
-                return Task.CompletedTask;
-            }
-        }
-
-        [Fact]
-        public async Task AfterConnectAsyncHandler()
-        {
-            var options = ConfigurationOptions.Parse(GetConfiguration());
-            var provider = new TestAfterConnectOptionsProvider();
-            options.Defaults = provider;
-
-            using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-
-            Assert.True(muxer.IsConnected);
-            Assert.Equal(1, provider.Calls);
-        }
-
-        public class TestClientNameOptionsProvider : DefaultOptionsProvider
-        {
-            protected override string GetDefaultClientName() => "Hey there";
-        }
-
-        [Fact]
-        public async Task ClientNameOverride()
-        {
-            var options = ConfigurationOptions.Parse(GetConfiguration());
-            options.Defaults = new TestClientNameOptionsProvider();
-
-            using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-
-            Assert.True(muxer.IsConnected);
-            Assert.Equal("Hey there", muxer.ClientName);
-        }
-
-        [Fact]
-        public async Task ClientNameExplicitWins()
-        {
-            var options = ConfigurationOptions.Parse(GetConfiguration() + ",name=FooBar");
-            options.Defaults = new TestClientNameOptionsProvider();
-
-            using var muxer = await ConnectionMultiplexer.ConnectAsync(options, Writer);
-
-            Assert.True(muxer.IsConnected);
-            Assert.Equal("FooBar", muxer.ClientName);
-        }
+        Assert.True(conn.IsConnected);
+        Assert.Equal("FooBar", conn.ClientName);
     }
 }

--- a/tests/StackExchange.Redis.Tests/DefaultPorts.cs
+++ b/tests/StackExchange.Redis.Tests/DefaultPorts.cs
@@ -2,57 +2,56 @@
 using System.Net;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class DefaultPorts
 {
-    public class DefaultPorts
+    [Theory]
+    [InlineData("foo", 6379)]
+    [InlineData("foo:6379", 6379)]
+    [InlineData("foo:6380", 6380)]
+    [InlineData("foo,ssl=false", 6379)]
+    [InlineData("foo:6379,ssl=false", 6379)]
+    [InlineData("foo:6380,ssl=false", 6380)]
+
+    [InlineData("foo,ssl=true", 6380)]
+    [InlineData("foo:6379,ssl=true", 6379)]
+    [InlineData("foo:6380,ssl=true", 6380)]
+    [InlineData("foo:6381,ssl=true", 6381)]
+    public void ConfigStringRoundTripWithDefaultPorts(string config, int expectedPort)
     {
-        [Theory]
-        [InlineData("foo", 6379)]
-        [InlineData("foo:6379", 6379)]
-        [InlineData("foo:6380", 6380)]
-        [InlineData("foo,ssl=false", 6379)]
-        [InlineData("foo:6379,ssl=false", 6379)]
-        [InlineData("foo:6380,ssl=false", 6380)]
+        var options = ConfigurationOptions.Parse(config);
+        string backAgain = options.ToString();
+        Assert.Equal(config, backAgain.Replace("=True", "=true").Replace("=False", "=false"));
 
-        [InlineData("foo,ssl=true", 6380)]
-        [InlineData("foo:6379,ssl=true", 6379)]
-        [InlineData("foo:6380,ssl=true", 6380)]
-        [InlineData("foo:6381,ssl=true", 6381)]
-        public void ConfigStringRoundTripWithDefaultPorts(string config, int expectedPort)
+        options.SetDefaultPorts(); // normally it is the multiplexer that calls this, not us
+        Assert.Equal(expectedPort, ((DnsEndPoint)options.EndPoints.Single()).Port);
+    }
+
+    [Theory]
+    [InlineData("foo", 0, false, 6379)]
+    [InlineData("foo", 6379, false, 6379)]
+    [InlineData("foo", 6380, false, 6380)]
+
+    [InlineData("foo", 0, true, 6380)]
+    [InlineData("foo", 6379, true, 6379)]
+    [InlineData("foo", 6380, true, 6380)]
+    [InlineData("foo", 6381, true, 6381)]
+
+    public void ConfigManualWithDefaultPorts(string host, int port, bool useSsl, int expectedPort)
+    {
+        var options = new ConfigurationOptions();
+        if (port == 0)
         {
-            var options = ConfigurationOptions.Parse(config);
-            string backAgain = options.ToString();
-            Assert.Equal(config, backAgain.Replace("=True", "=true").Replace("=False", "=false"));
-
-            options.SetDefaultPorts(); // normally it is the multiplexer that calls this, not us
-            Assert.Equal(expectedPort, ((DnsEndPoint)options.EndPoints.Single()).Port);
+            options.EndPoints.Add(host);
         }
-
-        [Theory]
-        [InlineData("foo", 0, false, 6379)]
-        [InlineData("foo", 6379, false, 6379)]
-        [InlineData("foo", 6380, false, 6380)]
-
-        [InlineData("foo", 0, true, 6380)]
-        [InlineData("foo", 6379, true, 6379)]
-        [InlineData("foo", 6380, true, 6380)]
-        [InlineData("foo", 6381, true, 6381)]
-
-        public void ConfigManualWithDefaultPorts(string host, int port, bool useSsl, int expectedPort)
+        else
         {
-            var options = new ConfigurationOptions();
-            if (port == 0)
-            {
-                options.EndPoints.Add(host);
-            }
-            else
-            {
-                options.EndPoints.Add(host, port);
-            }
-            if (useSsl) options.Ssl = true;
-
-            options.SetDefaultPorts(); // normally it is the multiplexer that calls this, not us
-            Assert.Equal(expectedPort, ((DnsEndPoint)options.EndPoints.Single()).Port);
+            options.EndPoints.Add(host, port);
         }
+        if (useSsl) options.Ssl = true;
+
+        options.SetDefaultPorts(); // normally it is the multiplexer that calls this, not us
+        Assert.Equal(expectedPort, ((DnsEndPoint)options.EndPoints.Single()).Port);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Deprecated.cs
+++ b/tests/StackExchange.Redis.Tests/Deprecated.cs
@@ -2,73 +2,72 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Testing that things we deprecate still parse, but are otherwise defaults.
+/// </summary>
+public class Deprecated : TestBase
 {
-    /// <summary>
-    /// Testing that things we deprecate still parse, but are otherwise defaults.
-    /// </summary>
-    public class Deprecated : TestBase
-    {
-        public Deprecated(ITestOutputHelper output) : base(output) { }
+    public Deprecated(ITestOutputHelper output) : base(output) { }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        [Fact]
-        public void HighPrioritySocketThreads()
-        {
-            Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.HighPrioritySocketThreads))!, typeof(ObsoleteAttribute)));
+    [Fact]
+    public void HighPrioritySocketThreads()
+    {
+        Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.HighPrioritySocketThreads))!, typeof(ObsoleteAttribute)));
 
-            var options = ConfigurationOptions.Parse("name=Hello");
-            Assert.False(options.HighPrioritySocketThreads);
+        var options = ConfigurationOptions.Parse("name=Hello");
+        Assert.False(options.HighPrioritySocketThreads);
 
-            options = ConfigurationOptions.Parse("highPriorityThreads=true");
-            Assert.Equal("", options.ToString());
-            Assert.False(options.HighPrioritySocketThreads);
+        options = ConfigurationOptions.Parse("highPriorityThreads=true");
+        Assert.Equal("", options.ToString());
+        Assert.False(options.HighPrioritySocketThreads);
 
-            options = ConfigurationOptions.Parse("highPriorityThreads=false");
-            Assert.Equal("", options.ToString());
-            Assert.False(options.HighPrioritySocketThreads);
-        }
-
-        [Fact]
-        public void PreserveAsyncOrder()
-        {
-            Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.PreserveAsyncOrder))!, typeof(ObsoleteAttribute)));
-
-            var options = ConfigurationOptions.Parse("name=Hello");
-            Assert.False(options.PreserveAsyncOrder);
-
-            options = ConfigurationOptions.Parse("preserveAsyncOrder=true");
-            Assert.Equal("", options.ToString());
-            Assert.False(options.PreserveAsyncOrder);
-
-            options = ConfigurationOptions.Parse("preserveAsyncOrder=false");
-            Assert.Equal("", options.ToString());
-            Assert.False(options.PreserveAsyncOrder);
-        }
-
-        [Fact]
-        public void WriteBufferParse()
-        {
-            Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.WriteBuffer))!, typeof(ObsoleteAttribute)));
-
-            var options = ConfigurationOptions.Parse("name=Hello");
-            Assert.Equal(0, options.WriteBuffer);
-
-            options = ConfigurationOptions.Parse("writeBuffer=8092");
-            Assert.Equal(0, options.WriteBuffer);
-        }
-
-        [Fact]
-        public void ResponseTimeout()
-        {
-            Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.ResponseTimeout))!, typeof(ObsoleteAttribute)));
-
-            var options = ConfigurationOptions.Parse("name=Hello");
-            Assert.Equal(0, options.ResponseTimeout);
-
-            options = ConfigurationOptions.Parse("responseTimeout=1000");
-            Assert.Equal(0, options.ResponseTimeout);
-        }
-#pragma warning restore CS0618
+        options = ConfigurationOptions.Parse("highPriorityThreads=false");
+        Assert.Equal("", options.ToString());
+        Assert.False(options.HighPrioritySocketThreads);
     }
+
+    [Fact]
+    public void PreserveAsyncOrder()
+    {
+        Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.PreserveAsyncOrder))!, typeof(ObsoleteAttribute)));
+
+        var options = ConfigurationOptions.Parse("name=Hello");
+        Assert.False(options.PreserveAsyncOrder);
+
+        options = ConfigurationOptions.Parse("preserveAsyncOrder=true");
+        Assert.Equal("", options.ToString());
+        Assert.False(options.PreserveAsyncOrder);
+
+        options = ConfigurationOptions.Parse("preserveAsyncOrder=false");
+        Assert.Equal("", options.ToString());
+        Assert.False(options.PreserveAsyncOrder);
+    }
+
+    [Fact]
+    public void WriteBufferParse()
+    {
+        Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.WriteBuffer))!, typeof(ObsoleteAttribute)));
+
+        var options = ConfigurationOptions.Parse("name=Hello");
+        Assert.Equal(0, options.WriteBuffer);
+
+        options = ConfigurationOptions.Parse("writeBuffer=8092");
+        Assert.Equal(0, options.WriteBuffer);
+    }
+
+    [Fact]
+    public void ResponseTimeout()
+    {
+        Assert.True(Attribute.IsDefined(typeof(ConfigurationOptions).GetProperty(nameof(ConfigurationOptions.ResponseTimeout))!, typeof(ObsoleteAttribute)));
+
+        var options = ConfigurationOptions.Parse("name=Hello");
+        Assert.Equal(0, options.ResponseTimeout);
+
+        options = ConfigurationOptions.Parse("responseTimeout=1000");
+        Assert.Equal(0, options.ResponseTimeout);
+    }
+#pragma warning restore CS0618
 }

--- a/tests/StackExchange.Redis.Tests/EnvoyTests.cs
+++ b/tests/StackExchange.Redis.Tests/EnvoyTests.cs
@@ -3,49 +3,47 @@ using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class EnvoyTests : TestBase
 {
-    public class EnvoyTests : TestBase
+    public EnvoyTests(ITestOutputHelper output) : base(output) { }
+
+    protected override string GetConfiguration() => TestConfig.Current.ProxyServerAndPort;
+
+    /// <summary>
+    /// Tests basic envoy connection with the ability to set and get a key.
+    /// </summary>
+    [Fact]
+    public void TestBasicEnvoyConnection()
     {
-        public EnvoyTests(ITestOutputHelper output) : base(output) { }
-
-        protected override string GetConfiguration() => TestConfig.Current.ProxyServerAndPort;
-
-        /// <summary>
-        /// Tests basic envoy connection with the ability to set and get a key.
-        /// </summary>
-        [Fact]
-        public void TestBasicEnvoyConnection()
+        var sb = new StringBuilder();
+        Writer.EchoTo(sb);
+        try
         {
-            var sb = new StringBuilder();
-            Writer.EchoTo(sb);
-            try
-            {
-                using (var muxer = Create(configuration: GetConfiguration(), keepAlive: 1, connectTimeout: 2000, allowAdmin: true, shared: false, proxy: Proxy.Envoyproxy, log: Writer))
-                {
-                    var db = muxer.GetDatabase();
+            using var conn = Create(configuration: GetConfiguration(), keepAlive: 1, connectTimeout: 2000, allowAdmin: true, shared: false, proxy: Proxy.Envoyproxy, log: Writer);
 
-                    const string key = "foobar";
-                    const string value = "barfoo";
-                    db.StringSet(key, value);
+            var db = conn.GetDatabase();
 
-                    var expectedVal = db.StringGet(key);
+            const string key = "foobar";
+            const string value = "barfoo";
+            db.StringSet(key, value);
 
-                    Assert.Equal(expectedVal, value);
-                }
-            }
-            catch (TimeoutException ex) when (ex.Message == "Connect timeout" || sb.ToString().Contains("Returned, but incorrectly"))
-            {
-                Skip.Inconclusive("Envoy server not found.");
-            }
-            catch (AggregateException)
-            {
-                Skip.Inconclusive("Envoy server not found.");
-            }
-            catch (RedisConnectionException) when (sb.ToString().Contains("It was not possible to connect to the redis server(s)"))
-            {
-                Skip.Inconclusive("Envoy server not found.");
-            }
+            var expectedVal = db.StringGet(key);
+
+            Assert.Equal(expectedVal, value);
+        }
+        catch (TimeoutException ex) when (ex.Message == "Connect timeout" || sb.ToString().Contains("Returned, but incorrectly"))
+        {
+            Skip.Inconclusive("Envoy server not found.");
+        }
+        catch (AggregateException)
+        {
+            Skip.Inconclusive("Envoy server not found.");
+        }
+        catch (RedisConnectionException) when (sb.ToString().Contains("It was not possible to connect to the redis server(s)"))
+        {
+            Skip.Inconclusive("Envoy server not found.");
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/EventArgsTests.cs
+++ b/tests/StackExchange.Redis.Tests/EventArgsTests.cs
@@ -2,81 +2,80 @@
 using NSubstitute;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class EventArgsTests
 {
-    public class EventArgsTests
+    [Fact]
+    public void EventArgsCanBeSubstituted()
     {
-        [Fact]
-        public void EventArgsCanBeSubstituted()
+        EndPointEventArgs endpointArgsMock
+            = Substitute.For<EndPointEventArgs>(default, default);
+
+        RedisErrorEventArgs redisErrorArgsMock
+            = Substitute.For<RedisErrorEventArgs>(default, default, default);
+
+        ConnectionFailedEventArgs connectionFailedArgsMock
+            = Substitute.For<ConnectionFailedEventArgs>(default, default, default, default, default, default);
+
+        InternalErrorEventArgs internalErrorArgsMock
+            = Substitute.For<InternalErrorEventArgs>(default, default, default, default, default);
+
+        HashSlotMovedEventArgs hashSlotMovedArgsMock
+            = Substitute.For<HashSlotMovedEventArgs>(default, default, default, default);
+
+        DiagnosticStub stub = new DiagnosticStub();
+
+        stub.ConfigurationChangedBroadcastHandler(default, endpointArgsMock);
+        Assert.Equal(stub.Message,DiagnosticStub.ConfigurationChangedBroadcastHandlerMessage);
+
+        stub.ErrorMessageHandler(default, redisErrorArgsMock);
+        Assert.Equal(stub.Message, DiagnosticStub.ErrorMessageHandlerMessage);
+
+        stub.ConnectionFailedHandler(default, connectionFailedArgsMock);
+        Assert.Equal(stub.Message, DiagnosticStub.ConnectionFailedHandlerMessage);
+
+        stub.InternalErrorHandler(default, internalErrorArgsMock);
+        Assert.Equal(stub.Message, DiagnosticStub.InternalErrorHandlerMessage);
+
+        stub.ConnectionRestoredHandler(default, connectionFailedArgsMock);
+        Assert.Equal(stub.Message, DiagnosticStub.ConnectionRestoredHandlerMessage);
+
+        stub.ConfigurationChangedHandler(default, endpointArgsMock);
+        Assert.Equal(stub.Message, DiagnosticStub.ConfigurationChangedHandlerMessage);
+
+        stub.HashSlotMovedHandler(default, hashSlotMovedArgsMock);
+        Assert.Equal(stub.Message, DiagnosticStub.HashSlotMovedHandlerMessage);
+    }
+
+    public class DiagnosticStub
+    {
+        public const string ConfigurationChangedBroadcastHandlerMessage = "ConfigurationChangedBroadcastHandler invoked";
+        public const string ErrorMessageHandlerMessage = "ErrorMessageHandler invoked";
+        public const string ConnectionFailedHandlerMessage = "ConnectionFailedHandler invoked";
+        public const string InternalErrorHandlerMessage = "InternalErrorHandler invoked";
+        public const string ConnectionRestoredHandlerMessage = "ConnectionRestoredHandler invoked";
+        public const string ConfigurationChangedHandlerMessage = "ConfigurationChangedHandler invoked";
+        public const string HashSlotMovedHandlerMessage = "HashSlotMovedHandler invoked";
+
+        public DiagnosticStub()
         {
-            EndPointEventArgs endpointArgsMock
-                = Substitute.For<EndPointEventArgs>(default, default);
-
-            RedisErrorEventArgs redisErrorArgsMock
-                = Substitute.For<RedisErrorEventArgs>(default, default, default);
-
-            ConnectionFailedEventArgs connectionFailedArgsMock
-                = Substitute.For<ConnectionFailedEventArgs>(default, default, default, default, default, default);
-
-            InternalErrorEventArgs internalErrorArgsMock
-                = Substitute.For<InternalErrorEventArgs>(default, default, default, default, default);
-
-            HashSlotMovedEventArgs hashSlotMovedArgsMock
-                = Substitute.For<HashSlotMovedEventArgs>(default, default, default, default);
-
-            DiagnosticStub stub = new DiagnosticStub();
-
-            stub.ConfigurationChangedBroadcastHandler(default, endpointArgsMock);
-            Assert.Equal(stub.Message,DiagnosticStub.ConfigurationChangedBroadcastHandlerMessage);
-
-            stub.ErrorMessageHandler(default, redisErrorArgsMock);
-            Assert.Equal(stub.Message, DiagnosticStub.ErrorMessageHandlerMessage);
-
-            stub.ConnectionFailedHandler(default, connectionFailedArgsMock);
-            Assert.Equal(stub.Message, DiagnosticStub.ConnectionFailedHandlerMessage);
-
-            stub.InternalErrorHandler(default, internalErrorArgsMock);
-            Assert.Equal(stub.Message, DiagnosticStub.InternalErrorHandlerMessage);
-
-            stub.ConnectionRestoredHandler(default, connectionFailedArgsMock);
-            Assert.Equal(stub.Message, DiagnosticStub.ConnectionRestoredHandlerMessage);
-
-            stub.ConfigurationChangedHandler(default, endpointArgsMock);
-            Assert.Equal(stub.Message, DiagnosticStub.ConfigurationChangedHandlerMessage);
-
-            stub.HashSlotMovedHandler(default, hashSlotMovedArgsMock);
-            Assert.Equal(stub.Message, DiagnosticStub.HashSlotMovedHandlerMessage);
+            ConfigurationChangedBroadcastHandler = (obj, args) => Message = ConfigurationChangedBroadcastHandlerMessage;
+            ErrorMessageHandler = (obj, args) => Message = ErrorMessageHandlerMessage;
+            ConnectionFailedHandler = (obj, args) => Message = ConnectionFailedHandlerMessage;
+            InternalErrorHandler = (obj, args) => Message = InternalErrorHandlerMessage;
+            ConnectionRestoredHandler = (obj, args) => Message = ConnectionRestoredHandlerMessage;
+            ConfigurationChangedHandler = (obj, args) => Message = ConfigurationChangedHandlerMessage;
+            HashSlotMovedHandler = (obj, args) => Message = HashSlotMovedHandlerMessage;
         }
 
-        public class DiagnosticStub
-        {
-            public const string ConfigurationChangedBroadcastHandlerMessage = "ConfigurationChangedBroadcastHandler invoked";
-            public const string ErrorMessageHandlerMessage = "ErrorMessageHandler invoked";
-            public const string ConnectionFailedHandlerMessage = "ConnectionFailedHandler invoked";
-            public const string InternalErrorHandlerMessage = "InternalErrorHandler invoked";
-            public const string ConnectionRestoredHandlerMessage = "ConnectionRestoredHandler invoked";
-            public const string ConfigurationChangedHandlerMessage = "ConfigurationChangedHandler invoked";
-            public const string HashSlotMovedHandlerMessage = "HashSlotMovedHandler invoked";
-
-            public DiagnosticStub()
-            {
-                ConfigurationChangedBroadcastHandler = (obj, args) => Message = ConfigurationChangedBroadcastHandlerMessage;
-                ErrorMessageHandler = (obj, args) => Message = ErrorMessageHandlerMessage;
-                ConnectionFailedHandler = (obj, args) => Message = ConnectionFailedHandlerMessage;
-                InternalErrorHandler = (obj, args) => Message = InternalErrorHandlerMessage;
-                ConnectionRestoredHandler = (obj, args) => Message = ConnectionRestoredHandlerMessage;
-                ConfigurationChangedHandler = (obj, args) => Message = ConfigurationChangedHandlerMessage;
-                HashSlotMovedHandler = (obj, args) => Message = HashSlotMovedHandlerMessage;
-            }
-
-            public string? Message { get; private set; }
-            public Action<object?, EndPointEventArgs> ConfigurationChangedBroadcastHandler { get; }
-            public Action<object?, RedisErrorEventArgs> ErrorMessageHandler { get; }
-            public Action<object?, ConnectionFailedEventArgs> ConnectionFailedHandler { get; }
-            public Action<object?, InternalErrorEventArgs> InternalErrorHandler { get; }
-            public Action<object?, ConnectionFailedEventArgs> ConnectionRestoredHandler { get; }
-            public Action<object?, EndPointEventArgs> ConfigurationChangedHandler { get; }
-            public Action<object?, HashSlotMovedEventArgs> HashSlotMovedHandler { get; }
-        }
+        public string? Message { get; private set; }
+        public Action<object?, EndPointEventArgs> ConfigurationChangedBroadcastHandler { get; }
+        public Action<object?, RedisErrorEventArgs> ErrorMessageHandler { get; }
+        public Action<object?, ConnectionFailedEventArgs> ConnectionFailedHandler { get; }
+        public Action<object?, InternalErrorEventArgs> InternalErrorHandler { get; }
+        public Action<object?, ConnectionFailedEventArgs> ConnectionRestoredHandler { get; }
+        public Action<object?, EndPointEventArgs> ConfigurationChangedHandler { get; }
+        public Action<object?, HashSlotMovedEventArgs> HashSlotMovedHandler { get; }
     }
 }

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -2,237 +2,232 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ExceptionFactoryTests : TestBase
 {
-    public class ExceptionFactoryTests : TestBase
+    public ExceptionFactoryTests(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void NullLastException()
     {
-        public ExceptionFactoryTests(ITestOutputHelper output) : base (output) { }
+        using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true);
 
-        [Fact]
-        public void NullLastException()
-        {
-            using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
-            {
-                muxer.GetDatabase();
-                Assert.Null(muxer.GetServerSnapshot()[0].LastException);
-                var ex = ExceptionFactory.NoConnectionAvailable((muxer as ConnectionMultiplexer)!, null, null);
-                Assert.Null(ex.InnerException);
-            }
-        }
+        conn.GetDatabase();
+        Assert.Null(conn.GetServerSnapshot()[0].LastException);
+        var ex = ExceptionFactory.NoConnectionAvailable((conn as ConnectionMultiplexer)!, null, null);
+        Assert.Null(ex.InnerException);
+    }
 
-        [Fact]
-        public void CanGetVersion()
-        {
-            var libVer = Utils.GetLibVersion();
-            Assert.Matches(@"2\.[0-9]+\.[0-9]+(\.[0-9]+)?", libVer);
-        }
+    [Fact]
+    public void CanGetVersion()
+    {
+        var libVer = Utils.GetLibVersion();
+        Assert.Matches(@"2\.[0-9]+\.[0-9]+(\.[0-9]+)?", libVer);
+    }
 
 #if DEBUG
-        [Fact]
-        public void MultipleEndpointsThrowConnectionException()
+    [Fact]
+    public void MultipleEndpointsThrowConnectionException()
+    {
+        try
         {
-            try
-            {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false))
-                {
-                    muxer.GetDatabase();
-                    muxer.AllowConnect = false;
+            using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false);
 
-                    foreach (var endpoint in muxer.GetEndPoints())
-                    {
-                        muxer.GetServer(endpoint).SimulateConnectionFailure(SimulatedFailureType.All);
-                    }
+            conn.GetDatabase();
+            conn.AllowConnect = false;
 
-                    var ex = ExceptionFactory.NoConnectionAvailable((muxer as ConnectionMultiplexer)!, null, null);
-                    var outer = Assert.IsType<RedisConnectionException>(ex);
-                    Assert.Equal(ConnectionFailureType.UnableToResolvePhysicalConnection, outer.FailureType);
-                    var inner = Assert.IsType<RedisConnectionException>(outer.InnerException);
-                    Assert.True(inner.FailureType == ConnectionFailureType.SocketFailure
-                             || inner.FailureType == ConnectionFailureType.InternalFailure);
-                }
-            }
-            finally
+            foreach (var endpoint in conn.GetEndPoints())
             {
-                ClearAmbientFailures();
+                conn.GetServer(endpoint).SimulateConnectionFailure(SimulatedFailureType.All);
             }
+
+            var ex = ExceptionFactory.NoConnectionAvailable((conn as ConnectionMultiplexer)!, null, null);
+            var outer = Assert.IsType<RedisConnectionException>(ex);
+            Assert.Equal(ConnectionFailureType.UnableToResolvePhysicalConnection, outer.FailureType);
+            var inner = Assert.IsType<RedisConnectionException>(outer.InnerException);
+            Assert.True(inner.FailureType == ConnectionFailureType.SocketFailure
+                     || inner.FailureType == ConnectionFailureType.InternalFailure);
         }
+        finally
+        {
+            ClearAmbientFailures();
+        }
+    }
 #endif
 
-        [Fact]
-        public void ServerTakesPrecendenceOverSnapshot()
+    [Fact]
+    public void ServerTakesPrecendenceOverSnapshot()
+    {
+        try
         {
-            try
-            {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast))
-                {
-                    muxer.GetDatabase();
-                    muxer.AllowConnect = false;
+            using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false, backlogPolicy: BacklogPolicy.FailFast);
 
-                    muxer.GetServer(muxer.GetEndPoints()[0]).SimulateConnectionFailure(SimulatedFailureType.All);
+            conn.GetDatabase();
+            conn.AllowConnect = false;
 
-                    var ex = ExceptionFactory.NoConnectionAvailable((muxer as ConnectionMultiplexer)!, null, muxer.GetServerSnapshot()[0]);
-                    Assert.IsType<RedisConnectionException>(ex);
-                    Assert.IsType<RedisConnectionException>(ex.InnerException);
-                    Assert.Equal(ex.InnerException, muxer.GetServerSnapshot()[0].LastException);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            conn.GetServer(conn.GetEndPoints()[0]).SimulateConnectionFailure(SimulatedFailureType.All);
+
+            var ex = ExceptionFactory.NoConnectionAvailable((conn as ConnectionMultiplexer)!, null, conn.GetServerSnapshot()[0]);
+            Assert.IsType<RedisConnectionException>(ex);
+            Assert.IsType<RedisConnectionException>(ex.InnerException);
+            Assert.Equal(ex.InnerException, conn.GetServerSnapshot()[0].LastException);
         }
-
-        [Fact]
-        public void NullInnerExceptionForMultipleEndpointsWithNoLastException()
+        finally
         {
-            try
-            {
-                using (var muxer = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true))
-                {
-                    muxer.GetDatabase();
-                    muxer.AllowConnect = false;
-                    var ex = ExceptionFactory.NoConnectionAvailable((muxer as ConnectionMultiplexer)!, null, null);
-                    Assert.IsType<RedisConnectionException>(ex);
-                    Assert.Null(ex.InnerException);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            ClearAmbientFailures();
         }
+    }
 
-        [Fact]
-        public void TimeoutException()
+    [Fact]
+    public void NullInnerExceptionForMultipleEndpointsWithNoLastException()
+    {
+        try
         {
-            try
-            {
-                using (var muxer = (Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false) as ConnectionMultiplexer)!)
-                {
-                    var server = GetServer(muxer);
-                    muxer.AllowConnect = false;
-                    var msg = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
-                    var rawEx = ExceptionFactory.Timeout(muxer, "Test Timeout", msg, new ServerEndPoint(muxer, server.EndPoint));
-                    var ex = Assert.IsType<RedisTimeoutException>(rawEx);
-                    Writer.WriteLine("Exception: " + ex.Message);
+            using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true);
 
-                    // Example format: "Test Timeout, command=PING, inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0, serverEndpoint: 127.0.0.1:6379, mgr: 10 of 10 available, clientName: TimeoutException, IOCP: (Busy=0,Free=1000,Min=8,Max=1000), WORKER: (Busy=2,Free=2045,Min=8,Max=2047), v: 2.1.0 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)";
-                    Assert.StartsWith("Test Timeout, command=PING", ex.Message);
-                    Assert.Contains("clientName: " + nameof(TimeoutException), ex.Message);
-                    // Ensure our pipe numbers are in place
-                    Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
-                    Assert.Contains("mc: 1/1/0", ex.Message);
-                    Assert.Contains("serverEndpoint: " + server.EndPoint, ex.Message);
-                    Assert.Contains("IOCP: ", ex.Message);
-                    Assert.Contains("WORKER: ", ex.Message);
+            conn.GetDatabase();
+            conn.AllowConnect = false;
+            var ex = ExceptionFactory.NoConnectionAvailable((conn as ConnectionMultiplexer)!, null, null);
+            Assert.IsType<RedisConnectionException>(ex);
+            Assert.Null(ex.InnerException);
+        }
+        finally
+        {
+            ClearAmbientFailures();
+        }
+    }
+
+    [Fact]
+    public void TimeoutException()
+    {
+        try
+        {
+            using var conn = (Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false) as ConnectionMultiplexer)!;
+
+            var server = GetServer(conn);
+            conn.AllowConnect = false;
+            var msg = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
+            var rawEx = ExceptionFactory.Timeout(conn, "Test Timeout", msg, new ServerEndPoint(conn, server.EndPoint));
+            var ex = Assert.IsType<RedisTimeoutException>(rawEx);
+            Writer.WriteLine("Exception: " + ex.Message);
+
+            // Example format: "Test Timeout, command=PING, inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0, serverEndpoint: 127.0.0.1:6379, mgr: 10 of 10 available, clientName: TimeoutException, IOCP: (Busy=0,Free=1000,Min=8,Max=1000), WORKER: (Busy=2,Free=2045,Min=8,Max=2047), v: 2.1.0 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)";
+            Assert.StartsWith("Test Timeout, command=PING", ex.Message);
+            Assert.Contains("clientName: " + nameof(TimeoutException), ex.Message);
+            // Ensure our pipe numbers are in place
+            Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
+            Assert.Contains("mc: 1/1/0", ex.Message);
+            Assert.Contains("serverEndpoint: " + server.EndPoint, ex.Message);
+            Assert.Contains("IOCP: ", ex.Message);
+            Assert.Contains("WORKER: ", ex.Message);
 #if NETCOREAPP
-                    Assert.Contains("POOL: ", ex.Message);
+                Assert.Contains("POOL: ", ex.Message);
 #endif
-                    Assert.DoesNotContain("Unspecified/", ex.Message);
-                    Assert.EndsWith(" (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)", ex.Message);
-                    Assert.Null(ex.InnerException);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
-            }
+            Assert.DoesNotContain("Unspecified/", ex.Message);
+            Assert.EndsWith(" (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)", ex.Message);
+            Assert.Null(ex.InnerException);
         }
-
-        [Theory]
-        [InlineData(false, 0, 0, true, "Connection to Redis never succeeded (attempts: 0 - connection likely in-progress), unable to service operation: PING")]
-        [InlineData(false, 1, 0, true, "Connection to Redis never succeeded (attempts: 1 - connection likely in-progress), unable to service operation: PING")]
-        [InlineData(false, 12, 0, true, "Connection to Redis never succeeded (attempts: 12 - check your config), unable to service operation: PING")]
-        [InlineData(false, 0, 0, false, "Connection to Redis never succeeded (attempts: 0 - connection likely in-progress), unable to service operation: PING")]
-        [InlineData(false, 1, 0, false, "Connection to Redis never succeeded (attempts: 1 - connection likely in-progress), unable to service operation: PING")]
-        [InlineData(false, 12, 0, false, "Connection to Redis never succeeded (attempts: 12 - check your config), unable to service operation: PING")]
-        [InlineData(true, 0, 0, true, "No connection is active/available to service this operation: PING")]
-        [InlineData(true, 1, 0, true, "No connection is active/available to service this operation: PING")]
-        [InlineData(true, 12, 0, true, "No connection is active/available to service this operation: PING")]
-        public void NoConnectionException(bool abortOnConnect, int connCount, int completeCount, bool hasDetail, string messageStart)
+        finally
         {
-            try
-            {
-                var options = new ConfigurationOptions()
-                {
-                    AbortOnConnectFail = abortOnConnect,
-                    BacklogPolicy = BacklogPolicy.FailFast,
-                    ConnectTimeout = 1000,
-                    SyncTimeout = 500,
-                    KeepAlive = 5000
-                };
+            ClearAmbientFailures();
+        }
+    }
 
-                ConnectionMultiplexer muxer;
-                if (abortOnConnect)
+    [Theory]
+    [InlineData(false, 0, 0, true, "Connection to Redis never succeeded (attempts: 0 - connection likely in-progress), unable to service operation: PING")]
+    [InlineData(false, 1, 0, true, "Connection to Redis never succeeded (attempts: 1 - connection likely in-progress), unable to service operation: PING")]
+    [InlineData(false, 12, 0, true, "Connection to Redis never succeeded (attempts: 12 - check your config), unable to service operation: PING")]
+    [InlineData(false, 0, 0, false, "Connection to Redis never succeeded (attempts: 0 - connection likely in-progress), unable to service operation: PING")]
+    [InlineData(false, 1, 0, false, "Connection to Redis never succeeded (attempts: 1 - connection likely in-progress), unable to service operation: PING")]
+    [InlineData(false, 12, 0, false, "Connection to Redis never succeeded (attempts: 12 - check your config), unable to service operation: PING")]
+    [InlineData(true, 0, 0, true, "No connection is active/available to service this operation: PING")]
+    [InlineData(true, 1, 0, true, "No connection is active/available to service this operation: PING")]
+    [InlineData(true, 12, 0, true, "No connection is active/available to service this operation: PING")]
+    public void NoConnectionException(bool abortOnConnect, int connCount, int completeCount, bool hasDetail, string messageStart)
+    {
+        try
+        {
+            var options = new ConfigurationOptions()
+            {
+                AbortOnConnectFail = abortOnConnect,
+                BacklogPolicy = BacklogPolicy.FailFast,
+                ConnectTimeout = 1000,
+                SyncTimeout = 500,
+                KeepAlive = 5000
+            };
+
+            ConnectionMultiplexer conn;
+            if (abortOnConnect)
+            {
+                options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
+                conn = ConnectionMultiplexer.Connect(options, Writer);
+            }
+            else
+            {
+                options.EndPoints.Add($"doesnot.exist.{Guid.NewGuid():N}:6379");
+                conn = ConnectionMultiplexer.Connect(options, Writer);
+            }
+
+            using (conn)
+            {
+                var server = conn.GetServer(conn.GetEndPoints()[0]);
+                conn.AllowConnect = false;
+                conn._connectAttemptCount = connCount;
+                conn._connectCompletedCount = completeCount;
+                options.IncludeDetailInExceptions = hasDetail;
+                options.IncludePerformanceCountersInExceptions = hasDetail;
+
+                var msg = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
+                var rawEx = ExceptionFactory.NoConnectionAvailable(conn, msg, new ServerEndPoint(conn, server.EndPoint));
+                var ex = Assert.IsType<RedisConnectionException>(rawEx);
+                Writer.WriteLine("Exception: " + ex.Message);
+
+                // Example format: "Exception: No connection is active/available to service this operation: PING, inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0, serverEndpoint: 127.0.0.1:6379, mc: 1/1/0, mgr: 10 of 10 available, clientName: NoConnectionException, IOCP: (Busy=0,Free=1000,Min=8,Max=1000), WORKER: (Busy=2,Free=2045,Min=8,Max=2047), Local-CPU: 100%, v: 2.1.0.5";
+                Assert.StartsWith(messageStart, ex.Message);
+
+                // Ensure our pipe numbers are in place if they should be
+                if (hasDetail)
                 {
-                    options.EndPoints.Add(TestConfig.Current.PrimaryServerAndPort);
-                    muxer = ConnectionMultiplexer.Connect(options, Writer);
+                    Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
+                    Assert.Contains($"mc: {connCount}/{completeCount}/0", ex.Message);
+                    Assert.Contains("serverEndpoint: " + server.EndPoint.ToString()?.Replace("Unspecified/", ""), ex.Message);
                 }
                 else
                 {
-                    options.EndPoints.Add($"doesnot.exist.{Guid.NewGuid():N}:6379");
-                    muxer = ConnectionMultiplexer.Connect(options, Writer);
+                    Assert.DoesNotContain("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
+                    Assert.DoesNotContain($"mc: {connCount}/{completeCount}/0", ex.Message);
+                    Assert.DoesNotContain("serverEndpoint: " + server.EndPoint.ToString()?.Replace("Unspecified/", ""), ex.Message);
                 }
-
-                using (muxer)
-                {
-                    var server = muxer.GetServer(muxer.GetEndPoints()[0]);
-                    muxer.AllowConnect = false;
-                    muxer._connectAttemptCount = connCount;
-                    muxer._connectCompletedCount = completeCount;
-                    options.IncludeDetailInExceptions = hasDetail;
-                    options.IncludePerformanceCountersInExceptions = hasDetail;
-
-                    var msg = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
-                    var rawEx = ExceptionFactory.NoConnectionAvailable(muxer, msg, new ServerEndPoint(muxer, server.EndPoint));
-                    var ex = Assert.IsType<RedisConnectionException>(rawEx);
-                    Writer.WriteLine("Exception: " + ex.Message);
-
-                    // Example format: "Exception: No connection is active/available to service this operation: PING, inst: 0, qu: 0, qs: 0, aw: False, in: 0, in-pipe: 0, out-pipe: 0, serverEndpoint: 127.0.0.1:6379, mc: 1/1/0, mgr: 10 of 10 available, clientName: NoConnectionException, IOCP: (Busy=0,Free=1000,Min=8,Max=1000), WORKER: (Busy=2,Free=2045,Min=8,Max=2047), Local-CPU: 100%, v: 2.1.0.5";
-                    Assert.StartsWith(messageStart, ex.Message);
-
-                    // Ensure our pipe numbers are in place if they should be
-                    if (hasDetail)
-                    {
-                        Assert.Contains("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
-                        Assert.Contains($"mc: {connCount}/{completeCount}/0", ex.Message);
-                        Assert.Contains("serverEndpoint: " + server.EndPoint.ToString()?.Replace("Unspecified/", ""), ex.Message);
-                    }
-                    else
-                    {
-                        Assert.DoesNotContain("inst: 0, qu: 0, qs: 0, aw: False, bw: Inactive, in: 0, in-pipe: 0, out-pipe: 0", ex.Message);
-                        Assert.DoesNotContain($"mc: {connCount}/{completeCount}/0", ex.Message);
-                        Assert.DoesNotContain("serverEndpoint: " + server.EndPoint.ToString()?.Replace("Unspecified/", ""), ex.Message);
-                    }
-                    Assert.DoesNotContain("Unspecified/", ex.Message);
-                }
-            }
-            finally
-            {
-                ClearAmbientFailures();
+                Assert.DoesNotContain("Unspecified/", ex.Message);
             }
         }
-
-        [Theory]
-        [InlineData(true, ConnectionFailureType.ProtocolFailure, "ProtocolFailure on [0]:GET myKey (StringProcessor), my annotation")]
-        [InlineData(true, ConnectionFailureType.ConnectionDisposed, "ConnectionDisposed on [0]:GET myKey (StringProcessor), my annotation")]
-        [InlineData(false, ConnectionFailureType.ProtocolFailure, "ProtocolFailure on [0]:GET (StringProcessor), my annotation")]
-        [InlineData(false, ConnectionFailureType.ConnectionDisposed, "ConnectionDisposed on [0]:GET (StringProcessor), my annotation")]
-        public void MessageFail(bool includeDetail, ConnectionFailureType failType, string messageStart)
+        finally
         {
-            using var muxer = Create(shared: false);
-            muxer.RawConfig.IncludeDetailInExceptions = includeDetail;
-
-            var message = Message.Create(0, CommandFlags.None, RedisCommand.GET, (RedisKey)"myKey");
-            var resultBox = SimpleResultBox<string>.Create();
-            message.SetSource(ResultProcessor.String, resultBox);
-
-            message.Fail(failType, null, "my annotation", muxer as ConnectionMultiplexer);
-
-            resultBox.GetResult(out var ex);
-            Assert.NotNull(ex);
-
-            Assert.StartsWith(messageStart, ex.Message);
+            ClearAmbientFailures();
         }
+    }
+
+    [Theory]
+    [InlineData(true, ConnectionFailureType.ProtocolFailure, "ProtocolFailure on [0]:GET myKey (StringProcessor), my annotation")]
+    [InlineData(true, ConnectionFailureType.ConnectionDisposed, "ConnectionDisposed on [0]:GET myKey (StringProcessor), my annotation")]
+    [InlineData(false, ConnectionFailureType.ProtocolFailure, "ProtocolFailure on [0]:GET (StringProcessor), my annotation")]
+    [InlineData(false, ConnectionFailureType.ConnectionDisposed, "ConnectionDisposed on [0]:GET (StringProcessor), my annotation")]
+    public void MessageFail(bool includeDetail, ConnectionFailureType failType, string messageStart)
+    {
+        using var conn = Create(shared: false);
+
+        conn.RawConfig.IncludeDetailInExceptions = includeDetail;
+
+        var message = Message.Create(0, CommandFlags.None, RedisCommand.GET, (RedisKey)"myKey");
+        var resultBox = SimpleResultBox<string>.Create();
+        message.SetSource(ResultProcessor.String, resultBox);
+
+        message.Fail(failType, null, "my annotation", conn as ConnectionMultiplexer);
+
+        resultBox.GetResult(out var ex);
+        Assert.NotNull(ex);
+
+        Assert.StartsWith(messageStart, ex.Message);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Execute.cs
+++ b/tests/StackExchange.Redis.Tests/Execute.cs
@@ -3,42 +3,39 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class ExecuteTests : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class ExecuteTests : TestBase
+    public ExecuteTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public async Task DBExecute()
     {
-        public ExecuteTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public async Task DBExecute()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase(4);
-                RedisKey key = Me();
-                db.StringSet(key, "some value");
+        var db = conn.GetDatabase(4);
+        RedisKey key = Me();
+        db.StringSet(key, "some value");
 
-                var actual = (string?)db.Execute("GET", key);
-                Assert.Equal("some value", actual);
+        var actual = (string?)db.Execute("GET", key);
+        Assert.Equal("some value", actual);
 
-                actual = (string?)await db.ExecuteAsync("GET", key).ForAwait();
-                Assert.Equal("some value", actual);
-            }
-        }
+        actual = (string?)await db.ExecuteAsync("GET", key).ForAwait();
+        Assert.Equal("some value", actual);
+    }
 
-        [Fact]
-        public async Task ServerExecute()
-        {
-            using (var conn = Create())
-            {
-                var server = conn.GetServer(conn.GetEndPoints().First());
-                var actual = (string?)server.Execute("echo", "some value");
-                Assert.Equal("some value", actual);
+    [Fact]
+    public async Task ServerExecute()
+    {
+        using var conn = Create();
 
-                actual = (string?)await server.ExecuteAsync("echo", "some value").ForAwait();
-                Assert.Equal("some value", actual);
-            }
-        }
+        var server = conn.GetServer(conn.GetEndPoints().First());
+        var actual = (string?)server.Execute("echo", "some value");
+        Assert.Equal("some value", actual);
+
+        actual = (string?)await server.ExecuteAsync("echo", "some value").ForAwait();
+        Assert.Equal("some value", actual);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Expiry.cs
+++ b/tests/StackExchange.Redis.Tests/Expiry.cs
@@ -3,197 +3,194 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Expiry : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Expiry : TestBase
+    public Expiry(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    private static string[]? GetMap(bool disablePTimes) => disablePTimes ? (new[] { "pexpire", "pexpireat", "pttl" }) : null;
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TestBasicExpiryTimeSpan(bool disablePTimes)
     {
-        public Expiry(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create(disabledCommands: GetMap(disablePTimes));
 
-        private static string[]? GetMap(bool disablePTimes) => disablePTimes ? (new[] { "pexpire", "pexpireat", "pttl" }) : null;
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestBasicExpiryTimeSpan(bool disablePTimes)
-        {
-            using (var muxer = Create(disabledCommands: GetMap(disablePTimes)))
-            {
-                RedisKey key = Me();
-                var conn = muxer.GetDatabase();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
+        var a = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, TimeSpan.FromHours(1), CommandFlags.FireAndForget);
+        var b = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, (TimeSpan?)null, CommandFlags.FireAndForget);
+        var c = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, TimeSpan.FromHours(1.5), CommandFlags.FireAndForget);
+        var d = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, TimeSpan.MaxValue, CommandFlags.FireAndForget);
+        var e = db.KeyTimeToLiveAsync(key);
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var f = db.KeyTimeToLiveAsync(key);
 
-                conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
-                var a = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, TimeSpan.FromHours(1), CommandFlags.FireAndForget);
-                var b = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, (TimeSpan?)null, CommandFlags.FireAndForget);
-                var c = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, TimeSpan.FromHours(1.5), CommandFlags.FireAndForget);
-                var d = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, TimeSpan.MaxValue, CommandFlags.FireAndForget);
-                var e = conn.KeyTimeToLiveAsync(key);
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var f = conn.KeyTimeToLiveAsync(key);
+        Assert.Null(await a);
+        var time = await b;
+        Assert.NotNull(time);
+        Assert.True(time > TimeSpan.FromMinutes(59.9) && time <= TimeSpan.FromMinutes(60));
+        Assert.Null(await c);
+        time = await d;
+        Assert.NotNull(time);
+        Assert.True(time > TimeSpan.FromMinutes(89.9) && time <= TimeSpan.FromMinutes(90));
+        Assert.Null(await e);
+        Assert.Null(await f);
+    }
 
-                Assert.Null(await a);
-                var time = await b;
-                Assert.NotNull(time);
-                Assert.True(time > TimeSpan.FromMinutes(59.9) && time <= TimeSpan.FromMinutes(60));
-                Assert.Null(await c);
-                time = await d;
-                Assert.NotNull(time);
-                Assert.True(time > TimeSpan.FromMinutes(89.9) && time <= TimeSpan.FromMinutes(90));
-                Assert.Null(await e);
-                Assert.Null(await f);
-            }
-        }
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TestExpiryOptions(bool disablePTimes)
+    {
+        using var conn = Create(disabledCommands: GetMap(disablePTimes), require: RedisFeatures.v7_0_0_rc1);
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void TestExpiryOptions(bool disablePTimes)
-        {
-            using var muxer = Create(disabledCommands: GetMap(disablePTimes), require: RedisFeatures.v7_0_0_rc1);
+        var key = Me();
+        var cb = conn.GetDatabase();
+        cb.KeyDelete(key, CommandFlags.FireAndForget);
+        cb.StringSet(key, "value", flags: CommandFlags.FireAndForget);
 
-            var key = Me();
-            var conn = muxer.GetDatabase();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-            conn.StringSet(key, "value", flags: CommandFlags.FireAndForget);
+        // The key has no expiry
+        Assert.False(cb.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasExpiry));
+        Assert.True(cb.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasNoExpiry));
 
-            // The key has no expiry
-            Assert.False(conn.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasExpiry));
-            Assert.True(conn.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasNoExpiry));
+        // The key has an existing expiry
+        Assert.True(cb.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasExpiry));
+        Assert.False(cb.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasNoExpiry));
 
-            // The key has an existing expiry
-            Assert.True(conn.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasExpiry));
-            Assert.False(conn.KeyExpire(key, TimeSpan.FromHours(1), ExpireWhen.HasNoExpiry));
+        // Set only when the new expiry is greater than current one
+        Assert.True(cb.KeyExpire(key, TimeSpan.FromHours(1.5), ExpireWhen.GreaterThanCurrentExpiry));
+        Assert.False(cb.KeyExpire(key, TimeSpan.FromHours(0.5), ExpireWhen.GreaterThanCurrentExpiry));
 
-            // Set only when the new expiry is greater than current one
-            Assert.True(conn.KeyExpire(key, TimeSpan.FromHours(1.5), ExpireWhen.GreaterThanCurrentExpiry));
-            Assert.False(conn.KeyExpire(key, TimeSpan.FromHours(0.5), ExpireWhen.GreaterThanCurrentExpiry));
+        // Set only when the new expiry is less than current one
+        Assert.True(cb.KeyExpire(key, TimeSpan.FromHours(0.5), ExpireWhen.LessThanCurrentExpiry));
+        Assert.False(cb.KeyExpire(key, TimeSpan.FromHours(1.5), ExpireWhen.LessThanCurrentExpiry));
+    }
 
-            // Set only when the new expiry is less than current one
-            Assert.True(conn.KeyExpire(key, TimeSpan.FromHours(0.5), ExpireWhen.LessThanCurrentExpiry));
-            Assert.False(conn.KeyExpire(key, TimeSpan.FromHours(1.5), ExpireWhen.LessThanCurrentExpiry));
-        }
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task TestBasicExpiryDateTime(bool disablePTimes, bool utc)
+    {
+        using var conn = Create(disabledCommands: GetMap(disablePTimes));
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public async Task TestBasicExpiryDateTime(bool disablePTimes, bool utc)
-        {
-            using (var muxer = Create(disabledCommands: GetMap(disablePTimes)))
-            {
-                RedisKey key = Me();
-                var conn = muxer.GetDatabase();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var now = utc ? DateTime.UtcNow : DateTime.Now;
-                var serverTime = GetServer(muxer).Time();
-                Log("Server time: {0}", serverTime);
-                var offset = DateTime.UtcNow - serverTime;
+        var now = utc ? DateTime.UtcNow : DateTime.Now;
+        var serverTime = GetServer(conn).Time();
+        Log("Server time: {0}", serverTime);
+        var offset = DateTime.UtcNow - serverTime;
 
-                Log("Now (local time): {0}", now);
-                conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
-                var a = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, now.AddHours(1), CommandFlags.FireAndForget);
-                var b = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, (DateTime?)null, CommandFlags.FireAndForget);
-                var c = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, now.AddHours(1.5), CommandFlags.FireAndForget);
-                var d = conn.KeyTimeToLiveAsync(key);
-                conn.KeyExpire(key, DateTime.MaxValue, CommandFlags.FireAndForget);
-                var e = conn.KeyTimeToLiveAsync(key);
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var f = conn.KeyTimeToLiveAsync(key);
+        Log("Now (local time): {0}", now);
+        db.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
+        var a = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, now.AddHours(1), CommandFlags.FireAndForget);
+        var b = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, (DateTime?)null, CommandFlags.FireAndForget);
+        var c = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, now.AddHours(1.5), CommandFlags.FireAndForget);
+        var d = db.KeyTimeToLiveAsync(key);
+        db.KeyExpire(key, DateTime.MaxValue, CommandFlags.FireAndForget);
+        var e = db.KeyTimeToLiveAsync(key);
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var f = db.KeyTimeToLiveAsync(key);
 
-                Assert.Null(await a);
-                var timeResult = await b;
-                Assert.NotNull(timeResult);
-                TimeSpan time = timeResult.Value;
+        Assert.Null(await a);
+        var timeResult = await b;
+        Assert.NotNull(timeResult);
+        TimeSpan time = timeResult.Value;
 
-                // Adjust for server time offset, if any when checking expectations
-                time -= offset;
+        // Adjust for server time offset, if any when checking expectations
+        time -= offset;
 
-                Log("Time: {0}, Expected: {1}-{2}", time, TimeSpan.FromMinutes(59), TimeSpan.FromMinutes(60));
-                Assert.True(time >= TimeSpan.FromMinutes(59));
-                Assert.True(time <= TimeSpan.FromMinutes(60.1));
-                Assert.Null(await c);
+        Log("Time: {0}, Expected: {1}-{2}", time, TimeSpan.FromMinutes(59), TimeSpan.FromMinutes(60));
+        Assert.True(time >= TimeSpan.FromMinutes(59));
+        Assert.True(time <= TimeSpan.FromMinutes(60.1));
+        Assert.Null(await c);
 
-                timeResult = await d;
-                Assert.NotNull(timeResult);
-                time = timeResult.Value;
+        timeResult = await d;
+        Assert.NotNull(timeResult);
+        time = timeResult.Value;
 
-                Assert.True(time >= TimeSpan.FromMinutes(89));
-                Assert.True(time <= TimeSpan.FromMinutes(90.1));
-                Assert.Null(await e);
-                Assert.Null(await f);
-            }
-        }
+        Assert.True(time >= TimeSpan.FromMinutes(89));
+        Assert.True(time <= TimeSpan.FromMinutes(90.1));
+        Assert.Null(await e);
+        Assert.Null(await f);
+    }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void KeyExpiryTime(bool disablePTimes)
-        {
-            using var muxer = Create(disabledCommands: GetMap(disablePTimes), require: RedisFeatures.v7_0_0_rc1);
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void KeyExpiryTime(bool disablePTimes)
+    {
+        using var conn = Create(disabledCommands: GetMap(disablePTimes), require: RedisFeatures.v7_0_0_rc1);
 
-            var key = Me();
-            var conn = muxer.GetDatabase();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-            var expireTime = DateTime.UtcNow.AddHours(1);
-            conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
-            conn.KeyExpire(key, expireTime, CommandFlags.FireAndForget);
+        var expireTime = DateTime.UtcNow.AddHours(1);
+        db.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
+        db.KeyExpire(key, expireTime, CommandFlags.FireAndForget);
 
-            var time = conn.KeyExpireTime(key);
-            Assert.NotNull(time);
-            Assert.Equal(expireTime, time.Value, TimeSpan.FromSeconds(30));
+        var time = db.KeyExpireTime(key);
+        Assert.NotNull(time);
+        Assert.Equal(expireTime, time.Value, TimeSpan.FromSeconds(30));
 
-            // Without associated expiration time
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-            conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
-            time = conn.KeyExpireTime(key);
-            Assert.Null(time);
+        // Without associated expiration time
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
+        time = db.KeyExpireTime(key);
+        Assert.Null(time);
 
-            // Non existing key
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-            time = conn.KeyExpireTime(key);
-            Assert.Null(time);
-        }
+        // Non existing key
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        time = db.KeyExpireTime(key);
+        Assert.Null(time);
+    }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task KeyExpiryTimeAsync(bool disablePTimes)
-        {
-            using var muxer = Create(disabledCommands: GetMap(disablePTimes), require: RedisFeatures.v7_0_0_rc1);
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task KeyExpiryTimeAsync(bool disablePTimes)
+    {
+        using var conn = Create(disabledCommands: GetMap(disablePTimes), require: RedisFeatures.v7_0_0_rc1);
 
-            var key = Me();
-            var conn = muxer.GetDatabase();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-            var expireTime = DateTime.UtcNow.AddHours(1);
-            conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
-            conn.KeyExpire(key, expireTime, CommandFlags.FireAndForget);
+        var expireTime = DateTime.UtcNow.AddHours(1);
+        db.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
+        db.KeyExpire(key, expireTime, CommandFlags.FireAndForget);
 
-            var time = await conn.KeyExpireTimeAsync(key);
-            Assert.NotNull(time);
-            Assert.Equal(expireTime, time.Value, TimeSpan.FromSeconds(30));
+        var time = await db.KeyExpireTimeAsync(key);
+        Assert.NotNull(time);
+        Assert.Equal(expireTime, time.Value, TimeSpan.FromSeconds(30));
 
-            // Without associated expiration time
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-            conn.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
-            time = await conn.KeyExpireTimeAsync(key);
-            Assert.Null(time);
+        // Without associated expiration time
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, "new value", flags: CommandFlags.FireAndForget);
+        time = await db.KeyExpireTimeAsync(key);
+        Assert.Null(time);
 
-            // Non existing key
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-            time = await conn.KeyExpireTimeAsync(key);
-            Assert.Null(time);
-        }
+        // Non existing key
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        time = await db.KeyExpireTimeAsync(key);
+        Assert.Null(time);
     }
 }

--- a/tests/StackExchange.Redis.Tests/FSharpCompat.cs
+++ b/tests/StackExchange.Redis.Tests/FSharpCompat.cs
@@ -1,26 +1,25 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class FSharpCompat : TestBase
 {
-    public class FSharpCompat : TestBase
+    public FSharpCompat(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void RedisKeyConstructor()
     {
-        public FSharpCompat(ITestOutputHelper output) : base (output) { }
+        Assert.Equal(default, new RedisKey());
+        Assert.Equal((RedisKey)"MyKey", new RedisKey("MyKey"));
+        Assert.Equal((RedisKey)"MyKey2", new RedisKey(null, "MyKey2"));
+    }
 
-        [Fact]
-        public void RedisKeyConstructor()
-        {
-            Assert.Equal(default, new RedisKey());
-            Assert.Equal((RedisKey)"MyKey", new RedisKey("MyKey"));
-            Assert.Equal((RedisKey)"MyKey2", new RedisKey(null, "MyKey2"));
-        }
-
-        [Fact]
-        public void RedisValueConstructor()
-        {
-            Assert.Equal(default, new RedisValue());
-            Assert.Equal((RedisValue)"MyKey", new RedisValue("MyKey"));
-            Assert.Equal((RedisValue)"MyKey2", new RedisValue("MyKey2", 0));
-        }
+    [Fact]
+    public void RedisValueConstructor()
+    {
+        Assert.Equal(default, new RedisValue());
+        Assert.Equal((RedisValue)"MyKey", new RedisValue("MyKey"));
+        Assert.Equal((RedisValue)"MyKey2", new RedisValue("MyKey2", 0));
     }
 }

--- a/tests/StackExchange.Redis.Tests/Failover.cs
+++ b/tests/StackExchange.Redis.Tests/Failover.cs
@@ -5,361 +5,353 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Failover : TestBase, IAsyncLifetime
 {
-    public class Failover : TestBase, IAsyncLifetime
+    protected override string GetConfiguration() => GetPrimaryReplicaConfig().ToString();
+
+    public Failover(ITestOutputHelper output) : base(output) { }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public async Task InitializeAsync()
     {
-        protected override string GetConfiguration() => GetPrimaryReplicaConfig().ToString();
+        using var conn = Create();
 
-        public Failover(ITestOutputHelper output) : base(output)
+        var shouldBePrimary = conn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort);
+        if (shouldBePrimary.IsReplica)
         {
+            Log(shouldBePrimary.EndPoint + " should be primary, fixing...");
+            await shouldBePrimary.MakePrimaryAsync(ReplicationChangeOptions.SetTiebreaker);
         }
 
-        public Task DisposeAsync() => Task.CompletedTask;
-
-        public async Task InitializeAsync()
+        var shouldBeReplica = conn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort);
+        if (!shouldBeReplica.IsReplica)
         {
-            using (var mutex = Create())
-            {
-                var shouldBePrimary = mutex.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort);
-                if (shouldBePrimary.IsReplica)
-                {
-                    Log(shouldBePrimary.EndPoint + " should be primary, fixing...");
-                    await shouldBePrimary.MakePrimaryAsync(ReplicationChangeOptions.SetTiebreaker);
-                }
+            Log(shouldBeReplica.EndPoint + " should be a replica, fixing...");
+            await shouldBeReplica.ReplicaOfAsync(shouldBePrimary.EndPoint);
+            await Task.Delay(2000).ForAwait();
+        }
+    }
 
-                var shouldBeReplica = mutex.GetServer(TestConfig.Current.FailoverReplicaServerAndPort);
-                if (!shouldBeReplica.IsReplica)
-                {
-                    Log(shouldBeReplica.EndPoint + " should be a replica, fixing...");
-                    await shouldBeReplica.ReplicaOfAsync(shouldBePrimary.EndPoint);
-                    await Task.Delay(2000).ForAwait();
-                }
+    private static ConfigurationOptions GetPrimaryReplicaConfig()
+    {
+        return new ConfigurationOptions
+        {
+            AllowAdmin = true,
+            SyncTimeout = 100000,
+            EndPoints =
+            {
+                { TestConfig.Current.FailoverPrimaryServer, TestConfig.Current.FailoverPrimaryPort },
+                { TestConfig.Current.FailoverReplicaServer, TestConfig.Current.FailoverReplicaPort },
             }
-        }
+        };
+    }
 
-        private static ConfigurationOptions GetPrimaryReplicaConfig()
+    [Fact]
+    public async Task ConfigureAsync()
+    {
+        using var conn = Create();
+
+        await Task.Delay(1000).ForAwait();
+        Log("About to reconfigure.....");
+        await conn.ConfigureAsync().ForAwait();
+        Log("Reconfigured");
+    }
+
+    [Fact]
+    public async Task ConfigureSync()
+    {
+        using var conn = Create();
+
+        await Task.Delay(1000).ForAwait();
+        Log("About to reconfigure.....");
+        conn.Configure();
+        Log("Reconfigured");
+    }
+
+    [Fact]
+    public async Task ConfigVerifyReceiveConfigChangeBroadcast()
+    {
+        _ = GetConfiguration();
+        using var senderConn = Create(allowAdmin: true);
+        using var receiverConn = Create(syncTimeout: 2000);
+
+        int total = 0;
+        receiverConn.ConfigurationChangedBroadcast += (s, a) =>
         {
-            return new ConfigurationOptions
-            {
-                AllowAdmin = true,
-                SyncTimeout = 100000,
-                EndPoints =
-                {
-                    { TestConfig.Current.FailoverPrimaryServer, TestConfig.Current.FailoverPrimaryPort },
-                    { TestConfig.Current.FailoverReplicaServer, TestConfig.Current.FailoverReplicaPort },
-                }
-            };
-        }
+            Log("Config changed: " + (a.EndPoint == null ? "(none)" : a.EndPoint.ToString()));
+            Interlocked.Increment(ref total);
+        };
+        // send a reconfigure/reconnect message
+        long count = senderConn.PublishReconfigure();
+        GetServer(receiverConn).Ping();
+        GetServer(receiverConn).Ping();
+        await Task.Delay(1000).ConfigureAwait(false);
+        Assert.True(count == -1 || count >= 2, "subscribers");
+        Assert.True(Interlocked.CompareExchange(ref total, 0, 0) >= 1, "total (1st)");
 
-        [Fact]
-        public async Task ConfigureAsync()
+        Interlocked.Exchange(ref total, 0);
+
+        // and send a second time via a re-primary operation
+        var server = GetServer(senderConn);
+        if (server.IsReplica) Skip.Inconclusive("didn't expect a replica");
+        await server.MakePrimaryAsync(ReplicationChangeOptions.Broadcast);
+        await Task.Delay(1000).ConfigureAwait(false);
+        GetServer(receiverConn).Ping();
+        GetServer(receiverConn).Ping();
+        Assert.True(Interlocked.CompareExchange(ref total, 0, 0) >= 1, "total (2nd)");
+    }
+
+    [Fact]
+    public async Task DereplicateGoesToPrimary()
+    {
+        ConfigurationOptions config = GetPrimaryReplicaConfig();
+        config.ConfigCheckSeconds = 5;
+
+        using var conn = ConnectionMultiplexer.Connect(config);
+
+        var primary = conn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort);
+        var secondary = conn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort);
+
+        primary.Ping();
+        secondary.Ping();
+
+        await primary.MakePrimaryAsync(ReplicationChangeOptions.SetTiebreaker);
+        await secondary.MakePrimaryAsync(ReplicationChangeOptions.None);
+
+        await Task.Delay(100).ConfigureAwait(false);
+
+        primary.Ping();
+        secondary.Ping();
+
+        using (var writer = new StringWriter())
         {
-            using (var muxer = Create())
-            {
-                await Task.Delay(1000).ForAwait();
-                Log("About to reconfigure.....");
-                await muxer.ConfigureAsync().ForAwait();
-                Log("Reconfigured");
-            }
+            conn.Configure(writer);
+            string log = writer.ToString();
+            Writer.WriteLine(log);
+            bool isUnanimous = log.Contains("tie-break is unanimous at " + TestConfig.Current.FailoverPrimaryServerAndPort);
+            if (!isUnanimous) Skip.Inconclusive("this is timing sensitive; unable to verify this time");
         }
+        // k, so we know everyone loves 6379; is that what we get?
 
-        [Fact]
-        public async Task ConfigureSync()
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferMaster));
+        Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.DemandMaster));
+        Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferReplica));
+
+        var ex = Assert.Throws<RedisConnectionException>(() => db.IdentifyEndpoint(key, CommandFlags.DemandReplica));
+        Assert.StartsWith("No connection is active/available to service this operation: EXISTS " + Me(), ex.Message);
+        Writer.WriteLine("Invoking MakePrimaryAsync()...");
+        await primary.MakePrimaryAsync(ReplicationChangeOptions.Broadcast | ReplicationChangeOptions.ReplicateToOtherEndpoints | ReplicationChangeOptions.SetTiebreaker, Writer);
+        Writer.WriteLine("Finished MakePrimaryAsync() call.");
+
+        await Task.Delay(100).ConfigureAwait(false);
+
+        Writer.WriteLine("Invoking Ping() (post-primary)");
+        primary.Ping();
+        secondary.Ping();
+        Writer.WriteLine("Finished Ping() (post-primary)");
+
+        Assert.True(primary.IsConnected, $"{primary.EndPoint} is not connected.");
+        Assert.True(secondary.IsConnected, $"{secondary.EndPoint} is not connected.");
+
+        Writer.WriteLine($"{primary.EndPoint}: {primary.ServerType}, Mode: {(primary.IsReplica ? "Replica" : "Primary")}");
+        Writer.WriteLine($"{secondary.EndPoint}: {secondary.ServerType}, Mode: {(secondary.IsReplica ? "Replica" : "Primary")}");
+
+        // Create a separate multiplexer with a valid view of the world to distinguish between failures of
+        // server topology changes from failures to recognize those changes
+        Writer.WriteLine("Connecting to secondary validation connection.");
+        using (var conn2 = ConnectionMultiplexer.Connect(config))
         {
-            using (var muxer = Create())
-            {
-                await Task.Delay(1000).ForAwait();
-                Log("About to reconfigure.....");
-                muxer.Configure();
-                Log("Reconfigured");
-            }
+            var primary2 = conn2.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort);
+            var secondary2 = conn2.GetServer(TestConfig.Current.FailoverReplicaServerAndPort);
+
+            Writer.WriteLine($"Check: {primary2.EndPoint}: {primary2.ServerType}, Mode: {(primary2.IsReplica ? "Replica" : "Primary")}");
+            Writer.WriteLine($"Check: {secondary2.EndPoint}: {secondary2.ServerType}, Mode: {(secondary2.IsReplica ? "Replica" : "Primary")}");
+
+            Assert.False(primary2.IsReplica, $"{primary2.EndPoint} should be a primary (verification connection).");
+            Assert.True(secondary2.IsReplica, $"{secondary2.EndPoint} should be a replica (verification connection).");
+
+            var db2 = conn2.GetDatabase();
+
+            Assert.Equal(primary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.PreferMaster));
+            Assert.Equal(primary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.DemandMaster));
+            Assert.Equal(secondary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.PreferReplica));
+            Assert.Equal(secondary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.DemandReplica));
         }
 
-        [Fact]
-        public async Task ConfigVerifyReceiveConfigChangeBroadcast()
-        {
-            _ = GetConfiguration();
-            using (var sender = Create(allowAdmin: true))
-            using (var receiver = Create(syncTimeout: 2000))
-            {
-                int total = 0;
-                receiver.ConfigurationChangedBroadcast += (s, a) =>
-                {
-                    Log("Config changed: " + (a.EndPoint == null ? "(none)" : a.EndPoint.ToString()));
-                    Interlocked.Increment(ref total);
-                };
-                // send a reconfigure/reconnect message
-                long count = sender.PublishReconfigure();
-                GetServer(receiver).Ping();
-                GetServer(receiver).Ping();
-                await Task.Delay(1000).ConfigureAwait(false);
-                Assert.True(count == -1 || count >= 2, "subscribers");
-                Assert.True(Interlocked.CompareExchange(ref total, 0, 0) >= 1, "total (1st)");
+        await UntilConditionAsync(TimeSpan.FromSeconds(20), () => !primary.IsReplica && secondary.IsReplica);
 
-                Interlocked.Exchange(ref total, 0);
+        Assert.False(primary.IsReplica, $"{primary.EndPoint} should be a primary.");
+        Assert.True(secondary.IsReplica, $"{secondary.EndPoint} should be a replica.");
 
-                // and send a second time via a re-primary operation
-                var server = GetServer(sender);
-                if (server.IsReplica) Skip.Inconclusive("didn't expect a replica");
-                await server.MakePrimaryAsync(ReplicationChangeOptions.Broadcast);
-                await Task.Delay(1000).ConfigureAwait(false);
-                GetServer(receiver).Ping();
-                GetServer(receiver).Ping();
-                Assert.True(Interlocked.CompareExchange(ref total, 0, 0) >= 1, "total (2nd)");
-            }
-        }
-
-        [Fact]
-        public async Task DereplicateGoesToPrimary()
-        {
-            ConfigurationOptions config = GetPrimaryReplicaConfig();
-            config.ConfigCheckSeconds = 5;
-            using (var conn = ConnectionMultiplexer.Connect(config))
-            {
-                var primary = conn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort);
-                var secondary = conn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort);
-
-                primary.Ping();
-                secondary.Ping();
-
-                await primary.MakePrimaryAsync(ReplicationChangeOptions.SetTiebreaker);
-                await secondary.MakePrimaryAsync(ReplicationChangeOptions.None);
-
-                await Task.Delay(100).ConfigureAwait(false);
-
-                primary.Ping();
-                secondary.Ping();
-
-                using (var writer = new StringWriter())
-                {
-                    conn.Configure(writer);
-                    string log = writer.ToString();
-                    Writer.WriteLine(log);
-                    bool isUnanimous = log.Contains("tie-break is unanimous at " + TestConfig.Current.FailoverPrimaryServerAndPort);
-                    if (!isUnanimous) Skip.Inconclusive("this is timing sensitive; unable to verify this time");
-                }
-                // k, so we know everyone loves 6379; is that what we get?
-
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-
-                Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferMaster));
-                Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.DemandMaster));
-                Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferReplica));
-
-                var ex = Assert.Throws<RedisConnectionException>(() => db.IdentifyEndpoint(key, CommandFlags.DemandReplica));
-                Assert.StartsWith("No connection is active/available to service this operation: EXISTS " + Me(), ex.Message);
-                Writer.WriteLine("Invoking MakePrimaryAsync()...");
-                await primary.MakePrimaryAsync(ReplicationChangeOptions.Broadcast | ReplicationChangeOptions.ReplicateToOtherEndpoints | ReplicationChangeOptions.SetTiebreaker, Writer);
-                Writer.WriteLine("Finished MakePrimaryAsync() call.");
-
-                await Task.Delay(100).ConfigureAwait(false);
-
-                Writer.WriteLine("Invoking Ping() (post-primary)");
-                primary.Ping();
-                secondary.Ping();
-                Writer.WriteLine("Finished Ping() (post-primary)");
-
-                Assert.True(primary.IsConnected, $"{primary.EndPoint} is not connected.");
-                Assert.True(secondary.IsConnected, $"{secondary.EndPoint} is not connected.");
-
-                Writer.WriteLine($"{primary.EndPoint}: {primary.ServerType}, Mode: {(primary.IsReplica ? "Replica" : "Primary")}");
-                Writer.WriteLine($"{secondary.EndPoint}: {secondary.ServerType}, Mode: {(secondary.IsReplica ? "Replica" : "Primary")}");
-
-                // Create a separate multiplexer with a valid view of the world to distinguish between failures of
-                // server topology changes from failures to recognize those changes
-                Writer.WriteLine("Connecting to secondary validation connection.");
-                using (var conn2 = ConnectionMultiplexer.Connect(config))
-                {
-                    var primary2 = conn2.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort);
-                    var secondary2 = conn2.GetServer(TestConfig.Current.FailoverReplicaServerAndPort);
-
-                    Writer.WriteLine($"Check: {primary2.EndPoint}: {primary2.ServerType}, Mode: {(primary2.IsReplica ? "Replica" : "Primary")}");
-                    Writer.WriteLine($"Check: {secondary2.EndPoint}: {secondary2.ServerType}, Mode: {(secondary2.IsReplica ? "Replica" : "Primary")}");
-
-                    Assert.False(primary2.IsReplica, $"{primary2.EndPoint} should be a primary (verification connection).");
-                    Assert.True(secondary2.IsReplica, $"{secondary2.EndPoint} should be a replica (verification connection).");
-
-                    var db2 = conn2.GetDatabase();
-
-                    Assert.Equal(primary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.PreferMaster));
-                    Assert.Equal(primary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.DemandMaster));
-                    Assert.Equal(secondary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.PreferReplica));
-                    Assert.Equal(secondary2.EndPoint, db2.IdentifyEndpoint(key, CommandFlags.DemandReplica));
-                }
-
-                await UntilConditionAsync(TimeSpan.FromSeconds(20), () => !primary.IsReplica && secondary.IsReplica);
-
-                Assert.False(primary.IsReplica, $"{primary.EndPoint} should be a primary.");
-                Assert.True(secondary.IsReplica, $"{secondary.EndPoint} should be a replica.");
-
-                Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferMaster));
-                Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.DemandMaster));
-                Assert.Equal(secondary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferReplica));
-                Assert.Equal(secondary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.DemandReplica));
-            }
-        }
+        Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferMaster));
+        Assert.Equal(primary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.DemandMaster));
+        Assert.Equal(secondary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.PreferReplica));
+        Assert.Equal(secondary.EndPoint, db.IdentifyEndpoint(key, CommandFlags.DemandReplica));
+    }
 
 #if DEBUG
-        [Fact]
-        public async Task SubscriptionsSurvivePrimarySwitchAsync()
+    [Fact]
+    public async Task SubscriptionsSurvivePrimarySwitchAsync()
+    {
+        static void TopologyFail() => Skip.Inconclusive("Replication topology change failed...and that's both inconsistent and not what we're testing.");
+
+        if (RunningInCI)
         {
-            static void TopologyFail() => Skip.Inconclusive("Replication topology change failed...and that's both inconsistent and not what we're testing.");
-
-            if (RunningInCI)
-            {
-                Skip.Inconclusive("TODO: Fix race in broadcast reconfig a zero latency.");
-            }
-
-            using (var a = Create(allowAdmin: true, shared: false))
-            using (var b = Create(allowAdmin: true, shared: false))
-            {
-                RedisChannel channel = Me();
-                Log("Using Channel: " + channel);
-                var subA = a.GetSubscriber();
-                var subB = b.GetSubscriber();
-
-                long primaryChanged = 0, aCount = 0, bCount = 0;
-                a.ConfigurationChangedBroadcast += delegate
-                {
-                    Log("A noticed config broadcast: " + Interlocked.Increment(ref primaryChanged));
-                };
-                b.ConfigurationChangedBroadcast += delegate
-                {
-                    Log("B noticed config broadcast: " + Interlocked.Increment(ref primaryChanged));
-                };
-                subA.Subscribe(channel, (_, message) =>
-                {
-                    Log("A got message: " + message);
-                    Interlocked.Increment(ref aCount);
-                });
-                subB.Subscribe(channel, (_, message) =>
-                {
-                    Log("B got message: " + message);
-                    Interlocked.Increment(ref bCount);
-                });
-
-                Assert.False(a.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a primary");
-                if (!a.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica)
-                {
-                    TopologyFail();
-                }
-                Assert.True(a.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a replica");
-                Assert.False(b.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica, $"B Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a primary");
-                Assert.True(b.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"B Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a replica");
-
-                Log("Failover 1 Complete");
-                var epA = subA.SubscribedEndpoint(channel);
-                var epB = subB.SubscribedEndpoint(channel);
-                Log("  A: " + EndPointCollection.ToString(epA));
-                Log("  B: " + EndPointCollection.ToString(epB));
-                subA.Publish(channel, "A1");
-                subB.Publish(channel, "B1");
-                Log("  SubA ping: " + subA.Ping());
-                Log("  SubB ping: " + subB.Ping());
-                // If redis is under load due to this suite, it may take a moment to send across.
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => Interlocked.Read(ref aCount) == 2 && Interlocked.Read(ref bCount) == 2).ForAwait();
-
-                Assert.Equal(2, Interlocked.Read(ref aCount));
-                Assert.Equal(2, Interlocked.Read(ref bCount));
-                Assert.Equal(0, Interlocked.Read(ref primaryChanged));
-
-                try
-                {
-                    Interlocked.Exchange(ref primaryChanged, 0);
-                    Interlocked.Exchange(ref aCount, 0);
-                    Interlocked.Exchange(ref bCount, 0);
-                    Log("Changing primary...");
-                    using (var sw = new StringWriter())
-                    {
-                        await a.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).MakePrimaryAsync(ReplicationChangeOptions.All, sw);
-                        Log(sw.ToString());
-                    }
-                    Log("Waiting for connection B to detect...");
-                    await UntilConditionAsync(TimeSpan.FromSeconds(10), () => b.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica).ForAwait();
-                    subA.Ping();
-                    subB.Ping();
-                    Log("Failover 2 Attempted. Pausing...");
-                    Log("  A " + TestConfig.Current.FailoverPrimaryServerAndPort + " status: " + (a.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica ? "Replica" : "Primary"));
-                    Log("  A " + TestConfig.Current.FailoverReplicaServerAndPort + " status: " + (a.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica ? "Replica" : "Primary"));
-                    Log("  B " + TestConfig.Current.FailoverPrimaryServerAndPort + " status: " + (b.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica ? "Replica" : "Primary"));
-                    Log("  B " + TestConfig.Current.FailoverReplicaServerAndPort + " status: " + (b.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica ? "Replica" : "Primary"));
-
-                    if (!a.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica)
-                    {
-                        TopologyFail();
-                    }
-                    Log("Failover 2 Complete.");
-
-                    Assert.True(a.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a replica");
-                    Assert.False(a.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a primary");
-                    await UntilConditionAsync(TimeSpan.FromSeconds(10), () => b.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica).ForAwait();
-                    var sanityCheck = b.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica;
-                    if (!sanityCheck)
-                    {
-                        Log("FAILURE: B has not detected the topology change.");
-                        foreach (var server in b.GetServerSnapshot().ToArray())
-                        {
-                            Log("  Server" + server.EndPoint);
-                            Log("    State: " + server.ConnectionState);
-                            Log("    IsReplica: " + !server.IsReplica);
-                            Log("    Type: " + server.ServerType);
-                        }
-                        //Skip.Inconclusive("Not enough latency.");
-                    }
-                    Assert.True(sanityCheck, $"B Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a replica");
-                    Assert.False(b.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"B Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a primary");
-
-                    Log("Pause complete");
-                    Log("  A outstanding: " + a.GetCounters().TotalOutstanding);
-                    Log("  B outstanding: " + b.GetCounters().TotalOutstanding);
-                    subA.Ping();
-                    subB.Ping();
-                    await Task.Delay(5000).ForAwait();
-                    epA = subA.SubscribedEndpoint(channel);
-                    epB = subB.SubscribedEndpoint(channel);
-                    Log("Subscription complete");
-                    Log("  A: " + EndPointCollection.ToString(epA));
-                    Log("  B: " + EndPointCollection.ToString(epB));
-                    var aSentTo = subA.Publish(channel, "A2");
-                    var bSentTo = subB.Publish(channel, "B2");
-                    Log("  A2 sent to: " + aSentTo);
-                    Log("  B2 sent to: " + bSentTo);
-                    subA.Ping();
-                    subB.Ping();
-                    Log("Ping Complete. Checking...");
-                    await UntilConditionAsync(TimeSpan.FromSeconds(10), () => Interlocked.Read(ref aCount) == 2 && Interlocked.Read(ref bCount) == 2).ForAwait();
-
-                    Log("Counts so far:");
-                    Log("  aCount: " + Interlocked.Read(ref aCount));
-                    Log("  bCount: " + Interlocked.Read(ref bCount));
-                    Log("  primaryChanged: " + Interlocked.Read(ref primaryChanged));
-
-                    Assert.Equal(2, Interlocked.Read(ref aCount));
-                    Assert.Equal(2, Interlocked.Read(ref bCount));
-                    // Expect 12, because a sees a, but b sees a and b due to replication
-                    Assert.Equal(12, Interlocked.CompareExchange(ref primaryChanged, 0, 0));
-                }
-                catch
-                {
-                    LogNoTime("");
-                    Log("ERROR: Something went bad - see above! Roooooolling back. Back it up. Baaaaaack it on up.");
-                    LogNoTime("");
-                    throw;
-                }
-                finally
-                {
-                    Log("Restoring configuration...");
-                    try
-                    {
-                        await a.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).MakePrimaryAsync(ReplicationChangeOptions.All);
-                        await Task.Delay(1000).ForAwait();
-                    }
-                    catch { /* Don't bomb here */ }
-                }
-            }
+            Skip.Inconclusive("TODO: Fix race in broadcast reconfig a zero latency.");
         }
-#endif
+
+        using var aConn = Create(allowAdmin: true, shared: false);
+        using var bConn = Create(allowAdmin: true, shared: false);
+
+        RedisChannel channel = Me();
+        Log("Using Channel: " + channel);
+        var subA = aConn.GetSubscriber();
+        var subB = bConn.GetSubscriber();
+
+        long primaryChanged = 0, aCount = 0, bCount = 0;
+        aConn.ConfigurationChangedBroadcast += delegate
+        {
+            Log("A noticed config broadcast: " + Interlocked.Increment(ref primaryChanged));
+        };
+        bConn.ConfigurationChangedBroadcast += delegate
+        {
+            Log("B noticed config broadcast: " + Interlocked.Increment(ref primaryChanged));
+        };
+        subA.Subscribe(channel, (_, message) =>
+        {
+            Log("A got message: " + message);
+            Interlocked.Increment(ref aCount);
+        });
+        subB.Subscribe(channel, (_, message) =>
+        {
+            Log("B got message: " + message);
+            Interlocked.Increment(ref bCount);
+        });
+
+        Assert.False(aConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a primary");
+        if (!aConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica)
+        {
+            TopologyFail();
+        }
+        Assert.True(aConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a replica");
+        Assert.False(bConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica, $"B Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a primary");
+        Assert.True(bConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"B Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a replica");
+
+        Log("Failover 1 Complete");
+        var epA = subA.SubscribedEndpoint(channel);
+        var epB = subB.SubscribedEndpoint(channel);
+        Log("  A: " + EndPointCollection.ToString(epA));
+        Log("  B: " + EndPointCollection.ToString(epB));
+        subA.Publish(channel, "A1");
+        subB.Publish(channel, "B1");
+        Log("  SubA ping: " + subA.Ping());
+        Log("  SubB ping: " + subB.Ping());
+        // If redis is under load due to this suite, it may take a moment to send across.
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => Interlocked.Read(ref aCount) == 2 && Interlocked.Read(ref bCount) == 2).ForAwait();
+
+        Assert.Equal(2, Interlocked.Read(ref aCount));
+        Assert.Equal(2, Interlocked.Read(ref bCount));
+        Assert.Equal(0, Interlocked.Read(ref primaryChanged));
+
+        try
+        {
+            Interlocked.Exchange(ref primaryChanged, 0);
+            Interlocked.Exchange(ref aCount, 0);
+            Interlocked.Exchange(ref bCount, 0);
+            Log("Changing primary...");
+            using (var sw = new StringWriter())
+            {
+                await aConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).MakePrimaryAsync(ReplicationChangeOptions.All, sw);
+                Log(sw.ToString());
+            }
+            Log("Waiting for connection B to detect...");
+            await UntilConditionAsync(TimeSpan.FromSeconds(10), () => bConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica).ForAwait();
+            subA.Ping();
+            subB.Ping();
+            Log("Failover 2 Attempted. Pausing...");
+            Log("  A " + TestConfig.Current.FailoverPrimaryServerAndPort + " status: " + (aConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica ? "Replica" : "Primary"));
+            Log("  A " + TestConfig.Current.FailoverReplicaServerAndPort + " status: " + (aConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica ? "Replica" : "Primary"));
+            Log("  B " + TestConfig.Current.FailoverPrimaryServerAndPort + " status: " + (bConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica ? "Replica" : "Primary"));
+            Log("  B " + TestConfig.Current.FailoverReplicaServerAndPort + " status: " + (bConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica ? "Replica" : "Primary"));
+
+            if (!aConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica)
+            {
+                TopologyFail();
+            }
+            Log("Failover 2 Complete.");
+
+            Assert.True(aConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a replica");
+            Assert.False(aConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"A Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a primary");
+            await UntilConditionAsync(TimeSpan.FromSeconds(10), () => bConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica).ForAwait();
+            var sanityCheck = bConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).IsReplica;
+            if (!sanityCheck)
+            {
+                Log("FAILURE: B has not detected the topology change.");
+                foreach (var server in bConn.GetServerSnapshot().ToArray())
+                {
+                    Log("  Server" + server.EndPoint);
+                    Log("    State: " + server.ConnectionState);
+                    Log("    IsReplica: " + !server.IsReplica);
+                    Log("    Type: " + server.ServerType);
+                }
+                //Skip.Inconclusive("Not enough latency.");
+            }
+            Assert.True(sanityCheck, $"B Connection: {TestConfig.Current.FailoverPrimaryServerAndPort} should be a replica");
+            Assert.False(bConn.GetServer(TestConfig.Current.FailoverReplicaServerAndPort).IsReplica, $"B Connection: {TestConfig.Current.FailoverReplicaServerAndPort} should be a primary");
+
+            Log("Pause complete");
+            Log("  A outstanding: " + aConn.GetCounters().TotalOutstanding);
+            Log("  B outstanding: " + bConn.GetCounters().TotalOutstanding);
+            subA.Ping();
+            subB.Ping();
+            await Task.Delay(5000).ForAwait();
+            epA = subA.SubscribedEndpoint(channel);
+            epB = subB.SubscribedEndpoint(channel);
+            Log("Subscription complete");
+            Log("  A: " + EndPointCollection.ToString(epA));
+            Log("  B: " + EndPointCollection.ToString(epB));
+            var aSentTo = subA.Publish(channel, "A2");
+            var bSentTo = subB.Publish(channel, "B2");
+            Log("  A2 sent to: " + aSentTo);
+            Log("  B2 sent to: " + bSentTo);
+            subA.Ping();
+            subB.Ping();
+            Log("Ping Complete. Checking...");
+            await UntilConditionAsync(TimeSpan.FromSeconds(10), () => Interlocked.Read(ref aCount) == 2 && Interlocked.Read(ref bCount) == 2).ForAwait();
+
+            Log("Counts so far:");
+            Log("  aCount: " + Interlocked.Read(ref aCount));
+            Log("  bCount: " + Interlocked.Read(ref bCount));
+            Log("  primaryChanged: " + Interlocked.Read(ref primaryChanged));
+
+            Assert.Equal(2, Interlocked.Read(ref aCount));
+            Assert.Equal(2, Interlocked.Read(ref bCount));
+            // Expect 12, because a sees a, but b sees a and b due to replication
+            Assert.Equal(12, Interlocked.CompareExchange(ref primaryChanged, 0, 0));
+        }
+        catch
+        {
+            LogNoTime("");
+            Log("ERROR: Something went bad - see above! Roooooolling back. Back it up. Baaaaaack it on up.");
+            LogNoTime("");
+            throw;
+        }
+        finally
+        {
+            Log("Restoring configuration...");
+            try
+            {
+                await aConn.GetServer(TestConfig.Current.FailoverPrimaryServerAndPort).MakePrimaryAsync(ReplicationChangeOptions.All);
+                await Task.Delay(1000).ForAwait();
+            }
+            catch { /* Don't bomb here */ }
+        }
     }
+#endif
 }

--- a/tests/StackExchange.Redis.Tests/FeatureFlags.cs
+++ b/tests/StackExchange.Redis.Tests/FeatureFlags.cs
@@ -1,26 +1,25 @@
 ﻿using Xunit;
 
-namespace StackExchange.Redis.Tests
-{
-    [Collection(NonParallelCollection.Name)]
-    public class FeatureFlags
-    {
-        [Fact]
-        public void UnknownFlagToggle()
-        {
-            Assert.False(ConnectionMultiplexer.GetFeatureFlag("nope"));
-            ConnectionMultiplexer.SetFeatureFlag("nope", true);
-            Assert.False(ConnectionMultiplexer.GetFeatureFlag("nope"));
-        }
+namespace StackExchange.Redis.Tests;
 
-        [Fact]
-        public void KnownFlagToggle()
-        {
-            Assert.False(ConnectionMultiplexer.GetFeatureFlag("preventthreadtheft"));
-            ConnectionMultiplexer.SetFeatureFlag("preventthreadtheft", true);
-            Assert.True(ConnectionMultiplexer.GetFeatureFlag("preventthreadtheft"));
-            ConnectionMultiplexer.SetFeatureFlag("preventthreadtheft", false);
-            Assert.False(ConnectionMultiplexer.GetFeatureFlag("preventthreadtheft"));
-        }
+[Collection(NonParallelCollection.Name)]
+public class FeatureFlags
+{
+    [Fact]
+    public void UnknownFlagToggle()
+    {
+        Assert.False(ConnectionMultiplexer.GetFeatureFlag("nope"));
+        ConnectionMultiplexer.SetFeatureFlag("nope", true);
+        Assert.False(ConnectionMultiplexer.GetFeatureFlag("nope"));
+    }
+
+    [Fact]
+    public void KnownFlagToggle()
+    {
+        Assert.False(ConnectionMultiplexer.GetFeatureFlag("preventthreadtheft"));
+        ConnectionMultiplexer.SetFeatureFlag("preventthreadtheft", true);
+        Assert.True(ConnectionMultiplexer.GetFeatureFlag("preventthreadtheft"));
+        ConnectionMultiplexer.SetFeatureFlag("preventthreadtheft", false);
+        Assert.False(ConnectionMultiplexer.GetFeatureFlag("preventthreadtheft"));
     }
 }

--- a/tests/StackExchange.Redis.Tests/FloatingPoint.cs
+++ b/tests/StackExchange.Redis.Tests/FloatingPoint.cs
@@ -3,163 +3,158 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class FloatingPoint : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class FloatingPoint : TestBase
+    public FloatingPoint(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    private static bool Within(double x, double y, double delta) => Math.Abs(x - y) <= delta;
+
+    [Fact]
+    public void IncrDecrFloatingPoint()
     {
-        public FloatingPoint(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
 
-        private static bool Within(double x, double y, double delta) => Math.Abs(x - y) <= delta;
-
-        [Fact]
-        public void IncrDecrFloatingPoint()
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        double[] incr =
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                double[] incr =
-                {
-                    12.134,
-                    -14561.0000002,
-                    125.3421,
-                    -2.49892498
-                }, decr =
-                {
-                    99.312,
-                    12,
-                    -35
-                };
-                double sum = 0;
-                foreach (var value in incr)
-                {
-                    db.StringIncrement(key, value, CommandFlags.FireAndForget);
-                    sum += value;
-                }
-                foreach (var value in decr)
-                {
-                    db.StringDecrement(key, value, CommandFlags.FireAndForget);
-                    sum -= value;
-                }
-                var val = (double)db.StringGet(key);
-
-                Assert.True(Within(sum, val, 0.0001));
-            }
-        }
-
-        [Fact]
-        public async Task IncrDecrFloatingPointAsync()
+                12.134,
+                -14561.0000002,
+                125.3421,
+                -2.49892498
+            }, decr =
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                double[] incr =
-                {
-                    12.134,
-                    -14561.0000002,
-                    125.3421,
-                    -2.49892498
-                }, decr =
-                {
-                    99.312,
-                    12,
-                    -35
-                };
-                double sum = 0;
-                foreach (var value in incr)
-                {
-                    await db.StringIncrementAsync(key, value).ForAwait();
-                    sum += value;
-                }
-                foreach (var value in decr)
-                {
-                    await db.StringDecrementAsync(key, value).ForAwait();
-                    sum -= value;
-                }
-                var val = (double)await db.StringGetAsync(key).ForAwait();
-
-                Assert.True(Within(sum, val, 0.0001));
-            }
-        }
-
-        [Fact]
-        public void HashIncrDecrFloatingPoint()
+                99.312,
+                12,
+                -35
+            };
+        double sum = 0;
+        foreach (var value in incr)
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                RedisValue field = "foo";
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                double[] incr =
-                {
-                    12.134,
-                    -14561.0000002,
-                    125.3421,
-                    -2.49892498
-                }, decr =
-                {
-                    99.312,
-                    12,
-                    -35
-                };
-                double sum = 0;
-                foreach (var value in incr)
-                {
-                    db.HashIncrement(key, field, value, CommandFlags.FireAndForget);
-                    sum += value;
-                }
-                foreach (var value in decr)
-                {
-                    db.HashDecrement(key, field, value, CommandFlags.FireAndForget);
-                    sum -= value;
-                }
-                var val = (double)db.HashGet(key, field);
-
-                Assert.True(Within(sum, val, 0.0001), $"{sum} not within 0.0001 of {val}");
-            }
+            db.StringIncrement(key, value, CommandFlags.FireAndForget);
+            sum += value;
         }
-
-        [Fact]
-        public async Task HashIncrDecrFloatingPointAsync()
+        foreach (var value in decr)
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                RedisValue field = "bar";
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                double[] incr =
-                {
-                    12.134,
-                    -14561.0000002,
-                    125.3421,
-                    -2.49892498
-                }, decr =
-                {
-                    99.312,
-                    12,
-                    -35
-                };
-                double sum = 0;
-                foreach (var value in incr)
-                {
-                    _ = db.HashIncrementAsync(key, field, value);
-                    sum += value;
-                }
-                foreach (var value in decr)
-                {
-                    _ = db.HashDecrementAsync(key, field, value);
-                    sum -= value;
-                }
-                var val = (double)await db.HashGetAsync(key, field).ForAwait();
-
-                Assert.True(Within(sum, val, 0.0001));
-            }
+            db.StringDecrement(key, value, CommandFlags.FireAndForget);
+            sum -= value;
         }
+        var val = (double)db.StringGet(key);
+
+        Assert.True(Within(sum, val, 0.0001));
+    }
+
+    [Fact]
+    public async Task IncrDecrFloatingPointAsync()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        double[] incr =
+        {
+                12.134,
+                -14561.0000002,
+                125.3421,
+                -2.49892498
+            }, decr =
+        {
+                99.312,
+                12,
+                -35
+            };
+        double sum = 0;
+        foreach (var value in incr)
+        {
+            await db.StringIncrementAsync(key, value).ForAwait();
+            sum += value;
+        }
+        foreach (var value in decr)
+        {
+            await db.StringDecrementAsync(key, value).ForAwait();
+            sum -= value;
+        }
+        var val = (double)await db.StringGetAsync(key).ForAwait();
+
+        Assert.True(Within(sum, val, 0.0001));
+    }
+
+    [Fact]
+    public void HashIncrDecrFloatingPoint()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        RedisValue field = "foo";
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        double[] incr =
+        {
+                12.134,
+                -14561.0000002,
+                125.3421,
+                -2.49892498
+            }, decr =
+        {
+                99.312,
+                12,
+                -35
+            };
+        double sum = 0;
+        foreach (var value in incr)
+        {
+            db.HashIncrement(key, field, value, CommandFlags.FireAndForget);
+            sum += value;
+        }
+        foreach (var value in decr)
+        {
+            db.HashDecrement(key, field, value, CommandFlags.FireAndForget);
+            sum -= value;
+        }
+        var val = (double)db.HashGet(key, field);
+
+        Assert.True(Within(sum, val, 0.0001), $"{sum} not within 0.0001 of {val}");
+    }
+
+    [Fact]
+    public async Task HashIncrDecrFloatingPointAsync()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        RedisValue field = "bar";
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        double[] incr =
+        {
+                12.134,
+                -14561.0000002,
+                125.3421,
+                -2.49892498
+            }, decr =
+        {
+                99.312,
+                12,
+                -35
+            };
+        double sum = 0;
+        foreach (var value in incr)
+        {
+            _ = db.HashIncrementAsync(key, field, value);
+            sum += value;
+        }
+        foreach (var value in decr)
+        {
+            _ = db.HashDecrementAsync(key, field, value);
+            sum -= value;
+        }
+        var val = (double)await db.HashGetAsync(key, field).ForAwait();
+
+        Assert.True(Within(sum, val, 0.0001));
     }
 }

--- a/tests/StackExchange.Redis.Tests/FormatTests.cs
+++ b/tests/StackExchange.Redis.Tests/FormatTests.cs
@@ -3,80 +3,79 @@ using System.Net;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class FormatTests : TestBase
 {
-    public class FormatTests : TestBase
+    public FormatTests(ITestOutputHelper output) : base(output) { }
+
+    public static IEnumerable<object[]> EndpointData()
     {
-        public FormatTests(ITestOutputHelper output) : base(output) { }
-
-        public static IEnumerable<object[]> EndpointData()
-        {
-            // DNS
-            yield return new object[] { "localhost", new DnsEndPoint("localhost", 0) };
-            yield return new object[] { "localhost:6390", new DnsEndPoint("localhost", 6390) };
-            yield return new object[] { "bob.the.builder.com", new DnsEndPoint("bob.the.builder.com", 0) };
-            yield return new object[] { "bob.the.builder.com:6390", new DnsEndPoint("bob.the.builder.com", 6390) };
-            // IPv4
-            yield return new object[] { "0.0.0.0", new IPEndPoint(IPAddress.Parse("0.0.0.0"), 0) };
-            yield return new object[] { "127.0.0.1", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 0) };
-            yield return new object[] { "127.1", new IPEndPoint(IPAddress.Parse("127.1"), 0) };
-            yield return new object[] { "127.1:6389", new IPEndPoint(IPAddress.Parse("127.1"), 6389) };
-            yield return new object[] { "127.0.0.1:6389", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 6389) };
-            yield return new object[] { "127.0.0.1:1", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1) };
-            yield return new object[] { "127.0.0.1:2", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 2) };
-            yield return new object[] { "10.10.9.18:2", new IPEndPoint(IPAddress.Parse("10.10.9.18"), 2) };
-            // IPv6
-            yield return new object[] { "::1", new IPEndPoint(IPAddress.Parse("::1"), 0) };
-            yield return new object[] { "::1:6379", new IPEndPoint(IPAddress.Parse("::0.1.99.121"), 0) }; // remember your brackets!
-            yield return new object[] { "[::1]:6379", new IPEndPoint(IPAddress.Parse("::1"), 6379) };
-            yield return new object[] { "[::1]", new IPEndPoint(IPAddress.Parse("::1"), 0) };
-            yield return new object[] { "[::1]:1000", new IPEndPoint(IPAddress.Parse("::1"), 1000) };
-            yield return new object[] { "[2001:db7:85a3:8d2:1319:8a2e:370:7348]", new IPEndPoint(IPAddress.Parse("2001:db7:85a3:8d2:1319:8a2e:370:7348"), 0) };
-            yield return new object[] { "[2001:db7:85a3:8d2:1319:8a2e:370:7348]:1000", new IPEndPoint(IPAddress.Parse("2001:db7:85a3:8d2:1319:8a2e:370:7348"), 1000) };
-        }
-
-        [Theory]
-        [MemberData(nameof(EndpointData))]
-        public void ParseEndPoint(string data, EndPoint expected)
-        {
-            _ = Format.TryParseEndPoint(data, out var result);
-            Assert.Equal(expected, result);
-        }
-
-        [Theory]
-        [InlineData(CommandFlags.None, "None")]
-#if NET472
-        [InlineData(CommandFlags.PreferReplica, "PreferMaster, PreferReplica")] // 2-bit flag is hit-and-miss
-        [InlineData(CommandFlags.DemandReplica, "PreferMaster, DemandReplica")] // 2-bit flag is hit-and-miss
-#else
-        [InlineData(CommandFlags.PreferReplica, "PreferReplica")] // 2-bit flag is hit-and-miss
-        [InlineData(CommandFlags.DemandReplica, "DemandReplica")] // 2-bit flag is hit-and-miss
-#endif
-        [InlineData(CommandFlags.PreferReplica | CommandFlags.FireAndForget, "PreferMaster, FireAndForget, PreferReplica")] // 2-bit flag is hit-and-miss
-        [InlineData(CommandFlags.DemandReplica | CommandFlags.FireAndForget, "PreferMaster, FireAndForget, DemandReplica")] // 2-bit flag is hit-and-miss
-        public void CommandFlagsFormatting(CommandFlags value, string expected)
-            => Assert.Equal(expected, value.ToString());
-
-        [Theory]
-        [InlineData(ClientType.Normal, "Normal")]
-        [InlineData(ClientType.Replica, "Replica")]
-        [InlineData(ClientType.PubSub, "PubSub")]
-        public void ClientTypeFormatting(ClientType value, string expected)
-            => Assert.Equal(expected, value.ToString());
-
-        [Theory]
-        [InlineData(ClientFlags.None, "None")]
-        [InlineData(ClientFlags.Replica | ClientFlags.Transaction, "Replica, Transaction")]
-        [InlineData(ClientFlags.Transaction | ClientFlags.ReplicaMonitor | ClientFlags.UnixDomainSocket, "ReplicaMonitor, Transaction, UnixDomainSocket")]
-        public void ClientFlagsFormatting(ClientFlags value, string expected)
-            => Assert.Equal(expected, value.ToString());
-
-        [Theory]
-        [InlineData(ReplicationChangeOptions.None, "None")]
-        [InlineData(ReplicationChangeOptions.ReplicateToOtherEndpoints, "ReplicateToOtherEndpoints")]
-        [InlineData(ReplicationChangeOptions.SetTiebreaker | ReplicationChangeOptions.ReplicateToOtherEndpoints, "SetTiebreaker, ReplicateToOtherEndpoints")]
-        [InlineData(ReplicationChangeOptions.Broadcast | ReplicationChangeOptions.SetTiebreaker | ReplicationChangeOptions.ReplicateToOtherEndpoints, "All")]
-        public void ReplicationChangeOptionsFormatting(ReplicationChangeOptions value, string expected)
-            => Assert.Equal(expected, value.ToString());
+        // DNS
+        yield return new object[] { "localhost", new DnsEndPoint("localhost", 0) };
+        yield return new object[] { "localhost:6390", new DnsEndPoint("localhost", 6390) };
+        yield return new object[] { "bob.the.builder.com", new DnsEndPoint("bob.the.builder.com", 0) };
+        yield return new object[] { "bob.the.builder.com:6390", new DnsEndPoint("bob.the.builder.com", 6390) };
+        // IPv4
+        yield return new object[] { "0.0.0.0", new IPEndPoint(IPAddress.Parse("0.0.0.0"), 0) };
+        yield return new object[] { "127.0.0.1", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 0) };
+        yield return new object[] { "127.1", new IPEndPoint(IPAddress.Parse("127.1"), 0) };
+        yield return new object[] { "127.1:6389", new IPEndPoint(IPAddress.Parse("127.1"), 6389) };
+        yield return new object[] { "127.0.0.1:6389", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 6389) };
+        yield return new object[] { "127.0.0.1:1", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1) };
+        yield return new object[] { "127.0.0.1:2", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 2) };
+        yield return new object[] { "10.10.9.18:2", new IPEndPoint(IPAddress.Parse("10.10.9.18"), 2) };
+        // IPv6
+        yield return new object[] { "::1", new IPEndPoint(IPAddress.Parse("::1"), 0) };
+        yield return new object[] { "::1:6379", new IPEndPoint(IPAddress.Parse("::0.1.99.121"), 0) }; // remember your brackets!
+        yield return new object[] { "[::1]:6379", new IPEndPoint(IPAddress.Parse("::1"), 6379) };
+        yield return new object[] { "[::1]", new IPEndPoint(IPAddress.Parse("::1"), 0) };
+        yield return new object[] { "[::1]:1000", new IPEndPoint(IPAddress.Parse("::1"), 1000) };
+        yield return new object[] { "[2001:db7:85a3:8d2:1319:8a2e:370:7348]", new IPEndPoint(IPAddress.Parse("2001:db7:85a3:8d2:1319:8a2e:370:7348"), 0) };
+        yield return new object[] { "[2001:db7:85a3:8d2:1319:8a2e:370:7348]:1000", new IPEndPoint(IPAddress.Parse("2001:db7:85a3:8d2:1319:8a2e:370:7348"), 1000) };
     }
+
+    [Theory]
+    [MemberData(nameof(EndpointData))]
+    public void ParseEndPoint(string data, EndPoint expected)
+    {
+        _ = Format.TryParseEndPoint(data, out var result);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(CommandFlags.None, "None")]
+#if NET472
+    [InlineData(CommandFlags.PreferReplica, "PreferMaster, PreferReplica")] // 2-bit flag is hit-and-miss
+    [InlineData(CommandFlags.DemandReplica, "PreferMaster, DemandReplica")] // 2-bit flag is hit-and-miss
+#else
+    [InlineData(CommandFlags.PreferReplica, "PreferReplica")] // 2-bit flag is hit-and-miss
+    [InlineData(CommandFlags.DemandReplica, "DemandReplica")] // 2-bit flag is hit-and-miss
+#endif
+    [InlineData(CommandFlags.PreferReplica | CommandFlags.FireAndForget, "PreferMaster, FireAndForget, PreferReplica")] // 2-bit flag is hit-and-miss
+    [InlineData(CommandFlags.DemandReplica | CommandFlags.FireAndForget, "PreferMaster, FireAndForget, DemandReplica")] // 2-bit flag is hit-and-miss
+    public void CommandFlagsFormatting(CommandFlags value, string expected)
+        => Assert.Equal(expected, value.ToString());
+
+    [Theory]
+    [InlineData(ClientType.Normal, "Normal")]
+    [InlineData(ClientType.Replica, "Replica")]
+    [InlineData(ClientType.PubSub, "PubSub")]
+    public void ClientTypeFormatting(ClientType value, string expected)
+        => Assert.Equal(expected, value.ToString());
+
+    [Theory]
+    [InlineData(ClientFlags.None, "None")]
+    [InlineData(ClientFlags.Replica | ClientFlags.Transaction, "Replica, Transaction")]
+    [InlineData(ClientFlags.Transaction | ClientFlags.ReplicaMonitor | ClientFlags.UnixDomainSocket, "ReplicaMonitor, Transaction, UnixDomainSocket")]
+    public void ClientFlagsFormatting(ClientFlags value, string expected)
+        => Assert.Equal(expected, value.ToString());
+
+    [Theory]
+    [InlineData(ReplicationChangeOptions.None, "None")]
+    [InlineData(ReplicationChangeOptions.ReplicateToOtherEndpoints, "ReplicateToOtherEndpoints")]
+    [InlineData(ReplicationChangeOptions.SetTiebreaker | ReplicationChangeOptions.ReplicateToOtherEndpoints, "SetTiebreaker, ReplicateToOtherEndpoints")]
+    [InlineData(ReplicationChangeOptions.Broadcast | ReplicationChangeOptions.SetTiebreaker | ReplicationChangeOptions.ReplicateToOtherEndpoints, "All")]
+    public void ReplicationChangeOptionsFormatting(ReplicationChangeOptions value, string expected)
+        => Assert.Equal(expected, value.ToString());
 }

--- a/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
+++ b/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
@@ -3,54 +3,53 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)] // because I need to measure some things that could get confused
+public class GarbageCollectionTests : TestBase
 {
-    [Collection(NonParallelCollection.Name)] // because I need to measure some things that could get confused
-    public class GarbageCollectionTests : TestBase
+    public GarbageCollectionTests(ITestOutputHelper helper) : base(helper) { }
+
+    private static void ForceGC()
     {
-        public GarbageCollectionTests(ITestOutputHelper helper) : base(helper) { }
-
-        private static void ForceGC()
+        for (int i = 0; i < 3; i++)
         {
-            for (int i = 0; i < 3; i++)
-            {
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
-                GC.WaitForPendingFinalizers();
-            }
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+            GC.WaitForPendingFinalizers();
         }
+    }
 
-        [Fact]
-        public async Task MuxerIsCollected()
-        {
+    [Fact]
+    public async Task MuxerIsCollected()
+    {
 #if DEBUG
-            Skip.Inconclusive("Only predictable in release builds");
+        Skip.Inconclusive("Only predictable in release builds");
 #endif
-            // this is more nuanced than it looks; multiple sockets with
-            // async callbacks, plus a heartbeat on a timer
+        // this is more nuanced than it looks; multiple sockets with
+        // async callbacks, plus a heartbeat on a timer
 
-            // deliberately not "using" - we *want* to leak this
-            var muxer = Create();
-            muxer.GetDatabase().Ping(); // smoke-test
+        // deliberately not "using" - we *want* to leak this
+        var conn = Create();
+        conn.GetDatabase().Ping(); // smoke-test
 
-            ForceGC();
+        ForceGC();
 
 //#if DEBUG // this counter only exists in debug
 //            int before = ConnectionMultiplexer.CollectedWithoutDispose;
 //#endif
-            var wr = new WeakReference(muxer);
-            muxer = null;
+        var wr = new WeakReference(conn);
+        conn = null;
 
-            ForceGC();
-            await Task.Delay(2000).ForAwait(); // GC is twitchy
-            ForceGC();
+        ForceGC();
+        await Task.Delay(2000).ForAwait(); // GC is twitchy
+        ForceGC();
 
-            // should be collectable
-            Assert.Null(wr.Target);
+        // should be collectable
+        Assert.Null(wr.Target);
 
 //#if DEBUG // this counter only exists in debug
 //            int after = ConnectionMultiplexer.CollectedWithoutDispose;
 //            Assert.Equal(before + 1, after);
 //#endif
-        }
     }
 }

--- a/tests/StackExchange.Redis.Tests/GeoTests.cs
+++ b/tests/StackExchange.Redis.Tests/GeoTests.cs
@@ -3,640 +3,625 @@ using System;
 using Xunit.Abstractions;
 using System.Threading.Tasks;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class GeoTests : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class GeoTests : TestBase
+    public GeoTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    private static readonly GeoEntry
+        palermo = new GeoEntry(13.361389, 38.115556, "Palermo"),
+        catania = new GeoEntry(15.087269, 37.502669, "Catania"),
+        agrigento = new GeoEntry(13.5765, 37.311, "Agrigento"),
+        cefalù = new GeoEntry(14.0188, 38.0084, "Cefalù");
+    private static readonly GeoEntry[] all = { palermo, catania, agrigento, cefalù };
+
+    [Fact]
+    public void GeoAdd()
     {
-        public GeoTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
-
-        private static readonly GeoEntry
-            palermo = new GeoEntry(13.361389, 38.115556, "Palermo"),
-            catania = new GeoEntry(15.087269, 37.502669, "Catania"),
-            agrigento = new GeoEntry(13.5765, 37.311, "Agrigento"),
-            cefalù = new GeoEntry(14.0188, 38.0084, "Cefalù");
-        private static readonly GeoEntry[] all = { palermo, catania, agrigento, cefalù };
-
-        [Fact]
-        public void GeoAdd()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                // add while not there
-                Assert.True(db.GeoAdd(key, cefalù.Longitude, cefalù.Latitude, cefalù.Member));
-                Assert.Equal(2, db.GeoAdd(key, new [] { palermo, catania }));
-                Assert.True(db.GeoAdd(key, agrigento));
-
-                // now add again
-                Assert.False(db.GeoAdd(key, cefalù.Longitude, cefalù.Latitude, cefalù.Member));
-                Assert.Equal(0, db.GeoAdd(key, new [] { palermo, catania }));
-                Assert.False(db.GeoAdd(key, agrigento));
-
-                // Validate
-                var pos = db.GeoPosition(key, palermo.Member);
-                Assert.NotNull(pos);
-                Assert.Equal(palermo.Longitude, pos.Value.Longitude, 5);
-                Assert.Equal(palermo.Latitude, pos.Value.Latitude, 5);
-            }
-        }
-
-        [Fact]
-        public void GetDistance()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.GeoAdd(key, all, CommandFlags.FireAndForget);
-                var val = db.GeoDistance(key, "Palermo", "Catania", GeoUnit.Meters);
-                Assert.True(val.HasValue);
-                Assert.Equal(166274.1516, val);
-
-                val = db.GeoDistance(key, "Palermo", "Nowhere", GeoUnit.Meters);
-                Assert.False(val.HasValue);
-            }
-        }
-
-        [Fact]
-        public void GeoHash()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.GeoAdd(key, all, CommandFlags.FireAndForget);
-
-                var hashes = db.GeoHash(key, new RedisValue[] { palermo.Member, "Nowhere", agrigento.Member });
-                Assert.NotNull(hashes);
-                Assert.Equal(3, hashes.Length);
-                Assert.Equal("sqc8b49rny0", hashes[0]);
-                Assert.Null(hashes[1]);
-                Assert.Equal("sq9skbq0760", hashes[2]);
-
-                var hash = db.GeoHash(key, "Palermo");
-                Assert.Equal("sqc8b49rny0", hash);
-
-                hash = db.GeoHash(key, "Nowhere");
-                Assert.Null(hash);
-            }
-        }
-
-        [Fact]
-        public void GeoGetPosition()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.GeoAdd(key, all, CommandFlags.FireAndForget);
-
-                var pos = db.GeoPosition(key, palermo.Member);
-                Assert.True(pos.HasValue);
-                Assert.Equal(Math.Round(palermo.Longitude, 6), Math.Round(pos.Value.Longitude, 6));
-                Assert.Equal(Math.Round(palermo.Latitude, 6), Math.Round(pos.Value.Latitude, 6));
-
-                pos = db.GeoPosition(key, "Nowhere");
-                Assert.False(pos.HasValue);
-            }
-        }
-
-        [Fact]
-        public void GeoRemove()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.GeoAdd(key, all, CommandFlags.FireAndForget);
-
-                var pos = db.GeoPosition(key, "Palermo");
-                Assert.True(pos.HasValue);
-
-                Assert.False(db.GeoRemove(key, "Nowhere"));
-                Assert.True(db.GeoRemove(key, "Palermo"));
-                Assert.False(db.GeoRemove(key, "Palermo"));
-
-                pos = db.GeoPosition(key, "Palermo");
-                Assert.False(pos.HasValue);
-            }
-        }
-
-        [Fact]
-        public void GeoRadius()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.GeoAdd(key, all, CommandFlags.FireAndForget);
-
-                var results = db.GeoRadius(key, cefalù.Member, 60, GeoUnit.Miles, 2, Order.Ascending);
-                Assert.Equal(2, results.Length);
-
-                Assert.Equal(results[0].Member, cefalù.Member);
-                Assert.Equal(0, results[0].Distance);
-                var position0 = results[0].Position;
-                Assert.NotNull(position0);
-                Assert.Equal(Math.Round(position0.Value.Longitude, 5), Math.Round(cefalù.Position.Longitude, 5));
-                Assert.Equal(Math.Round(position0.Value.Latitude, 5), Math.Round(cefalù.Position.Latitude, 5));
-                Assert.False(results[0].Hash.HasValue);
-
-                Assert.Equal(results[1].Member, palermo.Member);
-                var distance1 = results[1].Distance;
-                Assert.NotNull(distance1);
-                Assert.Equal(Math.Round(36.5319, 6), Math.Round(distance1.Value, 6));
-                var position1 = results[1].Position;
-                Assert.NotNull(position1);
-                Assert.Equal(Math.Round(position1.Value.Longitude, 5), Math.Round(palermo.Position.Longitude, 5));
-                Assert.Equal(Math.Round(position1.Value.Latitude, 5), Math.Round(palermo.Position.Latitude, 5));
-                Assert.False(results[1].Hash.HasValue);
-
-                results = db.GeoRadius(key, cefalù.Member, 60, GeoUnit.Miles, 2, Order.Ascending, GeoRadiusOptions.None);
-                Assert.Equal(2, results.Length);
-                Assert.Equal(results[0].Member, cefalù.Member);
-                Assert.False(results[0].Position.HasValue);
-                Assert.False(results[0].Distance.HasValue);
-                Assert.False(results[0].Hash.HasValue);
-
-                Assert.Equal(results[1].Member, palermo.Member);
-                Assert.False(results[1].Position.HasValue);
-                Assert.False(results[1].Distance.HasValue);
-                Assert.False(results[1].Hash.HasValue);
-            }
-        }
-
-        [Fact]
-        public async Task GeoRadiusOverloads()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                Assert.True(db.GeoAdd(key, -1.759925, 52.19493, "steve"));
-                Assert.True(db.GeoAdd(key, -3.360655, 54.66395, "dave"));
-
-                // Invalid overload
-                // Since this would throw ERR could not decode requested zset member, we catch and return something more useful to the user earlier.
-                var ex = Assert.Throws<ArgumentException>(() => db.GeoRadius(key, -1.759925, 52.19493, GeoUnit.Miles, 500, Order.Ascending, GeoRadiusOptions.WithDistance));
-                Assert.StartsWith("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload.", ex.Message);
-                Assert.Equal("member", ex.ParamName);
-                ex = await Assert.ThrowsAsync<ArgumentException>(() => db.GeoRadiusAsync(key, -1.759925, 52.19493, GeoUnit.Miles, 500, Order.Ascending, GeoRadiusOptions.WithDistance)).ForAwait();
-                Assert.StartsWith("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload.", ex.Message);
-                Assert.Equal("member", ex.ParamName);
-
-                // The good stuff
-                GeoRadiusResult[] result = db.GeoRadius(key, -1.759925, 52.19493, 500, unit: GeoUnit.Miles, order: Order.Ascending, options: GeoRadiusOptions.WithDistance);
-                Assert.NotNull(result);
-
-                result = await db.GeoRadiusAsync(key, -1.759925, 52.19493, 500, unit: GeoUnit.Miles, order: Order.Ascending, options: GeoRadiusOptions.WithDistance).ForAwait();
-                Assert.NotNull(result);
-            }
-        }
-
-        private async Task GeoSearchSetupAsync(RedisKey key, IDatabase db)
-        {
-            await db.KeyDeleteAsync(key);
-            await db.GeoAddAsync(key, 82.6534, 27.7682, "rays");
-            await db.GeoAddAsync(key, 79.3891, 43.6418, "blue jays");
-            await db.GeoAddAsync(key, 76.6217, 39.2838, "orioles");
-            await db.GeoAddAsync(key, 71.0927, 42.3467, "red sox");
-            await db.GeoAddAsync(key, 73.9262, 40.8296, "yankees");
-        }
-
-        private void GeoSearchSetup(RedisKey key, IDatabase db)
-        {
-            db.KeyDelete(key);
-            db.GeoAdd(key, 82.6534, 27.7682, "rays");
-            db.GeoAdd(key, 79.3891, 43.6418, "blue jays");
-            db.GeoAdd(key, 76.6217, 39.2838, "orioles");
-            db.GeoAdd(key, 71.0927, 42.3467, "red sox");
-            db.GeoAdd(key, 73.9262, 40.8296, "yankees");
-        }
-
-        [Fact]
-        public async Task GeoSearchCircleMemberAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Miles);
-            var res = await db.GeoSearchAsync(key, "yankees", circle);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Contains(res, x => x.Member == "blue jays");
-            Assert.NotNull(res[0].Distance);
-            Assert.NotNull(res[0].Position);
-            Assert.Null(res[0].Hash);
-            Assert.Equal(4, res.Length);
-        }
-
-        [Fact]
-        public async Task GeoSearchCircleMemberAsyncOnlyHash()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Miles);
-            var res = await db.GeoSearchAsync(key, "yankees", circle, options: GeoRadiusOptions.WithGeoHash);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Contains(res, x => x.Member == "blue jays");
-            Assert.Null(res[0].Distance);
-            Assert.Null(res[0].Position);
-            Assert.NotNull(res[0].Hash);
-            Assert.Equal(4, res.Length);
-        }
-
-        [Fact]
-        public async Task GeoSearchCircleMemberAsyncHashAndDistance()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Miles);
-            var res = await db.GeoSearchAsync(key, "yankees", circle, options: GeoRadiusOptions.WithGeoHash | GeoRadiusOptions.WithDistance);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Contains(res, x => x.Member == "blue jays");
-            Assert.NotNull(res[0].Distance);
-            Assert.Null(res[0].Position);
-            Assert.NotNull(res[0].Hash);
-            Assert.Equal(4, res.Length);
-        }
-
-        [Fact]
-        public async Task GeoSearchCircleLonLatAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Miles);
-            var res = await db.GeoSearchAsync(key, 73.9262, 40.8296, circle);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Contains(res, x => x.Member == "blue jays");
-            Assert.Equal(4, res.Length);
-        }
-
-        [Fact]
-        public void GeoSearchCircleMember()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            GeoSearchSetup(key, db);
-
-            var circle = new GeoSearchCircle(500 * 1609);
-            var res = db.GeoSearch(key, "yankees", circle);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Contains(res, x => x.Member == "blue jays");
-            Assert.Equal(4, res.Length);
-        }
-
-        [Fact]
-        public void GeoSearchCircleLonLat()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            GeoSearchSetup(key, db);
-
-            var circle = new GeoSearchCircle(500 * 5280, GeoUnit.Feet);
-            var res = db.GeoSearch(key, 73.9262, 40.8296, circle);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Contains(res, x => x.Member == "blue jays");
-            Assert.Equal(4, res.Length);
-        }
-
-        [Fact]
-        public async Task GeoSearchBoxMemberAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAsync(key, "yankees", box);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(3, res.Length);
-        }
-
-        [Fact]
-        public async Task GeoSearchBoxLonLatAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAsync(key, 73.9262, 40.8296, box);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(3, res.Length);
-        }
-
-        [Fact]
-        public void GeoSearchBoxMember()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            GeoSearchSetup(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = db.GeoSearch(key, "yankees", box);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(3, res.Length);
-        }
-
-        [Fact]
-        public void GeoSearchBoxLonLat()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            GeoSearchSetup(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = db.GeoSearch(key, 73.9262, 40.8296, box);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(3, res.Length);
-        }
-
-        [Fact]
-        public void GeoSearchLimitCount()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            GeoSearchSetup(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = db.GeoSearch(key, 73.9262, 40.8296, box, count: 2);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(2, res.Length);
-        }
-
-        [Fact]
-        public void GeoSearchLimitCountMakeNoDemands()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            GeoSearchSetup(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = db.GeoSearch(key, 73.9262, 40.8296, box, count: 2, demandClosest: false);
-            Assert.Contains(res, x => x.Member == "red sox"); // this order MIGHT not be fully deterministic, seems to work for our purposes.
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(2, res.Length);
-        }
-
-        [Fact]
-        public async Task GeoSearchBoxLonLatDescending()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await GeoSearchSetupAsync(key, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAsync(key, 73.9262, 40.8296, box, order: Order.Descending);
-            Assert.Contains(res, x => x.Member == "yankees");
-            Assert.Contains(res, x => x.Member == "red sox");
-            Assert.Contains(res, x => x.Member == "orioles");
-            Assert.Equal(3, res.Length);
-            Assert.Equal("red sox", res[0].Member);
-        }
-
-        [Fact]
-        public async Task GeoSearchBoxMemberAndStoreAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            await db.KeyDeleteAsync(destinationKey);
-            await GeoSearchSetupAsync(sourceKey, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, "yankees", box);
-            var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
-            Assert.Contains(set, x => x.Member == "yankees");
-            Assert.Contains(set, x => x.Member == "red sox");
-            Assert.Contains(set, x => x.Member == "orioles");
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public async Task GeoSearchBoxLonLatAndStoreAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            await db.KeyDeleteAsync(destinationKey);
-            await GeoSearchSetupAsync(sourceKey, db);
-
-            var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, 73.9262, 40.8296, box);
-            var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
-            Assert.Contains(set, x => x.Member == "yankees");
-            Assert.Contains(set, x => x.Member == "red sox");
-            Assert.Contains(set, x => x.Member == "orioles");
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public async Task GeoSearchCircleMemberAndStoreAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            await db.KeyDeleteAsync(destinationKey);
-            await GeoSearchSetupAsync(sourceKey, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, "yankees", circle);
-            var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
-            Assert.Contains(set, x => x.Member == "yankees");
-            Assert.Contains(set, x => x.Member == "red sox");
-            Assert.Contains(set, x => x.Member == "orioles");
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public async Task GeoSearchCircleLonLatAndStoreAsync()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            await db.KeyDeleteAsync(destinationKey);
-            await GeoSearchSetupAsync(sourceKey, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
-            var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, 73.9262, 40.8296, circle);
-            var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
-            Assert.Contains(set, x => x.Member == "yankees");
-            Assert.Contains(set, x => x.Member == "red sox");
-            Assert.Contains(set, x => x.Member == "orioles");
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public void GeoSearchCircleMemberAndStore()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            db.KeyDelete(destinationKey);
-            GeoSearchSetup(sourceKey, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
-            var res = db.GeoSearchAndStore(sourceKey, destinationKey, "yankees", circle);
-            var set = db.GeoSearch(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
-            Assert.Contains(set, x => x.Member == "yankees");
-            Assert.Contains(set, x => x.Member == "red sox");
-            Assert.Contains(set, x => x.Member == "orioles");
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public void GeoSearchCircleLonLatAndStore()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            db.KeyDelete(destinationKey);
-            GeoSearchSetup(sourceKey, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
-            var res = db.GeoSearchAndStore(sourceKey, destinationKey, 73.9262, 40.8296, circle);
-            var set = db.GeoSearch(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
-            Assert.Contains(set, x => x.Member == "yankees");
-            Assert.Contains(set, x => x.Member == "red sox");
-            Assert.Contains(set, x => x.Member == "orioles");
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public void GeoSearchCircleAndStoreDistOnly()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var me = Me();
-            var db = conn.GetDatabase();
-            RedisKey sourceKey = $"{me}:source";
-            RedisKey destinationKey = $"{me}:destination";
-            db.KeyDelete(destinationKey);
-            GeoSearchSetup(sourceKey, db);
-
-            var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
-            var res = db.GeoSearchAndStore(sourceKey, destinationKey, 73.9262, 40.8296, circle, storeDistances: true);
-            var set = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Contains(set, x => x.Element == "yankees");
-            Assert.Contains(set, x => x.Element == "red sox");
-            Assert.Contains(set, x => x.Element == "orioles");
-            Assert.InRange(Array.Find(set, x => x.Element == "yankees").Score, 0, .2);
-            Assert.InRange(Array.Find(set, x => x.Element == "orioles").Score, 286, 287);
-            Assert.InRange(Array.Find(set, x => x.Element == "red sox").Score, 289, 290);
-            Assert.Equal(3, set.Length);
-            Assert.Equal(3, res);
-        }
-
-        [Fact]
-        public void GeoSearchBadArgs()
-        {
-            using var conn = Create(require: RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            db.KeyDelete(key);
-            var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
-            var exception = Assert.Throws<ArgumentException>(() =>
-                db.GeoSearch(key, "irrelevant", circle, demandClosest: false));
-
-            Assert.Contains("demandClosest must be true if you are not limiting the count for a GEOSEARCH",
-                exception.Message);
-        }
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        // add while not there
+        Assert.True(db.GeoAdd(key, cefalù.Longitude, cefalù.Latitude, cefalù.Member));
+        Assert.Equal(2, db.GeoAdd(key, new[] { palermo, catania }));
+        Assert.True(db.GeoAdd(key, agrigento));
+
+        // now add again
+        Assert.False(db.GeoAdd(key, cefalù.Longitude, cefalù.Latitude, cefalù.Member));
+        Assert.Equal(0, db.GeoAdd(key, new[] { palermo, catania }));
+        Assert.False(db.GeoAdd(key, agrigento));
+
+        // Validate
+        var pos = db.GeoPosition(key, palermo.Member);
+        Assert.NotNull(pos);
+        Assert.Equal(palermo.Longitude, pos.Value.Longitude, 5);
+        Assert.Equal(palermo.Latitude, pos.Value.Latitude, 5);
+    }
+
+    [Fact]
+    public void GetDistance()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.GeoAdd(key, all, CommandFlags.FireAndForget);
+        var val = db.GeoDistance(key, "Palermo", "Catania", GeoUnit.Meters);
+        Assert.True(val.HasValue);
+        Assert.Equal(166274.1516, val);
+
+        val = db.GeoDistance(key, "Palermo", "Nowhere", GeoUnit.Meters);
+        Assert.False(val.HasValue);
+    }
+
+    [Fact]
+    public void GeoHash()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.GeoAdd(key, all, CommandFlags.FireAndForget);
+
+        var hashes = db.GeoHash(key, new RedisValue[] { palermo.Member, "Nowhere", agrigento.Member });
+        Assert.NotNull(hashes);
+        Assert.Equal(3, hashes.Length);
+        Assert.Equal("sqc8b49rny0", hashes[0]);
+        Assert.Null(hashes[1]);
+        Assert.Equal("sq9skbq0760", hashes[2]);
+
+        var hash = db.GeoHash(key, "Palermo");
+        Assert.Equal("sqc8b49rny0", hash);
+
+        hash = db.GeoHash(key, "Nowhere");
+        Assert.Null(hash);
+    }
+
+    [Fact]
+    public void GeoGetPosition()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.GeoAdd(key, all, CommandFlags.FireAndForget);
+
+        var pos = db.GeoPosition(key, palermo.Member);
+        Assert.True(pos.HasValue);
+        Assert.Equal(Math.Round(palermo.Longitude, 6), Math.Round(pos.Value.Longitude, 6));
+        Assert.Equal(Math.Round(palermo.Latitude, 6), Math.Round(pos.Value.Latitude, 6));
+
+        pos = db.GeoPosition(key, "Nowhere");
+        Assert.False(pos.HasValue);
+    }
+
+    [Fact]
+    public void GeoRemove()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.GeoAdd(key, all, CommandFlags.FireAndForget);
+
+        var pos = db.GeoPosition(key, "Palermo");
+        Assert.True(pos.HasValue);
+
+        Assert.False(db.GeoRemove(key, "Nowhere"));
+        Assert.True(db.GeoRemove(key, "Palermo"));
+        Assert.False(db.GeoRemove(key, "Palermo"));
+
+        pos = db.GeoPosition(key, "Palermo");
+        Assert.False(pos.HasValue);
+    }
+
+    [Fact]
+    public void GeoRadius()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.GeoAdd(key, all, CommandFlags.FireAndForget);
+
+        var results = db.GeoRadius(key, cefalù.Member, 60, GeoUnit.Miles, 2, Order.Ascending);
+        Assert.Equal(2, results.Length);
+
+        Assert.Equal(results[0].Member, cefalù.Member);
+        Assert.Equal(0, results[0].Distance);
+        var position0 = results[0].Position;
+        Assert.NotNull(position0);
+        Assert.Equal(Math.Round(position0.Value.Longitude, 5), Math.Round(cefalù.Position.Longitude, 5));
+        Assert.Equal(Math.Round(position0.Value.Latitude, 5), Math.Round(cefalù.Position.Latitude, 5));
+        Assert.False(results[0].Hash.HasValue);
+
+        Assert.Equal(results[1].Member, palermo.Member);
+        var distance1 = results[1].Distance;
+        Assert.NotNull(distance1);
+        Assert.Equal(Math.Round(36.5319, 6), Math.Round(distance1.Value, 6));
+        var position1 = results[1].Position;
+        Assert.NotNull(position1);
+        Assert.Equal(Math.Round(position1.Value.Longitude, 5), Math.Round(palermo.Position.Longitude, 5));
+        Assert.Equal(Math.Round(position1.Value.Latitude, 5), Math.Round(palermo.Position.Latitude, 5));
+        Assert.False(results[1].Hash.HasValue);
+
+        results = db.GeoRadius(key, cefalù.Member, 60, GeoUnit.Miles, 2, Order.Ascending, GeoRadiusOptions.None);
+        Assert.Equal(2, results.Length);
+        Assert.Equal(results[0].Member, cefalù.Member);
+        Assert.False(results[0].Position.HasValue);
+        Assert.False(results[0].Distance.HasValue);
+        Assert.False(results[0].Hash.HasValue);
+
+        Assert.Equal(results[1].Member, palermo.Member);
+        Assert.False(results[1].Position.HasValue);
+        Assert.False(results[1].Distance.HasValue);
+        Assert.False(results[1].Hash.HasValue);
+    }
+
+    [Fact]
+    public async Task GeoRadiusOverloads()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        Assert.True(db.GeoAdd(key, -1.759925, 52.19493, "steve"));
+        Assert.True(db.GeoAdd(key, -3.360655, 54.66395, "dave"));
+
+        // Invalid overload
+        // Since this would throw ERR could not decode requested zset member, we catch and return something more useful to the user earlier.
+        var ex = Assert.Throws<ArgumentException>(() => db.GeoRadius(key, -1.759925, 52.19493, GeoUnit.Miles, 500, Order.Ascending, GeoRadiusOptions.WithDistance));
+        Assert.StartsWith("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload.", ex.Message);
+        Assert.Equal("member", ex.ParamName);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.GeoRadiusAsync(key, -1.759925, 52.19493, GeoUnit.Miles, 500, Order.Ascending, GeoRadiusOptions.WithDistance)).ForAwait();
+        Assert.StartsWith("Member should not be a double, you likely want the GeoRadius(RedisKey, double, double, ...) overload.", ex.Message);
+        Assert.Equal("member", ex.ParamName);
+
+        // The good stuff
+        GeoRadiusResult[] result = db.GeoRadius(key, -1.759925, 52.19493, 500, unit: GeoUnit.Miles, order: Order.Ascending, options: GeoRadiusOptions.WithDistance);
+        Assert.NotNull(result);
+
+        result = await db.GeoRadiusAsync(key, -1.759925, 52.19493, 500, unit: GeoUnit.Miles, order: Order.Ascending, options: GeoRadiusOptions.WithDistance).ForAwait();
+        Assert.NotNull(result);
+    }
+
+    private async Task GeoSearchSetupAsync(RedisKey key, IDatabase db)
+    {
+        await db.KeyDeleteAsync(key);
+        await db.GeoAddAsync(key, 82.6534, 27.7682, "rays");
+        await db.GeoAddAsync(key, 79.3891, 43.6418, "blue jays");
+        await db.GeoAddAsync(key, 76.6217, 39.2838, "orioles");
+        await db.GeoAddAsync(key, 71.0927, 42.3467, "red sox");
+        await db.GeoAddAsync(key, 73.9262, 40.8296, "yankees");
+    }
+
+    private void GeoSearchSetup(RedisKey key, IDatabase db)
+    {
+        db.KeyDelete(key);
+        db.GeoAdd(key, 82.6534, 27.7682, "rays");
+        db.GeoAdd(key, 79.3891, 43.6418, "blue jays");
+        db.GeoAdd(key, 76.6217, 39.2838, "orioles");
+        db.GeoAdd(key, 71.0927, 42.3467, "red sox");
+        db.GeoAdd(key, 73.9262, 40.8296, "yankees");
+    }
+
+    [Fact]
+    public async Task GeoSearchCircleMemberAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Miles);
+        var res = await db.GeoSearchAsync(key, "yankees", circle);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Contains(res, x => x.Member == "blue jays");
+        Assert.NotNull(res[0].Distance);
+        Assert.NotNull(res[0].Position);
+        Assert.Null(res[0].Hash);
+        Assert.Equal(4, res.Length);
+    }
+
+    [Fact]
+    public async Task GeoSearchCircleMemberAsyncOnlyHash()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Miles);
+        var res = await db.GeoSearchAsync(key, "yankees", circle, options: GeoRadiusOptions.WithGeoHash);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Contains(res, x => x.Member == "blue jays");
+        Assert.Null(res[0].Distance);
+        Assert.Null(res[0].Position);
+        Assert.NotNull(res[0].Hash);
+        Assert.Equal(4, res.Length);
+    }
+
+    [Fact]
+    public async Task GeoSearchCircleMemberAsyncHashAndDistance()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Miles);
+        var res = await db.GeoSearchAsync(key, "yankees", circle, options: GeoRadiusOptions.WithGeoHash | GeoRadiusOptions.WithDistance);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Contains(res, x => x.Member == "blue jays");
+        Assert.NotNull(res[0].Distance);
+        Assert.Null(res[0].Position);
+        Assert.NotNull(res[0].Hash);
+        Assert.Equal(4, res.Length);
+    }
+
+    [Fact]
+    public async Task GeoSearchCircleLonLatAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Miles);
+        var res = await db.GeoSearchAsync(key, 73.9262, 40.8296, circle);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Contains(res, x => x.Member == "blue jays");
+        Assert.Equal(4, res.Length);
+    }
+
+    [Fact]
+    public void GeoSearchCircleMember()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        GeoSearchSetup(key, db);
+
+        var circle = new GeoSearchCircle(500 * 1609);
+        var res = db.GeoSearch(key, "yankees", circle);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Contains(res, x => x.Member == "blue jays");
+        Assert.Equal(4, res.Length);
+    }
+
+    [Fact]
+    public void GeoSearchCircleLonLat()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        GeoSearchSetup(key, db);
+
+        var circle = new GeoSearchCircle(500 * 5280, GeoUnit.Feet);
+        var res = db.GeoSearch(key, 73.9262, 40.8296, circle);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Contains(res, x => x.Member == "blue jays");
+        Assert.Equal(4, res.Length);
+    }
+
+    [Fact]
+    public async Task GeoSearchBoxMemberAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAsync(key, "yankees", box);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(3, res.Length);
+    }
+
+    [Fact]
+    public async Task GeoSearchBoxLonLatAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAsync(key, 73.9262, 40.8296, box);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(3, res.Length);
+    }
+
+    [Fact]
+    public void GeoSearchBoxMember()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        GeoSearchSetup(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = db.GeoSearch(key, "yankees", box);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(3, res.Length);
+    }
+
+    [Fact]
+    public void GeoSearchBoxLonLat()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        GeoSearchSetup(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = db.GeoSearch(key, 73.9262, 40.8296, box);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(3, res.Length);
+    }
+
+    [Fact]
+    public void GeoSearchLimitCount()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        GeoSearchSetup(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = db.GeoSearch(key, 73.9262, 40.8296, box, count: 2);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(2, res.Length);
+    }
+
+    [Fact]
+    public void GeoSearchLimitCountMakeNoDemands()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        GeoSearchSetup(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = db.GeoSearch(key, 73.9262, 40.8296, box, count: 2, demandClosest: false);
+        Assert.Contains(res, x => x.Member == "red sox"); // this order MIGHT not be fully deterministic, seems to work for our purposes.
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(2, res.Length);
+    }
+
+    [Fact]
+    public async Task GeoSearchBoxLonLatDescending()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await GeoSearchSetupAsync(key, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAsync(key, 73.9262, 40.8296, box, order: Order.Descending);
+        Assert.Contains(res, x => x.Member == "yankees");
+        Assert.Contains(res, x => x.Member == "red sox");
+        Assert.Contains(res, x => x.Member == "orioles");
+        Assert.Equal(3, res.Length);
+        Assert.Equal("red sox", res[0].Member);
+    }
+
+    [Fact]
+    public async Task GeoSearchBoxMemberAndStoreAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        await db.KeyDeleteAsync(destinationKey);
+        await GeoSearchSetupAsync(sourceKey, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, "yankees", box);
+        var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
+        Assert.Contains(set, x => x.Member == "yankees");
+        Assert.Contains(set, x => x.Member == "red sox");
+        Assert.Contains(set, x => x.Member == "orioles");
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public async Task GeoSearchBoxLonLatAndStoreAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        await db.KeyDeleteAsync(destinationKey);
+        await GeoSearchSetupAsync(sourceKey, db);
+
+        var box = new GeoSearchBox(500, 500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, 73.9262, 40.8296, box);
+        var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
+        Assert.Contains(set, x => x.Member == "yankees");
+        Assert.Contains(set, x => x.Member == "red sox");
+        Assert.Contains(set, x => x.Member == "orioles");
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public async Task GeoSearchCircleMemberAndStoreAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        await db.KeyDeleteAsync(destinationKey);
+        await GeoSearchSetupAsync(sourceKey, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, "yankees", circle);
+        var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
+        Assert.Contains(set, x => x.Member == "yankees");
+        Assert.Contains(set, x => x.Member == "red sox");
+        Assert.Contains(set, x => x.Member == "orioles");
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public async Task GeoSearchCircleLonLatAndStoreAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        await db.KeyDeleteAsync(destinationKey);
+        await GeoSearchSetupAsync(sourceKey, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
+        var res = await db.GeoSearchAndStoreAsync(sourceKey, destinationKey, 73.9262, 40.8296, circle);
+        var set = await db.GeoSearchAsync(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
+        Assert.Contains(set, x => x.Member == "yankees");
+        Assert.Contains(set, x => x.Member == "red sox");
+        Assert.Contains(set, x => x.Member == "orioles");
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public void GeoSearchCircleMemberAndStore()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        db.KeyDelete(destinationKey);
+        GeoSearchSetup(sourceKey, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
+        var res = db.GeoSearchAndStore(sourceKey, destinationKey, "yankees", circle);
+        var set = db.GeoSearch(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
+        Assert.Contains(set, x => x.Member == "yankees");
+        Assert.Contains(set, x => x.Member == "red sox");
+        Assert.Contains(set, x => x.Member == "orioles");
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public void GeoSearchCircleLonLatAndStore()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        db.KeyDelete(destinationKey);
+        GeoSearchSetup(sourceKey, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
+        var res = db.GeoSearchAndStore(sourceKey, destinationKey, 73.9262, 40.8296, circle);
+        var set = db.GeoSearch(destinationKey, "yankees", new GeoSearchCircle(10000, GeoUnit.Miles));
+        Assert.Contains(set, x => x.Member == "yankees");
+        Assert.Contains(set, x => x.Member == "red sox");
+        Assert.Contains(set, x => x.Member == "orioles");
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public void GeoSearchCircleAndStoreDistOnly()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var me = Me();
+        var db = conn.GetDatabase();
+        RedisKey sourceKey = $"{me}:source";
+        RedisKey destinationKey = $"{me}:destination";
+        db.KeyDelete(destinationKey);
+        GeoSearchSetup(sourceKey, db);
+
+        var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
+        var res = db.GeoSearchAndStore(sourceKey, destinationKey, 73.9262, 40.8296, circle, storeDistances: true);
+        var set = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Contains(set, x => x.Element == "yankees");
+        Assert.Contains(set, x => x.Element == "red sox");
+        Assert.Contains(set, x => x.Element == "orioles");
+        Assert.InRange(Array.Find(set, x => x.Element == "yankees").Score, 0, .2);
+        Assert.InRange(Array.Find(set, x => x.Element == "orioles").Score, 286, 287);
+        Assert.InRange(Array.Find(set, x => x.Element == "red sox").Score, 289, 290);
+        Assert.Equal(3, set.Length);
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public void GeoSearchBadArgs()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key);
+        var circle = new GeoSearchCircle(500, GeoUnit.Kilometers);
+        var exception = Assert.Throws<ArgumentException>(() =>
+            db.GeoSearch(key, "irrelevant", circle, demandClosest: false));
+
+        Assert.Contains("demandClosest must be true if you are not limiting the count for a GEOSEARCH",
+            exception.Message);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Hashes.cs
+++ b/tests/StackExchange.Redis.Tests/Hashes.cs
@@ -6,671 +6,642 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Threading.Tasks;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Hashes : TestBase // https://redis.io/commands#hash
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Hashes : TestBase // https://redis.io/commands#hash
+    public Hashes(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public async Task TestIncrBy()
     {
-        public Hashes(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public async Task TestIncrBy()
+        var db = conn.GetDatabase();
+        var key = Me();
+        _ = db.KeyDeleteAsync(key).ForAwait();
+
+        const int iterations = 100;
+        var aTasks = new Task<long>[iterations];
+        var bTasks = new Task<long>[iterations];
+        for (int i = 1; i < iterations + 1; i++)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                _ = conn.KeyDeleteAsync(key).ForAwait();
+            aTasks[i - 1] = db.HashIncrementAsync(key, "a", 1);
+            bTasks[i - 1] = db.HashIncrementAsync(key, "b", -1);
+        }
+        await Task.WhenAll(bTasks).ForAwait();
+        for (int i = 1; i < iterations + 1; i++)
+        {
+            Assert.Equal(i, aTasks[i - 1].Result);
+            Assert.Equal(-i, bTasks[i - 1].Result);
+        }
+    }
 
-                const int iterations = 100;
-                var aTasks = new Task<long>[iterations];
-                var bTasks = new Task<long>[iterations];
-                for (int i = 1; i < iterations + 1; i++)
-                {
-                    aTasks[i - 1] = conn.HashIncrementAsync(key, "a", 1);
-                    bTasks[i - 1] = conn.HashIncrementAsync(key, "b", -1);
-                }
-                await Task.WhenAll(bTasks).ForAwait();
-                for (int i = 1; i < iterations + 1; i++)
-                {
-                    Assert.Equal(i, aTasks[i - 1].Result);
-                    Assert.Equal(-i, bTasks[i - 1].Result);
-                }
-            }
+    [Fact]
+    public async Task ScanAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v2_8_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        await db.KeyDeleteAsync(key);
+        for (int i = 0; i < 200; i++)
+        {
+            await db.HashSetAsync(key, "key" + i, "value " + i);
         }
 
-        [Fact]
-        public async Task ScanAsync()
+        int count = 0;
+        // works for async
+        await foreach (var _ in db.HashScanAsync(key, pageSize: 20))
         {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_8_0);
+            count++;
+        }
+        Assert.Equal(200, count);
 
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                await conn.KeyDeleteAsync(key);
-                for(int i = 0; i < 200; i++)
-                {
-                    await conn.HashSetAsync(key, "key" + i, "value " + i);
-                }
+        // and sync=>async (via cast)
+        count = 0;
+        await foreach (var _ in (IAsyncEnumerable<HashEntry>)db.HashScan(key, pageSize: 20))
+        {
+            count++;
+        }
+        Assert.Equal(200, count);
 
-                int count = 0;
-                // works for async
-                await foreach(var _ in conn.HashScanAsync(key, pageSize: 20))
-                {
-                    count++;
-                }
-                Assert.Equal(200, count);
+        // and sync (native)
+        count = 0;
+        foreach (var _ in db.HashScan(key, pageSize: 20))
+        {
+            count++;
+        }
+        Assert.Equal(200, count);
 
-                // and sync=>async (via cast)
-                count = 0;
-                await foreach (var _ in (IAsyncEnumerable<HashEntry>)conn.HashScan(key, pageSize: 20))
-                {
-                    count++;
-                }
-                Assert.Equal(200, count);
+        // and async=>sync (via cast)
+        count = 0;
+        foreach (var _ in (IEnumerable<HashEntry>)db.HashScanAsync(key, pageSize: 20))
+        {
+            count++;
+        }
+        Assert.Equal(200, count);
+    }
 
-                // and sync (native)
-                count = 0;
-                foreach (var _ in conn.HashScan(key, pageSize: 20))
-                {
-                    count++;
-                }
-                Assert.Equal(200, count);
+    [Fact]
+    public void Scan()
+    {
+        using var conn = Create(require: RedisFeatures.v2_8_0);
 
-                // and async=>sync (via cast)
-                count = 0;
-                foreach (var _ in (IEnumerable<HashEntry>)conn.HashScanAsync(key, pageSize: 20))
-                {
-                    count++;
-                }
-                Assert.Equal(200, count);
-            }
+        var db = conn.GetDatabase();
+
+        var key = Me();
+        db.KeyDeleteAsync(key);
+        db.HashSetAsync(key, "abc", "def");
+        db.HashSetAsync(key, "ghi", "jkl");
+        db.HashSetAsync(key, "mno", "pqr");
+
+        var t1 = db.HashScan(key);
+        var t2 = db.HashScan(key, "*h*");
+        var t3 = db.HashScan(key);
+        var t4 = db.HashScan(key, "*h*");
+
+        var v1 = t1.ToArray();
+        var v2 = t2.ToArray();
+        var v3 = t3.ToArray();
+        var v4 = t4.ToArray();
+
+        Assert.Equal(3, v1.Length);
+        Assert.Single(v2);
+        Assert.Equal(3, v3.Length);
+        Assert.Single(v4);
+        Array.Sort(v1, (x, y) => string.Compare(x.Name, y.Name));
+        Array.Sort(v2, (x, y) => string.Compare(x.Name, y.Name));
+        Array.Sort(v3, (x, y) => string.Compare(x.Name, y.Name));
+        Array.Sort(v4, (x, y) => string.Compare(x.Name, y.Name));
+
+        Assert.Equal("abc=def,ghi=jkl,mno=pqr", string.Join(",", v1.Select(pair => pair.Name + "=" + pair.Value)));
+        Assert.Equal("ghi=jkl", string.Join(",", v2.Select(pair => pair.Name + "=" + pair.Value)));
+        Assert.Equal("abc=def,ghi=jkl,mno=pqr", string.Join(",", v3.Select(pair => pair.Name + "=" + pair.Value)));
+        Assert.Equal("ghi=jkl", string.Join(",", v4.Select(pair => pair.Name + "=" + pair.Value)));
+    }
+
+    [Fact]
+    public void TestIncrementOnHashThatDoesntExist()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        db.KeyDeleteAsync("keynotexist");
+        var result1 = db.Wait(db.HashIncrementAsync("keynotexist", "fieldnotexist", 1));
+        var result2 = db.Wait(db.HashIncrementAsync("keynotexist", "anotherfieldnotexist", 1));
+        Assert.Equal(1, result1);
+        Assert.Equal(1, result2);
+    }
+
+    [Fact]
+    public async Task TestIncrByFloat()
+    {
+        using var conn = Create(require: RedisFeatures.v2_6_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        _ = db.KeyDeleteAsync(key).ForAwait();
+        var aTasks = new Task<double>[1000];
+        var bTasks = new Task<double>[1000];
+        for (int i = 1; i < 1001; i++)
+        {
+            aTasks[i - 1] = db.HashIncrementAsync(key, "a", 1.0);
+            bTasks[i - 1] = db.HashIncrementAsync(key, "b", -1.0);
+        }
+        await Task.WhenAll(bTasks).ForAwait();
+        for (int i = 1; i < 1001; i++)
+        {
+            Assert.Equal(i, aTasks[i - 1].Result);
+            Assert.Equal(-i, bTasks[i - 1].Result);
+        }
+    }
+
+    [Fact]
+    public async Task TestGetAll()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        await db.KeyDeleteAsync(key).ForAwait();
+        var shouldMatch = new Dictionary<Guid, int>();
+        var random = new Random();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            var guid = Guid.NewGuid();
+            var value = random.Next(int.MaxValue);
+
+            shouldMatch[guid] = value;
+
+            _ = db.HashIncrementAsync(key, guid.ToString(), value);
         }
 
-        [Fact]
-        public void Scan()
+        var inRedis = (await db.HashGetAllAsync(key).ForAwait()).ToDictionary(
+            x => Guid.Parse(x.Name!), x => int.Parse(x.Value!));
+
+        Assert.Equal(shouldMatch.Count, inRedis.Count);
+
+        foreach (var k in shouldMatch.Keys)
         {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_8_0);
+            Assert.Equal(shouldMatch[k], inRedis[k]);
+        }
+    }
 
-                var conn = muxer.GetDatabase();
+    [Fact]
+    public async Task TestGet()
+    {
+        using var conn = Create();
 
-                var key = Me();
-                conn.KeyDeleteAsync(key);
-                conn.HashSetAsync(key, "abc", "def");
-                conn.HashSetAsync(key, "ghi", "jkl");
-                conn.HashSetAsync(key, "mno", "pqr");
+        var key = Me();
+        var db = conn.GetDatabase();
+        var shouldMatch = new Dictionary<Guid, int>();
+        var random = new Random();
 
-                var t1 = conn.HashScan(key);
-                var t2 = conn.HashScan(key, "*h*");
-                var t3 = conn.HashScan(key);
-                var t4 = conn.HashScan(key, "*h*");
+        for (int i = 1; i < 1000; i++)
+        {
+            var guid = Guid.NewGuid();
+            var value = random.Next(int.MaxValue);
 
-                var v1 = t1.ToArray();
-                var v2 = t2.ToArray();
-                var v3 = t3.ToArray();
-                var v4 = t4.ToArray();
+            shouldMatch[guid] = value;
 
-                Assert.Equal(3, v1.Length);
-                Assert.Single(v2);
-                Assert.Equal(3, v3.Length);
-                Assert.Single(v4);
-                Array.Sort(v1, (x, y) => string.Compare(x.Name, y.Name));
-                Array.Sort(v2, (x, y) => string.Compare(x.Name, y.Name));
-                Array.Sort(v3, (x, y) => string.Compare(x.Name, y.Name));
-                Array.Sort(v4, (x, y) => string.Compare(x.Name, y.Name));
-
-                Assert.Equal("abc=def,ghi=jkl,mno=pqr", string.Join(",", v1.Select(pair => pair.Name + "=" + pair.Value)));
-                Assert.Equal("ghi=jkl", string.Join(",", v2.Select(pair => pair.Name + "=" + pair.Value)));
-                Assert.Equal("abc=def,ghi=jkl,mno=pqr", string.Join(",", v3.Select(pair => pair.Name + "=" + pair.Value)));
-                Assert.Equal("ghi=jkl", string.Join(",", v4.Select(pair => pair.Name + "=" + pair.Value)));
-            }
+            _ = db.HashIncrementAsync(key, guid.ToString(), value);
         }
 
-        [Fact]
-        public void TestIncrementOnHashThatDoesntExist()
+        foreach (var k in shouldMatch.Keys)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                conn.KeyDeleteAsync("keynotexist");
-                var result1 = conn.Wait(conn.HashIncrementAsync("keynotexist", "fieldnotexist", 1));
-                var result2 = conn.Wait(conn.HashIncrementAsync("keynotexist", "anotherfieldnotexist", 1));
-                Assert.Equal(1, result1);
-                Assert.Equal(1, result2);
-            }
+            var inRedis = await db.HashGetAsync(key, k.ToString()).ForAwait();
+            var num = int.Parse(inRedis!);
+
+            Assert.Equal(shouldMatch[k], num);
+        }
+    }
+
+    [Fact]
+    public async Task TestSet() // https://redis.io/commands/hset
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        var del = db.KeyDeleteAsync(hashkey).ForAwait();
+
+        var val0 = db.HashGetAsync(hashkey, "field").ForAwait();
+        var set0 = db.HashSetAsync(hashkey, "field", "value1").ForAwait();
+        var val1 = db.HashGetAsync(hashkey, "field").ForAwait();
+        var set1 = db.HashSetAsync(hashkey, "field", "value2").ForAwait();
+        var val2 = db.HashGetAsync(hashkey, "field").ForAwait();
+
+        var set2 = db.HashSetAsync(hashkey, "field-blob", Encoding.UTF8.GetBytes("value3")).ForAwait();
+        var val3 = db.HashGetAsync(hashkey, "field-blob").ForAwait();
+
+        var set3 = db.HashSetAsync(hashkey, "empty_type1", "").ForAwait();
+        var val4 = db.HashGetAsync(hashkey, "empty_type1").ForAwait();
+        var set4 = db.HashSetAsync(hashkey, "empty_type2", RedisValue.EmptyString).ForAwait();
+        var val5 = db.HashGetAsync(hashkey, "empty_type2").ForAwait();
+
+        await del;
+        Assert.Null((string?)(await val0));
+        Assert.True(await set0);
+        Assert.Equal("value1", await val1);
+        Assert.False(await set1);
+        Assert.Equal("value2", await val2);
+
+        Assert.True(await set2);
+        Assert.Equal("value3", await val3);
+
+        Assert.True(await set3);
+        Assert.Equal("", await val4);
+        Assert.True(await set4);
+        Assert.Equal("", await val5);
+    }
+
+    [Fact]
+    public async Task TestSetNotExists() // https://redis.io/commands/hsetnx
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        var del = db.KeyDeleteAsync(hashkey).ForAwait();
+
+        var val0 = db.HashGetAsync(hashkey, "field").ForAwait();
+        var set0 = db.HashSetAsync(hashkey, "field", "value1", When.NotExists).ForAwait();
+        var val1 = db.HashGetAsync(hashkey, "field").ForAwait();
+        var set1 = db.HashSetAsync(hashkey, "field", "value2", When.NotExists).ForAwait();
+        var val2 = db.HashGetAsync(hashkey, "field").ForAwait();
+
+        var set2 = db.HashSetAsync(hashkey, "field-blob", Encoding.UTF8.GetBytes("value3"), When.NotExists).ForAwait();
+        var val3 = db.HashGetAsync(hashkey, "field-blob").ForAwait();
+        var set3 = db.HashSetAsync(hashkey, "field-blob", Encoding.UTF8.GetBytes("value3"), When.NotExists).ForAwait();
+
+        await del;
+        Assert.Null((string?)(await val0));
+        Assert.True(await set0);
+        Assert.Equal("value1", await val1);
+        Assert.False(await set1);
+        Assert.Equal("value1", await val2);
+
+        Assert.True(await set2);
+        Assert.Equal("value3", await val3);
+        Assert.False(await set3);
+    }
+
+    [Fact]
+    public async Task TestDelSingle() // https://redis.io/commands/hdel
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        await db.KeyDeleteAsync(hashkey).ForAwait();
+        var del0 = db.HashDeleteAsync(hashkey, "field").ForAwait();
+
+        await db.HashSetAsync(hashkey, "field", "value").ForAwait();
+
+        var del1 = db.HashDeleteAsync(hashkey, "field").ForAwait();
+        var del2 = db.HashDeleteAsync(hashkey, "field").ForAwait();
+
+        Assert.False(await del0);
+        Assert.True(await del1);
+        Assert.False(await del2);
+    }
+
+    [Fact]
+    public async Task TestDelMulti() // https://redis.io/commands/hdel
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        db.HashSet(hashkey, "key1", "val1", flags: CommandFlags.FireAndForget);
+        db.HashSet(hashkey, "key2", "val2", flags: CommandFlags.FireAndForget);
+        db.HashSet(hashkey, "key3", "val3", flags: CommandFlags.FireAndForget);
+
+        var s1 = db.HashExistsAsync(hashkey, "key1");
+        var s2 = db.HashExistsAsync(hashkey, "key2");
+        var s3 = db.HashExistsAsync(hashkey, "key3");
+
+        var removed = db.HashDeleteAsync(hashkey, new RedisValue[] { "key1", "key3" });
+
+        var d1 = db.HashExistsAsync(hashkey, "key1");
+        var d2 = db.HashExistsAsync(hashkey, "key2");
+        var d3 = db.HashExistsAsync(hashkey, "key3");
+
+        Assert.True(await s1);
+        Assert.True(await s2);
+        Assert.True(await s3);
+
+        Assert.Equal(2, await removed);
+
+        Assert.False(await d1);
+        Assert.True(await d2);
+        Assert.False(await d3);
+
+        var removeFinal = db.HashDeleteAsync(hashkey, new RedisValue[] { "key2" });
+
+        Assert.Equal(0, await db.HashLengthAsync(hashkey).ForAwait());
+        Assert.Equal(1, await removeFinal);
+    }
+
+    [Fact]
+    public async Task TestDelMultiInsideTransaction() // https://redis.io/commands/hdel
+    {
+        using var conn = Create();
+
+        var tran = conn.GetDatabase().CreateTransaction();
+        {
+            var hashkey = Me();
+            _ = tran.HashSetAsync(hashkey, "key1", "val1");
+            _ = tran.HashSetAsync(hashkey, "key2", "val2");
+            _ = tran.HashSetAsync(hashkey, "key3", "val3");
+
+            var s1 = tran.HashExistsAsync(hashkey, "key1");
+            var s2 = tran.HashExistsAsync(hashkey, "key2");
+            var s3 = tran.HashExistsAsync(hashkey, "key3");
+
+            var removed = tran.HashDeleteAsync(hashkey, new RedisValue[] { "key1", "key3" });
+
+            var d1 = tran.HashExistsAsync(hashkey, "key1");
+            var d2 = tran.HashExistsAsync(hashkey, "key2");
+            var d3 = tran.HashExistsAsync(hashkey, "key3");
+
+            tran.Execute();
+
+            Assert.True(await s1);
+            Assert.True(await s2);
+            Assert.True(await s3);
+
+            Assert.Equal(2, await removed);
+
+            Assert.False(await d1);
+            Assert.True(await d2);
+            Assert.False(await d3);
+        }
+    }
+
+    [Fact]
+    public async Task TestExists() // https://redis.io/commands/hexists
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        _ = db.KeyDeleteAsync(hashkey).ForAwait();
+        var ex0 = db.HashExistsAsync(hashkey, "field").ForAwait();
+        _ = db.HashSetAsync(hashkey, "field", "value").ForAwait();
+        var ex1 = db.HashExistsAsync(hashkey, "field").ForAwait();
+        _ = db.HashDeleteAsync(hashkey, "field").ForAwait();
+        _ = db.HashExistsAsync(hashkey, "field").ForAwait();
+
+        Assert.False(await ex0);
+        Assert.True(await ex1);
+        Assert.False(await ex0);
+    }
+
+    [Fact]
+    public async Task TestHashKeys() // https://redis.io/commands/hkeys
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashKey = Me();
+        await db.KeyDeleteAsync(hashKey).ForAwait();
+
+        var keys0 = await db.HashKeysAsync(hashKey).ForAwait();
+        Assert.Empty(keys0);
+
+        await db.HashSetAsync(hashKey, "foo", "abc").ForAwait();
+        await db.HashSetAsync(hashKey, "bar", "def").ForAwait();
+
+        var keys1 = db.HashKeysAsync(hashKey);
+
+        var arr = await keys1;
+        Assert.Equal(2, arr.Length);
+        Assert.Equal("foo", arr[0]);
+        Assert.Equal("bar", arr[1]);
+    }
+
+    [Fact]
+    public async Task TestHashValues() // https://redis.io/commands/hvals
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        await db.KeyDeleteAsync(hashkey).ForAwait();
+
+        var keys0 = await db.HashValuesAsync(hashkey).ForAwait();
+
+        await db.HashSetAsync(hashkey, "foo", "abc").ForAwait();
+        await db.HashSetAsync(hashkey, "bar", "def").ForAwait();
+
+        var keys1 = db.HashValuesAsync(hashkey).ForAwait();
+
+        Assert.Empty(keys0);
+
+        var arr = await keys1;
+        Assert.Equal(2, arr.Length);
+        Assert.Equal("abc", Encoding.UTF8.GetString(arr[0]!));
+        Assert.Equal("def", Encoding.UTF8.GetString(arr[1]!));
+    }
+
+    [Fact]
+    public async Task TestHashLength() // https://redis.io/commands/hlen
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        db.KeyDelete(hashkey, CommandFlags.FireAndForget);
+
+        var len0 = db.HashLengthAsync(hashkey);
+
+        db.HashSet(hashkey, "foo", "abc", flags: CommandFlags.FireAndForget);
+        db.HashSet(hashkey, "bar", "def", flags: CommandFlags.FireAndForget);
+
+        var len1 = db.HashLengthAsync(hashkey);
+
+        Assert.Equal(0, await len0);
+        Assert.Equal(2, await len1);
+    }
+
+    [Fact]
+    public async Task TestGetMulti() // https://redis.io/commands/hmget
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        db.KeyDelete(hashkey, CommandFlags.FireAndForget);
+
+        RedisValue[] fields = { "foo", "bar", "blop" };
+        var arr0 = await db.HashGetAsync(hashkey, fields).ForAwait();
+
+        db.HashSet(hashkey, "foo", "abc", flags: CommandFlags.FireAndForget);
+        db.HashSet(hashkey, "bar", "def", flags: CommandFlags.FireAndForget);
+
+        var arr1 = await db.HashGetAsync(hashkey, fields).ForAwait();
+        var arr2 = await db.HashGetAsync(hashkey, fields).ForAwait();
+
+        Assert.Equal(3, arr0.Length);
+        Assert.Null((string?)arr0[0]);
+        Assert.Null((string?)arr0[1]);
+        Assert.Null((string?)arr0[2]);
+
+        Assert.Equal(3, arr1.Length);
+        Assert.Equal("abc", arr1[0]);
+        Assert.Equal("def", arr1[1]);
+        Assert.Null((string?)arr1[2]);
+
+        Assert.Equal(3, arr2.Length);
+        Assert.Equal("abc", arr2[0]);
+        Assert.Equal("def", arr2[1]);
+        Assert.Null((string?)arr2[2]);
+    }
+
+    [Fact]
+    public void TestGetPairs() // https://redis.io/commands/hgetall
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        db.KeyDeleteAsync(hashkey);
+
+        var result0 = db.HashGetAllAsync(hashkey);
+
+        db.HashSetAsync(hashkey, "foo", "abc");
+        db.HashSetAsync(hashkey, "bar", "def");
+
+        var result1 = db.HashGetAllAsync(hashkey);
+
+        Assert.Empty(conn.Wait(result0));
+        var result = conn.Wait(result1).ToStringDictionary();
+        Assert.Equal(2, result.Count);
+        Assert.Equal("abc", result["foo"]);
+        Assert.Equal("def", result["bar"]);
+    }
+
+    [Fact]
+    public void TestSetPairs() // https://redis.io/commands/hmset
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        db.KeyDeleteAsync(hashkey).ForAwait();
+
+        var result0 = db.HashGetAllAsync(hashkey);
+
+        var data = new[] {
+                new HashEntry("foo", Encoding.UTF8.GetBytes("abc")),
+                new HashEntry("bar", Encoding.UTF8.GetBytes("def"))
+            };
+        db.HashSetAsync(hashkey, data).ForAwait();
+
+        var result1 = db.Wait(db.HashGetAllAsync(hashkey));
+
+        Assert.Empty(result0.Result);
+        var result = result1.ToStringDictionary();
+        Assert.Equal(2, result.Count);
+        Assert.Equal("abc", result["foo"]);
+        Assert.Equal("def", result["bar"]);
+    }
+
+    [Fact]
+    public async Task TestWhenAlwaysAsync()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var hashkey = Me();
+        db.KeyDelete(hashkey, CommandFlags.FireAndForget);
+
+        var result1 = await db.HashSetAsync(hashkey, "foo", "bar", When.Always, CommandFlags.None);
+        var result2 = await db.HashSetAsync(hashkey, "foo2", "bar", When.Always, CommandFlags.None);
+        var result3 = await db.HashSetAsync(hashkey, "foo", "bar", When.Always, CommandFlags.None);
+        var result4 = await db.HashSetAsync(hashkey, "foo", "bar2", When.Always, CommandFlags.None);
+
+        Assert.True(result1, "Initial set key 1");
+        Assert.True(result2, "Initial set key 2");
+        // Fields modified *but not added* should be a zero/false. That's the behavior of HSET
+        Assert.False(result3, "Duplicate set key 1");
+        Assert.False(result4, "Duplicate se key 1 variant");
+    }
+
+    [Fact]
+    public async Task HashRandomFieldAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var hashKey = Me();
+        var items = new HashEntry[] { new("new york", "yankees"), new("baltimore", "orioles"), new("boston", "red sox"), new("Tampa Bay", "rays"), new("Toronto", "blue jays") };
+        await db.HashSetAsync(hashKey, items);
+
+        var singleField = await db.HashRandomFieldAsync(hashKey);
+        var multiFields = await db.HashRandomFieldsAsync(hashKey, 3);
+        var withValues = await db.HashRandomFieldsWithValuesAsync(hashKey, 3);
+        Assert.Equal(3, multiFields.Length);
+        Assert.Equal(3, withValues.Length);
+        Assert.Contains(items, x => x.Name == singleField);
+
+        foreach (var field in multiFields)
+        {
+            Assert.Contains(items, x => x.Name == field);
         }
 
-        [Fact]
-        public async Task TestIncrByFloat()
+        foreach (var field in withValues)
         {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                _ = conn.KeyDeleteAsync(key).ForAwait();
-                var aTasks = new Task<double>[1000];
-                var bTasks = new Task<double>[1000];
-                for (int i = 1; i < 1001; i++)
-                {
-                    aTasks[i-1] = conn.HashIncrementAsync(key, "a", 1.0);
-                    bTasks[i-1] = conn.HashIncrementAsync(key, "b", -1.0);
-                }
-                await Task.WhenAll(bTasks).ForAwait();
-                for (int i = 1; i < 1001; i++)
-                {
-                    Assert.Equal(i, aTasks[i-1].Result);
-                    Assert.Equal(-i, bTasks[i-1].Result);
-                }
-            }
+            Assert.Contains(items, x => x.Name == field.Name);
+        }
+    }
+
+    [Fact]
+    public void HashRandomField()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var hashKey = Me();
+        var items = new HashEntry[] { new("new york", "yankees"), new("baltimore", "orioles"), new("boston", "red sox"), new("Tampa Bay", "rays"), new("Toronto", "blue jays") };
+        db.HashSet(hashKey, items);
+
+        var singleField = db.HashRandomField(hashKey);
+        var multiFields = db.HashRandomFields(hashKey, 3);
+        var withValues = db.HashRandomFieldsWithValues(hashKey, 3);
+        Assert.Equal(3, multiFields.Length);
+        Assert.Equal(3, withValues.Length);
+        Assert.Contains(items, x => x.Name == singleField);
+
+        foreach (var field in multiFields)
+        {
+            Assert.Contains(items, x => x.Name == field);
         }
 
-        [Fact]
-        public async Task TestGetAll()
+        foreach (var field in withValues)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                await conn.KeyDeleteAsync(key).ForAwait();
-                var shouldMatch = new Dictionary<Guid, int>();
-                var random = new Random();
-
-                for (int i = 0; i < 1000; i++)
-                {
-                    var guid = Guid.NewGuid();
-                    var value = random.Next(int.MaxValue);
-
-                    shouldMatch[guid] = value;
-
-                    _ = conn.HashIncrementAsync(key, guid.ToString(), value);
-                }
-
-                var inRedis = (await conn.HashGetAllAsync(key).ForAwait()).ToDictionary(
-                    x => Guid.Parse(x.Name!), x => int.Parse(x.Value!));
-
-                Assert.Equal(shouldMatch.Count, inRedis.Count);
-
-                foreach (var k in shouldMatch.Keys)
-                {
-                    Assert.Equal(shouldMatch[k], inRedis[k]);
-                }
-            }
+            Assert.Contains(items, x => x.Name == field.Name);
         }
-
-        [Fact]
-        public async Task TestGet()
-        {
-            using (var muxer = Create())
-            {
-                var key = Me();
-                var conn = muxer.GetDatabase();
-                var shouldMatch = new Dictionary<Guid, int>();
-                var random = new Random();
-
-                for (int i = 1; i < 1000; i++)
-                {
-                    var guid = Guid.NewGuid();
-                    var value = random.Next(int.MaxValue);
-
-                    shouldMatch[guid] = value;
-
-                    _ = conn.HashIncrementAsync(key, guid.ToString(), value);
-                }
-
-                foreach (var k in shouldMatch.Keys)
-                {
-                    var inRedis = await conn.HashGetAsync(key, k.ToString()).ForAwait();
-                    var num = int.Parse(inRedis!);
-
-                    Assert.Equal(shouldMatch[k], num);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task TestSet() // https://redis.io/commands/hset
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                var del =  conn.KeyDeleteAsync(hashkey).ForAwait();
-
-                var val0 = conn.HashGetAsync(hashkey, "field").ForAwait();
-                var set0 = conn.HashSetAsync(hashkey, "field", "value1").ForAwait();
-                var val1 = conn.HashGetAsync(hashkey, "field").ForAwait();
-                var set1 = conn.HashSetAsync(hashkey, "field", "value2").ForAwait();
-                var val2 = conn.HashGetAsync(hashkey, "field").ForAwait();
-
-                var set2 = conn.HashSetAsync(hashkey, "field-blob", Encoding.UTF8.GetBytes("value3")).ForAwait();
-                var val3 = conn.HashGetAsync(hashkey, "field-blob").ForAwait();
-
-                var set3 = conn.HashSetAsync(hashkey, "empty_type1", "").ForAwait();
-                var val4 = conn.HashGetAsync(hashkey, "empty_type1").ForAwait();
-                var set4 = conn.HashSetAsync(hashkey, "empty_type2", RedisValue.EmptyString).ForAwait();
-                var val5 = conn.HashGetAsync(hashkey, "empty_type2").ForAwait();
-
-                await del;
-                Assert.Null((string?)(await val0));
-                Assert.True(await set0);
-                Assert.Equal("value1", await val1);
-                Assert.False(await set1);
-                Assert.Equal("value2", await val2);
-
-                Assert.True(await set2);
-                Assert.Equal("value3", await val3);
-
-                Assert.True(await set3);
-                Assert.Equal("", await val4);
-                Assert.True(await set4);
-                Assert.Equal("", await val5);
-            }
-        }
-
-        [Fact]
-        public async Task TestSetNotExists() // https://redis.io/commands/hsetnx
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                var del = conn.KeyDeleteAsync(hashkey).ForAwait();
-
-                var val0 = conn.HashGetAsync(hashkey, "field").ForAwait();
-                var set0 = conn.HashSetAsync(hashkey, "field", "value1", When.NotExists).ForAwait();
-                var val1 = conn.HashGetAsync(hashkey, "field").ForAwait();
-                var set1 = conn.HashSetAsync(hashkey, "field", "value2", When.NotExists).ForAwait();
-                var val2 = conn.HashGetAsync(hashkey, "field").ForAwait();
-
-                var set2 = conn.HashSetAsync(hashkey, "field-blob", Encoding.UTF8.GetBytes("value3"), When.NotExists).ForAwait();
-                var val3 = conn.HashGetAsync(hashkey, "field-blob").ForAwait();
-                var set3 = conn.HashSetAsync(hashkey, "field-blob", Encoding.UTF8.GetBytes("value3"), When.NotExists).ForAwait();
-
-                await del;
-                Assert.Null((string?)(await val0));
-                Assert.True(await set0);
-                Assert.Equal("value1", await val1);
-                Assert.False(await set1);
-                Assert.Equal("value1", await val2);
-
-                Assert.True(await set2);
-                Assert.Equal("value3", await val3);
-                Assert.False(await set3);
-            }
-        }
-
-        [Fact]
-        public async Task TestDelSingle() // https://redis.io/commands/hdel
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                await conn.KeyDeleteAsync(hashkey).ForAwait();
-                var del0 = conn.HashDeleteAsync(hashkey, "field").ForAwait();
-
-                await conn.HashSetAsync(hashkey, "field", "value").ForAwait();
-
-                var del1 = conn.HashDeleteAsync(hashkey, "field").ForAwait();
-                var del2 = conn.HashDeleteAsync(hashkey, "field").ForAwait();
-
-                Assert.False(await del0);
-                Assert.True(await del1);
-                Assert.False(await del2);
-            }
-        }
-
-        [Fact]
-        public async Task TestDelMulti() // https://redis.io/commands/hdel
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                conn.HashSet(hashkey, "key1", "val1", flags: CommandFlags.FireAndForget);
-                conn.HashSet(hashkey, "key2", "val2", flags: CommandFlags.FireAndForget);
-                conn.HashSet(hashkey, "key3", "val3", flags: CommandFlags.FireAndForget);
-
-                var s1 = conn.HashExistsAsync(hashkey, "key1");
-                var s2 = conn.HashExistsAsync(hashkey, "key2");
-                var s3 = conn.HashExistsAsync(hashkey, "key3");
-
-                var removed = conn.HashDeleteAsync(hashkey, new RedisValue[] { "key1", "key3" });
-
-                var d1 = conn.HashExistsAsync(hashkey, "key1");
-                var d2 = conn.HashExistsAsync(hashkey, "key2");
-                var d3 = conn.HashExistsAsync(hashkey, "key3");
-
-                Assert.True(await s1);
-                Assert.True(await s2);
-                Assert.True(await s3);
-
-                Assert.Equal(2, await removed);
-
-                Assert.False(await d1);
-                Assert.True(await d2);
-                Assert.False(await d3);
-
-                var removeFinal = conn.HashDeleteAsync(hashkey, new RedisValue[] { "key2" });
-
-                Assert.Equal(0, await conn.HashLengthAsync(hashkey).ForAwait());
-                Assert.Equal(1, await removeFinal);
-            }
-        }
-
-        [Fact]
-        public async Task TestDelMultiInsideTransaction() // https://redis.io/commands/hdel
-        {
-            using (var outer = Create())
-            {
-                var conn = outer.GetDatabase().CreateTransaction();
-                {
-                    var hashkey = Me();
-                    _ = conn.HashSetAsync(hashkey, "key1", "val1");
-                    _ = conn.HashSetAsync(hashkey, "key2", "val2");
-                    _ = conn.HashSetAsync(hashkey, "key3", "val3");
-
-                    var s1 = conn.HashExistsAsync(hashkey, "key1");
-                    var s2 = conn.HashExistsAsync(hashkey, "key2");
-                    var s3 = conn.HashExistsAsync(hashkey, "key3");
-
-                    var removed = conn.HashDeleteAsync(hashkey, new RedisValue[] { "key1", "key3" });
-
-                    var d1 = conn.HashExistsAsync(hashkey, "key1");
-                    var d2 = conn.HashExistsAsync(hashkey, "key2");
-                    var d3 = conn.HashExistsAsync(hashkey, "key3");
-
-                    conn.Execute();
-
-                    Assert.True(await s1);
-                    Assert.True(await s2);
-                    Assert.True(await s3);
-
-                    Assert.Equal(2, await removed);
-
-                    Assert.False(await d1);
-                    Assert.True(await d2);
-                    Assert.False(await d3);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task TestExists() // https://redis.io/commands/hexists
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                _ = conn.KeyDeleteAsync(hashkey).ForAwait();
-                var ex0 = conn.HashExistsAsync(hashkey, "field").ForAwait();
-                _ = conn.HashSetAsync(hashkey, "field", "value").ForAwait();
-                var ex1 = conn.HashExistsAsync(hashkey, "field").ForAwait();
-                _ = conn.HashDeleteAsync(hashkey, "field").ForAwait();
-                _ = conn.HashExistsAsync(hashkey, "field").ForAwait();
-
-                Assert.False(await ex0);
-                Assert.True(await ex1);
-                Assert.False(await ex0);
-            }
-        }
-
-        [Fact]
-        public async Task TestHashKeys() // https://redis.io/commands/hkeys
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashKey = Me();
-                await conn.KeyDeleteAsync(hashKey).ForAwait();
-
-                var keys0 = await conn.HashKeysAsync(hashKey).ForAwait();
-                Assert.Empty(keys0);
-
-                await conn.HashSetAsync(hashKey, "foo", "abc").ForAwait();
-                await conn.HashSetAsync(hashKey, "bar", "def").ForAwait();
-
-                var keys1 = conn.HashKeysAsync(hashKey);
-
-                var arr = await keys1;
-                Assert.Equal(2, arr.Length);
-                Assert.Equal("foo", arr[0]);
-                Assert.Equal("bar", arr[1]);
-            }
-        }
-
-        [Fact]
-        public async Task TestHashValues() // https://redis.io/commands/hvals
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                await conn.KeyDeleteAsync(hashkey).ForAwait();
-
-                var keys0 = await conn.HashValuesAsync(hashkey).ForAwait();
-
-                await conn.HashSetAsync(hashkey, "foo", "abc").ForAwait();
-                await conn.HashSetAsync(hashkey, "bar", "def").ForAwait();
-
-                var keys1 = conn.HashValuesAsync(hashkey).ForAwait();
-
-                Assert.Empty(keys0);
-
-                var arr = await keys1;
-                Assert.Equal(2, arr.Length);
-                Assert.Equal("abc", Encoding.UTF8.GetString(arr[0]!));
-                Assert.Equal("def", Encoding.UTF8.GetString(arr[1]!));
-            }
-        }
-
-        [Fact]
-        public async Task TestHashLength() // https://redis.io/commands/hlen
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                conn.KeyDelete(hashkey, CommandFlags.FireAndForget);
-
-                var len0 = conn.HashLengthAsync(hashkey);
-
-                conn.HashSet(hashkey, "foo", "abc", flags: CommandFlags.FireAndForget);
-                conn.HashSet(hashkey, "bar", "def", flags: CommandFlags.FireAndForget);
-
-                var len1 = conn.HashLengthAsync(hashkey);
-
-                Assert.Equal(0, await len0);
-                Assert.Equal(2, await len1);
-            }
-        }
-
-        [Fact]
-        public async Task TestGetMulti() // https://redis.io/commands/hmget
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                conn.KeyDelete(hashkey, CommandFlags.FireAndForget);
-
-                RedisValue[] fields = { "foo", "bar", "blop" };
-                var arr0 = await conn.HashGetAsync(hashkey, fields).ForAwait();
-
-                conn.HashSet(hashkey, "foo", "abc", flags: CommandFlags.FireAndForget);
-                conn.HashSet(hashkey, "bar", "def", flags: CommandFlags.FireAndForget);
-
-                var arr1 = await conn.HashGetAsync(hashkey, fields).ForAwait();
-                var arr2 = await conn.HashGetAsync(hashkey, fields).ForAwait();
-
-                Assert.Equal(3, arr0.Length);
-                Assert.Null((string?)arr0[0]);
-                Assert.Null((string?)arr0[1]);
-                Assert.Null((string?)arr0[2]);
-
-                Assert.Equal(3, arr1.Length);
-                Assert.Equal("abc", arr1[0]);
-                Assert.Equal("def", arr1[1]);
-                Assert.Null((string?)arr1[2]);
-
-                Assert.Equal(3, arr2.Length);
-                Assert.Equal("abc", arr2[0]);
-                Assert.Equal("def", arr2[1]);
-                Assert.Null((string?)arr2[2]);
-            }
-        }
-
-        [Fact]
-        public void TestGetPairs() // https://redis.io/commands/hgetall
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                conn.KeyDeleteAsync(hashkey);
-
-                var result0 = conn.HashGetAllAsync(hashkey);
-
-                conn.HashSetAsync(hashkey, "foo", "abc");
-                conn.HashSetAsync(hashkey, "bar", "def");
-
-                var result1 = conn.HashGetAllAsync(hashkey);
-
-                Assert.Empty(muxer.Wait(result0));
-                var result = muxer.Wait(result1).ToStringDictionary();
-                Assert.Equal(2, result.Count);
-                Assert.Equal("abc", result["foo"]);
-                Assert.Equal("def", result["bar"]);
-            }
-        }
-
-        [Fact]
-        public void TestSetPairs() // https://redis.io/commands/hmset
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                conn.KeyDeleteAsync(hashkey).ForAwait();
-
-                var result0 = conn.HashGetAllAsync(hashkey);
-
-                var data = new [] {
-                    new HashEntry("foo", Encoding.UTF8.GetBytes("abc")),
-                    new HashEntry("bar", Encoding.UTF8.GetBytes("def"))
-                };
-                conn.HashSetAsync(hashkey, data).ForAwait();
-
-                var result1 = conn.Wait(conn.HashGetAllAsync(hashkey));
-
-                Assert.Empty(result0.Result);
-                var result = result1.ToStringDictionary();
-                Assert.Equal(2, result.Count);
-                Assert.Equal("abc", result["foo"]);
-                Assert.Equal("def", result["bar"]);
-            }
-        }
-
-        [Fact]
-        public async Task TestWhenAlwaysAsync()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var hashkey = Me();
-                conn.KeyDelete(hashkey, CommandFlags.FireAndForget);
-
-                var result1 = await conn.HashSetAsync(hashkey, "foo", "bar", When.Always, CommandFlags.None);
-                var result2 = await conn.HashSetAsync(hashkey, "foo2", "bar", When.Always, CommandFlags.None);
-                var result3 = await conn.HashSetAsync(hashkey, "foo", "bar", When.Always, CommandFlags.None);
-                var result4 = await conn.HashSetAsync(hashkey, "foo", "bar2", When.Always, CommandFlags.None);
-
-                Assert.True(result1, "Initial set key 1");
-                Assert.True(result2, "Initial set key 2");
-                // Fields modified *but not added* should be a zero/false. That's the behavior of HSET
-                Assert.False(result3, "Duplicate set key 1");
-                Assert.False(result4, "Duplicate se key 1 variant");
-            }
-        }
-
-        [Fact]
-        public async Task HashRandomFieldAsync()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var db = muxer.GetDatabase();
-            var hashKey = Me();
-            var items = new HashEntry[] { new("new york", "yankees"), new("baltimore", "orioles"), new("boston", "red sox"), new("Tampa Bay", "rays"), new("Toronto", "blue jays") };
-            await db.HashSetAsync(hashKey, items);
-
-            var singleField = await db.HashRandomFieldAsync(hashKey);
-            var multiFields = await db.HashRandomFieldsAsync(hashKey, 3);
-            var withValues = await db.HashRandomFieldsWithValuesAsync(hashKey, 3);
-            Assert.Equal(3, multiFields.Length);
-            Assert.Equal(3, withValues.Length);
-            Assert.Contains(items, x => x.Name == singleField);
-
-            foreach (var field in multiFields)
-            {
-                Assert.Contains(items, x => x.Name == field);
-            }
-
-            foreach (var field in withValues)
-            {
-                Assert.Contains(items, x => x.Name == field.Name);
-            }
-        }
-
-        [Fact]
-        public void HashRandomField()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var db = muxer.GetDatabase();
-            var hashKey = Me();
-            var items = new HashEntry[] { new("new york", "yankees"), new("baltimore", "orioles"), new("boston", "red sox"), new("Tampa Bay", "rays"), new("Toronto", "blue jays") };
-            db.HashSet(hashKey, items);
-
-            var singleField = db.HashRandomField(hashKey);
-            var multiFields = db.HashRandomFields(hashKey, 3);
-            var withValues = db.HashRandomFieldsWithValues(hashKey, 3);
-            Assert.Equal(3, multiFields.Length);
-            Assert.Equal(3, withValues.Length);
-            Assert.Contains(items, x => x.Name == singleField);
-
-            foreach (var field in multiFields)
-            {
-                Assert.Contains(items, x => x.Name == field);
-            }
-
-            foreach (var field in withValues)
-            {
-                Assert.Contains(items, x => x.Name == field.Name);
-            }
-        }
-
-        [Fact]
-        public void HashRandomFieldEmptyHash()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var db = muxer.GetDatabase();
-            var hashKey = Me();
-
-            var singleField = db.HashRandomField(hashKey);
-            var multiFields = db.HashRandomFields(hashKey, 3);
-            var withValues = db.HashRandomFieldsWithValues(hashKey, 3);
-
-            Assert.Equal(RedisValue.Null, singleField);
-            Assert.Empty(multiFields);
-            Assert.Empty(withValues);
-        }
+    }
+
+    [Fact]
+    public void HashRandomFieldEmptyHash()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var hashKey = Me();
+
+        var singleField = db.HashRandomField(hashKey);
+        var multiFields = db.HashRandomFields(hashKey, 3);
+        var withValues = db.HashRandomFieldsWithValues(hashKey, 3);
+
+        Assert.Equal(RedisValue.Null, singleField);
+        Assert.Empty(multiFields);
+        Assert.Empty(withValues);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Helpers/Attributes.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Attributes.cs
@@ -6,184 +6,181 @@ using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// <para>Override for <see cref="Xunit.FactAttribute"/> that truncates our DisplayName down.</para>
+/// <para>
+/// Attribute that is applied to a method to indicate that it is a fact that should
+/// be run by the test runner. It can also be extended to support a customized definition
+/// of a test method.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("StackExchange.Redis.Tests.FactDiscoverer", "StackExchange.Redis.Tests")]
+public class FactAttribute : Xunit.FactAttribute { }
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public class FactLongRunningAttribute : FactAttribute
 {
-    /// <summary>
-    /// <para>Override for <see cref="Xunit.FactAttribute"/> that truncates our DisplayName down.</para>
-    /// <para>
-    /// Attribute that is applied to a method to indicate that it is a fact that should
-    /// be run by the test runner. It can also be extended to support a customized definition
-    /// of a test method.
-    /// </para>
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    [XunitTestCaseDiscoverer("StackExchange.Redis.Tests.FactDiscoverer", "StackExchange.Redis.Tests")]
-    public class FactAttribute : Xunit.FactAttribute
+    public override string Skip
+    {
+        get => TestConfig.Current.RunLongRunning ? base.Skip : "Config.RunLongRunning is false - skipping long test.";
+        set => base.Skip = value;
+    }
+}
+
+/// <summary>
+/// <para>Override for <see cref="Xunit.TheoryAttribute"/> that truncates our DisplayName down.</para>
+/// <para>
+/// Marks a test method as being a data theory. Data theories are tests which are
+/// fed various bits of data from a data source, mapping to parameters on the test
+/// method. If the data source contains multiple rows, then the test method is executed
+/// multiple times (once with each data row). Data is provided by attributes which
+/// derive from Xunit.Sdk.DataAttribute (notably, Xunit.InlineDataAttribute and Xunit.MemberDataAttribute).
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("StackExchange.Redis.Tests.TheoryDiscoverer", "StackExchange.Redis.Tests")]
+public class TheoryAttribute : Xunit.TheoryAttribute { }
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public class TheoryLongRunningAttribute : Xunit.TheoryAttribute
+{
+    public override string Skip
+    {
+        get => TestConfig.Current.RunLongRunning ? base.Skip : "Config.RunLongRunning is false - skipping long test.";
+        set => base.Skip = value;
+    }
+}
+
+public class FactDiscoverer : Xunit.Sdk.FactDiscoverer
+{
+    public FactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
+
+    protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        => new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
+}
+
+public class TheoryDiscoverer : Xunit.Sdk.TheoryDiscoverer
+{
+    public TheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+        => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow) };
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, string skipReason)
+        => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) };
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        => new[] { new SkippableTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) };
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkippedDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow, string skipReason)
+        => new[] { new NamedSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, skipReason, dataRow) };
+}
+
+public class SkippableTestCase : XunitTestCase
+{
+    protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName) =>
+        base.GetDisplayName(factAttribute, displayName).StripName();
+
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public SkippableTestCase() { }
+
+    public SkippableTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
     {
     }
 
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class FactLongRunningAttribute : FactAttribute
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
     {
-        public override string Skip
+        var skipMessageBus = new SkippableMessageBus(messageBus);
+        var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource).ForAwait();
+        return result.Update(skipMessageBus);
+    }
+}
+
+public class SkippableTheoryTestCase : XunitTheoryTestCase
+{
+    protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName) =>
+        base.GetDisplayName(factAttribute, displayName).StripName();
+
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public SkippableTheoryTestCase() { }
+
+    public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
+
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        var skipMessageBus = new SkippableMessageBus(messageBus);
+        var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource).ForAwait();
+        return result.Update(skipMessageBus);
+    }
+}
+
+public class NamedSkippedDataRowTestCase : XunitSkippedDataRowTestCase
+{
+    protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName) =>
+        base.GetDisplayName(factAttribute, displayName).StripName();
+
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public NamedSkippedDataRowTestCase() { }
+
+    public NamedSkippedDataRowTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, string skipReason, object[]? testMethodArguments = null)
+    : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, skipReason, testMethodArguments) { }
+}
+
+public class SkippableMessageBus : IMessageBus
+{
+    private readonly IMessageBus InnerBus;
+    public SkippableMessageBus(IMessageBus innerBus) => InnerBus = innerBus;
+
+    public int DynamicallySkippedTestCount { get; private set; }
+
+    public void Dispose()
+    {
+        InnerBus.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public bool QueueMessage(IMessageSinkMessage message)
+    {
+        if (message is ITestFailed testFailed)
         {
-            get => TestConfig.Current.RunLongRunning ? base.Skip : "Config.RunLongRunning is false - skipping long test.";
-            set => base.Skip = value;
-        }
-    }
-
-    /// <summary>
-    /// <para>Override for <see cref="Xunit.TheoryAttribute"/> that truncates our DisplayName down.</para>
-    /// <para>
-    /// Marks a test method as being a data theory. Data theories are tests which are
-    /// fed various bits of data from a data source, mapping to parameters on the test
-    /// method. If the data source contains multiple rows, then the test method is executed
-    /// multiple times (once with each data row). Data is provided by attributes which
-    /// derive from Xunit.Sdk.DataAttribute (notably, Xunit.InlineDataAttribute and Xunit.MemberDataAttribute).
-    /// </para>
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    [XunitTestCaseDiscoverer("StackExchange.Redis.Tests.TheoryDiscoverer", "StackExchange.Redis.Tests")]
-    public class TheoryAttribute : Xunit.TheoryAttribute { }
-
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class TheoryLongRunningAttribute : Xunit.TheoryAttribute
-    {
-        public override string Skip
-        {
-            get => TestConfig.Current.RunLongRunning ? base.Skip : "Config.RunLongRunning is false - skipping long test.";
-            set => base.Skip = value;
-        }
-    }
-
-    public class FactDiscoverer : Xunit.Sdk.FactDiscoverer
-    {
-        public FactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
-
-        protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
-            => new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
-    }
-
-    public class TheoryDiscoverer : Xunit.Sdk.TheoryDiscoverer
-    {
-        public TheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
-
-        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
-            => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow) };
-
-        protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, string skipReason)
-            => new[] { new SkippableTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) };
-
-        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
-            => new[] { new SkippableTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) };
-
-        protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkippedDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow, string skipReason)
-            => new[] { new NamedSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, skipReason, dataRow) };
-    }
-
-    public class SkippableTestCase : XunitTestCase
-    {
-        protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName) =>
-            base.GetDisplayName(factAttribute, displayName).StripName();
-
-        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
-        public SkippableTestCase() { }
-
-        public SkippableTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[]? testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
-        {
-        }
-
-        public override async Task<RunSummary> RunAsync(
-            IMessageSink diagnosticMessageSink,
-            IMessageBus messageBus,
-            object[] constructorArguments,
-            ExceptionAggregator aggregator,
-            CancellationTokenSource cancellationTokenSource)
-        {
-            var skipMessageBus = new SkippableMessageBus(messageBus);
-            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource).ForAwait();
-            return result.Update(skipMessageBus);
-        }
-    }
-
-    public class SkippableTheoryTestCase : XunitTheoryTestCase
-    {
-        protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName) =>
-            base.GetDisplayName(factAttribute, displayName).StripName();
-
-        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
-        public SkippableTheoryTestCase() { }
-
-        public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
-
-        public override async Task<RunSummary> RunAsync(
-            IMessageSink diagnosticMessageSink,
-            IMessageBus messageBus,
-            object[] constructorArguments,
-            ExceptionAggregator aggregator,
-            CancellationTokenSource cancellationTokenSource)
-        {
-            var skipMessageBus = new SkippableMessageBus(messageBus);
-            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource).ForAwait();
-            return result.Update(skipMessageBus);
-        }
-    }
-
-    public class NamedSkippedDataRowTestCase : XunitSkippedDataRowTestCase
-    {
-        protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName) =>
-            base.GetDisplayName(factAttribute, displayName).StripName();
-
-        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
-        public NamedSkippedDataRowTestCase() { }
-
-        public NamedSkippedDataRowTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, string skipReason, object[]? testMethodArguments = null)
-        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, skipReason, testMethodArguments) { }
-    }
-
-    public class SkippableMessageBus : IMessageBus
-    {
-        private readonly IMessageBus InnerBus;
-        public SkippableMessageBus(IMessageBus innerBus) => InnerBus = innerBus;
-
-        public int DynamicallySkippedTestCount { get; private set; }
-
-        public void Dispose()
-        {
-            InnerBus.Dispose();
-            GC.SuppressFinalize(this);
-        }
-
-        public bool QueueMessage(IMessageSinkMessage message)
-        {
-            if (message is ITestFailed testFailed)
+            var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+            if (exceptionType == typeof(SkipTestException).FullName)
             {
-                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
-                if (exceptionType == typeof(SkipTestException).FullName)
-                {
-                    DynamicallySkippedTestCount++;
-                    return InnerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
-                }
+                DynamicallySkippedTestCount++;
+                return InnerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
             }
-            return InnerBus.QueueMessage(message);
         }
+        return InnerBus.QueueMessage(message);
     }
+}
 
-    internal static class XUnitExtensions
+internal static class XUnitExtensions
+{
+    internal static string StripName(this string name) =>
+        name.Replace("StackExchange.Redis.Tests.", "");
+
+    public static RunSummary Update(this RunSummary summary, SkippableMessageBus bus)
     {
-        internal static string StripName(this string name) =>
-            name.Replace("StackExchange.Redis.Tests.", "");
-
-        public static RunSummary Update(this RunSummary summary, SkippableMessageBus bus)
+        if (bus.DynamicallySkippedTestCount > 0)
         {
-            if (bus.DynamicallySkippedTestCount > 0)
-            {
-                summary.Failed -= bus.DynamicallySkippedTestCount;
-                summary.Skipped += bus.DynamicallySkippedTestCount;
-            }
-            return summary;
+            summary.Failed -= bus.DynamicallySkippedTestCount;
+            summary.Skipped += bus.DynamicallySkippedTestCount;
         }
+        return summary;
     }
 }

--- a/tests/StackExchange.Redis.Tests/Helpers/Extensions.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Extensions.cs
@@ -2,29 +2,28 @@
 using System.Runtime.InteropServices;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Helpers
+namespace StackExchange.Redis.Tests.Helpers;
+
+public static class Extensions
 {
-    public static class Extensions
+    private static string VersionInfo { get; }
+
+    static Extensions()
     {
-        private static string VersionInfo { get; }
-
-        static Extensions()
-        {
 #if NET462
-            VersionInfo = "Compiled under .NET 4.6.2";
+        VersionInfo = "Compiled under .NET 4.6.2";
 #else
-            VersionInfo = $"Running under {RuntimeInformation.FrameworkDescription} ({Environment.Version})";
+        VersionInfo = $"Running under {RuntimeInformation.FrameworkDescription} ({Environment.Version})";
 #endif
-            try
-            {
-                VersionInfo += "\n   Running on: " + RuntimeInformation.OSDescription;
-            }
-            catch (Exception)
-            {
-                VersionInfo += "\n   Failed to get OS version";
-            }
+        try
+        {
+            VersionInfo += "\n   Running on: " + RuntimeInformation.OSDescription;
         }
-
-        public static void WriteFrameworkVersion(this ITestOutputHelper output) => output.WriteLine(VersionInfo);
+        catch (Exception)
+        {
+            VersionInfo += "\n   Failed to get OS version";
+        }
     }
+
+    public static void WriteFrameworkVersion(this ITestOutputHelper output) => output.WriteLine(VersionInfo);
 }

--- a/tests/StackExchange.Redis.Tests/Helpers/NonParallelCollection.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/NonParallelCollection.cs
@@ -1,10 +1,9 @@
 ﻿using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public static class NonParallelCollection
 {
-    [CollectionDefinition(Name, DisableParallelization = true)]
-    public static class NonParallelCollection
-    {
-        public const string Name = "NonParallel";
-    }
+    public const string Name = "NonParallel";
 }

--- a/tests/StackExchange.Redis.Tests/Helpers/Skip.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Skip.cs
@@ -15,18 +15,6 @@ public static class Skip
         }
     }
 
-    public static void IfBelow(IConnectionMultiplexer conn, Version minVersion)
-    {
-        var serverVersion = conn.GetServer(conn.GetEndPoints()[0]).Version;
-        if (minVersion > serverVersion)
-        {
-            throw new SkipTestException($"Requires server version {minVersion}, but server is only {serverVersion}.")
-            {
-                MissingFeatures = $"Server version >= {minVersion}."
-            };
-        }
-    }
-
     internal static void IfMissingDatabase(IConnectionMultiplexer conn, int dbId)
     {
         var dbCount = conn.GetServer(conn.GetEndPoints()[0]).DatabaseCount;

--- a/tests/StackExchange.Redis.Tests/Helpers/Skip.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Skip.cs
@@ -1,64 +1,42 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public static class Skip
 {
-    public static class Skip
+    public static void Inconclusive(string message) => throw new SkipTestException(message);
+
+    public static void IfNoConfig(string prop, [NotNull] string? value)
     {
-        public static void Inconclusive(string message) => throw new SkipTestException(message);
-
-        public static void IfNoConfig(string prop, [NotNull] string? value)
+        if (value.IsNullOrEmpty())
         {
-            if (value.IsNullOrEmpty())
-            {
-                throw new SkipTestException($"Config.{prop} is not set, skipping test.");
-            }
-        }
-
-        public static void IfNoConfig(string prop, [NotNull] List<string>? values)
-        {
-            if (values == null || values.Count == 0)
-            {
-                throw new SkipTestException($"Config.{prop} is not set, skipping test.");
-            }
-        }
-
-        public static void IfBelow(IConnectionMultiplexer conn, Version minVersion)
-        {
-            var serverVersion = conn.GetServer(conn.GetEndPoints()[0]).Version;
-            if (minVersion > serverVersion)
-            {
-                throw new SkipTestException($"Requires server version {minVersion}, but server is only {serverVersion}.")
-                {
-                    MissingFeatures = $"Server version >= {minVersion}."
-                };
-            }
-        }
-
-        public static void IfMissingFeature(IConnectionMultiplexer conn, string feature, Func<RedisFeatures, bool> check)
-        {
-            var features = conn.GetServer(conn.GetEndPoints()[0]).Features;
-            if (!check(features))
-            {
-                throw new SkipTestException($"'{feature}' is not supported on this server.")
-                {
-                    MissingFeatures = feature
-                };
-            }
-        }
-
-        internal static void IfMissingDatabase(IConnectionMultiplexer conn, int dbId)
-        {
-            var dbCount = conn.GetServer(conn.GetEndPoints()[0]).DatabaseCount;
-            if (dbId >= dbCount) throw new SkipTestException($"Database '{dbId}' is not supported on this server.");
+            throw new SkipTestException($"Config.{prop} is not set, skipping test.");
         }
     }
 
-    public class SkipTestException : Exception
+    public static void IfBelow(IConnectionMultiplexer conn, Version minVersion)
     {
-        public string? MissingFeatures { get; set; }
-
-        public SkipTestException(string reason) : base(reason) { }
+        var serverVersion = conn.GetServer(conn.GetEndPoints()[0]).Version;
+        if (minVersion > serverVersion)
+        {
+            throw new SkipTestException($"Requires server version {minVersion}, but server is only {serverVersion}.")
+            {
+                MissingFeatures = $"Server version >= {minVersion}."
+            };
+        }
     }
+
+    internal static void IfMissingDatabase(IConnectionMultiplexer conn, int dbId)
+    {
+        var dbCount = conn.GetServer(conn.GetEndPoints()[0]).DatabaseCount;
+        if (dbId >= dbCount) throw new SkipTestException($"Database '{dbId}' is not supported on this server.");
+    }
+}
+
+public class SkipTestException : Exception
+{
+    public string? MissingFeatures { get; set; }
+
+    public SkipTestException(string reason) : base(reason) { }
 }

--- a/tests/StackExchange.Redis.Tests/Helpers/TestConfig.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/TestConfig.cs
@@ -4,109 +4,108 @@ using Newtonsoft.Json;
 using System.Threading;
 using System.Linq;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public static class TestConfig
 {
-    public static class TestConfig
+    private const string FileName = "TestConfig.json";
+
+    public static Config Current { get; }
+
+    private static int _db = 17;
+    public static int GetDedicatedDB(IConnectionMultiplexer? conn = null)
     {
-        private const string FileName = "TestConfig.json";
+        int db = Interlocked.Increment(ref _db);
+        if (conn != null) Skip.IfMissingDatabase(conn, db);
+        return db;
+    }
 
-        public static Config Current { get; }
-
-        private static int _db = 17;
-        public static int GetDedicatedDB(IConnectionMultiplexer? conn = null)
+    static TestConfig()
+    {
+        Current = new Config();
+        try
         {
-            int db = Interlocked.Increment(ref _db);
-            if (conn != null) Skip.IfMissingDatabase(conn, db);
-            return db;
-        }
-
-        static TestConfig()
-        {
-            Current = new Config();
-            try
+            using (var stream = typeof(TestConfig).Assembly.GetManifestResourceStream("StackExchange.Redis.Tests." + FileName))
             {
-                using (var stream = typeof(TestConfig).Assembly.GetManifestResourceStream("StackExchange.Redis.Tests." + FileName))
+                if (stream != null)
                 {
-                    if (stream != null)
+                    using (var reader = new StreamReader(stream))
                     {
-                        using (var reader = new StreamReader(stream))
-                        {
-                            Current = JsonConvert.DeserializeObject<Config>(reader.ReadToEnd()) ?? new Config();
-                        }
+                        Current = JsonConvert.DeserializeObject<Config>(reader.ReadToEnd()) ?? new Config();
                     }
                 }
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Error Deserializing TestConfig.json: " + ex);
-            }
         }
-
-        public class Config
+        catch (Exception ex)
         {
-            public bool UseSharedConnection { get; set; } = true;
-            public bool RunLongRunning { get; set; }
-            public bool LogToConsole { get; set; }
-
-            public string PrimaryServer { get; set; } = "127.0.0.1";
-            public int PrimaryPort { get; set; } = 6379;
-            public string PrimaryServerAndPort => PrimaryServer + ":" + PrimaryPort.ToString();
-
-            public string ReplicaServer { get; set; } = "127.0.0.1";
-            public int ReplicaPort { get; set; } = 6380;
-            public string ReplicaServerAndPort => ReplicaServer + ":" + ReplicaPort.ToString();
-
-            public string SecureServer { get; set; } = "127.0.0.1";
-            public int SecurePort { get; set; } = 6381;
-            public string SecurePassword { get; set; } = "changeme";
-            public string SecureServerAndPort => SecureServer + ":" + SecurePort.ToString();
-
-            // Separate servers for failover tests, so they don't wreak havoc on all others
-            public string FailoverPrimaryServer { get; set; } = "127.0.0.1";
-            public int FailoverPrimaryPort { get; set; } = 6382;
-            public string FailoverPrimaryServerAndPort => FailoverPrimaryServer + ":" + FailoverPrimaryPort.ToString();
-
-            public string FailoverReplicaServer { get; set; } = "127.0.0.1";
-            public int FailoverReplicaPort { get; set; } = 6383;
-            public string FailoverReplicaServerAndPort => FailoverReplicaServer + ":" + FailoverReplicaPort.ToString();
-
-            public string IPv4Server { get; set; } = "127.0.0.1";
-            public int IPv4Port { get; set; } = 6379;
-            public string IPv6Server { get; set; } = "::1";
-            public int IPv6Port { get; set; } = 6379;
-
-            public string RemoteServer { get; set; } = "127.0.0.1";
-            public int RemotePort { get; set; } = 6379;
-            public string RemoteServerAndPort => RemoteServer + ":" + RemotePort.ToString();
-
-            public string SentinelServer { get; set; } = "127.0.0.1";
-            public int SentinelPortA { get; set; } = 26379;
-            public int SentinelPortB { get; set; } = 26380;
-            public int SentinelPortC { get; set; } = 26381;
-            public string SentinelSeviceName { get; set; } = "myprimary";
-
-            public string ClusterServer { get; set; } = "127.0.0.1";
-            public int ClusterStartPort { get; set; } = 7000;
-            public int ClusterServerCount { get; set; } = 6;
-            public string ClusterServersAndPorts => string.Join(",", Enumerable.Range(ClusterStartPort, ClusterServerCount).Select(port => ClusterServer + ":" + port));
-
-            public string? SslServer { get; set; }
-            public int SslPort { get; set; }
-
-            public string? RedisLabsSslServer { get; set; }
-            public int RedisLabsSslPort { get; set; } = 6379;
-            public string? RedisLabsPfxPath { get; set; }
-
-            public string? AzureCacheServer { get; set; }
-            public string? AzureCachePassword { get; set; }
-
-            public string? SSDBServer { get; set; }
-            public int SSDBPort { get; set; } = 8888;
-
-            public string ProxyServer { get; set; } = "127.0.0.1";
-            public int ProxyPort { get; set; } = 7015;
-
-            public string ProxyServerAndPort => ProxyServer + ":" + ProxyPort.ToString();
+            Console.WriteLine("Error Deserializing TestConfig.json: " + ex);
         }
+    }
+
+    public class Config
+    {
+        public bool UseSharedConnection { get; set; } = true;
+        public bool RunLongRunning { get; set; }
+        public bool LogToConsole { get; set; }
+
+        public string PrimaryServer { get; set; } = "127.0.0.1";
+        public int PrimaryPort { get; set; } = 6379;
+        public string PrimaryServerAndPort => PrimaryServer + ":" + PrimaryPort.ToString();
+
+        public string ReplicaServer { get; set; } = "127.0.0.1";
+        public int ReplicaPort { get; set; } = 6380;
+        public string ReplicaServerAndPort => ReplicaServer + ":" + ReplicaPort.ToString();
+
+        public string SecureServer { get; set; } = "127.0.0.1";
+        public int SecurePort { get; set; } = 6381;
+        public string SecurePassword { get; set; } = "changeme";
+        public string SecureServerAndPort => SecureServer + ":" + SecurePort.ToString();
+
+        // Separate servers for failover tests, so they don't wreak havoc on all others
+        public string FailoverPrimaryServer { get; set; } = "127.0.0.1";
+        public int FailoverPrimaryPort { get; set; } = 6382;
+        public string FailoverPrimaryServerAndPort => FailoverPrimaryServer + ":" + FailoverPrimaryPort.ToString();
+
+        public string FailoverReplicaServer { get; set; } = "127.0.0.1";
+        public int FailoverReplicaPort { get; set; } = 6383;
+        public string FailoverReplicaServerAndPort => FailoverReplicaServer + ":" + FailoverReplicaPort.ToString();
+
+        public string IPv4Server { get; set; } = "127.0.0.1";
+        public int IPv4Port { get; set; } = 6379;
+        public string IPv6Server { get; set; } = "::1";
+        public int IPv6Port { get; set; } = 6379;
+
+        public string RemoteServer { get; set; } = "127.0.0.1";
+        public int RemotePort { get; set; } = 6379;
+        public string RemoteServerAndPort => RemoteServer + ":" + RemotePort.ToString();
+
+        public string SentinelServer { get; set; } = "127.0.0.1";
+        public int SentinelPortA { get; set; } = 26379;
+        public int SentinelPortB { get; set; } = 26380;
+        public int SentinelPortC { get; set; } = 26381;
+        public string SentinelSeviceName { get; set; } = "myprimary";
+
+        public string ClusterServer { get; set; } = "127.0.0.1";
+        public int ClusterStartPort { get; set; } = 7000;
+        public int ClusterServerCount { get; set; } = 6;
+        public string ClusterServersAndPorts => string.Join(",", Enumerable.Range(ClusterStartPort, ClusterServerCount).Select(port => ClusterServer + ":" + port));
+
+        public string? SslServer { get; set; }
+        public int SslPort { get; set; }
+
+        public string? RedisLabsSslServer { get; set; }
+        public int RedisLabsSslPort { get; set; } = 6379;
+        public string? RedisLabsPfxPath { get; set; }
+
+        public string? AzureCacheServer { get; set; }
+        public string? AzureCachePassword { get; set; }
+
+        public string? SSDBServer { get; set; }
+        public int SSDBPort { get; set; } = 8888;
+
+        public string ProxyServer { get; set; } = "127.0.0.1";
+        public int ProxyPort { get; set; } = 7015;
+
+        public string ProxyServerAndPort => ProxyServer + ":" + ProxyPort.ToString();
     }
 }

--- a/tests/StackExchange.Redis.Tests/HyperLogLog.cs
+++ b/tests/StackExchange.Redis.Tests/HyperLogLog.cs
@@ -1,43 +1,40 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class HyperLogLog : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class HyperLogLog : TestBase
+    public HyperLogLog(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public void SingleKeyLength()
     {
-        public HyperLogLog(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void SingleKeyLength()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = "hll1";
+        var db = conn.GetDatabase();
+        RedisKey key = "hll1";
 
-                db.HyperLogLogAdd(key, "a");
-                db.HyperLogLogAdd(key, "b");
-                db.HyperLogLogAdd(key, "c");
+        db.HyperLogLogAdd(key, "a");
+        db.HyperLogLogAdd(key, "b");
+        db.HyperLogLogAdd(key, "c");
 
-                Assert.True(db.HyperLogLogLength(key) > 0);
-            }
-        }
+        Assert.True(db.HyperLogLogLength(key) > 0);
+    }
 
-        [Fact]
-        public void MultiKeyLength()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey[] keys = { "hll1", "hll2", "hll3" };
+    [Fact]
+    public void MultiKeyLength()
+    {
+        using var conn = Create();
 
-                db.HyperLogLogAdd(keys[0], "a");
-                db.HyperLogLogAdd(keys[1], "b");
-                db.HyperLogLogAdd(keys[2], "c");
+        var db = conn.GetDatabase();
+        RedisKey[] keys = { "hll1", "hll2", "hll3" };
 
-                Assert.True(db.HyperLogLogLength(keys) > 0);
-            }
-        }
+        db.HyperLogLogAdd(keys[0], "a");
+        db.HyperLogLogAdd(keys[1], "b");
+        db.HyperLogLogAdd(keys[2], "c");
+
+        Assert.True(db.HyperLogLogLength(keys) > 0);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/BgSaveResponse.cs
@@ -2,23 +2,21 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
-{
-    public class BgSaveResponse : TestBase
-    {
-        public BgSaveResponse(ITestOutputHelper output) : base (output) { }
+namespace StackExchange.Redis.Tests.Issues;
 
-        [Theory (Skip = "We don't need to test this, and it really screws local testing hard.")]
-        [InlineData(SaveType.BackgroundSave)]
-        [InlineData(SaveType.BackgroundRewriteAppendOnlyFile)]
-        public async Task ShouldntThrowException(SaveType saveType)
-        {
-            using (var conn = Create(null, null, true))
-            {
-                var Server = GetServer(conn);
-                Server.Save(saveType);
-                await Task.Delay(1000);
-            }
-        }
+public class BgSaveResponse : TestBase
+{
+    public BgSaveResponse(ITestOutputHelper output) : base (output) { }
+
+    [Theory (Skip = "We don't need to test this, and it really screws local testing hard.")]
+    [InlineData(SaveType.BackgroundSave)]
+    [InlineData(SaveType.BackgroundRewriteAppendOnlyFile)]
+    public async Task ShouldntThrowException(SaveType saveType)
+    {
+        using var conn = Create(null, null, true);
+
+        var Server = GetServer(conn);
+        Server.Save(saveType);
+        await Task.Delay(1000);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/DefaultDatabase.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/DefaultDatabase.cs
@@ -2,58 +2,55 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class DefaultDatabase : TestBase
 {
-    public class DefaultDatabase : TestBase
+    public DefaultDatabase(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void UnspecifiedDbId_ReturnsNull()
     {
-        public DefaultDatabase(ITestOutputHelper output) : base (output) { }
+        var config = ConfigurationOptions.Parse("localhost");
+        Assert.Null(config.DefaultDatabase);
+    }
 
-        [Fact]
-		public void UnspecifiedDbId_ReturnsNull()
-		{
-			var config = ConfigurationOptions.Parse("localhost");
-			Assert.Null(config.DefaultDatabase);
-		}
+    [Fact]
+    public void SpecifiedDbId_ReturnsExpected()
+    {
+        var config = ConfigurationOptions.Parse("localhost,defaultDatabase=3");
+        Assert.Equal(3, config.DefaultDatabase);
+    }
 
-		[Fact]
-		public void SpecifiedDbId_ReturnsExpected()
-		{
-			var config = ConfigurationOptions.Parse("localhost,defaultDatabase=3");
-			Assert.Equal(3, config.DefaultDatabase);
-		}
-
-        [Fact]
-        public void ConfigurationOptions_UnspecifiedDefaultDb()
+    [Fact]
+    public void ConfigurationOptions_UnspecifiedDefaultDb()
+    {
+        var log = new StringWriter();
+        try
         {
-            var log = new StringWriter();
-            try
-            {
-                using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServerAndPort, log)) {
-                    var db = conn.GetDatabase();
-                    Assert.Equal(0, db.Database);
-                }
-            }
-            finally
-            {
-                Log(log.ToString());
-            }
+            using var conn = ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServerAndPort, log);
+            var db = conn.GetDatabase();
+            Assert.Equal(0, db.Database);
         }
-
-        [Fact]
-        public void ConfigurationOptions_SpecifiedDefaultDb()
+        finally
         {
-            var log = new StringWriter();
-            try
-            {
-                using (var conn = ConnectionMultiplexer.Connect($"{TestConfig.Current.PrimaryServerAndPort},defaultDatabase=3", log)) {
-                    var db = conn.GetDatabase();
-                    Assert.Equal(3, db.Database);
-                }
-            }
-            finally
-            {
-                Log(log.ToString());
-            }
+            Log(log.ToString());
         }
-	}
+    }
+
+    [Fact]
+    public void ConfigurationOptions_SpecifiedDefaultDb()
+    {
+        var log = new StringWriter();
+        try
+        {
+            using var conn = ConnectionMultiplexer.Connect($"{TestConfig.Current.PrimaryServerAndPort},defaultDatabase=3", log);
+            var db = conn.GetDatabase();
+            Assert.Equal(3, db.Database);
+        }
+        finally
+        {
+            Log(log.ToString());
+        }
+    }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue10.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue10.cs
@@ -1,31 +1,29 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class Issue10 : TestBase
 {
-    public class Issue10 : TestBase
+    public Issue10(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void Execute()
     {
-        public Issue10(ITestOutputHelper output) : base(output) { }
+        using var conn = Create();
 
-        [Fact]
-        public void Execute()
-        {
-            using (var muxer = Create())
-            {
-                var key = Me();
-                var conn = muxer.GetDatabase();
-                conn.KeyDeleteAsync(key); // contents: nil
-                conn.ListLeftPushAsync(key, "abc"); // "abc"
-                conn.ListLeftPushAsync(key, "def"); // "def", "abc"
-                conn.ListLeftPushAsync(key, "ghi"); // "ghi", "def", "abc",
-                conn.ListSetByIndexAsync(key, 1, "jkl"); // "ghi", "jkl", "abc"
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDeleteAsync(key); // contents: nil
+        db.ListLeftPushAsync(key, "abc"); // "abc"
+        db.ListLeftPushAsync(key, "def"); // "def", "abc"
+        db.ListLeftPushAsync(key, "ghi"); // "ghi", "def", "abc",
+        db.ListSetByIndexAsync(key, 1, "jkl"); // "ghi", "jkl", "abc"
 
-                var contents = conn.Wait(conn.ListRangeAsync(key, 0, -1));
-                Assert.Equal(3, contents.Length);
-                Assert.Equal("ghi", contents[0]);
-                Assert.Equal("jkl", contents[1]);
-                Assert.Equal("abc", contents[2]);
-            }
-        }
+        var contents = db.Wait(db.ListRangeAsync(key, 0, -1));
+        Assert.Equal(3, contents.Length);
+        Assert.Equal("ghi", contents[0]);
+        Assert.Equal("jkl", contents[1]);
+        Assert.Equal("abc", contents[2]);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue1101.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue1101.cs
@@ -6,190 +6,186 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class Issue1101 : TestBase
 {
-    public class Issue1101 : TestBase
+    public Issue1101(ITestOutputHelper output) : base(output) { }
+
+    private static void AssertCounts(ISubscriber pubsub, in RedisChannel channel, bool has, int handlers, int queues)
     {
-        public Issue1101(ITestOutputHelper output) : base(output) { }
-
-        private static void AssertCounts(ISubscriber pubsub, in RedisChannel channel,
-            bool has, int handlers, int queues)
+        if (pubsub.Multiplexer is ConnectionMultiplexer muxer)
         {
-            if (pubsub.Multiplexer is ConnectionMultiplexer muxer)
-            {
-                var aHas = muxer.GetSubscriberCounts(channel, out var ah, out var aq);
-                Assert.Equal(has, aHas);
-                Assert.Equal(handlers, ah);
-                Assert.Equal(queues, aq);
-            }
+            var aHas = muxer.GetSubscriberCounts(channel, out var ah, out var aq);
+            Assert.Equal(has, aHas);
+            Assert.Equal(handlers, ah);
+            Assert.Equal(queues, aq);
         }
-        [Fact]
-        public async Task ExecuteWithUnsubscribeViaChannel()
+    }
+
+    [Fact]
+    public async Task ExecuteWithUnsubscribeViaChannel()
+    {
+        using var conn = Create(log: Writer);
+
+        RedisChannel name = Me();
+        var pubsub = conn.GetSubscriber();
+        AssertCounts(pubsub, name, false, 0, 0);
+
+        // subscribe and check we get data
+        var first = await pubsub.SubscribeAsync(name);
+        var second = await pubsub.SubscribeAsync(name);
+        AssertCounts(pubsub, name, true, 0, 2);
+        var values = new List<string?>();
+        int i = 0;
+        first.OnMessage(x =>
         {
-            using (var muxer = Create(log: Writer))
-            {
-                RedisChannel name = Me();
-                var pubsub = muxer.GetSubscriber();
-                AssertCounts(pubsub, name, false, 0, 0);
-
-                // subscribe and check we get data
-                var first = await pubsub.SubscribeAsync(name);
-                var second = await pubsub.SubscribeAsync(name);
-                AssertCounts(pubsub, name, true, 0, 2);
-                var values = new List<string?>();
-                int i = 0;
-                first.OnMessage(x =>
-                {
-                    lock (values) { values.Add(x.Message); }
-                    return Task.CompletedTask;
-                });
-                second.OnMessage(_ => Interlocked.Increment(ref i));
-                await Task.Delay(200);
-                await pubsub.PublishAsync(name, "abc");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                var subs = muxer.GetServer(muxer.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
-                Assert.Equal(1, subs);
-                Assert.False(first.Completion.IsCompleted, "completed");
-                Assert.False(second.Completion.IsCompleted, "completed");
-
-                await first.UnsubscribeAsync();
-                await Task.Delay(200);
-                await pubsub.PublishAsync(name, "def");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1 && Volatile.Read(ref i) == 2);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                Assert.Equal(2, Volatile.Read(ref i));
-                Assert.True(first.Completion.IsCompleted, "completed");
-                Assert.False(second.Completion.IsCompleted, "completed");
-                AssertCounts(pubsub, name, true, 0, 1);
-
-                await second.UnsubscribeAsync();
-                await Task.Delay(200);
-                await pubsub.PublishAsync(name, "ghi");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                Assert.Equal(2, Volatile.Read(ref i));
-                Assert.True(first.Completion.IsCompleted, "completed");
-                Assert.True(second.Completion.IsCompleted, "completed");
-                AssertCounts(pubsub, name, false, 0, 0);
-
-                subs = muxer.GetServer(muxer.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
-                Assert.Equal(0, subs);
-                Assert.True(first.Completion.IsCompleted, "completed");
-                Assert.True(second.Completion.IsCompleted, "completed");
-            }
-        }
-
-        [Fact]
-        public async Task ExecuteWithUnsubscribeViaSubscriber()
+            lock (values) { values.Add(x.Message); }
+            return Task.CompletedTask;
+        });
+        second.OnMessage(_ => Interlocked.Increment(ref i));
+        await Task.Delay(200);
+        await pubsub.PublishAsync(name, "abc");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
+        lock (values)
         {
-            using (var muxer = Create(shared: false, log: Writer))
-            {
-                RedisChannel name = Me();
-                var pubsub = muxer.GetSubscriber();
-                AssertCounts(pubsub, name, false, 0, 0);
-
-                // subscribe and check we get data
-                var first = await pubsub.SubscribeAsync(name);
-                var second = await pubsub.SubscribeAsync(name);
-                AssertCounts(pubsub, name, true, 0, 2);
-                var values = new List<string?>();
-                int i = 0;
-                first.OnMessage(x =>
-                {
-                    lock (values) { values.Add(x.Message); }
-                    return Task.CompletedTask;
-                });
-                second.OnMessage(_ => Interlocked.Increment(ref i));
-
-                await Task.Delay(100);
-                await pubsub.PublishAsync(name, "abc");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                var subs = muxer.GetServer(muxer.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
-                Assert.Equal(1, subs);
-                Assert.False(first.Completion.IsCompleted, "completed");
-                Assert.False(second.Completion.IsCompleted, "completed");
-
-                await pubsub.UnsubscribeAsync(name);
-                await Task.Delay(100);
-                await pubsub.PublishAsync(name, "def");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                Assert.Equal(1, Volatile.Read(ref i));
-
-                subs = muxer.GetServer(muxer.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
-                Assert.Equal(0, subs);
-                Assert.True(first.Completion.IsCompleted, "completed");
-                Assert.True(second.Completion.IsCompleted, "completed");
-                AssertCounts(pubsub, name, false, 0, 0);
-            }
+            Assert.Equal("abc", Assert.Single(values));
         }
+        var subs = conn.GetServer(conn.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
+        Assert.Equal(1, subs);
+        Assert.False(first.Completion.IsCompleted, "completed");
+        Assert.False(second.Completion.IsCompleted, "completed");
 
-        [Fact]
-        public async Task ExecuteWithUnsubscribeViaClearAll()
+        await first.UnsubscribeAsync();
+        await Task.Delay(200);
+        await pubsub.PublishAsync(name, "def");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1 && Volatile.Read(ref i) == 2);
+        lock (values)
         {
-            using (var muxer = Create(log: Writer))
-            {
-                RedisChannel name = Me();
-                var pubsub = muxer.GetSubscriber();
-                AssertCounts(pubsub, name, false, 0, 0);
-
-                // subscribe and check we get data
-                var first = await pubsub.SubscribeAsync(name);
-                var second = await pubsub.SubscribeAsync(name);
-                AssertCounts(pubsub, name, true, 0, 2);
-                var values = new List<string?>();
-                int i = 0;
-                first.OnMessage(x =>
-                {
-                    lock (values) { values.Add(x.Message); }
-                    return Task.CompletedTask;
-                });
-                second.OnMessage(_ => Interlocked.Increment(ref i));
-                await Task.Delay(100);
-                await pubsub.PublishAsync(name, "abc");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                var subs = muxer.GetServer(muxer.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
-                Assert.Equal(1, subs);
-                Assert.False(first.Completion.IsCompleted, "completed");
-                Assert.False(second.Completion.IsCompleted, "completed");
-
-                await pubsub.UnsubscribeAllAsync();
-                await Task.Delay(100);
-                await pubsub.PublishAsync(name, "def");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
-                lock (values)
-                {
-                    Assert.Equal("abc", Assert.Single(values));
-                }
-                Assert.Equal(1, Volatile.Read(ref i));
-
-                subs = muxer.GetServer(muxer.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
-                Assert.Equal(0, subs);
-                Assert.True(first.Completion.IsCompleted, "completed");
-                Assert.True(second.Completion.IsCompleted, "completed");
-                AssertCounts(pubsub, name, false, 0, 0);
-            }
+            Assert.Equal("abc", Assert.Single(values));
         }
+        Assert.Equal(2, Volatile.Read(ref i));
+        Assert.True(first.Completion.IsCompleted, "completed");
+        Assert.False(second.Completion.IsCompleted, "completed");
+        AssertCounts(pubsub, name, true, 0, 1);
+
+        await second.UnsubscribeAsync();
+        await Task.Delay(200);
+        await pubsub.PublishAsync(name, "ghi");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
+        lock (values)
+        {
+            Assert.Equal("abc", Assert.Single(values));
+        }
+        Assert.Equal(2, Volatile.Read(ref i));
+        Assert.True(first.Completion.IsCompleted, "completed");
+        Assert.True(second.Completion.IsCompleted, "completed");
+        AssertCounts(pubsub, name, false, 0, 0);
+
+        subs = conn.GetServer(conn.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
+        Assert.Equal(0, subs);
+        Assert.True(first.Completion.IsCompleted, "completed");
+        Assert.True(second.Completion.IsCompleted, "completed");
+    }
+
+    [Fact]
+    public async Task ExecuteWithUnsubscribeViaSubscriber()
+    {
+        using var conn = Create(shared: false, log: Writer);
+
+        RedisChannel name = Me();
+        var pubsub = conn.GetSubscriber();
+        AssertCounts(pubsub, name, false, 0, 0);
+
+        // subscribe and check we get data
+        var first = await pubsub.SubscribeAsync(name);
+        var second = await pubsub.SubscribeAsync(name);
+        AssertCounts(pubsub, name, true, 0, 2);
+        var values = new List<string?>();
+        int i = 0;
+        first.OnMessage(x =>
+        {
+            lock (values) { values.Add(x.Message); }
+            return Task.CompletedTask;
+        });
+        second.OnMessage(_ => Interlocked.Increment(ref i));
+
+        await Task.Delay(100);
+        await pubsub.PublishAsync(name, "abc");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
+        lock (values)
+        {
+            Assert.Equal("abc", Assert.Single(values));
+        }
+        var subs = conn.GetServer(conn.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
+        Assert.Equal(1, subs);
+        Assert.False(first.Completion.IsCompleted, "completed");
+        Assert.False(second.Completion.IsCompleted, "completed");
+
+        await pubsub.UnsubscribeAsync(name);
+        await Task.Delay(100);
+        await pubsub.PublishAsync(name, "def");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
+        lock (values)
+        {
+            Assert.Equal("abc", Assert.Single(values));
+        }
+        Assert.Equal(1, Volatile.Read(ref i));
+
+        subs = conn.GetServer(conn.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
+        Assert.Equal(0, subs);
+        Assert.True(first.Completion.IsCompleted, "completed");
+        Assert.True(second.Completion.IsCompleted, "completed");
+        AssertCounts(pubsub, name, false, 0, 0);
+    }
+
+    [Fact]
+    public async Task ExecuteWithUnsubscribeViaClearAll()
+    {
+        using var conn = Create(log: Writer);
+
+        RedisChannel name = Me();
+        var pubsub = conn.GetSubscriber();
+        AssertCounts(pubsub, name, false, 0, 0);
+
+        // subscribe and check we get data
+        var first = await pubsub.SubscribeAsync(name);
+        var second = await pubsub.SubscribeAsync(name);
+        AssertCounts(pubsub, name, true, 0, 2);
+        var values = new List<string?>();
+        int i = 0;
+        first.OnMessage(x =>
+        {
+            lock (values) { values.Add(x.Message); }
+            return Task.CompletedTask;
+        });
+        second.OnMessage(_ => Interlocked.Increment(ref i));
+        await Task.Delay(100);
+        await pubsub.PublishAsync(name, "abc");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
+        lock (values)
+        {
+            Assert.Equal("abc", Assert.Single(values));
+        }
+        var subs = conn.GetServer(conn.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
+        Assert.Equal(1, subs);
+        Assert.False(first.Completion.IsCompleted, "completed");
+        Assert.False(second.Completion.IsCompleted, "completed");
+
+        await pubsub.UnsubscribeAllAsync();
+        await Task.Delay(100);
+        await pubsub.PublishAsync(name, "def");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => values.Count == 1);
+        lock (values)
+        {
+            Assert.Equal("abc", Assert.Single(values));
+        }
+        Assert.Equal(1, Volatile.Read(ref i));
+
+        subs = conn.GetServer(conn.GetEndPoints().Single()).SubscriptionSubscriberCount(name);
+        Assert.Equal(0, subs);
+        Assert.True(first.Completion.IsCompleted, "completed");
+        Assert.True(second.Completion.IsCompleted, "completed");
+        AssertCounts(pubsub, name, false, 0, 0);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue1103.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue1103.cs
@@ -3,67 +3,65 @@ using Xunit;
 using Xunit.Abstractions;
 using static StackExchange.Redis.RedisValue;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class Issue1103 : TestBase
 {
-    public class Issue1103 : TestBase
+    public Issue1103(ITestOutputHelper output) : base(output) { }
+
+    [Theory]
+    [InlineData(142205255210238005UL, (int)StorageType.Int64)]
+    [InlineData(ulong.MaxValue, (int)StorageType.UInt64)]
+    [InlineData(ulong.MinValue, (int)StorageType.Int64)]
+    [InlineData(0x8000000000000000UL, (int)StorageType.UInt64)]
+    [InlineData(0x8000000000000001UL, (int)StorageType.UInt64)]
+    [InlineData(0x7FFFFFFFFFFFFFFFUL, (int)StorageType.Int64)]
+    public void LargeUInt64StoredCorrectly(ulong value, int storageType)
     {
-        public Issue1103(ITestOutputHelper output) : base(output) { }
+        using var conn = Create();
 
-        [Theory]
-        [InlineData(142205255210238005UL, (int)StorageType.Int64)]
-        [InlineData(ulong.MaxValue, (int)StorageType.UInt64)]
-        [InlineData(ulong.MinValue, (int)StorageType.Int64)]
-        [InlineData(0x8000000000000000UL, (int)StorageType.UInt64)]
-        [InlineData(0x8000000000000001UL, (int)StorageType.UInt64)]
-        [InlineData(0x7FFFFFFFFFFFFFFFUL, (int)StorageType.Int64)]
-        public void LargeUInt64StoredCorrectly(ulong value, int storageType)
-        {
-            RedisKey key = Me();
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                RedisValue typed = value;
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        RedisValue typed = value;
 
-                // only need UInt64 for 64-bits
-                Assert.Equal((StorageType)storageType, typed.Type);
-                db.StringSet(key, typed);
-                var fromRedis = db.StringGet(key);
+        // only need UInt64 for 64-bits
+        Assert.Equal((StorageType)storageType, typed.Type);
+        db.StringSet(key, typed);
+        var fromRedis = db.StringGet(key);
 
-                Log($"{fromRedis.Type}: {fromRedis}");
-                Assert.Equal(StorageType.Raw, fromRedis.Type);
-                Assert.Equal(value, (ulong)fromRedis);
-                Assert.Equal(value.ToString(CultureInfo.InvariantCulture), fromRedis.ToString());
+        Log($"{fromRedis.Type}: {fromRedis}");
+        Assert.Equal(StorageType.Raw, fromRedis.Type);
+        Assert.Equal(value, (ulong)fromRedis);
+        Assert.Equal(value.ToString(CultureInfo.InvariantCulture), fromRedis.ToString());
 
-                var simplified = fromRedis.Simplify();
-                Log($"{simplified.Type}: {simplified}");
-                Assert.Equal((StorageType)storageType, typed.Type);
-                Assert.Equal(value, (ulong)simplified);
-                Assert.Equal(value.ToString(CultureInfo.InvariantCulture), fromRedis.ToString());
-            }
-        }
+        var simplified = fromRedis.Simplify();
+        Log($"{simplified.Type}: {simplified}");
+        Assert.Equal((StorageType)storageType, typed.Type);
+        Assert.Equal(value, (ulong)simplified);
+        Assert.Equal(value.ToString(CultureInfo.InvariantCulture), fromRedis.ToString());
+    }
 
-        [Fact]
-        public void UnusualRedisValueOddities() // things we found while doing this
-        {
-            RedisValue x = 0, y = "0";
-            Assert.Equal(x, y);
-            Assert.Equal(y, x);
+    [Fact]
+    public void UnusualRedisValueOddities() // things we found while doing this
+    {
+        RedisValue x = 0, y = "0";
+        Assert.Equal(x, y);
+        Assert.Equal(y, x);
 
-            y = "-0";
-            Assert.Equal(x, y);
-            Assert.Equal(y, x);
+        y = "-0";
+        Assert.Equal(x, y);
+        Assert.Equal(y, x);
 
-            y = "-"; // this is the oddness; this used to return true
-            Assert.NotEqual(x, y);
-            Assert.NotEqual(y, x);
+        y = "-"; // this is the oddness; this used to return true
+        Assert.NotEqual(x, y);
+        Assert.NotEqual(y, x);
 
-            y = "+";
-            Assert.NotEqual(x, y);
-            Assert.NotEqual(y, x);
+        y = "+";
+        Assert.NotEqual(x, y);
+        Assert.NotEqual(y, x);
 
-            y = ".";
-            Assert.NotEqual(x, y);
-            Assert.NotEqual(y, x);
-        }
+        y = ".";
+        Assert.NotEqual(x, y);
+        Assert.NotEqual(y, x);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue182.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue182.cs
@@ -4,78 +4,75 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class Issue182 : TestBase
 {
-    public class Issue182 : TestBase
+    protected override string GetConfiguration() => $"{TestConfig.Current.PrimaryServerAndPort},responseTimeout=10000";
+
+    public Issue182(ITestOutputHelper output) : base (output) { }
+
+    [FactLongRunning]
+    public async Task SetMembers()
     {
-        protected override string GetConfiguration() => $"{TestConfig.Current.PrimaryServerAndPort},responseTimeout=10000";
+        using var conn = Create(syncTimeout: 20000);
 
-        public Issue182(ITestOutputHelper output) : base (output) { }
-
-        [FactLongRunning]
-        public async Task SetMembers()
+        conn.ConnectionFailed += (s, a) =>
         {
-            using (var conn = Create(syncTimeout: 20000))
-            {
-                conn.ConnectionFailed += (s, a) =>
-                {
-                    Log(a.FailureType.ToString());
-                    Log(a.Exception?.Message);
-                    Log(a.Exception?.StackTrace);
-                };
-                var db = conn.GetDatabase();
+            Log(a.FailureType.ToString());
+            Log(a.Exception?.Message);
+            Log(a.Exception?.StackTrace);
+        };
+        var db = conn.GetDatabase();
 
-                var key = Me();
-                const int count = (int)5e6;
-                var len = await db.SetLengthAsync(key).ForAwait();
+        var key = Me();
+        const int count = (int)5e6;
+        var len = await db.SetLengthAsync(key).ForAwait();
 
-                if (len != count)
-                {
-                    await db.KeyDeleteAsync(key).ForAwait();
-                    foreach (var _ in Enumerable.Range(0, count))
-                        db.SetAdd(key, Guid.NewGuid().ToByteArray(), CommandFlags.FireAndForget);
-
-                    Assert.Equal(count, await db.SetLengthAsync(key).ForAwait()); // SCARD for set
-                }
-                var result = await db.SetMembersAsync(key).ForAwait();
-                Assert.Equal(count, result.Length); // SMEMBERS result length
-            }
-        }
-
-        [FactLongRunning]
-        public async Task SetUnion()
+        if (len != count)
         {
-            using (var conn = Create(syncTimeout: 10000))
-            {
-                var db = conn.GetDatabase();
+            await db.KeyDeleteAsync(key).ForAwait();
+            foreach (var _ in Enumerable.Range(0, count))
+                db.SetAdd(key, Guid.NewGuid().ToByteArray(), CommandFlags.FireAndForget);
 
-                var key1 = Me() + ":1";
-                var key2 = Me() + ":2";
-                var dstkey = Me() + ":dst";
-
-                const int count = (int)5e6;
-
-                var len1 = await db.SetLengthAsync(key1).ForAwait();
-                var len2 = await db.SetLengthAsync(key2).ForAwait();
-                await db.KeyDeleteAsync(dstkey).ForAwait();
-
-                if (len1 != count || len2 != count)
-                {
-                    await db.KeyDeleteAsync(key1).ForAwait();
-                    await db.KeyDeleteAsync(key2).ForAwait();
-
-                    foreach (var _ in Enumerable.Range(0, count))
-                    {
-                        db.SetAdd(key1, Guid.NewGuid().ToByteArray(), CommandFlags.FireAndForget);
-                        db.SetAdd(key2, Guid.NewGuid().ToByteArray(), CommandFlags.FireAndForget);
-                    }
-                    Assert.Equal(count, await db.SetLengthAsync(key1).ForAwait()); // SCARD for set 1
-                    Assert.Equal(count, await db.SetLengthAsync(key2).ForAwait()); // SCARD for set 2
-                }
-                await db.SetCombineAndStoreAsync(SetOperation.Union, dstkey, key1, key2).ForAwait();
-                var dstLen = db.SetLength(dstkey);
-                Assert.Equal(count * 2, dstLen); // SCARD for destination set
-            }
+            Assert.Equal(count, await db.SetLengthAsync(key).ForAwait()); // SCARD for set
         }
+        var result = await db.SetMembersAsync(key).ForAwait();
+        Assert.Equal(count, result.Length); // SMEMBERS result length
+    }
+
+    [FactLongRunning]
+    public async Task SetUnion()
+    {
+        using var conn = Create(syncTimeout: 10000);
+
+        var db = conn.GetDatabase();
+
+        var key1 = Me() + ":1";
+        var key2 = Me() + ":2";
+        var dstkey = Me() + ":dst";
+
+        const int count = (int)5e6;
+
+        var len1 = await db.SetLengthAsync(key1).ForAwait();
+        var len2 = await db.SetLengthAsync(key2).ForAwait();
+        await db.KeyDeleteAsync(dstkey).ForAwait();
+
+        if (len1 != count || len2 != count)
+        {
+            await db.KeyDeleteAsync(key1).ForAwait();
+            await db.KeyDeleteAsync(key2).ForAwait();
+
+            foreach (var _ in Enumerable.Range(0, count))
+            {
+                db.SetAdd(key1, Guid.NewGuid().ToByteArray(), CommandFlags.FireAndForget);
+                db.SetAdd(key2, Guid.NewGuid().ToByteArray(), CommandFlags.FireAndForget);
+            }
+            Assert.Equal(count, await db.SetLengthAsync(key1).ForAwait()); // SCARD for set 1
+            Assert.Equal(count, await db.SetLengthAsync(key2).ForAwait()); // SCARD for set 2
+        }
+        await db.SetCombineAndStoreAsync(SetOperation.Union, dstkey, key1, key2).ForAwait();
+        var dstLen = db.SetLength(dstkey);
+        Assert.Equal(count * 2, dstLen); // SCARD for destination set
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue25.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue25.cs
@@ -2,44 +2,43 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class Issue25 : TestBase
 {
-    public class Issue25 : TestBase
+    public Issue25(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void CaseInsensitive()
     {
-        public Issue25(ITestOutputHelper output) : base (output) { }
+        var options = ConfigurationOptions.Parse("ssl=true");
+        Assert.True(options.Ssl);
+        Assert.Equal("ssl=True", options.ToString());
 
-        [Fact]
-        public void CaseInsensitive()
-        {
-            var options = ConfigurationOptions.Parse("ssl=true");
-            Assert.True(options.Ssl);
-            Assert.Equal("ssl=True", options.ToString());
+        options = ConfigurationOptions.Parse("SSL=TRUE");
+        Assert.True(options.Ssl);
+        Assert.Equal("ssl=True", options.ToString());
+    }
 
-            options = ConfigurationOptions.Parse("SSL=TRUE");
-            Assert.True(options.Ssl);
-            Assert.Equal("ssl=True", options.ToString());
-        }
+    [Fact]
+    public void UnkonwnKeywordHandling_Ignore()
+    {
+        ConfigurationOptions.Parse("ssl2=true", true);
+    }
 
-        [Fact]
-        public void UnkonwnKeywordHandling_Ignore()
-        {
-            ConfigurationOptions.Parse("ssl2=true", true);
-        }
+    [Fact]
+    public void UnkonwnKeywordHandling_ExplicitFail()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ConfigurationOptions.Parse("ssl2=true", false));
+        Assert.StartsWith("Keyword 'ssl2' is not supported", ex.Message);
+        Assert.Equal("ssl2", ex.ParamName);
+    }
 
-        [Fact]
-        public void UnkonwnKeywordHandling_ExplicitFail()
-        {
-            var ex = Assert.Throws<ArgumentException>(() => ConfigurationOptions.Parse("ssl2=true", false));
-            Assert.StartsWith("Keyword 'ssl2' is not supported", ex.Message);
-            Assert.Equal("ssl2", ex.ParamName);
-        }
-
-        [Fact]
-        public void UnkonwnKeywordHandling_ImplicitFail()
-        {
-            var ex = Assert.Throws<ArgumentException>(() => ConfigurationOptions.Parse("ssl2=true"));
-            Assert.StartsWith("Keyword 'ssl2' is not supported", ex.Message);
-            Assert.Equal("ssl2", ex.ParamName);
-        }
+    [Fact]
+    public void UnkonwnKeywordHandling_ImplicitFail()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ConfigurationOptions.Parse("ssl2=true"));
+        Assert.StartsWith("Keyword 'ssl2' is not supported", ex.Message);
+        Assert.Equal("ssl2", ex.ParamName);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue6.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue6.cs
@@ -1,21 +1,19 @@
 ﻿using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
-{
-    public class Issue6 :  TestBase
-    {
-        public Issue6(ITestOutputHelper output) : base (output) { }
+namespace StackExchange.Redis.Tests.Issues;
 
-        [Fact]
-        public void ShouldWorkWithoutEchoOrPing()
-        {
-            using(var conn = Create(proxy: Proxy.Twemproxy))
-            {
-                Log("config: " + conn.Configuration);
-                var db = conn.GetDatabase();
-                var time = db.Ping();
-                Log("ping time: " + time);
-            }
-        }
+public class Issue6 :  TestBase
+{
+    public Issue6(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void ShouldWorkWithoutEchoOrPing()
+    {
+        using var conn = Create(proxy: Proxy.Twemproxy);
+
+        Log("config: " + conn.Configuration);
+        var db = conn.GetDatabase();
+        var time = db.Ping();
+        Log("ping time: " + time);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO10504853.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO10504853.cs
@@ -23,9 +23,9 @@ public class SO10504853 : TestBase
         for (int i = 0; i < COUNT; i++)
         {
             Trace.WriteLine("### incr:" + i);
-            using var muxer = Create();
-            var conn = muxer.GetDatabase();
-            Assert.Equal(i + 1, conn.StringIncrement(key));
+            using var conn = Create();
+            var db = conn.GetDatabase();
+            Assert.Equal(i + 1, db.StringIncrement(key));
         }
         Trace.WriteLine("### close");
         using (var conn = Create())

--- a/tests/StackExchange.Redis.Tests/Issues/SO10504853.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO10504853.cs
@@ -3,89 +3,84 @@ using System.Diagnostics;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class SO10504853 : TestBase
 {
-    public class SO10504853 : TestBase
+    public SO10504853(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void LoopLotsOfTrivialStuff()
     {
-        public SO10504853(ITestOutputHelper output) : base(output) { }
-
-        [Fact]
-        public void LoopLotsOfTrivialStuff()
+        var key = Me();
+        Trace.WriteLine("### init");
+        using (var conn = Create())
         {
-            var key = Me();
-            Trace.WriteLine("### init");
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-            }
-            const int COUNT = 2;
-            for (int i = 0; i < COUNT; i++)
-            {
-                Trace.WriteLine("### incr:" + i);
-                using (var muxer = Create())
-                {
-                    var conn = muxer.GetDatabase();
-                    Assert.Equal(i + 1, conn.StringIncrement(key));
-                }
-            }
-            Trace.WriteLine("### close");
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                Assert.Equal(COUNT, (long)conn.StringGet(key));
-            }
+            var db = conn.GetDatabase();
+            db.KeyDelete(key, CommandFlags.FireAndForget);
         }
-
-        [Fact]
-        public void ExecuteWithEmptyStartingPoint()
+        const int COUNT = 2;
+        for (int i = 0; i < COUNT; i++)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                var task = new { priority = 3 };
-                conn.KeyDeleteAsync(key);
-                conn.HashSetAsync(key, "something else", "abc");
-                conn.HashSetAsync(key, "priority", task.priority.ToString());
-
-                var taskResult = conn.HashGetAsync(key, "priority");
-
-                conn.Wait(taskResult);
-
-                var priority = int.Parse(taskResult.Result!);
-
-                Assert.Equal(3, priority);
-            }
+            Trace.WriteLine("### incr:" + i);
+            using var muxer = Create();
+            var conn = muxer.GetDatabase();
+            Assert.Equal(i + 1, conn.StringIncrement(key));
         }
-
-        [Fact]
-        public void ExecuteWithNonHashStartingPoint()
+        Trace.WriteLine("### close");
+        using (var conn = Create())
         {
-            var key = Me();
-            Assert.Throws<RedisServerException>(() =>
-            {
-                using (var muxer = Create())
-                {
-                    var conn = muxer.GetDatabase();
-                    var task = new { priority = 3 };
-                    conn.KeyDeleteAsync(key);
-                    conn.StringSetAsync(key, "not a hash");
-                    conn.HashSetAsync(key, "priority", task.priority.ToString());
-
-                    var taskResult = conn.HashGetAsync(key, "priority");
-
-                    try
-                    {
-                        conn.Wait(taskResult);
-                        Assert.True(false, "Should throw a WRONGTYPE");
-                    }
-                    catch (AggregateException ex)
-                    {
-                        throw ex.InnerExceptions[0];
-                    }
-                }
-            }); // WRONGTYPE Operation against a key holding the wrong kind of value
+            var db = conn.GetDatabase();
+            Assert.Equal(COUNT, (long)db.StringGet(key));
         }
+    }
+
+    [Fact]
+    public void ExecuteWithEmptyStartingPoint()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        var task = new { priority = 3 };
+        db.KeyDeleteAsync(key);
+        db.HashSetAsync(key, "something else", "abc");
+        db.HashSetAsync(key, "priority", task.priority.ToString());
+
+        var taskResult = db.HashGetAsync(key, "priority");
+
+        db.Wait(taskResult);
+
+        var priority = int.Parse(taskResult.Result!);
+
+        Assert.Equal(3, priority);
+    }
+
+    [Fact]
+    public void ExecuteWithNonHashStartingPoint()
+    {
+        var key = Me();
+        Assert.Throws<RedisServerException>(() =>
+        {
+            using var conn = Create();
+
+            var db = conn.GetDatabase();
+            var task = new { priority = 3 };
+            db.KeyDeleteAsync(key);
+            db.StringSetAsync(key, "not a hash");
+            db.HashSetAsync(key, "priority", task.priority.ToString());
+
+            var taskResult = db.HashGetAsync(key, "priority");
+
+            try
+            {
+                db.Wait(taskResult);
+                Assert.True(false, "Should throw a WRONGTYPE");
+            }
+            catch (AggregateException ex)
+            {
+                throw ex.InnerExceptions[0];
+            }
+        }); // WRONGTYPE Operation against a key holding the wrong kind of value
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO11766033.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO11766033.cs
@@ -1,41 +1,38 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class SO11766033 : TestBase
 {
-    public class SO11766033 : TestBase
+    public SO11766033(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void TestNullString()
     {
-        public SO11766033(ITestOutputHelper output) : base(output) { }
+        using var conn = Create();
 
-        [Fact]
-        public void TestNullString()
-        {
-            using (var muxer = Create())
-            {
-                var redis = muxer.GetDatabase();
-                const string? expectedTestValue = null;
-                var uid = Me();
-                redis.StringSetAsync(uid, "abc");
-                redis.StringSetAsync(uid, expectedTestValue);
-                string? testValue = redis.StringGet(uid);
-                Assert.Null(testValue);
-            }
-        }
+        var db = conn.GetDatabase();
+        const string? expectedTestValue = null;
+        var uid = Me();
+        db.StringSetAsync(uid, "abc");
+        db.StringSetAsync(uid, expectedTestValue);
+        string? testValue = db.StringGet(uid);
+        Assert.Null(testValue);
+    }
 
-        [Fact]
-        public void TestEmptyString()
-        {
-            using (var muxer = Create())
-            {
-                var redis = muxer.GetDatabase();
-                const string expectedTestValue = "";
-                var uid = Me();
+    [Fact]
+    public void TestEmptyString()
+    {
+        using var conn = Create();
 
-                redis.StringSetAsync(uid, expectedTestValue);
-                string? testValue = redis.StringGet(uid);
+        var db = conn.GetDatabase();
+        const string expectedTestValue = "";
+        var uid = Me();
 
-                Assert.Equal(expectedTestValue, testValue);
-            }
-        }
+        db.StringSetAsync(uid, expectedTestValue);
+        string? testValue = db.StringGet(uid);
+
+        Assert.Equal(expectedTestValue, testValue);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO22786599.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO22786599.cs
@@ -3,35 +3,33 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class SO22786599 : TestBase
 {
-    public class SO22786599 : TestBase
+    public SO22786599(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void Execute()
     {
-        public SO22786599(ITestOutputHelper output) : base(output) { }
+        string CurrentIdsSetDbKey = Me() + ".x";
+        string CurrentDetailsSetDbKey = Me() + ".y";
 
-        [Fact]
-        public void Execute()
-        {
-            string CurrentIdsSetDbKey = Me() + ".x";
-            string CurrentDetailsSetDbKey = Me() + ".y";
+        RedisValue[] stringIds = Enumerable.Range(1, 750).Select(i => (RedisValue)(i + " id")).ToArray();
+        RedisValue[] stringDetails = Enumerable.Range(1, 750).Select(i => (RedisValue)(i + " detail")).ToArray();
 
-            RedisValue[] stringIds = Enumerable.Range(1, 750).Select(i => (RedisValue)(i + " id")).ToArray();
-            RedisValue[] stringDetails = Enumerable.Range(1, 750).Select(i => (RedisValue)(i + " detail")).ToArray();
+        using var conn = Create();
 
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var tran = db.CreateTransaction();
+        var db = conn.GetDatabase();
+        var tran = db.CreateTransaction();
 
-                tran.SetAddAsync(CurrentIdsSetDbKey, stringIds);
-                tran.SetAddAsync(CurrentDetailsSetDbKey, stringDetails);
+        tran.SetAddAsync(CurrentIdsSetDbKey, stringIds);
+        tran.SetAddAsync(CurrentDetailsSetDbKey, stringDetails);
 
-                var watch = Stopwatch.StartNew();
-                var isOperationSuccessful = tran.Execute();
-                watch.Stop();
-                Log("{0}ms", watch.ElapsedMilliseconds);
-                Assert.True(isOperationSuccessful);
-            }
-        }
+        var watch = Stopwatch.StartNew();
+        var isOperationSuccessful = tran.Execute();
+        watch.Stop();
+        Log("{0}ms", watch.ElapsedMilliseconds);
+        Assert.True(isOperationSuccessful);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO23949477.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO23949477.cs
@@ -1,40 +1,38 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
-{
-    public class SO23949477 : TestBase
-    {
-        public SO23949477(ITestOutputHelper output) : base (output) { }
+namespace StackExchange.Redis.Tests.Issues;
 
-        [Fact]
-        public void Execute()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, "c", 3, When.Always, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key,
-                    new[] {
-                        new SortedSetEntry("a", 1),
-                        new SortedSetEntry("b", 2),
-                        new SortedSetEntry("d", 4),
-                        new SortedSetEntry("e", 5)
-                    },
-                    When.Always,
-                    CommandFlags.FireAndForget);
-                var pairs = db.SortedSetRangeByScoreWithScores(
-                    key, order: Order.Descending, take: 3);
-                Assert.Equal(3, pairs.Length);
-                Assert.Equal(5, pairs[0].Score);
-                Assert.Equal("e", pairs[0].Element);
-                Assert.Equal(4, pairs[1].Score);
-                Assert.Equal("d", pairs[1].Element);
-                Assert.Equal(3, pairs[2].Score);
-                Assert.Equal("c", pairs[2].Element);
-            }
-        }
+public class SO23949477 : TestBase
+{
+    public SO23949477(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void Execute()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, "c", 3, When.Always, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key,
+            new[] {
+                    new SortedSetEntry("a", 1),
+                    new SortedSetEntry("b", 2),
+                    new SortedSetEntry("d", 4),
+                    new SortedSetEntry("e", 5)
+            },
+            When.Always,
+            CommandFlags.FireAndForget);
+        var pairs = db.SortedSetRangeByScoreWithScores(
+            key, order: Order.Descending, take: 3);
+        Assert.Equal(3, pairs.Length);
+        Assert.Equal(5, pairs[0].Score);
+        Assert.Equal("e", pairs[0].Element);
+        Assert.Equal(4, pairs[1].Score);
+        Assert.Equal("d", pairs[1].Element);
+        Assert.Equal(3, pairs[2].Score);
+        Assert.Equal("c", pairs[2].Element);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO24807536.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO24807536.cs
@@ -3,47 +3,45 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class SO24807536 : TestBase
 {
-    public class SO24807536 : TestBase
+    public SO24807536(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public async Task Exec()
     {
-        public SO24807536(ITestOutputHelper output) : base (output) { }
+        using var conn = Create();
 
-        [Fact]
-        public async Task Exec()
-        {
-            var key = Me();
-            using(var conn = Create())
-            {
-                var cache = conn.GetDatabase();
+        var key = Me();
+        var db = conn.GetDatabase();
 
-                // setup some data
-                cache.KeyDelete(key, CommandFlags.FireAndForget);
-                cache.HashSet(key, "full", "some value", flags: CommandFlags.FireAndForget);
-                cache.KeyExpire(key, TimeSpan.FromSeconds(4), CommandFlags.FireAndForget);
+        // setup some data
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.HashSet(key, "full", "some value", flags: CommandFlags.FireAndForget);
+        db.KeyExpire(key, TimeSpan.FromSeconds(4), CommandFlags.FireAndForget);
 
-                // test while exists
-                var keyExists = cache.KeyExists(key);
-                var ttl = cache.KeyTimeToLive(key);
-                var fullWait = cache.HashGetAsync(key, "full", flags: CommandFlags.None);
-                Assert.True(keyExists, "key exists");
-                Assert.NotNull(ttl);
-                Assert.Equal("some value", fullWait.Result);
+        // test while exists
+        var keyExists = db.KeyExists(key);
+        var ttl = db.KeyTimeToLive(key);
+        var fullWait = db.HashGetAsync(key, "full", flags: CommandFlags.None);
+        Assert.True(keyExists, "key exists");
+        Assert.NotNull(ttl);
+        Assert.Equal("some value", fullWait.Result);
 
-                // wait for expiry
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => !cache.KeyExists(key)).ForAwait();
+        // wait for expiry
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => !db.KeyExists(key)).ForAwait();
 
-                // test once expired
-                keyExists = cache.KeyExists(key);
-                ttl = cache.KeyTimeToLive(key);
-                fullWait = cache.HashGetAsync(key, "full", flags: CommandFlags.None);
+        // test once expired
+        keyExists = db.KeyExists(key);
+        ttl = db.KeyTimeToLive(key);
+        fullWait = db.HashGetAsync(key, "full", flags: CommandFlags.None);
 
-                Assert.False(keyExists);
-                Assert.Null(ttl);
-                var r = await fullWait;
-                Assert.True(r.IsNull);
-                Assert.Null((string?)r);
-            }
-        }
+        Assert.False(keyExists);
+        Assert.Null(ttl);
+        var r = await fullWait;
+        Assert.True(r.IsNull);
+        Assert.Null((string?)r);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO25113323.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO25113323.cs
@@ -3,40 +3,38 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
+namespace StackExchange.Redis.Tests.Issues;
+
+public class SO25113323 : TestBase
 {
-    public class SO25113323 : TestBase
+    public SO25113323(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public async Task SetExpirationToPassed()
     {
-        public SO25113323(ITestOutputHelper output) : base (output) { }
+        using var conn = Create();
 
-        [Fact]
-        public async Task SetExpirationToPassed()
-        {
-            var key = Me();
-            using (var conn =  Create())
-            {
-                // Given
-                var cache = conn.GetDatabase();
-                cache.KeyDelete(key, CommandFlags.FireAndForget);
-                cache.HashSet(key, "full", "test", When.NotExists, CommandFlags.PreferMaster);
+        // Given
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.HashSet(key, "full", "test", When.NotExists, CommandFlags.PreferMaster);
 
-                await Task.Delay(2000).ForAwait();
+        await Task.Delay(2000).ForAwait();
 
-                // When
-                var serverTime = GetServer(conn).Time();
-                var expiresOn = serverTime.AddSeconds(-2);
+        // When
+        var serverTime = GetServer(conn).Time();
+        var expiresOn = serverTime.AddSeconds(-2);
 
-                var firstResult = cache.KeyExpire(key, expiresOn, CommandFlags.PreferMaster);
-                var secondResult = cache.KeyExpire(key, expiresOn, CommandFlags.PreferMaster);
-                var exists = cache.KeyExists(key);
-                var ttl = cache.KeyTimeToLive(key);
+        var firstResult = db.KeyExpire(key, expiresOn, CommandFlags.PreferMaster);
+        var secondResult = db.KeyExpire(key, expiresOn, CommandFlags.PreferMaster);
+        var exists = db.KeyExists(key);
+        var ttl = db.KeyTimeToLive(key);
 
-                // Then
-                Assert.True(firstResult); // could set the first time, but this nukes the key
-                Assert.False(secondResult); // can't set, since nuked
-                Assert.False(exists); // does not exist since nuked
-                Assert.Null(ttl); // no expiry since nuked
-            }
-        }
+        // Then
+        Assert.True(firstResult); // could set the first time, but this nukes the key
+        Assert.False(secondResult); // can't set, since nuked
+        Assert.False(exists); // does not exist since nuked
+        Assert.Null(ttl); // no expiry since nuked
     }
 }

--- a/tests/StackExchange.Redis.Tests/Issues/SO25567566.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/SO25567566.cs
@@ -3,73 +3,71 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests.Issues
-{
-    public class SO25567566 : TestBase
-    {
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
-        public SO25567566(ITestOutputHelper output) : base(output) { }
+namespace StackExchange.Redis.Tests.Issues;
 
-        [FactLongRunning]
-        public async Task Execute()
+public class SO25567566 : TestBase
+{
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+    public SO25567566(ITestOutputHelper output) : base(output) { }
+
+    [FactLongRunning]
+    public async Task Execute()
+    {
+        using var conn = ConnectionMultiplexer.Connect(GetConfiguration());
+
+        for (int i = 0; i < 100; i++)
         {
-            using (var conn = ConnectionMultiplexer.Connect(GetConfiguration())) // Create())
-            {
-                for (int i = 0; i < 100; i++)
-                {
-                    Assert.Equal("ok", await DoStuff(conn).ForAwait());
-                }
-            }
+            Assert.Equal("ok", await DoStuff(conn).ForAwait());
+        }
+    }
+
+    private static async Task<string> DoStuff(ConnectionMultiplexer conn)
+    {
+        var db = conn.GetDatabase();
+
+        var timeout = Task.Delay(5000);
+        var key = Me();
+        var key2 = key + "2";
+        var len = db.ListLengthAsync(key);
+
+        if (await Task.WhenAny(timeout, len).ForAwait() != len)
+        {
+            return "Timeout getting length";
         }
 
-        private static async Task<string> DoStuff(ConnectionMultiplexer conn)
+        if ((await len.ForAwait()) == 0)
         {
-            var db = conn.GetDatabase();
+            db.ListRightPush(key, "foo", flags: CommandFlags.FireAndForget);
+        }
+        var tran = db.CreateTransaction();
+        var x = tran.ListRightPopLeftPushAsync(key, key2);
+        var y = tran.SetAddAsync(key + "set", "bar");
+        var z = tran.KeyExpireAsync(key2, TimeSpan.FromSeconds(60));
+        timeout = Task.Delay(5000);
 
-            var timeout = Task.Delay(5000);
-            var key = Me();
-            var key2 = key + "2";
-            var len = db.ListLengthAsync(key);
+        var exec = tran.ExecuteAsync();
+        // SWAP THESE TWO
+        bool ok = await Task.WhenAny(exec, timeout).ForAwait() == exec;
+        //bool ok = true;
 
-            if (await Task.WhenAny(timeout, len).ForAwait() != len)
+        if (ok)
+        {
+            if (await exec.ForAwait())
             {
-                return "Timeout getting length";
-            }
+                await Task.WhenAll(x, y, z).ForAwait();
 
-            if ((await len.ForAwait()) == 0)
-            {
-                db.ListRightPush(key, "foo", flags: CommandFlags.FireAndForget);
-            }
-            var tran = db.CreateTransaction();
-            var x = tran.ListRightPopLeftPushAsync(key, key2);
-            var y = tran.SetAddAsync(key + "set", "bar");
-            var z = tran.KeyExpireAsync(key2, TimeSpan.FromSeconds(60));
-            timeout = Task.Delay(5000);
-
-            var exec = tran.ExecuteAsync();
-            // SWAP THESE TWO
-            bool ok = await Task.WhenAny(exec, timeout).ForAwait() == exec;
-            //bool ok = true;
-
-            if (ok)
-            {
-                if (await exec.ForAwait())
-                {
-                    await Task.WhenAll(x, y, z).ForAwait();
-
-                    var db2 = conn.GetDatabase();
-                    db2.HashGet(key + "hash", "whatever");
-                    return "ok";
-                }
-                else
-                {
-                    return "Transaction aborted";
-                }
+                var db2 = conn.GetDatabase();
+                db2.HashGet(key + "hash", "whatever");
+                return "ok";
             }
             else
             {
-                return "Timeout during exec";
+                return "Transaction aborted";
             }
+        }
+        else
+        {
+            return "Timeout during exec";
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/KeysAndValues.cs
+++ b/tests/StackExchange.Redis.Tests/KeysAndValues.cs
@@ -3,175 +3,174 @@ using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class KeysAndValues
 {
-    public class KeysAndValues
+    [Fact]
+    public void TestValues()
     {
-        [Fact]
-        public void TestValues()
-        {
-            RedisValue @default = default(RedisValue);
-            CheckNull(@default);
+        RedisValue @default = default(RedisValue);
+        CheckNull(@default);
 
-            RedisValue nullString = (string?)null;
-            CheckNull(nullString);
+        RedisValue nullString = (string?)null;
+        CheckNull(nullString);
 
-            RedisValue nullBlob = (byte[]?)null;
-            CheckNull(nullBlob);
+        RedisValue nullBlob = (byte[]?)null;
+        CheckNull(nullBlob);
 
-            RedisValue emptyString = "";
-            CheckNotNull(emptyString);
+        RedisValue emptyString = "";
+        CheckNotNull(emptyString);
 
-            RedisValue emptyBlob = Array.Empty<byte>();
-            CheckNotNull(emptyBlob);
+        RedisValue emptyBlob = Array.Empty<byte>();
+        CheckNotNull(emptyBlob);
 
-            RedisValue a0 = new string('a', 1);
-            CheckNotNull(a0);
-            RedisValue a1 = new string('a', 1);
-            CheckNotNull(a1);
-            RedisValue b0 = new[] { (byte)'b' };
-            CheckNotNull(b0);
-            RedisValue b1 = new[] { (byte)'b' };
-            CheckNotNull(b1);
+        RedisValue a0 = new string('a', 1);
+        CheckNotNull(a0);
+        RedisValue a1 = new string('a', 1);
+        CheckNotNull(a1);
+        RedisValue b0 = new[] { (byte)'b' };
+        CheckNotNull(b0);
+        RedisValue b1 = new[] { (byte)'b' };
+        CheckNotNull(b1);
 
-            RedisValue i4 = 1;
-            CheckNotNull(i4);
-            RedisValue i8 = 1L;
-            CheckNotNull(i8);
+        RedisValue i4 = 1;
+        CheckNotNull(i4);
+        RedisValue i8 = 1L;
+        CheckNotNull(i8);
 
-            RedisValue bool1 = true;
-            CheckNotNull(bool1);
-            RedisValue bool2 = false;
-            CheckNotNull(bool2);
-            RedisValue bool3 = true;
-            CheckNotNull(bool3);
+        RedisValue bool1 = true;
+        CheckNotNull(bool1);
+        RedisValue bool2 = false;
+        CheckNotNull(bool2);
+        RedisValue bool3 = true;
+        CheckNotNull(bool3);
 
-            CheckSame(a0, a0);
-            CheckSame(a1, a1);
-            CheckSame(a0, a1);
+        CheckSame(a0, a0);
+        CheckSame(a1, a1);
+        CheckSame(a0, a1);
 
-            CheckSame(b0, b0);
-            CheckSame(b1, b1);
-            CheckSame(b0, b1);
+        CheckSame(b0, b0);
+        CheckSame(b1, b1);
+        CheckSame(b0, b1);
 
-            CheckSame(i4, i4);
-            CheckSame(i8, i8);
-            CheckSame(i4, i8);
+        CheckSame(i4, i4);
+        CheckSame(i8, i8);
+        CheckSame(i4, i8);
 
-            CheckSame(bool1, bool3);
-            CheckNotSame(bool1, bool2);
-        }
+        CheckSame(bool1, bool3);
+        CheckNotSame(bool1, bool2);
+    }
 
-        internal static void CheckSame(RedisValue x, RedisValue y)
-        {
-            Assert.True(Equals(x, y), "Equals(x, y)");
-            Assert.True(Equals(y, x), "Equals(y, x)");
-            Assert.True(EqualityComparer<RedisValue>.Default.Equals(x, y), "EQ(x,y)");
-            Assert.True(EqualityComparer<RedisValue>.Default.Equals(y, x), "EQ(y,x)");
-            Assert.True(x == y, "x==y");
-            Assert.True(y == x, "y==x");
-            Assert.False(x != y, "x!=y");
-            Assert.False(y != x, "y!=x");
-            Assert.True(x.Equals(y),"x.EQ(y)");
-            Assert.True(y.Equals(x), "y.EQ(x)");
-            Assert.True(x.GetHashCode() == y.GetHashCode(), "GetHashCode");
-        }
+    internal static void CheckSame(RedisValue x, RedisValue y)
+    {
+        Assert.True(Equals(x, y), "Equals(x, y)");
+        Assert.True(Equals(y, x), "Equals(y, x)");
+        Assert.True(EqualityComparer<RedisValue>.Default.Equals(x, y), "EQ(x,y)");
+        Assert.True(EqualityComparer<RedisValue>.Default.Equals(y, x), "EQ(y,x)");
+        Assert.True(x == y, "x==y");
+        Assert.True(y == x, "y==x");
+        Assert.False(x != y, "x!=y");
+        Assert.False(y != x, "y!=x");
+        Assert.True(x.Equals(y),"x.EQ(y)");
+        Assert.True(y.Equals(x), "y.EQ(x)");
+        Assert.True(x.GetHashCode() == y.GetHashCode(), "GetHashCode");
+    }
 
-        private static void CheckNotSame(RedisValue x, RedisValue y)
-        {
-            Assert.False(Equals(x, y));
-            Assert.False(Equals(y, x));
-            Assert.False(EqualityComparer<RedisValue>.Default.Equals(x, y));
-            Assert.False(EqualityComparer<RedisValue>.Default.Equals(y, x));
-            Assert.False(x == y);
-            Assert.False(y == x);
-            Assert.True(x != y);
-            Assert.True(y != x);
-            Assert.False(x.Equals(y));
-            Assert.False(y.Equals(x));
-            Assert.False(x.GetHashCode() == y.GetHashCode()); // well, very unlikely
-        }
+    private static void CheckNotSame(RedisValue x, RedisValue y)
+    {
+        Assert.False(Equals(x, y));
+        Assert.False(Equals(y, x));
+        Assert.False(EqualityComparer<RedisValue>.Default.Equals(x, y));
+        Assert.False(EqualityComparer<RedisValue>.Default.Equals(y, x));
+        Assert.False(x == y);
+        Assert.False(y == x);
+        Assert.True(x != y);
+        Assert.True(y != x);
+        Assert.False(x.Equals(y));
+        Assert.False(y.Equals(x));
+        Assert.False(x.GetHashCode() == y.GetHashCode()); // well, very unlikely
+    }
 
-        private static void CheckNotNull(RedisValue value)
-        {
-            Assert.False(value.IsNull);
-            Assert.NotNull((byte[]?)value);
-            Assert.NotNull((string?)value);
-            Assert.NotEqual(-1, value.GetHashCode());
+    private static void CheckNotNull(RedisValue value)
+    {
+        Assert.False(value.IsNull);
+        Assert.NotNull((byte[]?)value);
+        Assert.NotNull((string?)value);
+        Assert.NotEqual(-1, value.GetHashCode());
 
-            Assert.NotNull((string?)value);
-            Assert.NotNull((byte[]?)value);
+        Assert.NotNull((string?)value);
+        Assert.NotNull((byte[]?)value);
 
-            CheckSame(value, value);
-            CheckNotSame(value, default(RedisValue));
-            CheckNotSame(value, (string?)null);
-            CheckNotSame(value, (byte[]?)null);
-        }
+        CheckSame(value, value);
+        CheckNotSame(value, default(RedisValue));
+        CheckNotSame(value, (string?)null);
+        CheckNotSame(value, (byte[]?)null);
+    }
 
-        internal static void CheckNull(RedisValue value)
-        {
-            Assert.True(value.IsNull);
-            Assert.True(value.IsNullOrEmpty);
-            Assert.False(value.IsInteger);
-            Assert.Equal(-1, value.GetHashCode());
+    internal static void CheckNull(RedisValue value)
+    {
+        Assert.True(value.IsNull);
+        Assert.True(value.IsNullOrEmpty);
+        Assert.False(value.IsInteger);
+        Assert.Equal(-1, value.GetHashCode());
 
-            Assert.Null((string?)value);
-            Assert.Null((byte[]?)value);
+        Assert.Null((string?)value);
+        Assert.Null((byte[]?)value);
 
-            Assert.Equal(0, (int)value);
-            Assert.Equal(0L, (long)value);
+        Assert.Equal(0, (int)value);
+        Assert.Equal(0L, (long)value);
 
-            CheckSame(value, value);
-            //CheckSame(value, default(RedisValue));
-            //CheckSame(value, (string)null);
-            //CheckSame(value, (byte[])null);
-        }
+        CheckSame(value, value);
+        //CheckSame(value, default(RedisValue));
+        //CheckSame(value, (string)null);
+        //CheckSame(value, (byte[])null);
+    }
 
-        [Fact]
-        public void ValuesAreConvertible()
-        {
-            RedisValue val = 123;
-            object o = val;
-            byte[] blob = (byte[])Convert.ChangeType(o, typeof(byte[]));
+    [Fact]
+    public void ValuesAreConvertible()
+    {
+        RedisValue val = 123;
+        object o = val;
+        byte[] blob = (byte[])Convert.ChangeType(o, typeof(byte[]));
 
-            Assert.Equal(3, blob.Length);
-            Assert.Equal((byte)'1', blob[0]);
-            Assert.Equal((byte)'2', blob[1]);
-            Assert.Equal((byte)'3', blob[2]);
+        Assert.Equal(3, blob.Length);
+        Assert.Equal((byte)'1', blob[0]);
+        Assert.Equal((byte)'2', blob[1]);
+        Assert.Equal((byte)'3', blob[2]);
 
-            Assert.Equal(123, Convert.ToDouble(o));
+        Assert.Equal(123, Convert.ToDouble(o));
 
-            IConvertible c = (IConvertible)o;
-            // ReSharper disable RedundantCast
-            Assert.Equal((short)123, c.ToInt16(CultureInfo.InvariantCulture));
-            Assert.Equal((int)123, c.ToInt32(CultureInfo.InvariantCulture));
-            Assert.Equal((long)123, c.ToInt64(CultureInfo.InvariantCulture));
-            Assert.Equal((float)123, c.ToSingle(CultureInfo.InvariantCulture));
-            Assert.Equal("123", c.ToString(CultureInfo.InvariantCulture));
-            Assert.Equal((double)123, c.ToDouble(CultureInfo.InvariantCulture));
-            Assert.Equal((decimal)123, c.ToDecimal(CultureInfo.InvariantCulture));
-            Assert.Equal((ushort)123, c.ToUInt16(CultureInfo.InvariantCulture));
-            Assert.Equal((uint)123, c.ToUInt32(CultureInfo.InvariantCulture));
-            Assert.Equal((ulong)123, c.ToUInt64(CultureInfo.InvariantCulture));
+        IConvertible c = (IConvertible)o;
+        // ReSharper disable RedundantCast
+        Assert.Equal((short)123, c.ToInt16(CultureInfo.InvariantCulture));
+        Assert.Equal((int)123, c.ToInt32(CultureInfo.InvariantCulture));
+        Assert.Equal((long)123, c.ToInt64(CultureInfo.InvariantCulture));
+        Assert.Equal((float)123, c.ToSingle(CultureInfo.InvariantCulture));
+        Assert.Equal("123", c.ToString(CultureInfo.InvariantCulture));
+        Assert.Equal((double)123, c.ToDouble(CultureInfo.InvariantCulture));
+        Assert.Equal((decimal)123, c.ToDecimal(CultureInfo.InvariantCulture));
+        Assert.Equal((ushort)123, c.ToUInt16(CultureInfo.InvariantCulture));
+        Assert.Equal((uint)123, c.ToUInt32(CultureInfo.InvariantCulture));
+        Assert.Equal((ulong)123, c.ToUInt64(CultureInfo.InvariantCulture));
 
-            blob = (byte[])c.ToType(typeof(byte[]), CultureInfo.InvariantCulture);
-            Assert.Equal(3, blob.Length);
-            Assert.Equal((byte)'1', blob[0]);
-            Assert.Equal((byte)'2', blob[1]);
-            Assert.Equal((byte)'3', blob[2]);
-        }
+        blob = (byte[])c.ToType(typeof(byte[]), CultureInfo.InvariantCulture);
+        Assert.Equal(3, blob.Length);
+        Assert.Equal((byte)'1', blob[0]);
+        Assert.Equal((byte)'2', blob[1]);
+        Assert.Equal((byte)'3', blob[2]);
+    }
 
-        [Fact]
-        public void CanBeDynamic()
-        {
-            RedisValue val = "abc";
-            object o = val;
-            dynamic d = o;
-            byte[] blob = (byte[])d; // could be in a try/catch
-            Assert.Equal(3, blob.Length);
-            Assert.Equal((byte)'a', blob[0]);
-            Assert.Equal((byte)'b', blob[1]);
-            Assert.Equal((byte)'c', blob[2]);
-        }
+    [Fact]
+    public void CanBeDynamic()
+    {
+        RedisValue val = "abc";
+        object o = val;
+        dynamic d = o;
+        byte[] blob = (byte[])d; // could be in a try/catch
+        Assert.Equal(3, blob.Length);
+        Assert.Equal((byte)'a', blob[0]);
+        Assert.Equal((byte)'b', blob[1]);
+        Assert.Equal((byte)'c', blob[2]);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Latency.cs
+++ b/tests/StackExchange.Redis.Tests/Latency.cs
@@ -2,86 +2,81 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Latency : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Latency : TestBase
+    public Latency(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public async Task CanCallDoctor()
     {
-        public Latency(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public async Task CanCallDoctor()
-        {
-            using (var conn = Create())
-            {
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                string? doctor = server.LatencyDoctor();
-                Assert.NotNull(doctor);
-                Assert.NotEqual("", doctor);
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        string? doctor = server.LatencyDoctor();
+        Assert.NotNull(doctor);
+        Assert.NotEqual("", doctor);
 
-                doctor = await server.LatencyDoctorAsync();
-                Assert.NotNull(doctor);
-                Assert.NotEqual("", doctor);
-            }
-        }
+        doctor = await server.LatencyDoctorAsync();
+        Assert.NotNull(doctor);
+        Assert.NotEqual("", doctor);
+    }
 
-        [Fact]
-        public async Task CanReset()
-        {
-            using (var conn = Create())
-            {
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                _ = server.LatencyReset();
-                var count = await server.LatencyResetAsync(new [] { "command" });
-                Assert.Equal(0, count);
+    [Fact]
+    public async Task CanReset()
+    {
+        using var conn = Create();
 
-                count = await server.LatencyResetAsync(new [] { "command", "fast-command" });
-                Assert.Equal(0, count);
-            }
-        }
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        _ = server.LatencyReset();
+        var count = await server.LatencyResetAsync(new[] { "command" });
+        Assert.Equal(0, count);
 
-        [Fact]
-        public async Task GetLatest()
-        {
-            using (var conn = Create(allowAdmin: true))
-            {
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                server.ConfigSet("latency-monitor-threshold", 100);
-                server.LatencyReset();
-                var arr = server.LatencyLatest();
-                Assert.Empty(arr);
+        count = await server.LatencyResetAsync(new[] { "command", "fast-command" });
+        Assert.Equal(0, count);
+    }
 
-                var now = await server.TimeAsync();
-                server.Execute("debug", "sleep", "0.5"); // cause something to be slow
+    [Fact]
+    public async Task GetLatest()
+    {
+        using var conn = Create(allowAdmin: true);
 
-                arr = await server.LatencyLatestAsync();
-                var item = Assert.Single(arr);
-                Assert.Equal("command", item.EventName);
-                Assert.True(item.DurationMilliseconds >= 400 && item.DurationMilliseconds <= 600);
-                Assert.Equal(item.DurationMilliseconds, item.MaxDurationMilliseconds);
-                Assert.True(item.Timestamp >= now.AddSeconds(-2) && item.Timestamp <= now.AddSeconds(2));
-            }
-        }
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        server.ConfigSet("latency-monitor-threshold", 100);
+        server.LatencyReset();
+        var arr = server.LatencyLatest();
+        Assert.Empty(arr);
 
-        [Fact]
-        public async Task GetHistory()
-        {
-            using (var conn = Create(allowAdmin: true))
-            {
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                server.ConfigSet("latency-monitor-threshold", 100);
-                server.LatencyReset();
-                var arr = server.LatencyHistory("command");
-                Assert.Empty(arr);
+        var now = await server.TimeAsync();
+        server.Execute("debug", "sleep", "0.5"); // cause something to be slow
 
-                var now = await server.TimeAsync();
-                server.Execute("debug", "sleep", "0.5"); // cause something to be slow
+        arr = await server.LatencyLatestAsync();
+        var item = Assert.Single(arr);
+        Assert.Equal("command", item.EventName);
+        Assert.True(item.DurationMilliseconds >= 400 && item.DurationMilliseconds <= 600);
+        Assert.Equal(item.DurationMilliseconds, item.MaxDurationMilliseconds);
+        Assert.True(item.Timestamp >= now.AddSeconds(-2) && item.Timestamp <= now.AddSeconds(2));
+    }
 
-                arr = await server.LatencyHistoryAsync("command");
-                var item = Assert.Single(arr);
-                Assert.True(item.DurationMilliseconds >= 400 && item.DurationMilliseconds <= 600);
-                Assert.True(item.Timestamp >= now.AddSeconds(-2) && item.Timestamp <= now.AddSeconds(2));
-            }
-        }
+    [Fact]
+    public async Task GetHistory()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        server.ConfigSet("latency-monitor-threshold", 100);
+        server.LatencyReset();
+        var arr = server.LatencyHistory("command");
+        Assert.Empty(arr);
+
+        var now = await server.TimeAsync();
+        server.Execute("debug", "sleep", "0.5"); // cause something to be slow
+
+        arr = await server.LatencyHistoryAsync("command");
+        var item = Assert.Single(arr);
+        Assert.True(item.DurationMilliseconds >= 400 && item.DurationMilliseconds <= 600);
+        Assert.True(item.Timestamp >= now.AddSeconds(-2) && item.Timestamp <= now.AddSeconds(2));
     }
 }

--- a/tests/StackExchange.Redis.Tests/Lex.cs
+++ b/tests/StackExchange.Redis.Tests/Lex.cs
@@ -1,108 +1,105 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Lex : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Lex : TestBase
+    public Lex(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void QueryRangeAndLengthByLex()
     {
-        public Lex(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void QueryRangeAndLengthByLex()
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key,
+            new[]
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
+                new SortedSetEntry("a", 0),
+                new SortedSetEntry("b", 0),
+                new SortedSetEntry("c", 0),
+                new SortedSetEntry("d", 0),
+                new SortedSetEntry("e", 0),
+                new SortedSetEntry("f", 0),
+                new SortedSetEntry("g", 0),
+        }, CommandFlags.FireAndForget);
 
-                db.SortedSetAdd(key,
-                    new []
-                {
-                    new SortedSetEntry("a", 0),
-                    new SortedSetEntry("b", 0),
-                    new SortedSetEntry("c", 0),
-                    new SortedSetEntry("d", 0),
-                    new SortedSetEntry("e", 0),
-                    new SortedSetEntry("f", 0),
-                    new SortedSetEntry("g", 0),
-                }, CommandFlags.FireAndForget);
+        var set = db.SortedSetRangeByValue(key, default(RedisValue), "c");
+        var count = db.SortedSetLengthByValue(key, default(RedisValue), "c");
+        Equate(set, count, "a", "b", "c");
 
-                var set = db.SortedSetRangeByValue(key, default(RedisValue), "c");
-                var count = db.SortedSetLengthByValue(key, default(RedisValue), "c");
-                Equate(set, count, "a", "b", "c");
+        set = db.SortedSetRangeByValue(key, default(RedisValue), "c", Exclude.Stop);
+        count = db.SortedSetLengthByValue(key, default(RedisValue), "c", Exclude.Stop);
+        Equate(set, count, "a", "b");
 
-                set = db.SortedSetRangeByValue(key, default(RedisValue), "c", Exclude.Stop);
-                count = db.SortedSetLengthByValue(key, default(RedisValue), "c", Exclude.Stop);
-                Equate(set, count, "a", "b");
+        set = db.SortedSetRangeByValue(key, "aaa", "g", Exclude.Stop);
+        count = db.SortedSetLengthByValue(key, "aaa", "g", Exclude.Stop);
+        Equate(set, count, "b", "c", "d", "e", "f");
 
-                set = db.SortedSetRangeByValue(key, "aaa", "g", Exclude.Stop);
-                count = db.SortedSetLengthByValue(key, "aaa", "g", Exclude.Stop);
-                Equate(set, count, "b", "c", "d", "e", "f");
+        set = db.SortedSetRangeByValue(key, "aaa", "g", Exclude.Stop, 1, 3);
+        Equate(set, set.Length, "c", "d", "e");
 
-                set = db.SortedSetRangeByValue(key, "aaa", "g", Exclude.Stop, 1, 3);
-                Equate(set, set.Length, "c", "d", "e");
+        set = db.SortedSetRangeByValue(key, "aaa", "g", Exclude.Stop, Order.Descending, 1, 3);
+        Equate(set, set.Length, "e", "d", "c");
 
-                set = db.SortedSetRangeByValue(key, "aaa", "g", Exclude.Stop, Order.Descending, 1, 3);
-                Equate(set, set.Length, "e", "d", "c");
+        set = db.SortedSetRangeByValue(key, "g", "aaa", Exclude.Start, Order.Descending, 1, 3);
+        Equate(set, set.Length, "e", "d", "c");
 
-                set = db.SortedSetRangeByValue(key, "g", "aaa", Exclude.Start, Order.Descending, 1, 3);
-                Equate(set, set.Length, "e", "d", "c");
+        set = db.SortedSetRangeByValue(key, "e", default(RedisValue));
+        count = db.SortedSetLengthByValue(key, "e", default(RedisValue));
+        Equate(set, count, "e", "f", "g");
+    }
 
-                set = db.SortedSetRangeByValue(key, "e", default(RedisValue));
-                count = db.SortedSetLengthByValue(key, "e", default(RedisValue));
-                Equate(set, count, "e", "f", "g");
-            }
-        }
+    [Fact]
+    public void RemoveRangeByLex()
+    {
+        using var conn = Create();
 
-        [Fact]
-        public void RemoveRangeByLex()
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key,
+            new[]
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                db.SortedSetAdd(key,
-                    new []
-                {
-                    new SortedSetEntry("aaaa", 0),
-                    new SortedSetEntry("b", 0),
-                    new SortedSetEntry("c", 0),
-                    new SortedSetEntry("d", 0),
-                    new SortedSetEntry("e", 0),
-                }, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key,
-                    new []
-                {
-                    new SortedSetEntry("foo", 0),
-                    new SortedSetEntry("zap", 0),
-                    new SortedSetEntry("zip", 0),
-                    new SortedSetEntry("ALPHA", 0),
-                    new SortedSetEntry("alpha", 0),
-                }, CommandFlags.FireAndForget);
-
-                var set = db.SortedSetRangeByRank(key);
-                Equate(set, set.Length, "ALPHA", "aaaa", "alpha", "b", "c", "d", "e", "foo", "zap", "zip");
-
-                long removed = db.SortedSetRemoveRangeByValue(key, "alpha", "omega");
-                Assert.Equal(6, removed);
-
-                set = db.SortedSetRangeByRank(key);
-                Equate(set, set.Length, "ALPHA", "aaaa", "zap", "zip");
-            }
-        }
-
-        private static void Equate(RedisValue[] actual, long count, params string[] expected)
+                new SortedSetEntry("aaaa", 0),
+                new SortedSetEntry("b", 0),
+                new SortedSetEntry("c", 0),
+                new SortedSetEntry("d", 0),
+                new SortedSetEntry("e", 0),
+        }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key,
+            new[]
         {
-            Assert.Equal(expected.Length, count);
-            Assert.Equal(expected.Length, actual.Length);
-            for (int i = 0; i < actual.Length; i++)
-            {
-                Assert.Equal(expected[i], actual[i]);
-            }
+                new SortedSetEntry("foo", 0),
+                new SortedSetEntry("zap", 0),
+                new SortedSetEntry("zip", 0),
+                new SortedSetEntry("ALPHA", 0),
+                new SortedSetEntry("alpha", 0),
+        }, CommandFlags.FireAndForget);
+
+        var set = db.SortedSetRangeByRank(key);
+        Equate(set, set.Length, "ALPHA", "aaaa", "alpha", "b", "c", "d", "e", "foo", "zap", "zip");
+
+        long removed = db.SortedSetRemoveRangeByValue(key, "alpha", "omega");
+        Assert.Equal(6, removed);
+
+        set = db.SortedSetRangeByRank(key);
+        Equate(set, set.Length, "ALPHA", "aaaa", "zap", "zip");
+    }
+
+    private static void Equate(RedisValue[] actual, long count, params string[] expected)
+    {
+        Assert.Equal(expected.Length, count);
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < actual.Length; i++)
+        {
+            Assert.Equal(expected[i], actual[i]);
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/Lists.cs
+++ b/tests/StackExchange.Redis.Tests/Lists.cs
@@ -4,875 +4,831 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Lists : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Lists : TestBase
+    public Lists(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void Ranges()
     {
-        public Lists(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void Ranges()
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.ListRightPush(key, "abcdefghijklmnopqrstuvwxyz".Select(x => (RedisValue)x.ToString()).ToArray(), CommandFlags.FireAndForget);
+
+        Assert.Equal(26, db.ListLength(key));
+        Assert.Equal("abcdefghijklmnopqrstuvwxyz", string.Concat(db.ListRange(key)));
+
+        var last10 = db.ListRange(key, -10, -1);
+        Assert.Equal("qrstuvwxyz", string.Concat(last10));
+        db.ListTrim(key, 0, -11, CommandFlags.FireAndForget);
+
+        Assert.Equal(16, db.ListLength(key));
+        Assert.Equal("abcdefghijklmnop", string.Concat(db.ListRange(key)));
+    }
+
+    [Fact]
+    public void ListLeftPushEmptyValues()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = db.ListLeftPush(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ListLeftPushKeyDoesNotExists()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = db.ListLeftPush(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ListLeftPushToExisitingKey()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = db.ListLeftPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = db.ListLeftPush(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
+        Assert.Equal(2, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(2, rangeResult.Length);
+        Assert.Equal("testvalue2", rangeResult[0]);
+        Assert.Equal("testvalue1", rangeResult[1]);
+    }
+
+    [Fact]
+    public void ListLeftPushMultipleToExisitingKey()
+    {
+        using var conn = Create(require: RedisFeatures.v4_0_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = db.ListLeftPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = db.ListLeftPush(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
+        Assert.Equal(3, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(3, rangeResult.Length);
+        Assert.Equal("testvalue3", rangeResult[0]);
+        Assert.Equal("testvalue2", rangeResult[1]);
+        Assert.Equal("testvalue1", rangeResult[2]);
+    }
+
+    [Fact]
+    public async Task ListLeftPushAsyncEmptyValues()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = await db.ListLeftPushAsync(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task ListLeftPushAsyncKeyDoesNotExists()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task ListLeftPushAsyncToExisitingKey()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
+        Assert.Equal(2, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(2, rangeResult.Length);
+        Assert.Equal("testvalue2", rangeResult[0]);
+        Assert.Equal("testvalue1", rangeResult[1]);
+    }
+
+    [Fact]
+    public async Task ListLeftPushAsyncMultipleToExisitingKey()
+    {
+        using var conn = Create(require: RedisFeatures.v4_0_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
+        Assert.Equal(3, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(3, rangeResult.Length);
+        Assert.Equal("testvalue3", rangeResult[0]);
+        Assert.Equal("testvalue2", rangeResult[1]);
+        Assert.Equal("testvalue1", rangeResult[2]);
+    }
+
+    [Fact]
+    public void ListRightPushEmptyValues()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = db.ListRightPush(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ListRightPushKeyDoesNotExists()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = db.ListRightPush(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void ListRightPushToExisitingKey()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = db.ListRightPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = db.ListRightPush(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
+        Assert.Equal(2, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(2, rangeResult.Length);
+        Assert.Equal("testvalue1", rangeResult[0]);
+        Assert.Equal("testvalue2", rangeResult[1]);
+    }
+
+    [Fact]
+    public void ListRightPushMultipleToExisitingKey()
+    {
+        using var conn = Create(require: RedisFeatures.v4_0_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = db.ListRightPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = db.ListRightPush(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
+        Assert.Equal(3, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(3, rangeResult.Length);
+        Assert.Equal("testvalue1", rangeResult[0]);
+        Assert.Equal("testvalue2", rangeResult[1]);
+        Assert.Equal("testvalue3", rangeResult[2]);
+    }
+
+    [Fact]
+    public async Task ListRightPushAsyncEmptyValues()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = await db.ListRightPushAsync(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task ListRightPushAsyncKeyDoesNotExists()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var result = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task ListRightPushAsyncToExisitingKey()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
+        Assert.Equal(2, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(2, rangeResult.Length);
+        Assert.Equal("testvalue1", rangeResult[0]);
+        Assert.Equal("testvalue2", rangeResult[1]);
+    }
+
+    [Fact]
+    public async Task ListRightPushAsyncMultipleToExisitingKey()
+    {
+        using var conn = Create(require: RedisFeatures.v4_0_0);
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var pushResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
+        Assert.Equal(1, pushResult);
+        var pushXResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
+        Assert.Equal(3, pushXResult);
+
+        var rangeResult = db.ListRange(key, 0, -1);
+        Assert.Equal(3, rangeResult.Length);
+        Assert.Equal("testvalue1", rangeResult[0]);
+        Assert.Equal("testvalue2", rangeResult[1]);
+        Assert.Equal("testvalue3", rangeResult[2]);
+    }
+
+    [Fact]
+    public async Task ListMove()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey src = Me();
+        RedisKey dest = Me() + "dest";
+        db.KeyDelete(src, CommandFlags.FireAndForget);
+
+        var pushResult = await db.ListRightPushAsync(src, new RedisValue[] { "testvalue1", "testvalue2" });
+        Assert.Equal(2, pushResult);
+
+        var rangeResult1 = db.ListMove(src, dest, ListSide.Left, ListSide.Right);
+        var rangeResult2 = db.ListMove(src, dest, ListSide.Left, ListSide.Left);
+        var rangeResult3 = db.ListMove(dest, src, ListSide.Right, ListSide.Right);
+        var rangeResult4 = db.ListMove(dest, src, ListSide.Right, ListSide.Left);
+        Assert.Equal("testvalue1", rangeResult1);
+        Assert.Equal("testvalue2", rangeResult2);
+        Assert.Equal("testvalue1", rangeResult3);
+        Assert.Equal("testvalue2", rangeResult4);
+    }
+
+    [Fact]
+    public void ListMoveKeyDoesNotExist()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        RedisKey src = Me();
+        RedisKey dest = Me() + "dest";
+        db.KeyDelete(src, CommandFlags.FireAndForget);
+
+        var rangeResult1 = db.ListMove(src, dest, ListSide.Left, ListSide.Right);
+        Assert.True(rangeResult1.IsNull);
+    }
+
+    [Fact]
+    public void ListPositionHappyPath()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string val = "foo";
+        db.KeyDelete(key);
+
+        db.ListLeftPush(key, val);
+        var res = db.ListPosition(key, val);
+
+        Assert.Equal(0, res);
+    }
+
+    [Fact]
+    public void ListPositionEmpty()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string val = "foo";
+        db.KeyDelete(key);
+
+        var res = db.ListPosition(key, val);
+
+        Assert.Equal(-1, res);
+    }
+
+    [Fact]
+    public void ListPositionsHappyPath()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.ListRightPush(key, "abcdefghijklmnopqrstuvwxyz".Select(x => (RedisValue)x.ToString()).ToArray(), CommandFlags.FireAndForget);
-
-                Assert.Equal(26, db.ListLength(key));
-                Assert.Equal("abcdefghijklmnopqrstuvwxyz", string.Concat(db.ListRange(key)));
-
-                var last10 = db.ListRange(key, -10, -1);
-                Assert.Equal("qrstuvwxyz", string.Concat(last10));
-                db.ListTrim(key, 0, -11, CommandFlags.FireAndForget);
-
-                Assert.Equal(16, db.ListLength(key));
-                Assert.Equal("abcdefghijklmnop", string.Concat(db.ListRange(key)));
-            }
-        }
-
-        [Fact]
-        public void ListLeftPushEmptyValues()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = db.ListLeftPush(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public void ListLeftPushKeyDoesNotExists()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = db.ListLeftPush(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public void ListLeftPushToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = db.ListLeftPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = db.ListLeftPush(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
-                Assert.Equal(2, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(2, rangeResult.Length);
-                Assert.Equal("testvalue2", rangeResult[0]);
-                Assert.Equal("testvalue1", rangeResult[1]);
-            }
-        }
-
-        [Fact]
-        public void ListLeftPushMultipleToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = db.ListLeftPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = db.ListLeftPush(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
-                Assert.Equal(3, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(3, rangeResult.Length);
-                Assert.Equal("testvalue3", rangeResult[0]);
-                Assert.Equal("testvalue2", rangeResult[1]);
-                Assert.Equal("testvalue1", rangeResult[2]);
-            }
-        }
-
-        [Fact]
-        public async Task ListLeftPushAsyncEmptyValues()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = await db.ListLeftPushAsync(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public async Task ListLeftPushAsyncKeyDoesNotExists()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public async Task ListLeftPushAsyncToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
-                Assert.Equal(2, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(2, rangeResult.Length);
-                Assert.Equal("testvalue2", rangeResult[0]);
-                Assert.Equal("testvalue1", rangeResult[1]);
-            }
-        }
-
-        [Fact]
-        public async Task ListLeftPushAsyncMultipleToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = await db.ListLeftPushAsync(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
-                Assert.Equal(3, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(3, rangeResult.Length);
-                Assert.Equal("testvalue3", rangeResult[0]);
-                Assert.Equal("testvalue2", rangeResult[1]);
-                Assert.Equal("testvalue1", rangeResult[2]);
-            }
-        }
-
-        [Fact]
-        public void ListRightPushEmptyValues()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = db.ListRightPush(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public void ListRightPushKeyDoesNotExists()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = db.ListRightPush(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public void ListRightPushToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = db.ListRightPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = db.ListRightPush(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
-                Assert.Equal(2, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(2, rangeResult.Length);
-                Assert.Equal("testvalue1", rangeResult[0]);
-                Assert.Equal("testvalue2", rangeResult[1]);
-            }
-        }
-
-        [Fact]
-        public void ListRightPushMultipleToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = db.ListRightPush(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = db.ListRightPush(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
-                Assert.Equal(3, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(3, rangeResult.Length);
-                Assert.Equal("testvalue1", rangeResult[0]);
-                Assert.Equal("testvalue2", rangeResult[1]);
-                Assert.Equal("testvalue3", rangeResult[2]);
-            }
-        }
-
-        [Fact]
-        public async Task ListRightPushAsyncEmptyValues()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = await db.ListRightPushAsync(key, Array.Empty<RedisValue>(), When.Always, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public async Task ListRightPushAsyncKeyDoesNotExists()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var result = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue" }, When.Exists, CommandFlags.None);
-                Assert.Equal(0, result);
-            }
-        }
-
-        [Fact]
-        public async Task ListRightPushAsyncToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue2" }, When.Exists, CommandFlags.None);
-                Assert.Equal(2, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(2, rangeResult.Length);
-                Assert.Equal("testvalue1", rangeResult[0]);
-                Assert.Equal("testvalue2", rangeResult[1]);
-            }
-        }
-
-        [Fact]
-        public async Task ListRightPushAsyncMultipleToExisitingKey()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v4_0_0);
-                var db = conn.GetDatabase();
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var pushResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue1" }, CommandFlags.None);
-                Assert.Equal(1, pushResult);
-                var pushXResult = await db.ListRightPushAsync(key, new RedisValue[] { "testvalue2", "testvalue3" }, When.Exists, CommandFlags.None);
-                Assert.Equal(3, pushXResult);
-
-                var rangeResult = db.ListRange(key, 0, -1);
-                Assert.Equal(3, rangeResult.Length);
-                Assert.Equal("testvalue1", rangeResult[0]);
-                Assert.Equal("testvalue2", rangeResult[1]);
-                Assert.Equal("testvalue3", rangeResult[2]);
-            }
-        }
-
-        [Fact]
-        public async Task ListMove()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            RedisKey src = Me();
-            RedisKey dest = Me() + "dest";
-            db.KeyDelete(src, CommandFlags.FireAndForget);
-
-            var pushResult = await db.ListRightPushAsync(src, new RedisValue[] { "testvalue1", "testvalue2" });
-            Assert.Equal(2, pushResult);
-
-            var rangeResult1 = db.ListMove(src, dest, ListSide.Left, ListSide.Right);
-            var rangeResult2 = db.ListMove(src, dest, ListSide.Left, ListSide.Left);
-            var rangeResult3 = db.ListMove(dest, src, ListSide.Right, ListSide.Right);
-            var rangeResult4 = db.ListMove(dest, src, ListSide.Right, ListSide.Left);
-            Assert.Equal("testvalue1", rangeResult1);
-            Assert.Equal("testvalue2", rangeResult2);
-            Assert.Equal("testvalue1", rangeResult3);
-            Assert.Equal("testvalue2", rangeResult4);
-        }
-
-        [Fact]
-        public void ListMoveKeyDoesNotExist()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            RedisKey src = Me();
-            RedisKey dest = Me() + "dest";
-            db.KeyDelete(src, CommandFlags.FireAndForget);
-
-            var rangeResult1 = db.ListMove(src, dest, ListSide.Left, ListSide.Right);
-            Assert.True(rangeResult1.IsNull);
-        }
-
-        [Fact]
-        public void ListPositionHappyPath()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var val = "foo";
-            db.KeyDelete(key);
-
-            db.ListLeftPush(key, val);
-            var res = db.ListPosition(key, val);
-
-            Assert.Equal(0, res);
-        }
-
-        [Fact]
-        public void ListPositionEmpty()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var val = "foo";
-            db.KeyDelete(key);
-
-            var res = db.ListPosition(key, val);
-
-            Assert.Equal(-1, res);
-        }
-
-        [Fact]
-        public void ListPositionsHappyPath()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, foo);
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            var res = db.ListPositions(key, foo, 5);
-
-            foreach (var item in res)
-            {
-                Assert.Equal(2, item % 3);
-            }
-
-            Assert.Equal(5,res.Count());
-        }
-
-        [Fact]
-        public void ListPositionsTooFew()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
             db.ListLeftPush(key, foo);
-
-            var res = db.ListPositions(key, foo, 5);
-            Assert.Single(res);
-            Assert.Equal(0, res.Single());
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public void ListPositionsAll()
+        var res = db.ListPositions(key, foo, 5);
+
+        foreach (var item in res)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, foo);
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            var res = db.ListPositions(key, foo, 0);
-
-            foreach (var item in res)
-            {
-                Assert.Equal(2, item % 3);
-            }
-
-            Assert.Equal(10,res.Count());
+            Assert.Equal(2, item % 3);
         }
 
-        [Fact]
-        public void ListPositionsAllLimitLength()
+        Assert.Equal(5, res.Length);
+    }
+
+    [Fact]
+    public void ListPositionsTooFew()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, foo);
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            var res = db.ListPositions(key, foo, 0, maxLength: 15);
-
-            foreach (var item in res)
-            {
-                Assert.Equal(2, item % 3);
-            }
-
-            Assert.Equal(5,res.Count());
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public void ListPositionsEmpty()
+        db.ListLeftPush(key, foo);
+
+        var res = db.ListPositions(key, foo, 5);
+        Assert.Single(res);
+        Assert.Equal(0, res.Single());
+    }
+
+    [Fact]
+    public void ListPositionsAll()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            var res = db.ListPositions(key, foo, 5);
-
-            Assert.Empty(res);
-        }
-
-        [Fact]
-        public void ListPositionByRank()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, foo);
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            var rank = 6;
-
-            var res = db.ListPosition(key, foo, rank: rank);
-
-            Assert.Equal(3*rank-1, res);
-        }
-
-        [Fact]
-        public void ListPositionLimitSoNull()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            db.ListRightPush(key, foo);
-
-            var res = db.ListPosition(key, foo, maxLength: 20);
-
-            Assert.Equal(-1, res);
-        }
-
-        [Fact]
-        public async Task ListPositionHappyPathAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var val = "foo";
-            await db.KeyDeleteAsync(key);
-
-            await db.ListLeftPushAsync(key, val);
-            var res = await db.ListPositionAsync(key, val);
-
-            Assert.Equal(0, res);
-        }
-
-        [Fact]
-        public async Task ListPositionEmptyAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var val = "foo";
-            await db.KeyDeleteAsync(key);
-
-            var res = await db.ListPositionAsync(key, val);
-
-            Assert.Equal(-1, res);
-        }
-
-        [Fact]
-        public async Task ListPositionsHappyPathAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, foo);
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            var res = await db.ListPositionsAsync(key, foo, 5);
-
-            foreach (var item in res)
-            {
-                Assert.Equal(2, item % 3);
-            }
-
-            Assert.Equal(5,res.Count());
-        }
-
-        [Fact]
-        public async Task ListPositionsTooFewAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
             db.ListLeftPush(key, foo);
-
-            var res = await db.ListPositionsAsync(key, foo, 5);
-            Assert.Single(res);
-            Assert.Equal(0, res.Single());
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public async Task ListPositionsAllAsync()
+        var res = db.ListPositions(key, foo, 0);
+
+        foreach (var item in res)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, foo);
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            var res = await db.ListPositionsAsync(key, foo, 0);
-
-            foreach (var item in res)
-            {
-                Assert.Equal(2, item % 3);
-            }
-
-            Assert.Equal(10,res.Count());
+            Assert.Equal(2, item % 3);
         }
 
-        [Fact]
-        public async Task ListPositionsAllLimitLengthAsync()
+        Assert.Equal(10, res.Length);
+    }
+
+    [Fact]
+    public void ListPositionsAllLimitLength()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, foo);
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            var res = await db.ListPositionsAsync(key, foo, 0, maxLength: 15);
-
-            foreach (var item in res)
-            {
-                Assert.Equal(2, item % 3);
-            }
-
-            Assert.Equal(5,res.Count());
+            db.ListLeftPush(key, foo);
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public async Task ListPositionsEmptyAsync()
+        var res = db.ListPositions(key, foo, 0, maxLength: 15);
+
+        foreach (var item in res)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            var res = await db.ListPositionsAsync(key, foo, 5);
-
-            Assert.Empty(res);
+            Assert.Equal(2, item % 3);
         }
 
-        [Fact]
-        public async Task ListPositionByRankAsync()
+        Assert.Equal(5, res.Length);
+    }
+
+    [Fact]
+    public void ListPositionsEmpty()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, foo);
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            var rank = 6;
-
-            var res = await db.ListPositionAsync(key, foo, rank: rank);
-
-            Assert.Equal(3 * rank - 1, res);
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public async Task ListPositionLimitSoNullAsync()
+        var res = db.ListPositions(key, foo, 5);
+
+        Assert.Empty(res);
+    }
+
+    [Fact]
+    public void ListPositionByRank()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            await db.ListRightPushAsync(key, foo);
-
-            var res = await db.ListPositionAsync(key, foo, maxLength: 20);
-
-            Assert.Equal(-1, res);
+            db.ListLeftPush(key, foo);
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public async Task ListPositionFireAndForgetAsync()
+        const int rank = 6;
+
+        var res = db.ListPosition(key, foo, rank: rank);
+
+        Assert.Equal((3 * rank) - 1, res);
+    }
+
+    [Fact]
+    public void ListPositionLimitSoNull()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            await db.KeyDeleteAsync(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                await db.ListLeftPushAsync(key, foo);
-                await db.ListLeftPushAsync(key, bar);
-                await db.ListLeftPushAsync(key, baz);
-            }
-
-            await db.ListRightPushAsync(key, foo);
-
-            var res = await db.ListPositionAsync(key, foo, maxLength: 20, flags: CommandFlags.FireAndForget);
-
-            Assert.Equal(-1, res);
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
         }
 
-        [Fact]
-        public void ListPositionFireAndForget()
+        db.ListRightPush(key, foo);
+
+        var res = db.ListPosition(key, foo, maxLength: 20);
+
+        Assert.Equal(-1, res);
+    }
+
+    [Fact]
+    public async Task ListPositionHappyPathAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string val = "foo";
+        await db.KeyDeleteAsync(key);
+
+        await db.ListLeftPushAsync(key, val);
+        var res = await db.ListPositionAsync(key, val);
+
+        Assert.Equal(0, res);
+    }
+
+    [Fact]
+    public async Task ListPositionEmptyAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string val = "foo";
+        await db.KeyDeleteAsync(key);
+
+        var res = await db.ListPositionAsync(key, val);
+
+        Assert.Equal(-1, res);
+    }
+
+    [Fact]
+    public async Task ListPositionsHappyPathAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_0_6);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var foo = "foo";
-            var bar = "bar";
-            var baz = "baz";
-
-            db.KeyDelete(key);
-
-            for (var i = 0; i < 10; i++)
-            {
-                db.ListLeftPush(key, foo);
-                db.ListLeftPush(key, bar);
-                db.ListLeftPush(key, baz);
-            }
-
-            db.ListRightPush(key, foo);
-
-            var res = db.ListPosition(key, foo, maxLength: 20, flags: CommandFlags.FireAndForget);
-
-            Assert.Equal(-1, res);
+            await db.ListLeftPushAsync(key, foo);
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
         }
+
+        var res = await db.ListPositionsAsync(key, foo, 5);
+
+        foreach (var item in res)
+        {
+            Assert.Equal(2, item % 3);
+        }
+
+        Assert.Equal(5, res.Length);
+    }
+
+    [Fact]
+    public async Task ListPositionsTooFewAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        db.ListLeftPush(key, foo);
+
+        var res = await db.ListPositionsAsync(key, foo, 5);
+        Assert.Single(res);
+        Assert.Equal(0, res.Single());
+    }
+
+    [Fact]
+    public async Task ListPositionsAllAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, foo);
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        var res = await db.ListPositionsAsync(key, foo, 0);
+
+        foreach (var item in res)
+        {
+            Assert.Equal(2, item % 3);
+        }
+
+        Assert.Equal(10, res.Length);
+    }
+
+    [Fact]
+    public async Task ListPositionsAllLimitLengthAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, foo);
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        var res = await db.ListPositionsAsync(key, foo, 0, maxLength: 15);
+
+        foreach (var item in res)
+        {
+            Assert.Equal(2, item % 3);
+        }
+
+        Assert.Equal(5, res.Length);
+    }
+
+    [Fact]
+    public async Task ListPositionsEmptyAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        var res = await db.ListPositionsAsync(key, foo, 5);
+
+        Assert.Empty(res);
+    }
+
+    [Fact]
+    public async Task ListPositionByRankAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, foo);
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        const int rank = 6;
+
+        var res = await db.ListPositionAsync(key, foo, rank: rank);
+
+        Assert.Equal((3 * rank) - 1, res);
+    }
+
+    [Fact]
+    public async Task ListPositionLimitSoNullAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        await db.ListRightPushAsync(key, foo);
+
+        var res = await db.ListPositionAsync(key, foo, maxLength: 20);
+
+        Assert.Equal(-1, res);
+    }
+
+    [Fact]
+    public async Task ListPositionFireAndForgetAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        await db.KeyDeleteAsync(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await db.ListLeftPushAsync(key, foo);
+            await db.ListLeftPushAsync(key, bar);
+            await db.ListLeftPushAsync(key, baz);
+        }
+
+        await db.ListRightPushAsync(key, foo);
+
+        var res = await db.ListPositionAsync(key, foo, maxLength: 20, flags: CommandFlags.FireAndForget);
+
+        Assert.Equal(-1, res);
+    }
+
+    [Fact]
+    public void ListPositionFireAndForget()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_6);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string foo = "foo",
+                     bar = "bar",
+                     baz = "baz";
+
+        db.KeyDelete(key);
+
+        for (var i = 0; i < 10; i++)
+        {
+            db.ListLeftPush(key, foo);
+            db.ListLeftPush(key, bar);
+            db.ListLeftPush(key, baz);
+        }
+
+        db.ListRightPush(key, foo);
+
+        var res = db.ListPosition(key, foo, maxLength: 20, flags: CommandFlags.FireAndForget);
+
+        Assert.Equal(-1, res);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Locking.cs
+++ b/tests/StackExchange.Redis.Tests/Locking.cs
@@ -5,241 +5,208 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class Locking : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class Locking : TestBase
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+    public Locking(ITestOutputHelper output) : base (output) { }
+
+    public enum TestMode
     {
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
-        public Locking(ITestOutputHelper output) : base (output) { }
+        MultiExec,
+        NoMultiExec,
+        Twemproxy
+    }
 
-        public enum TestMode
-        {
-            MultiExec,
-            NoMultiExec,
-            Twemproxy
-        }
+    public static IEnumerable<object[]> TestModes()
+    {
+        yield return new object[] { TestMode.MultiExec };
+        yield return new object[] { TestMode.NoMultiExec };
+        yield return new object[] { TestMode.Twemproxy };
+    }
 
-        public static IEnumerable<object[]> TestModes()
+    [Theory, MemberData(nameof(TestModes))]
+    public void AggressiveParallel(TestMode testMode)
+    {
+        int count = 2;
+        int errorCount = 0;
+        int bgErrorCount = 0;
+        var evt = new ManualResetEvent(false);
+        var key = Me();
+        using (var conn1 = Create(testMode))
+        using (var conn2 = Create(testMode))
         {
-            yield return new object[] { TestMode.MultiExec };
-            yield return new object[] { TestMode.NoMultiExec };
-            yield return new object[] { TestMode.Twemproxy };
-        }
-
-        [Theory, MemberData(nameof(TestModes))]
-        public void AggressiveParallel(TestMode testMode)
-        {
-            int count = 2;
-            int errorCount = 0;
-            int bgErrorCount = 0;
-            var evt = new ManualResetEvent(false);
-            var key = Me();
-            using (var c1 = Create(testMode))
-            using (var c2 = Create(testMode))
+            void cb(object? obj)
             {
-                void cb(object? obj)
+                try
                 {
-                    try
-                    {
-                        var conn = (IDatabase?)obj!;
-                        conn.Multiplexer.ErrorMessage += delegate { Interlocked.Increment(ref errorCount); };
+                    var conn = (IDatabase?)obj!;
+                    conn.Multiplexer.ErrorMessage += delegate { Interlocked.Increment(ref errorCount); };
 
-                        for (int i = 0; i < 1000; i++)
-                        {
-                            conn.LockTakeAsync(key, "def", TimeSpan.FromSeconds(5));
-                        }
-                        conn.Ping();
-                        if (Interlocked.Decrement(ref count) == 0) evt.Set();
-                    }
-                    catch
+                    for (int i = 0; i < 1000; i++)
                     {
-                        Interlocked.Increment(ref bgErrorCount);
+                        conn.LockTakeAsync(key, "def", TimeSpan.FromSeconds(5));
                     }
+                    conn.Ping();
+                    if (Interlocked.Decrement(ref count) == 0) evt.Set();
                 }
-                int db = testMode == TestMode.Twemproxy ? 0 : 2;
-                ThreadPool.QueueUserWorkItem(cb, c1.GetDatabase(db));
-                ThreadPool.QueueUserWorkItem(cb, c2.GetDatabase(db));
-                evt.WaitOne(8000);
-            }
-            Assert.Equal(0, Interlocked.CompareExchange(ref errorCount, 0, 0));
-            Assert.Equal(0, bgErrorCount);
-        }
-
-        [Fact]
-        public void TestOpCountByVersionLocal_UpLevel()
-        {
-            using (var conn = Create(shared: false))
-            {
-                TestLockOpCountByVersion(conn, 1, false);
-                TestLockOpCountByVersion(conn, 1, true);
-            }
-        }
-
-        private static void TestLockOpCountByVersion(IConnectionMultiplexer conn, int expectedOps, bool existFirst)
-        {
-            const int LockDuration = 30;
-            RedisKey Key = Me();
-
-            var db = conn.GetDatabase();
-            db.KeyDelete(Key, CommandFlags.FireAndForget);
-            RedisValue newVal = "us:" + Guid.NewGuid().ToString();
-            RedisValue expectedVal = newVal;
-            if (existFirst)
-            {
-                expectedVal = "other:" + Guid.NewGuid().ToString();
-                db.StringSet(Key, expectedVal, TimeSpan.FromSeconds(LockDuration), flags: CommandFlags.FireAndForget);
-            }
-            long countBefore = GetServer(conn).GetCounters().Interactive.OperationCount;
-
-            var taken = db.LockTake(Key, newVal, TimeSpan.FromSeconds(LockDuration));
-
-            long countAfter = GetServer(conn).GetCounters().Interactive.OperationCount;
-            var valAfter = db.StringGet(Key);
-
-            Assert.Equal(!existFirst, taken);
-            Assert.Equal(expectedVal, valAfter);
-            // note we get a ping from GetCounters
-            Assert.True(countAfter - countBefore >= expectedOps, $"({countAfter} - {countBefore}) >= {expectedOps}");
-        }
-
-        private IConnectionMultiplexer Create(TestMode mode) => mode switch
-        {
-            TestMode.MultiExec => Create(),
-            TestMode.NoMultiExec => Create(disabledCommands: new[] { "multi", "exec" }),
-            TestMode.Twemproxy => Create(proxy: Proxy.Twemproxy),
-            _ => throw new NotSupportedException(mode.ToString()),
-        };
-
-        [Theory, MemberData(nameof(TestModes))]
-        public async Task TakeLockAndExtend(TestMode mode)
-        {
-            bool withTran = mode == TestMode.MultiExec;
-            using (var conn = Create(mode))
-            {
-                RedisValue right = Guid.NewGuid().ToString(),
-                    wrong = Guid.NewGuid().ToString();
-
-                int DB = mode == TestMode.Twemproxy ? 0 : 7;
-                RedisKey Key = Me();
-
-                var db = conn.GetDatabase(DB);
-
-                db.KeyDelete(Key, CommandFlags.FireAndForget);
-
-                var t1 = db.LockTakeAsync(Key, right, TimeSpan.FromSeconds(20));
-                var t1b = db.LockTakeAsync(Key, wrong, TimeSpan.FromSeconds(10));
-                var t2 = db.LockQueryAsync(Key);
-                var t3 = withTran ? db.LockReleaseAsync(Key, wrong) : null;
-                var t4 = db.LockQueryAsync(Key);
-                var t5 = withTran ? db.LockExtendAsync(Key, wrong, TimeSpan.FromSeconds(60)) : null;
-                var t6 = db.LockQueryAsync(Key);
-                var t7 = db.KeyTimeToLiveAsync(Key);
-                var t8 = db.LockExtendAsync(Key, right, TimeSpan.FromSeconds(60));
-                var t9 = db.LockQueryAsync(Key);
-                var t10 = db.KeyTimeToLiveAsync(Key);
-                var t11 = db.LockReleaseAsync(Key, right);
-                var t12 = db.LockQueryAsync(Key);
-                var t13 = db.LockTakeAsync(Key, wrong, TimeSpan.FromSeconds(10));
-
-                Assert.NotEqual(default(RedisValue), right);
-                Assert.NotEqual(default(RedisValue), wrong);
-                Assert.NotEqual(right, wrong);
-                Assert.True(await t1, "1");
-                Assert.False(await t1b, "1b");
-                Assert.Equal(right, await t2);
-                if (withTran) Assert.False(await t3!, "3");
-                Assert.Equal(right, await t4);
-                if (withTran) Assert.False(await t5!, "5");
-                Assert.Equal(right, await t6);
-                var ttl = (await t7).Value.TotalSeconds;
-                Assert.True(ttl > 0 && ttl <= 20, "7");
-                Assert.True(await t8, "8");
-                Assert.Equal(right, await t9);
-                ttl = (await t10).Value.TotalSeconds;
-                Assert.True(ttl > 50 && ttl <= 60, "10");
-                Assert.True(await t11, "11");
-                Assert.Null((string?)await t12);
-                Assert.True(await t13, "13");
-            }
-        }
-
-        //public void TestManualLockOpCountByVersion(RedisConnection conn, int expected, bool existFirst)
-        //{
-        //    const int DB = 0, LockDuration = 30;
-        //    const string Key = "TestManualLockOpCountByVersion";
-        //    conn.Wait(conn.Open());
-        //    conn.Keys.Remove(DB, Key);
-        //    var newVal = "us:" + CreateUniqueName();
-        //    string expectedVal = newVal;
-        //    if (existFirst)
-        //    {
-        //        expectedVal = "other:" + CreateUniqueName();
-        //        conn.Strings.Set(DB, Key, expectedVal, LockDuration);
-        //    }
-        //    int countBefore = conn.GetCounters().MessagesSent;
-
-        //    var tran = conn.CreateTransaction();
-        //    tran.AddCondition(Condition.KeyNotExists(DB, Key));
-        //    tran.Strings.Set(DB, Key, newVal, LockDuration);
-        //    var taken = conn.Wait(tran.Execute());
-
-        //    int countAfter = conn.GetCounters().MessagesSent;
-        //    var valAfter = conn.Wait(conn.Strings.GetString(DB, Key));
-        //    Assert.Equal(!existFirst, taken, "lock taken (manual)");
-        //    Assert.Equal(expectedVal, valAfter, "taker (manual)");
-        //    Assert.Equal(expected, (countAfter - countBefore) - 1, "expected ops (including ping) (manual)");
-        //    // note we get a ping from GetCounters
-        //}
-
-        [Theory, MemberData(nameof(TestModes))]
-        public async Task TestBasicLockNotTaken(TestMode testMode)
-        {
-            using (var conn = Create(testMode))
-            {
-                int errorCount = 0;
-                conn.ErrorMessage += delegate { Interlocked.Increment(ref errorCount); };
-                Task<bool>? taken = null;
-                Task<RedisValue>? newValue = null;
-                Task<TimeSpan?>? ttl = null;
-
-                const int LOOP = 50;
-                var db = conn.GetDatabase();
-                var key = Me();
-                for (int i = 0; i < LOOP; i++)
+                catch
                 {
-                    _ = db.KeyDeleteAsync(key);
-                    taken = db.LockTakeAsync(key, "new-value", TimeSpan.FromSeconds(10));
-                    newValue = db.StringGetAsync(key);
-                    ttl = db.KeyTimeToLiveAsync(key);
+                    Interlocked.Increment(ref bgErrorCount);
                 }
-                Assert.True(await taken!, "taken");
-                Assert.Equal("new-value", await newValue!);
-                var ttlValue = (await ttl!).Value.TotalSeconds;
-                Assert.True(ttlValue >= 8 && ttlValue <= 10, "ttl");
-
-                Assert.Equal(0, errorCount);
             }
+            int db = testMode == TestMode.Twemproxy ? 0 : 2;
+            ThreadPool.QueueUserWorkItem(cb, conn1.GetDatabase(db));
+            ThreadPool.QueueUserWorkItem(cb, conn2.GetDatabase(db));
+            evt.WaitOne(8000);
         }
+        Assert.Equal(0, Interlocked.CompareExchange(ref errorCount, 0, 0));
+        Assert.Equal(0, bgErrorCount);
+    }
 
-        [Theory, MemberData(nameof(TestModes))]
-        public async Task TestBasicLockTaken(TestMode testMode)
+    [Fact]
+    public void TestOpCountByVersionLocal_UpLevel()
+    {
+        using var conn = Create(shared: false);
+
+        TestLockOpCountByVersion(conn, 1, false);
+        TestLockOpCountByVersion(conn, 1, true);
+    }
+
+    private static void TestLockOpCountByVersion(IConnectionMultiplexer conn, int expectedOps, bool existFirst)
+    {
+        const int LockDuration = 30;
+        RedisKey Key = Me();
+
+        var db = conn.GetDatabase();
+        db.KeyDelete(Key, CommandFlags.FireAndForget);
+        RedisValue newVal = "us:" + Guid.NewGuid().ToString();
+        RedisValue expectedVal = newVal;
+        if (existFirst)
         {
-            using (var conn = Create(testMode))
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringSet(key, "old-value", TimeSpan.FromSeconds(20), flags: CommandFlags.FireAndForget);
-                var taken = db.LockTakeAsync(key, "new-value", TimeSpan.FromSeconds(10));
-                var newValue = db.StringGetAsync(key);
-                var ttl = db.KeyTimeToLiveAsync(key);
-
-                Assert.False(await taken, "taken");
-                Assert.Equal("old-value", await newValue);
-                var ttlValue = (await ttl).Value.TotalSeconds;
-                Assert.True(ttlValue >= 18 && ttlValue <= 20, "ttl");
-            }
+            expectedVal = "other:" + Guid.NewGuid().ToString();
+            db.StringSet(Key, expectedVal, TimeSpan.FromSeconds(LockDuration), flags: CommandFlags.FireAndForget);
         }
+        long countBefore = GetServer(conn).GetCounters().Interactive.OperationCount;
+
+        var taken = db.LockTake(Key, newVal, TimeSpan.FromSeconds(LockDuration));
+
+        long countAfter = GetServer(conn).GetCounters().Interactive.OperationCount;
+        var valAfter = db.StringGet(Key);
+
+        Assert.Equal(!existFirst, taken);
+        Assert.Equal(expectedVal, valAfter);
+        // note we get a ping from GetCounters
+        Assert.True(countAfter - countBefore >= expectedOps, $"({countAfter} - {countBefore}) >= {expectedOps}");
+    }
+
+    private IConnectionMultiplexer Create(TestMode mode) => mode switch
+    {
+        TestMode.MultiExec => Create(),
+        TestMode.NoMultiExec => Create(disabledCommands: new[] { "multi", "exec" }),
+        TestMode.Twemproxy => Create(proxy: Proxy.Twemproxy),
+        _ => throw new NotSupportedException(mode.ToString()),
+    };
+
+    [Theory, MemberData(nameof(TestModes))]
+    public async Task TakeLockAndExtend(TestMode mode)
+    {
+        using var conn = Create(mode);
+
+        RedisValue right = Guid.NewGuid().ToString(),
+            wrong = Guid.NewGuid().ToString();
+
+        int DB = mode == TestMode.Twemproxy ? 0 : 7;
+        RedisKey Key = Me();
+
+        var db = conn.GetDatabase(DB);
+
+        db.KeyDelete(Key, CommandFlags.FireAndForget);
+
+        bool withTran = mode == TestMode.MultiExec;
+        var t1 = db.LockTakeAsync(Key, right, TimeSpan.FromSeconds(20));
+        var t1b = db.LockTakeAsync(Key, wrong, TimeSpan.FromSeconds(10));
+        var t2 = db.LockQueryAsync(Key);
+        var t3 = withTran ? db.LockReleaseAsync(Key, wrong) : null;
+        var t4 = db.LockQueryAsync(Key);
+        var t5 = withTran ? db.LockExtendAsync(Key, wrong, TimeSpan.FromSeconds(60)) : null;
+        var t6 = db.LockQueryAsync(Key);
+        var t7 = db.KeyTimeToLiveAsync(Key);
+        var t8 = db.LockExtendAsync(Key, right, TimeSpan.FromSeconds(60));
+        var t9 = db.LockQueryAsync(Key);
+        var t10 = db.KeyTimeToLiveAsync(Key);
+        var t11 = db.LockReleaseAsync(Key, right);
+        var t12 = db.LockQueryAsync(Key);
+        var t13 = db.LockTakeAsync(Key, wrong, TimeSpan.FromSeconds(10));
+
+        Assert.NotEqual(default(RedisValue), right);
+        Assert.NotEqual(default(RedisValue), wrong);
+        Assert.NotEqual(right, wrong);
+        Assert.True(await t1, "1");
+        Assert.False(await t1b, "1b");
+        Assert.Equal(right, await t2);
+        if (withTran) Assert.False(await t3!, "3");
+        Assert.Equal(right, await t4);
+        if (withTran) Assert.False(await t5!, "5");
+        Assert.Equal(right, await t6);
+        var ttl = (await t7).Value.TotalSeconds;
+        Assert.True(ttl > 0 && ttl <= 20, "7");
+        Assert.True(await t8, "8");
+        Assert.Equal(right, await t9);
+        ttl = (await t10).Value.TotalSeconds;
+        Assert.True(ttl > 50 && ttl <= 60, "10");
+        Assert.True(await t11, "11");
+        Assert.Null((string?)await t12);
+        Assert.True(await t13, "13");
+    }
+
+    [Theory, MemberData(nameof(TestModes))]
+    public async Task TestBasicLockNotTaken(TestMode testMode)
+    {
+        using var conn = Create(testMode);
+
+        int errorCount = 0;
+        conn.ErrorMessage += delegate { Interlocked.Increment(ref errorCount); };
+        Task<bool>? taken = null;
+        Task<RedisValue>? newValue = null;
+        Task<TimeSpan?>? ttl = null;
+
+        const int LOOP = 50;
+        var db = conn.GetDatabase();
+        var key = Me();
+        for (int i = 0; i < LOOP; i++)
+        {
+            _ = db.KeyDeleteAsync(key);
+            taken = db.LockTakeAsync(key, "new-value", TimeSpan.FromSeconds(10));
+            newValue = db.StringGetAsync(key);
+            ttl = db.KeyTimeToLiveAsync(key);
+        }
+        Assert.True(await taken!, "taken");
+        Assert.Equal("new-value", await newValue!);
+        var ttlValue = (await ttl!).Value.TotalSeconds;
+        Assert.True(ttlValue >= 8 && ttlValue <= 10, "ttl");
+
+        Assert.Equal(0, errorCount);
+    }
+
+    [Theory, MemberData(nameof(TestModes))]
+    public async Task TestBasicLockTaken(TestMode testMode)
+    {
+        using var conn = Create(testMode);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, "old-value", TimeSpan.FromSeconds(20), flags: CommandFlags.FireAndForget);
+        var taken = db.LockTakeAsync(key, "new-value", TimeSpan.FromSeconds(10));
+        var newValue = db.StringGetAsync(key);
+        var ttl = db.KeyTimeToLiveAsync(key);
+
+        Assert.False(await taken, "taken");
+        Assert.Equal("old-value", await newValue);
+        var ttlValue = (await ttl).Value.TotalSeconds;
+        Assert.True(ttlValue >= 18 && ttlValue <= 20, "ttl");
     }
 }

--- a/tests/StackExchange.Redis.Tests/MassiveOps.cs
+++ b/tests/StackExchange.Redis.Tests/MassiveOps.cs
@@ -4,118 +4,113 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class MassiveOps : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class MassiveOps : TestBase
+    public MassiveOps(ITestOutputHelper output) : base(output) { }
+
+    [FactLongRunning]
+    public async Task LongRunning()
     {
-        public MassiveOps(ITestOutputHelper output) : base(output) { }
+        using var conn = Create();
 
-        [FactLongRunning]
-        public async Task LongRunning()
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, "test value", flags: CommandFlags.FireAndForget);
+        for (var i = 0; i < 200; i++)
         {
-            var key = Me();
-            using (var conn = Create())
+            var val = await db.StringGetAsync(key).ForAwait();
+            Assert.Equal("test value", val);
+            await Task.Delay(50).ForAwait();
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MassiveBulkOpsAsync(bool withContinuation)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        await db.PingAsync().ForAwait();
+        static void nonTrivial(Task _)
+        {
+            Thread.SpinWait(5);
+        }
+        var watch = Stopwatch.StartNew();
+        for (int i = 0; i <= AsyncOpsQty; i++)
+        {
+            var t = db.StringSetAsync(key, i);
+            if (withContinuation)
             {
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.StringSet(key, "test value", flags: CommandFlags.FireAndForget);
-                for (var i = 0; i < 200; i++)
-                {
-                    var val = await db.StringGetAsync(key).ForAwait();
-                    Assert.Equal("test value", val);
-                    await Task.Delay(50).ForAwait();
-                }
+                // Intentionally unawaited
+                _ = t.ContinueWith(nonTrivial);
             }
         }
+        Assert.Equal(AsyncOpsQty, await db.StringGetAsync(key).ForAwait());
+        watch.Stop();
+        Log("{2}: Time for {0} ops: {1}ms ({3}, any order); ops/s: {4}", AsyncOpsQty, watch.ElapsedMilliseconds, Me(),
+            withContinuation ? "with continuation" : "no continuation", AsyncOpsQty / watch.Elapsed.TotalSeconds);
+    }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task MassiveBulkOpsAsync(bool withContinuation)
+    [TheoryLongRunning]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(50)]
+    public void MassiveBulkOpsSync(int threads)
+    {
+        using var conn = Create(syncTimeout: 30000);
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        int workPerThread = SyncOpsQty / threads;
+        var timeTaken = RunConcurrent(delegate
         {
-            using (var muxer = Create())
+            for (int i = 0; i < workPerThread; i++)
             {
-                RedisKey key = Me();
-                var conn = muxer.GetDatabase();
-                await conn.PingAsync().ForAwait();
-                static void nonTrivial(Task _)
-                {
-                    Thread.SpinWait(5);
-                }
-                var watch = Stopwatch.StartNew();
-                for (int i = 0; i <= AsyncOpsQty; i++)
-                {
-                    var t = conn.StringSetAsync(key, i);
-                    if (withContinuation)
-                    {
-                        // Intentionally unawaited
-                        _ = t.ContinueWith(nonTrivial);
-                    }
-                }
-                Assert.Equal(AsyncOpsQty, await conn.StringGetAsync(key).ForAwait());
-                watch.Stop();
-                Log("{2}: Time for {0} ops: {1}ms ({3}, any order); ops/s: {4}", AsyncOpsQty, watch.ElapsedMilliseconds, Me(),
-                    withContinuation ? "with continuation" : "no continuation", AsyncOpsQty / watch.Elapsed.TotalSeconds);
+                db.StringIncrement(key, flags: CommandFlags.FireAndForget);
             }
-        }
+        }, threads);
 
-        [TheoryLongRunning]
-        [InlineData(1)]
-        [InlineData(5)]
-        [InlineData(10)]
-        [InlineData(50)]
-        public void MassiveBulkOpsSync(int threads)
+        int val = (int)db.StringGet(key);
+        Assert.Equal(workPerThread * threads, val);
+        Log("{2}: Time for {0} ops on {3} threads: {1}ms (any order); ops/s: {4}",
+            threads * workPerThread, timeTaken.TotalMilliseconds, Me(), threads, (workPerThread * threads) / timeTaken.TotalSeconds);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    public void MassiveBulkOpsFireAndForget(int threads)
+    {
+        using var conn = Create(syncTimeout: 30000);
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.Ping();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        int perThread = AsyncOpsQty / threads;
+        var elapsed = RunConcurrent(delegate
         {
-            int workPerThread = SyncOpsQty / threads;
-            using (var muxer = Create(syncTimeout: 30000))
+            for (int i = 0; i < perThread; i++)
             {
-                RedisKey key = Me();
-                var conn = muxer.GetDatabase();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var timeTaken = RunConcurrent(delegate
-                {
-                    for (int i = 0; i < workPerThread; i++)
-                    {
-                        conn.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                    }
-                }, threads);
-
-                int val = (int)conn.StringGet(key);
-                Assert.Equal(workPerThread * threads, val);
-                Log("{2}: Time for {0} ops on {3} threads: {1}ms (any order); ops/s: {4}",
-                    threads * workPerThread, timeTaken.TotalMilliseconds, Me(), threads, (workPerThread * threads) / timeTaken.TotalSeconds);
+                db.StringIncrement(key, flags: CommandFlags.FireAndForget);
             }
-        }
+            db.Ping();
+        }, threads);
+        var val = (long)db.StringGet(key);
+        Assert.Equal(perThread * threads, val);
 
-        [Theory]
-        [InlineData(1)]
-        [InlineData(5)]
-        public void MassiveBulkOpsFireAndForget(int threads)
-        {
-            using (var muxer = Create(syncTimeout: 30000))
-            {
-                RedisKey key = Me();
-                var conn = muxer.GetDatabase();
-                conn.Ping();
-
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                int perThread = AsyncOpsQty / threads;
-                var elapsed = RunConcurrent(delegate
-                {
-                    for (int i = 0; i < perThread; i++)
-                    {
-                        conn.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                    }
-                    conn.Ping();
-                }, threads);
-                var val = (long)conn.StringGet(key);
-                Assert.Equal(perThread * threads, val);
-
-                Log("{2}: Time for {0} ops over {4} threads: {1:###,###}ms (any order); ops/s: {3:###,###,##0}",
-                    val, elapsed.TotalMilliseconds, Me(),
-                    val / elapsed.TotalSeconds, threads);
-            }
-        }
+        Log("{2}: Time for {0} ops over {4} threads: {1:###,###}ms (any order); ops/s: {3:###,###,##0}",
+            val, elapsed.TotalMilliseconds, Me(),
+            val / elapsed.TotalSeconds, threads);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Migrate.cs
+++ b/tests/StackExchange.Redis.Tests/Migrate.cs
@@ -4,55 +4,54 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Migrate : TestBase
 {
-    public class Migrate : TestBase
+    public Migrate(ITestOutputHelper output) : base (output) { }
+
+    [FactLongRunning]
+    public async Task Basic()
     {
-        public Migrate(ITestOutputHelper output) : base (output) { }
+        var fromConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.SecureServer, TestConfig.Current.SecurePort } }, Password = TestConfig.Current.SecurePassword, AllowAdmin = true };
+        var toConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort } }, AllowAdmin = true };
 
-        [FactLongRunning]
-        public async Task Basic()
-        {
-            var fromConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.SecureServer, TestConfig.Current.SecurePort } }, Password = TestConfig.Current.SecurePassword, AllowAdmin = true };
-            var toConfig = new ConfigurationOptions { EndPoints = { { TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort } }, AllowAdmin = true };
-            using (var from = ConnectionMultiplexer.Connect(fromConfig, Writer))
-            using (var to = ConnectionMultiplexer.Connect(toConfig, Writer))
-            {
-                if (await IsWindows(from) || await IsWindows(to))
-                    Skip.Inconclusive("'migrate' is unreliable on redis-64");
+        using var fromConn = ConnectionMultiplexer.Connect(fromConfig, Writer);
+        using var toConn = ConnectionMultiplexer.Connect(toConfig, Writer);
 
-                RedisKey key = Me();
-                var fromDb = from.GetDatabase();
-                var toDb = to.GetDatabase();
-                fromDb.KeyDelete(key, CommandFlags.FireAndForget);
-                toDb.KeyDelete(key, CommandFlags.FireAndForget);
-                fromDb.StringSet(key, "foo", flags: CommandFlags.FireAndForget);
-                var dest = to.GetEndPoints(true).Single();
-                Log("Migrating key...");
-                fromDb.KeyMigrate(key, dest, migrateOptions: MigrateOptions.Replace);
-                Log("Migration command complete");
+        if (await IsWindows(fromConn) || await IsWindows(toConn))
+            Skip.Inconclusive("'migrate' is unreliable on redis-64");
 
-                // this is *meant* to be synchronous at the redis level, but
-                // we keep seeing it fail on the CI server where the key has *left* the origin, but
-                // has *not* yet arrived at the destination; adding a pause while we investigate with
-                // the redis folks
-                await UntilConditionAsync(TimeSpan.FromSeconds(15), () => !fromDb.KeyExists(key) && toDb.KeyExists(key));
+        RedisKey key = Me();
+        var fromDb = fromConn.GetDatabase();
+        var toDb = toConn.GetDatabase();
+        fromDb.KeyDelete(key, CommandFlags.FireAndForget);
+        toDb.KeyDelete(key, CommandFlags.FireAndForget);
+        fromDb.StringSet(key, "foo", flags: CommandFlags.FireAndForget);
+        var dest = toConn.GetEndPoints(true).Single();
+        Log("Migrating key...");
+        fromDb.KeyMigrate(key, dest, migrateOptions: MigrateOptions.Replace);
+        Log("Migration command complete");
 
-                Assert.False(fromDb.KeyExists(key), "Exists at source");
-                Assert.True(toDb.KeyExists(key), "Exists at destination");
-                string? s = toDb.StringGet(key);
-                Assert.Equal("foo", s);
-            }
-        }
+        // this is *meant* to be synchronous at the redis level, but
+        // we keep seeing it fail on the CI server where the key has *left* the origin, but
+        // has *not* yet arrived at the destination; adding a pause while we investigate with
+        // the redis folks
+        await UntilConditionAsync(TimeSpan.FromSeconds(15), () => !fromDb.KeyExists(key) && toDb.KeyExists(key));
 
-        private static async Task<bool> IsWindows(ConnectionMultiplexer conn)
-        {
-            var server = conn.GetServer(conn.GetEndPoints().First());
-            var section = (await server.InfoAsync("server")).Single();
-            var os = section.FirstOrDefault(
-                x => string.Equals("os", x.Key, StringComparison.OrdinalIgnoreCase));
-            // note: WSL returns things like "os:Linux 4.4.0-17134-Microsoft x86_64"
-            return string.Equals("windows", os.Value, StringComparison.OrdinalIgnoreCase);
-        }
+        Assert.False(fromDb.KeyExists(key), "Exists at source");
+        Assert.True(toDb.KeyExists(key), "Exists at destination");
+        string? s = toDb.StringGet(key);
+        Assert.Equal("foo", s);
+    }
+
+    private static async Task<bool> IsWindows(ConnectionMultiplexer conn)
+    {
+        var server = conn.GetServer(conn.GetEndPoints().First());
+        var section = (await server.InfoAsync("server")).Single();
+        var os = section.FirstOrDefault(
+            x => string.Equals("os", x.Key, StringComparison.OrdinalIgnoreCase));
+        // note: WSL returns things like "os:Linux 4.4.0-17134-Microsoft x86_64"
+        return string.Equals("windows", os.Value, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/StackExchange.Redis.Tests/MultiAdd.cs
+++ b/tests/StackExchange.Redis.Tests/MultiAdd.cs
@@ -2,117 +2,111 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class MultiAdd : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class MultiAdd : TestBase
+    public MultiAdd(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void AddSortedSetEveryWay()
     {
-        public MultiAdd(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void AddSortedSetEveryWay()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
 
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, "a", 1, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, new[] {
-                    new SortedSetEntry("b", 2) }, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, new[] {
-                    new SortedSetEntry("c", 3),
-                    new SortedSetEntry("d", 4)}, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, new[] {
-                    new SortedSetEntry("e", 5),
-                    new SortedSetEntry("f", 6),
-                    new SortedSetEntry("g", 7)}, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, new[] {
-                    new SortedSetEntry("h", 8),
-                    new SortedSetEntry("i", 9),
-                    new SortedSetEntry("j", 10),
-                    new SortedSetEntry("k", 11)}, CommandFlags.FireAndForget);
-                var vals = db.SortedSetRangeByScoreWithScores(key);
-                string s = string.Join(",", vals.OrderByDescending(x => x.Score).Select(x => x.Element));
-                Assert.Equal("k,j,i,h,g,f,e,d,c,b,a", s);
-                s = string.Join(",", vals.OrderBy(x => x.Score).Select(x => x.Score));
-                Assert.Equal("1,2,3,4,5,6,7,8,9,10,11", s);
-            }
-        }
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, "a", 1, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, new[] {
+                new SortedSetEntry("b", 2) }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, new[] {
+                new SortedSetEntry("c", 3),
+                new SortedSetEntry("d", 4)}, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, new[] {
+                new SortedSetEntry("e", 5),
+                new SortedSetEntry("f", 6),
+                new SortedSetEntry("g", 7)}, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, new[] {
+                new SortedSetEntry("h", 8),
+                new SortedSetEntry("i", 9),
+                new SortedSetEntry("j", 10),
+                new SortedSetEntry("k", 11)}, CommandFlags.FireAndForget);
+        var vals = db.SortedSetRangeByScoreWithScores(key);
+        string s = string.Join(",", vals.OrderByDescending(x => x.Score).Select(x => x.Element));
+        Assert.Equal("k,j,i,h,g,f,e,d,c,b,a", s);
+        s = string.Join(",", vals.OrderBy(x => x.Score).Select(x => x.Score));
+        Assert.Equal("1,2,3,4,5,6,7,8,9,10,11", s);
+    }
 
-        [Fact]
-        public void AddHashEveryWay()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
+    [Fact]
+    public void AddHashEveryWay()
+    {
+        using var conn = Create();
 
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.HashSet(key, "a", 1, flags: CommandFlags.FireAndForget);
-                db.HashSet(key, new[] {
-                    new HashEntry("b", 2) }, CommandFlags.FireAndForget);
-                db.HashSet(key, new[] {
-                    new HashEntry("c", 3),
-                    new HashEntry("d", 4)}, CommandFlags.FireAndForget);
-                db.HashSet(key, new[] {
-                    new HashEntry("e", 5),
-                    new HashEntry("f", 6),
-                    new HashEntry("g", 7)}, CommandFlags.FireAndForget);
-                db.HashSet(key, new[] {
-                    new HashEntry("h", 8),
-                    new HashEntry("i", 9),
-                    new HashEntry("j", 10),
-                    new HashEntry("k", 11)}, CommandFlags.FireAndForget);
-                var vals = db.HashGetAll(key);
-                string s = string.Join(",", vals.OrderByDescending(x => (double)x.Value).Select(x => x.Name));
-                Assert.Equal("k,j,i,h,g,f,e,d,c,b,a", s);
-                s = string.Join(",", vals.OrderBy(x => (double)x.Value).Select(x => x.Value));
-                Assert.Equal("1,2,3,4,5,6,7,8,9,10,11", s);
-            }
-        }
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
 
-        [Fact]
-        public void AddSetEveryWay()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.HashSet(key, "a", 1, flags: CommandFlags.FireAndForget);
+        db.HashSet(key, new[] {
+                new HashEntry("b", 2) }, CommandFlags.FireAndForget);
+        db.HashSet(key, new[] {
+                new HashEntry("c", 3),
+                new HashEntry("d", 4)}, CommandFlags.FireAndForget);
+        db.HashSet(key, new[] {
+                new HashEntry("e", 5),
+                new HashEntry("f", 6),
+                new HashEntry("g", 7)}, CommandFlags.FireAndForget);
+        db.HashSet(key, new[] {
+                new HashEntry("h", 8),
+                new HashEntry("i", 9),
+                new HashEntry("j", 10),
+                new HashEntry("k", 11)}, CommandFlags.FireAndForget);
+        var vals = db.HashGetAll(key);
+        string s = string.Join(",", vals.OrderByDescending(x => (double)x.Value).Select(x => x.Name));
+        Assert.Equal("k,j,i,h,g,f,e,d,c,b,a", s);
+        s = string.Join(",", vals.OrderBy(x => (double)x.Value).Select(x => x.Value));
+        Assert.Equal("1,2,3,4,5,6,7,8,9,10,11", s);
+    }
 
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SetAdd(key, "a", CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "b" }, CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "c", "d" }, CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "e", "f", "g" }, CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "h", "i", "j", "k" }, CommandFlags.FireAndForget);
+    [Fact]
+    public void AddSetEveryWay()
+    {
+        using var conn = Create();
 
-                var vals = db.SetMembers(key);
-                string s = string.Join(",", vals.OrderByDescending(x => x));
-                Assert.Equal("k,j,i,h,g,f,e,d,c,b,a", s);
-            }
-        }
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
 
-        [Fact]
-        public void AddSetEveryWayNumbers()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SetAdd(key, "a", CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "b" }, CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "c", "d" }, CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "e", "f", "g" }, CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "h", "i", "j", "k" }, CommandFlags.FireAndForget);
 
-                RedisKey key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SetAdd(key, "a", CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "1" }, CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "11", "2" }, CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "10", "3", "1.5" }, CommandFlags.FireAndForget);
-                db.SetAdd(key, new RedisValue[] { "2.2", "-1", "s", "t" }, CommandFlags.FireAndForget);
+        var vals = db.SetMembers(key);
+        string s = string.Join(",", vals.OrderByDescending(x => x));
+        Assert.Equal("k,j,i,h,g,f,e,d,c,b,a", s);
+    }
 
-                var vals = db.SetMembers(key);
-                string s = string.Join(",", vals.OrderByDescending(x => x));
-                Assert.Equal("t,s,a,11,10,3,2.2,2,1.5,1,-1", s);
-            }
-        }
+    [Fact]
+    public void AddSetEveryWayNumbers()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SetAdd(key, "a", CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "1" }, CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "11", "2" }, CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "10", "3", "1.5" }, CommandFlags.FireAndForget);
+        db.SetAdd(key, new RedisValue[] { "2.2", "-1", "s", "t" }, CommandFlags.FireAndForget);
+
+        var vals = db.SetMembers(key);
+        string s = string.Join(",", vals.OrderByDescending(x => x));
+        Assert.Equal("t,s,a,11,10,3,2.2,2,1.5,1,-1", s);
     }
 }

--- a/tests/StackExchange.Redis.Tests/MultiPrimary.cs
+++ b/tests/StackExchange.Redis.Tests/MultiPrimary.cs
@@ -4,92 +4,90 @@ using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class MultiPrimary : TestBase
 {
-    public class MultiPrimary : TestBase
+    protected override string GetConfiguration() =>
+        TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.SecureServerAndPort + ",password=" + TestConfig.Current.SecurePassword;
+    public MultiPrimary(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void CannotFlushReplica()
     {
-        protected override string GetConfiguration() =>
-            TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.SecureServerAndPort + ",password=" + TestConfig.Current.SecurePassword;
-        public MultiPrimary(ITestOutputHelper output) : base (output) { }
-
-        [Fact]
-        public void CannotFlushReplica()
+        var ex = Assert.Throws<RedisCommandException>(() =>
         {
-            var ex = Assert.Throws<RedisCommandException>(() =>
-            {
-                using (var conn = ConnectionMultiplexer.Connect(TestConfig.Current.ReplicaServerAndPort + ",allowAdmin=true"))
-                {
-                    var servers = conn.GetEndPoints().Select(e => conn.GetServer(e));
-                    var replica = servers.FirstOrDefault(x => x.IsReplica);
-                    Assert.NotNull(replica); // replica not found, ruh roh
-                    replica.FlushDatabase();
-                }
-            });
-            Assert.Equal("Command cannot be issued to a replica: FLUSHDB", ex.Message);
+            using var conn = ConnectionMultiplexer.Connect(TestConfig.Current.ReplicaServerAndPort + ",allowAdmin=true");
+
+            var servers = conn.GetEndPoints().Select(e => conn.GetServer(e));
+            var replica = servers.FirstOrDefault(x => x.IsReplica);
+            Assert.NotNull(replica); // replica not found, ruh roh
+            replica.FlushDatabase();
+        });
+        Assert.Equal("Command cannot be issued to a replica: FLUSHDB", ex.Message);
+    }
+
+    [Fact]
+    public void TestMultiNoTieBreak()
+    {
+        var log = new StringBuilder();
+        Writer.EchoTo(log);
+        using (Create(log: Writer, tieBreaker: ""))
+        {
+            Assert.Contains("Choosing primary arbitrarily", log.ToString());
+        }
+    }
+
+    public static IEnumerable<object?[]> GetConnections()
+    {
+        yield return new object[] { TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.PrimaryServerAndPort };
+        yield return new object[] { TestConfig.Current.SecureServerAndPort, TestConfig.Current.SecureServerAndPort, TestConfig.Current.SecureServerAndPort };
+        yield return new object?[] { TestConfig.Current.SecureServerAndPort, TestConfig.Current.PrimaryServerAndPort, null };
+        yield return new object?[] { TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.SecureServerAndPort, null };
+
+        yield return new object?[] { null, TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.PrimaryServerAndPort };
+        yield return new object?[] { TestConfig.Current.PrimaryServerAndPort, null, TestConfig.Current.PrimaryServerAndPort };
+        yield return new object?[] { null, TestConfig.Current.SecureServerAndPort, TestConfig.Current.SecureServerAndPort };
+        yield return new object?[] { TestConfig.Current.SecureServerAndPort, null, TestConfig.Current.SecureServerAndPort };
+        yield return new object?[] { null, null, null };
+    }
+
+    [Theory, MemberData(nameof(GetConnections))]
+    public void TestMultiWithTiebreak(string a, string b, string elected)
+    {
+        const string TieBreak = "__tie__";
+        // set the tie-breakers to the expected state
+        using (var aConn = ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServerAndPort))
+        {
+            aConn.GetDatabase().StringSet(TieBreak, a);
+        }
+        using (var aConn = ConnectionMultiplexer.Connect(TestConfig.Current.SecureServerAndPort + ",password=" + TestConfig.Current.SecurePassword))
+        {
+            aConn.GetDatabase().StringSet(TieBreak, b);
         }
 
-        [Fact]
-        public void TestMultiNoTieBreak()
+        // see what happens
+        var log = new StringBuilder();
+        Writer.EchoTo(log);
+
+        using (Create(log: Writer, tieBreaker: TieBreak))
         {
-            var log = new StringBuilder();
-            Writer.EchoTo(log);
-            using (Create(log: Writer, tieBreaker: ""))
+            string text = log.ToString();
+            Assert.False(text.Contains("failed to nominate"), "failed to nominate");
+            if (elected != null)
             {
-                Assert.Contains("Choosing primary arbitrarily", log.ToString());
+                Assert.True(text.Contains("Elected: " + elected), "elected");
             }
-        }
-
-        public static IEnumerable<object?[]> GetConnections()
-        {
-            yield return new object[] { TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.PrimaryServerAndPort };
-            yield return new object[] { TestConfig.Current.SecureServerAndPort, TestConfig.Current.SecureServerAndPort, TestConfig.Current.SecureServerAndPort };
-            yield return new object?[] { TestConfig.Current.SecureServerAndPort, TestConfig.Current.PrimaryServerAndPort, null };
-            yield return new object?[] { TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.SecureServerAndPort, null };
-
-            yield return new object?[] { null, TestConfig.Current.PrimaryServerAndPort, TestConfig.Current.PrimaryServerAndPort };
-            yield return new object?[] { TestConfig.Current.PrimaryServerAndPort, null, TestConfig.Current.PrimaryServerAndPort };
-            yield return new object?[] { null, TestConfig.Current.SecureServerAndPort, TestConfig.Current.SecureServerAndPort };
-            yield return new object?[] { TestConfig.Current.SecureServerAndPort, null, TestConfig.Current.SecureServerAndPort };
-            yield return new object?[] { null, null, null };
-        }
-
-        [Theory, MemberData(nameof(GetConnections))]
-        public void TestMultiWithTiebreak(string a, string b, string elected)
-        {
-            const string TieBreak = "__tie__";
-            // set the tie-breakers to the expected state
-            using (var aConn = ConnectionMultiplexer.Connect(TestConfig.Current.PrimaryServerAndPort))
+            int nullCount = (a == null ? 1 : 0) + (b == null ? 1 : 0);
+            if ((a == b && nullCount == 0) || nullCount == 1)
             {
-                aConn.GetDatabase().StringSet(TieBreak, a);
+                Assert.True(text.Contains("Election: Tie-breaker unanimous"), "unanimous");
+                Assert.False(text.Contains("Election: Choosing primary arbitrarily"), "arbitrarily");
             }
-            using (var aConn = ConnectionMultiplexer.Connect(TestConfig.Current.SecureServerAndPort + ",password=" + TestConfig.Current.SecurePassword))
+            else
             {
-                aConn.GetDatabase().StringSet(TieBreak, b);
-            }
-
-            // see what happens
-            var log = new StringBuilder();
-            Writer.EchoTo(log);
-
-            using (Create(log: Writer, tieBreaker: TieBreak))
-            {
-                string text = log.ToString();
-                Assert.False(text.Contains("failed to nominate"), "failed to nominate");
-                if (elected != null)
-                {
-                    Assert.True(text.Contains("Elected: " + elected), "elected");
-                }
-                int nullCount = (a == null ? 1 : 0) + (b == null ? 1 : 0);
-                if ((a == b && nullCount == 0) || nullCount == 1)
-                {
-                    Assert.True(text.Contains("Election: Tie-breaker unanimous"), "unanimous");
-                    Assert.False(text.Contains("Election: Choosing primary arbitrarily"), "arbitrarily");
-                }
-                else
-                {
-                    Assert.False(text.Contains("Election: Tie-breaker unanimous"), "unanimous");
-                    Assert.True(text.Contains("Election: Choosing primary arbitrarily"), "arbitrarily");
-                }
+                Assert.False(text.Contains("Election: Tie-breaker unanimous"), "unanimous");
+                Assert.True(text.Contains("Election: Choosing primary arbitrarily"), "arbitrarily");
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/Naming.cs
+++ b/tests/StackExchange.Redis.Tests/Naming.cs
@@ -6,232 +6,220 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Naming : TestBase
 {
-    public class Naming : TestBase
+    public Naming(ITestOutputHelper output) : base(output) { }
+
+    [Theory]
+    [InlineData(typeof(IDatabase), false)]
+    [InlineData(typeof(IDatabaseAsync), true)]
+    [InlineData(typeof(Condition), false)]
+    public void CheckSignatures(Type type, bool isAsync)
     {
-        public Naming(ITestOutputHelper output) : base(output) { }
-
-        [Theory]
-        [InlineData(typeof(IDatabase), false)]
-        [InlineData(typeof(IDatabaseAsync), true)]
-        [InlineData(typeof(Condition), false)]
-        public void CheckSignatures(Type type, bool isAsync)
+        // check that all methods and interfaces look appropriate for their sync/async nature
+        CheckName(type, isAsync);
+        var members = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        foreach (var member in members)
         {
-            // check that all methods and interfaces look appropriate for their sync/async nature
-            CheckName(type, isAsync);
-            var members = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly);
-            foreach (var member in members)
+            if (member.Name.StartsWith("get_") || member.Name.StartsWith("set_") || member.Name.StartsWith("add_") || member.Name.StartsWith("remove_")) continue;
+            CheckMethod(member, isAsync);
+        }
+    }
+
+    [Fact]
+    public void ShowReadOnlyOperations()
+    {
+        List<object> primaryReplica = new List<object>();
+        List<object> primaryOnly = new List<object>();
+        foreach (var val in (RedisCommand[])Enum.GetValues(typeof(RedisCommand)))
+        {
+            bool isPrimaryOnly = Message.IsPrimaryOnly(val);
+            (isPrimaryOnly ? primaryOnly : primaryReplica).Add(val);
+
+            if (!isPrimaryOnly)
             {
-                if (member.Name.StartsWith("get_") || member.Name.StartsWith("set_") || member.Name.StartsWith("add_") || member.Name.StartsWith("remove_")) continue;
-                CheckMethod(member, isAsync);
+                Log(val.ToString());
             }
         }
-
-        [Fact]
-        public void ShowReadOnlyOperations()
+        Log("primary-only: {0}, vs primary/replica: {1}", primaryOnly.Count, primaryReplica.Count);
+        Log("");
+        Log("primary-only:");
+        foreach (var val in primaryOnly)
         {
-            List<object> primaryReplica = new List<object>();
-            List<object> primaryOnly = new List<object>();
-            foreach (var val in (RedisCommand[])Enum.GetValues(typeof(RedisCommand)))
-            {
-                bool isPrimaryOnly = Message.IsPrimaryOnly(val);
-                (isPrimaryOnly ? primaryOnly : primaryReplica).Add(val);
-
-                if (!isPrimaryOnly)
-                {
-                    Log(val.ToString());
-                }
-            }
-            Log("primary-only: {0}, vs primary/replica: {1}", primaryOnly.Count, primaryReplica.Count);
-            Log("");
-            Log("primary-only:");
-            foreach (var val in primaryOnly)
-            {
-                Log(val?.ToString());
-            }
-            Log("");
-            Log("primary/replica:");
-            foreach (var val in primaryReplica)
-            {
-                Log(val?.ToString());
-            }
+            Log(val?.ToString());
         }
-
-        [Theory]
-        [InlineData(typeof(IDatabase))]
-        [InlineData(typeof(IDatabaseAsync))]
-        public void CheckDatabaseMethodsUseKeys(Type type)
+        Log("");
+        Log("primary/replica:");
+        foreach (var val in primaryReplica)
         {
-            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
-            {
-                if (IgnoreMethodConventions(method)) continue;
-
-                switch (method.Name)
-                {
-                    case nameof(IDatabase.KeyRandom):
-                    case nameof(IDatabaseAsync.KeyRandomAsync):
-                    case nameof(IDatabase.Publish):
-                    case nameof(IDatabaseAsync.PublishAsync):
-                    case nameof(IDatabase.Execute):
-                    case nameof(IDatabaseAsync.ExecuteAsync):
-                    case nameof(IDatabase.ScriptEvaluate):
-                    case nameof(IDatabaseAsync.ScriptEvaluateAsync):
-                    case nameof(IDatabase.StreamRead):
-                    case nameof(IDatabase.StreamReadAsync):
-                    case nameof(IDatabase.StreamReadGroup):
-                    case nameof(IDatabase.StreamReadGroupAsync):
-                        continue; // they're fine, but don't want to widen check to return type
-                }
-
-                bool usesKey = method.GetParameters().Any(p => UsesKey(p.ParameterType));
-                Assert.True(usesKey, type.Name + ":" + method.Name);
-            }
+            Log(val?.ToString());
         }
+    }
 
-        private static bool UsesKey(Type type)
+    [Theory]
+    [InlineData(typeof(IDatabase))]
+    [InlineData(typeof(IDatabaseAsync))]
+    public void CheckDatabaseMethodsUseKeys(Type type)
+    {
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
         {
-            if (type == typeof(RedisKey)) return true;
+            if (IgnoreMethodConventions(method)) continue;
 
-            if (type.IsArray)
+            switch (method.Name)
             {
-                if (UsesKey(type.GetElementType()!)) return true;
-            }
-            if (type.IsGenericType) // KVP, etc
-            {
-                var args = type.GetGenericArguments();
-                if (args.Any(UsesKey)) return true;
-            }
-            return false;
-        }
-
-        private static bool IgnoreMethodConventions(MethodInfo method)
-        {
-            string name = method.Name;
-            if (name.StartsWith("get_") || name.StartsWith("set_") || name.StartsWith("add_") || name.StartsWith("remove_")) return true;
-            switch (name)
-            {
-                case nameof(IDatabase.CreateBatch):
-                case nameof(IDatabase.CreateTransaction):
+                case nameof(IDatabase.KeyRandom):
+                case nameof(IDatabaseAsync.KeyRandomAsync):
+                case nameof(IDatabase.Publish):
+                case nameof(IDatabaseAsync.PublishAsync):
                 case nameof(IDatabase.Execute):
                 case nameof(IDatabaseAsync.ExecuteAsync):
-                case nameof(IDatabase.IsConnected):
-                case nameof(IDatabase.SetScan):
-                case nameof(IDatabase.SortedSetScan):
-                case nameof(IDatabase.HashScan):
-                case nameof(ISubscriber.SubscribedEndpoint):
-                    return true;
+                case nameof(IDatabase.ScriptEvaluate):
+                case nameof(IDatabaseAsync.ScriptEvaluateAsync):
+                case nameof(IDatabase.StreamRead):
+                case nameof(IDatabase.StreamReadAsync):
+                case nameof(IDatabase.StreamReadGroup):
+                case nameof(IDatabase.StreamReadGroupAsync):
+                    continue; // they're fine, but don't want to widen check to return type
             }
+
+            bool usesKey = method.GetParameters().Any(p => UsesKey(p.ParameterType));
+            Assert.True(usesKey, type.Name + ":" + method.Name);
+        }
+    }
+
+    private static bool UsesKey(Type type) =>
+        type == typeof(RedisKey)
+        || (type.IsArray && UsesKey(type.GetElementType()!))
+        || (type.IsGenericType && type.GetGenericArguments().Any(UsesKey));
+
+    private static bool IgnoreMethodConventions(MethodInfo method)
+    {
+        string name = method.Name;
+        if (name.StartsWith("get_") || name.StartsWith("set_") || name.StartsWith("add_") || name.StartsWith("remove_")) return true;
+        switch (name)
+        {
+            case nameof(IDatabase.CreateBatch):
+            case nameof(IDatabase.CreateTransaction):
+            case nameof(IDatabase.Execute):
+            case nameof(IDatabaseAsync.ExecuteAsync):
+            case nameof(IDatabase.IsConnected):
+            case nameof(IDatabase.SetScan):
+            case nameof(IDatabase.SortedSetScan):
+            case nameof(IDatabase.HashScan):
+            case nameof(ISubscriber.SubscribedEndpoint):
+                return true;
+        }
+        return false;
+    }
+
+    [Theory]
+    [InlineData(typeof(IDatabase), typeof(IDatabaseAsync))]
+    [InlineData(typeof(IDatabaseAsync), typeof(IDatabase))]
+    public void CheckSyncAsyncMethodsMatch(Type from, Type to)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+        int count = 0;
+        foreach (var method in from.GetMethods(flags))
+        {
+            if (IgnoreMethodConventions(method)) continue;
+
+            string name = method.Name, huntName;
+
+            if (name.EndsWith("Async")) huntName = name.Substring(0, name.Length - 5);
+            else huntName = name + "Async";
+            var pFrom = method.GetParameters();
+            Type[] args = pFrom.Select(x => x.ParameterType).ToArray();
+            Log("Checking: {0}.{1}", from.Name, method.Name);
+            Assert.Equal(typeof(CommandFlags), args.Last());
+            var found = to.GetMethod(huntName, flags, null, method.CallingConvention, args, null);
+            Assert.NotNull(found); // "Found " + name + ", no " + huntName
+            var pTo = found.GetParameters();
+
+            for (int i = 0; i < pFrom.Length; i++)
+            {
+                Assert.Equal(pFrom[i].Name, pTo[i].Name); // method.Name + ":" + pFrom[i].Name
+                Assert.Equal(pFrom[i].ParameterType, pTo[i].ParameterType); // method.Name + ":" + pFrom[i].Name
+            }
+
+            count++;
+        }
+        Log("Validated: {0} ({1} methods)", from.Name, count);
+    }
+
+    private void CheckMethod(MethodInfo method, bool isAsync)
+    {
+        string shortName = method.Name, fullName = method.DeclaringType?.Name + "." + shortName;
+
+        switch (shortName)
+        {
+            case nameof(IDatabaseAsync.IsConnected):
+                return;
+            case nameof(IDatabase.CreateBatch):
+            case nameof(IDatabase.CreateTransaction):
+            case nameof(IDatabase.IdentifyEndpoint):
+            case nameof(IDatabase.Sort):
+            case nameof(IDatabase.SortAndStore):
+            case nameof(IDatabaseAsync.IdentifyEndpointAsync):
+            case nameof(IDatabaseAsync.SortAsync):
+            case nameof(IDatabaseAsync.SortAndStoreAsync):
+                CheckName(method, isAsync);
+                break;
+            default:
+                CheckName(method, isAsync);
+                var isValid = shortName.StartsWith("Debug")
+                    || shortName.StartsWith("Execute")
+                    || shortName.StartsWith("Geo")
+                    || shortName.StartsWith("Hash")
+                    || shortName.StartsWith("HyperLogLog")
+                    || shortName.StartsWith("Key")
+                    || shortName.StartsWith("List")
+                    || shortName.StartsWith("Lock")
+                    || shortName.StartsWith("Publish")
+                    || shortName.StartsWith("Set")
+                    || shortName.StartsWith("Script")
+                    || shortName.StartsWith("SortedSet")
+                    || shortName.StartsWith("String")
+                    || shortName.StartsWith("Stream");
+                Log(fullName + ": " + (isValid ? "valid" : "invalid"));
+                Assert.True(isValid, fullName + ":Prefix");
+                break;
+        }
+
+        Assert.False(shortName.Contains("If"), fullName + ":If"); // should probably be a When option
+
+        var returnType = method.ReturnType ?? typeof(void);
+
+        if (isAsync)
+        {
+            Assert.True(IsAsyncMethod(returnType), fullName + ":Task");
+        }
+        else
+        {
+            Assert.False(IsAsyncMethod(returnType), fullName + ":Task");
+        }
+
+        static bool IsAsyncMethod(Type returnType)
+        {
+            if (returnType == typeof(Task)) return true;
+            if (returnType == typeof(ValueTask)) return true;
+
+            if (returnType.IsGenericType)
+            {
+                var genDef = returnType.GetGenericTypeDefinition();
+                if (genDef == typeof(Task<>)) return true;
+                if (genDef == typeof(ValueTask<>)) return true;
+                if (genDef == typeof(IAsyncEnumerable<>)) return true;
+            }
+
             return false;
         }
+    }
 
-        [Theory]
-        [InlineData(typeof(IDatabase), typeof(IDatabaseAsync))]
-        [InlineData(typeof(IDatabaseAsync), typeof(IDatabase))]
-        public void CheckSyncAsyncMethodsMatch(Type from, Type to)
-        {
-            const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            int count = 0;
-            foreach (var method in from.GetMethods(flags))
-            {
-                if (IgnoreMethodConventions(method)) continue;
-
-                string name = method.Name, huntName;
-
-                if (name.EndsWith("Async")) huntName = name.Substring(0, name.Length - 5);
-                else huntName = name + "Async";
-                var pFrom = method.GetParameters();
-                Type[] args = pFrom.Select(x => x.ParameterType).ToArray();
-                Log("Checking: {0}.{1}", from.Name, method.Name);
-                Assert.Equal(typeof(CommandFlags), args.Last());
-                var found = to.GetMethod(huntName, flags, null, method.CallingConvention, args, null);
-                Assert.NotNull(found); // "Found " + name + ", no " + huntName
-                var pTo = found.GetParameters();
-
-                for (int i = 0; i < pFrom.Length; i++)
-                {
-                    Assert.Equal(pFrom[i].Name, pTo[i].Name); // method.Name + ":" + pFrom[i].Name
-                    Assert.Equal(pFrom[i].ParameterType, pTo[i].ParameterType); // method.Name + ":" + pFrom[i].Name
-                }
-
-                count++;
-            }
-            Log("Validated: {0} ({1} methods)", from.Name, count);
-        }
-
-        private void CheckMethod(MethodInfo method, bool isAsync)
-        {
-            string shortName = method.Name, fullName = method.DeclaringType?.Name + "." + shortName;
-
-            switch (shortName)
-            {
-                case nameof(IDatabaseAsync.IsConnected):
-                    return;
-                case nameof(IDatabase.CreateBatch):
-                case nameof(IDatabase.CreateTransaction):
-                case nameof(IDatabase.IdentifyEndpoint):
-                case nameof(IDatabase.Sort):
-                case nameof(IDatabase.SortAndStore):
-                case nameof(IDatabaseAsync.IdentifyEndpointAsync):
-                case nameof(IDatabaseAsync.SortAsync):
-                case nameof(IDatabaseAsync.SortAndStoreAsync):
-                    CheckName(method, isAsync);
-                    break;
-                default:
-                    CheckName(method, isAsync);
-                    var isValid = shortName.StartsWith("Debug")
-                        || shortName.StartsWith("Execute")
-                        || shortName.StartsWith("Geo")
-                        || shortName.StartsWith("Hash")
-                        || shortName.StartsWith("HyperLogLog")
-                        || shortName.StartsWith("Key")
-                        || shortName.StartsWith("List")
-                        || shortName.StartsWith("Lock")
-                        || shortName.StartsWith("Publish")
-                        || shortName.StartsWith("Set")
-                        || shortName.StartsWith("Script")
-                        || shortName.StartsWith("SortedSet")
-                        || shortName.StartsWith("String")
-                        || shortName.StartsWith("Stream");
-                    Log(fullName + ": " + (isValid ? "valid" : "invalid"));
-                    Assert.True(isValid, fullName + ":Prefix");
-                    break;
-            }
-
-            Assert.False(shortName.Contains("If"), fullName + ":If"); // should probably be a When option
-
-            var returnType = method.ReturnType ?? typeof(void);
-
-            if (isAsync)
-            {
-                Assert.True(IsAsyncMethod(returnType), fullName + ":Task");
-            }
-            else
-            {
-                Assert.False(IsAsyncMethod(returnType), fullName + ":Task");
-            }
-
-            static bool IsAsyncMethod(Type returnType)
-            {
-                if (returnType == typeof(Task)) return true;
-                if (returnType == typeof(ValueTask)) return true;
-
-                if (returnType.IsGenericType)
-                {
-                    var genDef = returnType.GetGenericTypeDefinition();
-                    if (genDef == typeof(Task<>)) return true;
-                    if (genDef == typeof(ValueTask<>)) return true;
-                    if (genDef == typeof(IAsyncEnumerable<>)) return true;
-                }
-
-                return false;
-            }
-        }
-
-        private static void CheckName(MemberInfo member, bool isAsync)
-        {
-            if (isAsync) Assert.True(member.Name.EndsWith("Async"), member.Name + ":Name - end *Async");
-            else Assert.False(member.Name.EndsWith("Async"), member.Name + ":Name - don't end *Async");
-        }
+    private static void CheckName(MemberInfo member, bool isAsync)
+    {
+        if (isAsync) Assert.True(member.Name.EndsWith("Async"), member.Name + ":Name - end *Async");
+        else Assert.False(member.Name.EndsWith("Async"), member.Name + ":Name - don't end *Async");
     }
 }

--- a/tests/StackExchange.Redis.Tests/Parse.cs
+++ b/tests/StackExchange.Redis.Tests/Parse.cs
@@ -6,95 +6,94 @@ using Pipelines.Sockets.Unofficial.Arenas;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class ParseTests : TestBase
 {
-    public class ParseTests : TestBase
+    public ParseTests(ITestOutputHelper output) : base(output) { }
+
+    public static IEnumerable<object[]> GetTestData()
     {
-        public ParseTests(ITestOutputHelper output) : base(output) { }
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPON", 1 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG", 1 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r", 1 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\n", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nP", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPO", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPON", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG\r", 2 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG\r\n", 3 };
+        yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG\r\n$", 3 };
+    }
 
-        public static IEnumerable<object[]> GetTestData()
+    [Theory]
+    [MemberData(nameof(GetTestData))]
+    public void ParseAsSingleChunk(string ascii, int expected)
+    {
+        var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(ascii));
+        using (var arena = new Arena<RawResult>())
         {
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPON", 1 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG", 1 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r", 1 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\n", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nP", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPO", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPON", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG\r", 2 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG\r\n", 3 };
-            yield return new object[] { "$4\r\nPING\r\n$4\r\nPONG\r\n$4\r\nPONG\r\n$", 3 };
+            ProcessMessages(arena, buffer, expected);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetTestData))]
+    public void ParseAsLotsOfChunks(string ascii, int expected)
+    {
+        var bytes = Encoding.ASCII.GetBytes(ascii);
+        FragmentedSegment<byte>? chain = null, tail = null;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            var next = new FragmentedSegment<byte>(i, new ReadOnlyMemory<byte>(bytes, i, 1));
+            if (tail == null)
+            {
+                chain = next;
+            }
+            else
+            {
+                tail.Next = next;
+            }
+            tail = next;
+        }
+        var buffer = new ReadOnlySequence<byte>(chain!, 0, tail!, 1);
+        Assert.Equal(bytes.Length, buffer.Length);
+        using (var arena = new Arena<RawResult>())
+        {
+            ProcessMessages(arena, buffer, expected);
+        }
+    }
+
+    private void ProcessMessages(Arena<RawResult> arena, ReadOnlySequence<byte> buffer, int expected)
+    {
+        Writer.WriteLine($"chain: {buffer.Length}");
+        var reader = new BufferReader(buffer);
+        RawResult result;
+        int found = 0;
+        while (!(result = PhysicalConnection.TryParseResult(arena, buffer, ref reader, false, null, false)).IsNull)
+        {
+            Writer.WriteLine($"{result} - {result.GetString()}");
+            found++;
+        }
+        Assert.Equal(expected, found);
+    }
+
+    private class FragmentedSegment<T> : ReadOnlySequenceSegment<T>
+    {
+        public FragmentedSegment(long runningIndex, ReadOnlyMemory<T> memory)
+        {
+            RunningIndex = runningIndex;
+            Memory = memory;
         }
 
-        [Theory]
-        [MemberData(nameof(GetTestData))]
-        public void ParseAsSingleChunk(string ascii, int expected)
+        public new FragmentedSegment<T>? Next
         {
-            var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(ascii));
-            using (var arena = new Arena<RawResult>())
-            {
-                ProcessMessages(arena, buffer, expected);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(GetTestData))]
-        public void ParseAsLotsOfChunks(string ascii, int expected)
-        {
-            var bytes = Encoding.ASCII.GetBytes(ascii);
-            FragmentedSegment<byte>? chain = null, tail = null;
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                var next = new FragmentedSegment<byte>(i, new ReadOnlyMemory<byte>(bytes, i, 1));
-                if (tail == null)
-                {
-                    chain = next;
-                }
-                else
-                {
-                    tail.Next = next;
-                }
-                tail = next;
-            }
-            var buffer = new ReadOnlySequence<byte>(chain!, 0, tail!, 1);
-            Assert.Equal(bytes.Length, buffer.Length);
-            using (var arena = new Arena<RawResult>())
-            {
-                ProcessMessages(arena, buffer, expected);
-            }
-        }
-
-        private void ProcessMessages(Arena<RawResult> arena, ReadOnlySequence<byte> buffer, int expected)
-        {
-            Writer.WriteLine($"chain: {buffer.Length}");
-            var reader = new BufferReader(buffer);
-            RawResult result;
-            int found = 0;
-            while (!(result = PhysicalConnection.TryParseResult(arena, buffer, ref reader, false, null, false)).IsNull)
-            {
-                Writer.WriteLine($"{result} - {result.GetString()}");
-                found++;
-            }
-            Assert.Equal(expected, found);
-        }
-
-        private class FragmentedSegment<T> : ReadOnlySequenceSegment<T>
-        {
-            public FragmentedSegment(long runningIndex, ReadOnlyMemory<T> memory)
-            {
-                RunningIndex = runningIndex;
-                Memory = memory;
-            }
-
-            public new FragmentedSegment<T>? Next
-            {
-                get => (FragmentedSegment<T>?)base.Next;
-                set => base.Next = value;
-            }
+            get => (FragmentedSegment<T>?)base.Next;
+            set => base.Next = value;
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/Performance.cs
+++ b/tests/StackExchange.Redis.Tests/Performance.cs
@@ -4,129 +4,127 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class Performance : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class Performance : TestBase
+    public Performance(ITestOutputHelper output) : base(output) { }
+
+    [FactLongRunning]
+    public void VerifyPerformanceImprovement()
     {
-        public Performance(ITestOutputHelper output) : base(output) { }
-
-        [FactLongRunning]
-        public void VerifyPerformanceImprovement()
+        int asyncTimer, sync, op = 0, asyncFaF, syncFaF;
+        var key = Me();
+        using (var conn = Create())
         {
-            int asyncTimer, sync, op = 0, asyncFaF, syncFaF;
-            var key = Me();
-            using (var muxer = Create())
+            // do these outside the timings, just to ensure the core methods are JITted etc
+            for (int dbId = 0; dbId < 5; dbId++)
             {
-                // do these outside the timings, just to ensure the core methods are JITted etc
-                for (int db = 0; db < 5; db++)
-                {
-                    muxer.GetDatabase(db).KeyDeleteAsync(key);
-                }
-
-                var timer = Stopwatch.StartNew();
-                for (int i = 0; i < 100; i++)
-                {
-                    // want to test multiplex scenario; test each db, but to make it fair we'll
-                    // do in batches of 10 on each
-                    for (int db = 0; db < 5; db++)
-                    {
-                        var conn = muxer.GetDatabase(db);
-                        for (int j = 0; j < 10; j++)
-                            conn.StringIncrementAsync(key);
-                    }
-                }
-                asyncFaF = (int)timer.ElapsedMilliseconds;
-                var final = new Task<RedisValue>[5];
-                for (int db = 0; db < 5; db++)
-                    final[db] = muxer.GetDatabase(db).StringGetAsync(key);
-                muxer.WaitAll(final);
-                timer.Stop();
-                asyncTimer = (int)timer.ElapsedMilliseconds;
-                Log("async to completion (local): {0}ms", timer.ElapsedMilliseconds);
-                for (int db = 0; db < 5; db++)
-                {
-                    Assert.Equal(1000, (long)final[db].Result); // "async, db:" + db
-                }
+                conn.GetDatabase(dbId).KeyDeleteAsync(key);
             }
 
-            using (var conn = new RedisSharp.Redis(TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort))
+            var timer = Stopwatch.StartNew();
+            for (int i = 0; i < 100; i++)
             {
-                // do these outside the timings, just to ensure the core methods are JITted etc
+                // want to test multiplex scenario; test each db, but to make it fair we'll
+                // do in batches of 10 on each
+                for (int dbId = 0; dbId < 5; dbId++)
+                {
+                    var db = conn.GetDatabase(dbId);
+                    for (int j = 0; j < 10; j++)
+                        db.StringIncrementAsync(key);
+                }
+            }
+            asyncFaF = (int)timer.ElapsedMilliseconds;
+            var final = new Task<RedisValue>[5];
+            for (int db = 0; db < 5; db++)
+                final[db] = conn.GetDatabase(db).StringGetAsync(key);
+            conn.WaitAll(final);
+            timer.Stop();
+            asyncTimer = (int)timer.ElapsedMilliseconds;
+            Log("async to completion (local): {0}ms", timer.ElapsedMilliseconds);
+            for (int db = 0; db < 5; db++)
+            {
+                Assert.Equal(1000, (long)final[db].Result); // "async, db:" + db
+            }
+        }
+
+        using (var conn = new RedisSharp.Redis(TestConfig.Current.PrimaryServer, TestConfig.Current.PrimaryPort))
+        {
+            // do these outside the timings, just to ensure the core methods are JITted etc
+            for (int db = 0; db < 5; db++)
+            {
+                conn.Db = db;
+                conn.Remove(key);
+            }
+
+            var timer = Stopwatch.StartNew();
+            for (int i = 0; i < 100; i++)
+            {
+                // want to test multiplex scenario; test each db, but to make it fair we'll
+                // do in batches of 10 on each
                 for (int db = 0; db < 5; db++)
                 {
                     conn.Db = db;
-                    conn.Remove(key);
-                }
-
-                var timer = Stopwatch.StartNew();
-                for (int i = 0; i < 100; i++)
-                {
-                    // want to test multiplex scenario; test each db, but to make it fair we'll
-                    // do in batches of 10 on each
-                    for (int db = 0; db < 5; db++)
+                    op++;
+                    for (int j = 0; j < 10; j++)
                     {
-                        conn.Db = db;
+                        conn.Increment(key);
                         op++;
-                        for (int j = 0; j < 10; j++)
-                        {
-                            conn.Increment(key);
-                            op++;
-                        }
                     }
                 }
-                syncFaF = (int)timer.ElapsedMilliseconds;
-                string[] final = new string[5];
-                for (int db = 0; db < 5; db++)
-                {
-                    conn.Db = db;
-                    final[db] = Encoding.ASCII.GetString(conn.Get(key));
-                }
-                timer.Stop();
-                sync = (int)timer.ElapsedMilliseconds;
-                Log("sync to completion (local): {0}ms", timer.ElapsedMilliseconds);
-                for (int db = 0; db < 5; db++)
-                {
-                    Assert.Equal("1000", final[db]); // "async, db:" + db
-                }
             }
-            int effectiveAsync = ((10 * asyncTimer) + 3) / 10;
-            int effectiveSync = ((10 * sync) + (op * 3)) / 10;
-            Log("async to completion with assumed 0.3ms LAN latency: " + effectiveAsync);
-            Log("sync to completion with assumed 0.3ms LAN latency: " + effectiveSync);
-            Log("fire-and-forget: {0}ms sync vs {1}ms async ", syncFaF, asyncFaF);
-            Assert.True(effectiveAsync < effectiveSync, "Everything");
-            Assert.True(asyncFaF < syncFaF, "Fire and Forget");
-        }
-
-        [Fact]
-        public async Task BasicStringGetPerf()
-        {
-            using (var conn = Create())
+            syncFaF = (int)timer.ElapsedMilliseconds;
+            string[] final = new string[5];
+            for (int db = 0; db < 5; db++)
             {
-                RedisKey key = Me();
-                var db = conn.GetDatabase();
-                await db.StringSetAsync(key, "some value").ForAwait();
-
-                // this is just to JIT everything before we try testing
-                var syncVal = db.StringGet(key);
-                var asyncVal = await db.StringGetAsync(key).ForAwait();
-
-                var syncTimer = Stopwatch.StartNew();
-                syncVal = db.StringGet(key);
-                syncTimer.Stop();
-
-                var asyncTimer = Stopwatch.StartNew();
-                asyncVal = await db.StringGetAsync(key).ForAwait();
-                asyncTimer.Stop();
-
-                Log($"Sync: {syncTimer.ElapsedMilliseconds}; Async: {asyncTimer.ElapsedMilliseconds}");
-                Assert.Equal("some value", syncVal);
-                Assert.Equal("some value", asyncVal);
-                // let's allow 20% async overhead
-                // But with a floor, since the base can often be zero
-                Assert.True(asyncTimer.ElapsedMilliseconds <= System.Math.Max(syncTimer.ElapsedMilliseconds * 1.2M, 50));
+                conn.Db = db;
+                final[db] = Encoding.ASCII.GetString(conn.Get(key));
+            }
+            timer.Stop();
+            sync = (int)timer.ElapsedMilliseconds;
+            Log("sync to completion (local): {0}ms", timer.ElapsedMilliseconds);
+            for (int db = 0; db < 5; db++)
+            {
+                Assert.Equal("1000", final[db]); // "async, db:" + db
             }
         }
+        int effectiveAsync = ((10 * asyncTimer) + 3) / 10;
+        int effectiveSync = ((10 * sync) + (op * 3)) / 10;
+        Log("async to completion with assumed 0.3ms LAN latency: " + effectiveAsync);
+        Log("sync to completion with assumed 0.3ms LAN latency: " + effectiveSync);
+        Log("fire-and-forget: {0}ms sync vs {1}ms async ", syncFaF, asyncFaF);
+        Assert.True(effectiveAsync < effectiveSync, "Everything");
+        Assert.True(asyncFaF < syncFaF, "Fire and Forget");
+    }
+
+    [Fact]
+    public async Task BasicStringGetPerf()
+    {
+        using var conn = Create();
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        await db.StringSetAsync(key, "some value").ForAwait();
+
+        // this is just to JIT everything before we try testing
+        var syncVal = db.StringGet(key);
+        var asyncVal = await db.StringGetAsync(key).ForAwait();
+
+        var syncTimer = Stopwatch.StartNew();
+        syncVal = db.StringGet(key);
+        syncTimer.Stop();
+
+        var asyncTimer = Stopwatch.StartNew();
+        asyncVal = await db.StringGetAsync(key).ForAwait();
+        asyncTimer.Stop();
+
+        Log($"Sync: {syncTimer.ElapsedMilliseconds}; Async: {asyncTimer.ElapsedMilliseconds}");
+        Assert.Equal("some value", syncVal);
+        Assert.Equal("some value", asyncVal);
+        // let's allow 20% async overhead
+        // But with a floor, since the base can often be zero
+        Assert.True(asyncTimer.ElapsedMilliseconds <= System.Math.Max(syncTimer.ElapsedMilliseconds * 1.2M, 50));
     }
 }

--- a/tests/StackExchange.Redis.Tests/PreserveOrder.cs
+++ b/tests/StackExchange.Redis.Tests/PreserveOrder.cs
@@ -5,65 +5,63 @@ using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class PreserveOrder : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class PreserveOrder : TestBase
+    public PreserveOrder(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public void Execute()
     {
-        public PreserveOrder(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void Execute()
+        var sub = conn.GetSubscriber();
+        var channel = Me();
+        var received = new List<int>();
+        Log("Subscribing...");
+        const int COUNT = 500;
+        sub.Subscribe(channel, (_, message) =>
         {
-            using (var conn = Create())
+            lock (received)
             {
-                var sub = conn.GetSubscriber();
-                var channel = Me();
-                var received = new List<int>();
-                Log("Subscribing...");
-                const int COUNT = 500;
-                sub.Subscribe(channel, (_, message) =>
-                {
-                    lock (received)
-                    {
-                        received.Add((int)message);
-                        if (received.Count == COUNT)
-                            Monitor.PulseAll(received); // wake the test rig
-                    }
-                });
-                Log("");
-                Log("Sending (any order)...");
-                lock (received)
-                {
-                    received.Clear();
-                    // we'll also use received as a wait-detection mechanism; sneaky
-
-                    // note: this does not do any cheating;
-                    // it all goes to the server and back
-                    for (int i = 0; i < COUNT; i++)
-                    {
-                        sub.Publish(channel, i, CommandFlags.FireAndForget);
-                    }
-
-                    Log("Allowing time for delivery etc...");
-                    var watch = Stopwatch.StartNew();
-                    if (!Monitor.Wait(received, 10000))
-                    {
-                        Log("Timed out; expect less data");
-                    }
-                    watch.Stop();
-                    Log("Checking...");
-                    lock (received)
-                    {
-                        Log("Received: {0} in {1}ms", received.Count, watch.ElapsedMilliseconds);
-                        int wrongOrder = 0;
-                        for (int i = 0; i < Math.Min(COUNT, received.Count); i++)
-                        {
-                            if (received[i] != i) wrongOrder++;
-                        }
-                        Log("Out of order: " + wrongOrder);
-                    }
+                received.Add((int)message);
+                if (received.Count == COUNT)
+                    Monitor.PulseAll(received); // wake the test rig
                 }
+        });
+        Log("");
+        Log("Sending (any order)...");
+        lock (received)
+        {
+            received.Clear();
+            // we'll also use received as a wait-detection mechanism; sneaky
+
+            // note: this does not do any cheating;
+            // it all goes to the server and back
+            for (int i = 0; i < COUNT; i++)
+            {
+                sub.Publish(channel, i, CommandFlags.FireAndForget);
+            }
+
+            Log("Allowing time for delivery etc...");
+            var watch = Stopwatch.StartNew();
+            if (!Monitor.Wait(received, 10000))
+            {
+                Log("Timed out; expect less data");
+            }
+            watch.Stop();
+            Log("Checking...");
+            lock (received)
+            {
+                Log("Received: {0} in {1}ms", received.Count, watch.ElapsedMilliseconds);
+                int wrongOrder = 0;
+                for (int i = 0; i < Math.Min(COUNT, received.Count); i++)
+                {
+                    if (received[i] != i) wrongOrder++;
+                }
+                Log("Out of order: " + wrongOrder);
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/Profiling.cs
+++ b/tests/StackExchange.Redis.Tests/Profiling.cs
@@ -8,413 +8,401 @@ using Xunit;
 using Xunit.Abstractions;
 using StackExchange.Redis.Profiling;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class Profiling : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class Profiling : TestBase
+    public Profiling(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void Simple()
     {
-        public Profiling(ITestOutputHelper output) : base(output) { }
+        using var conn = Create();
 
-        [Fact]
-        public void Simple()
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        var script = LuaScript.Prepare("return redis.call('get', @key)");
+        var loaded = script.Load(server);
+        var key = Me();
+
+        var session = new ProfilingSession();
+
+        conn.RegisterProfiler(() => session);
+
+        var dbId = TestConfig.GetDedicatedDB();
+        var db = conn.GetDatabase(dbId);
+        db.StringSet(key, "world");
+        var result = db.ScriptEvaluate(script, new { key = (RedisKey)key });
+        Assert.NotNull(result);
+        Assert.Equal("world", result.AsString());
+        var loadedResult = db.ScriptEvaluate(loaded, new { key = (RedisKey)key });
+        Assert.NotNull(loadedResult);
+        Assert.Equal("world", loadedResult.AsString());
+        var val = db.StringGet(key);
+        Assert.Equal("world", val);
+        var s = (string?)db.Execute("ECHO", "fii");
+        Assert.Equal("fii", s);
+
+        var cmds = session.FinishProfiling();
+        var i = 0;
+        foreach (var cmd in cmds)
         {
-            using (var conn = Create())
+            Log("Command {0} (DB: {1}): {2}", i++, cmd.Db, cmd?.ToString()?.Replace("\n", ", "));
+        }
+
+        var all = string.Join(",", cmds.Select(x => x.Command));
+        Assert.Equal("SET,EVAL,EVALSHA,GET,ECHO", all);
+        Log("Checking for SET");
+        var set = cmds.SingleOrDefault(cmd => cmd.Command == "SET");
+        Assert.NotNull(set);
+        Log("Checking for GET");
+        var get = cmds.SingleOrDefault(cmd => cmd.Command == "GET");
+        Assert.NotNull(get);
+        Log("Checking for EVAL");
+        var eval = cmds.SingleOrDefault(cmd => cmd.Command == "EVAL");
+        Assert.NotNull(eval);
+        Log("Checking for EVALSHA");
+        var evalSha = cmds.SingleOrDefault(cmd => cmd.Command == "EVALSHA");
+        Assert.NotNull(evalSha);
+        Log("Checking for ECHO");
+        var echo = cmds.SingleOrDefault(cmd => cmd.Command == "ECHO");
+        Assert.NotNull(echo);
+
+        Assert.Equal(5, cmds.Count());
+
+        Assert.True(set.CommandCreated <= eval.CommandCreated);
+        Assert.True(eval.CommandCreated <= evalSha.CommandCreated);
+        Assert.True(evalSha.CommandCreated <= get.CommandCreated);
+
+        AssertProfiledCommandValues(set, conn, dbId);
+
+        AssertProfiledCommandValues(get, conn, dbId);
+
+        AssertProfiledCommandValues(eval, conn, dbId);
+
+        AssertProfiledCommandValues(evalSha, conn, dbId);
+
+        AssertProfiledCommandValues(echo, conn, dbId);
+    }
+
+    private static void AssertProfiledCommandValues(IProfiledCommand command, IConnectionMultiplexer conn, int dbId)
+    {
+        Assert.Equal(dbId, command.Db);
+        Assert.Equal(conn.GetEndPoints()[0], command.EndPoint);
+        Assert.True(command.CreationToEnqueued > TimeSpan.Zero, nameof(command.CreationToEnqueued));
+        Assert.True(command.EnqueuedToSending > TimeSpan.Zero, nameof(command.EnqueuedToSending));
+        Assert.True(command.SentToResponse > TimeSpan.Zero, nameof(command.SentToResponse));
+        Assert.True(command.ResponseToCompletion >= TimeSpan.Zero, nameof(command.ResponseToCompletion));
+        Assert.True(command.ElapsedTime > TimeSpan.Zero, nameof(command.ElapsedTime));
+        Assert.True(command.ElapsedTime > command.CreationToEnqueued && command.ElapsedTime > command.EnqueuedToSending && command.ElapsedTime > command.SentToResponse, "Comparisons");
+        Assert.True(command.RetransmissionOf == null, nameof(command.RetransmissionOf));
+        Assert.True(command.RetransmissionReason == null, nameof(command.RetransmissionReason));
+    }
+
+    [FactLongRunning]
+    public void ManyThreads()
+    {
+        using var conn = Create();
+
+        var session = new ProfilingSession();
+        var prefix = Me();
+
+        conn.RegisterProfiler(() => session);
+
+        var threads = new List<Thread>();
+        const int CountPer = 100;
+        for (var i = 1; i <= 16; i++)
+        {
+            var db = conn.GetDatabase(i);
+
+            threads.Add(new Thread(() =>
             {
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                var script = LuaScript.Prepare("return redis.call('get', @key)");
-                var loaded = script.Load(server);
-                var key = Me();
+                var threadTasks = new List<Task>();
 
-                var session = new ProfilingSession();
-
-                conn.RegisterProfiler(() => session);
-
-                var dbId = TestConfig.GetDedicatedDB();
-                var db = conn.GetDatabase(dbId);
-                db.StringSet(key, "world");
-                var result = db.ScriptEvaluate(script, new { key = (RedisKey)key });
-                Assert.NotNull(result);
-                Assert.Equal("world", result.AsString());
-                var loadedResult = db.ScriptEvaluate(loaded, new { key = (RedisKey)key });
-                Assert.NotNull(loadedResult);
-                Assert.Equal("world", loadedResult.AsString());
-                var val = db.StringGet(key);
-                Assert.Equal("world", val);
-                var s = (string?)db.Execute("ECHO", "fii");
-                Assert.Equal("fii", s);
-
-                var cmds = session.FinishProfiling();
-                var i = 0;
-                foreach (var cmd in cmds)
+                for (var j = 0; j < CountPer; j++)
                 {
-                    Log("Command {0} (DB: {1}): {2}", i++, cmd.Db, cmd?.ToString()?.Replace("\n", ", "));
+                    var task = db.StringSetAsync(prefix + j, "" + j);
+                    threadTasks.Add(task);
                 }
 
-                var all = string.Join(",", cmds.Select(x => x.Command));
-                Assert.Equal("SET,EVAL,EVALSHA,GET,ECHO", all);
-                Log("Checking for SET");
-                var set = cmds.SingleOrDefault(cmd => cmd.Command == "SET");
-                Assert.NotNull(set);
-                Log("Checking for GET");
-                var get = cmds.SingleOrDefault(cmd => cmd.Command == "GET");
-                Assert.NotNull(get);
-                Log("Checking for EVAL");
-                var eval = cmds.SingleOrDefault(cmd => cmd.Command == "EVAL");
-                Assert.NotNull(eval);
-                Log("Checking for EVALSHA");
-                var evalSha = cmds.SingleOrDefault(cmd => cmd.Command == "EVALSHA");
-                Assert.NotNull(evalSha);
-                Log("Checking for ECHO");
-                var echo = cmds.SingleOrDefault(cmd => cmd.Command == "ECHO");
-                Assert.NotNull(echo);
-
-                Assert.Equal(5, cmds.Count());
-
-                Assert.True(set.CommandCreated <= eval.CommandCreated);
-                Assert.True(eval.CommandCreated <= evalSha.CommandCreated);
-                Assert.True(evalSha.CommandCreated <= get.CommandCreated);
-
-                AssertProfiledCommandValues(set, conn, dbId);
-
-                AssertProfiledCommandValues(get, conn, dbId);
-
-                AssertProfiledCommandValues(eval, conn, dbId);
-
-                AssertProfiledCommandValues(evalSha, conn, dbId);
-
-                AssertProfiledCommandValues(echo, conn, dbId);
-            }
+                Task.WaitAll(threadTasks.ToArray());
+            }));
         }
 
-        private static void AssertProfiledCommandValues(IProfiledCommand command, IConnectionMultiplexer conn, int dbId)
+        threads.ForEach(thread => thread.Start());
+        threads.ForEach(thread => thread.Join());
+
+        var allVals = session.FinishProfiling();
+        var relevant = allVals.Where(cmd => cmd.Db > 0).ToList();
+
+        var kinds = relevant.Select(cmd => cmd.Command).Distinct().ToList();
+        foreach (var k in kinds)
         {
-            Assert.Equal(dbId, command.Db);
-            Assert.Equal(conn.GetEndPoints()[0], command.EndPoint);
-            Assert.True(command.CreationToEnqueued > TimeSpan.Zero, nameof(command.CreationToEnqueued));
-            Assert.True(command.EnqueuedToSending > TimeSpan.Zero, nameof(command.EnqueuedToSending));
-            Assert.True(command.SentToResponse > TimeSpan.Zero, nameof(command.SentToResponse));
-            Assert.True(command.ResponseToCompletion >= TimeSpan.Zero, nameof(command.ResponseToCompletion));
-            Assert.True(command.ElapsedTime > TimeSpan.Zero, nameof(command.ElapsedTime));
-            Assert.True(command.ElapsedTime > command.CreationToEnqueued && command.ElapsedTime > command.EnqueuedToSending && command.ElapsedTime > command.SentToResponse, "Comparisons");
-            Assert.True(command.RetransmissionOf == null, nameof(command.RetransmissionOf));
-            Assert.True(command.RetransmissionReason == null, nameof(command.RetransmissionReason));
+            Log("Kind Seen: " + k);
+        }
+        Assert.True(kinds.Count <= 2);
+        Assert.Contains("SET", kinds);
+        if (kinds.Count == 2 && !kinds.Contains("SELECT") && !kinds.Contains("GET"))
+        {
+            Assert.True(false, "Non-SET, Non-SELECT, Non-GET command seen");
         }
 
-        [FactLongRunning]
-        public void ManyThreads()
+        Assert.Equal(16 * CountPer, relevant.Count);
+        Assert.Equal(16, relevant.Select(cmd => cmd.Db).Distinct().Count());
+
+        for (var i = 1; i <= 16; i++)
         {
-            using (var conn = Create())
+            var setsInDb = relevant.Count(cmd => cmd.Db == i);
+            Assert.Equal(CountPer, setsInDb);
+        }
+    }
+
+    [FactLongRunning]
+    public void ManyContexts()
+    {
+        using var conn = Create();
+
+        var profiler = new AsyncLocalProfiler();
+        var prefix = Me();
+        conn.RegisterProfiler(profiler.GetSession);
+
+        var tasks = new Task[16];
+
+        var results = new ProfiledCommandEnumerable[tasks.Length];
+
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            var ix = i;
+            tasks[ix] = Task.Run(async () =>
             {
-                var session = new ProfilingSession();
-                var prefix = Me();
+                var db = conn.GetDatabase(ix);
 
-                conn.RegisterProfiler(() => session);
+                var allTasks = new List<Task>();
 
-                var threads = new List<Thread>();
-                const int CountPer = 100;
-                for (var i = 1; i <= 16; i++)
+                for (var j = 0; j < 1000; j++)
                 {
-                    var db = conn.GetDatabase(i);
-
-                    threads.Add(new Thread(() =>
-                    {
-                        var threadTasks = new List<Task>();
-
-                        for (var j = 0; j < CountPer; j++)
-                        {
-                            var task = db.StringSetAsync(prefix + j, "" + j);
-                            threadTasks.Add(task);
-                        }
-
-                        Task.WaitAll(threadTasks.ToArray());
-                    }));
+                    var g = db.StringGetAsync(prefix + ix);
+                    var s = db.StringSetAsync(prefix + ix, "world" + ix);
+                        // overlap the g+s, just for fun
+                        await g;
+                    await s;
                 }
 
-                threads.ForEach(thread => thread.Start());
-                threads.ForEach(thread => thread.Join());
-
-                var allVals = session.FinishProfiling();
-                var relevant = allVals.Where(cmd => cmd.Db > 0).ToList();
-
-                var kinds = relevant.Select(cmd => cmd.Command).Distinct().ToList();
-                foreach (var k in kinds)
-                {
-                    Log("Kind Seen: " + k);
-                }
-                Assert.True(kinds.Count <= 2);
-                Assert.Contains("SET", kinds);
-                if (kinds.Count == 2 && !kinds.Contains("SELECT") && !kinds.Contains("GET"))
-                {
-                    Assert.True(false, "Non-SET, Non-SELECT, Non-GET command seen");
-                }
-
-                Assert.Equal(16 * CountPer, relevant.Count);
-                Assert.Equal(16, relevant.Select(cmd => cmd.Db).Distinct().Count());
-
-                for (var i = 1; i <= 16; i++)
-                {
-                    var setsInDb = relevant.Count(cmd => cmd.Db == i);
-                    Assert.Equal(CountPer, setsInDb);
-                }
-            }
+                results[ix] = profiler.GetSession().FinishProfiling();
+            });
         }
+        Task.WhenAll(tasks).Wait();
 
-        [FactLongRunning]
-        public void ManyContexts()
+        for (var i = 0; i < results.Length; i++)
         {
-            using (var conn = Create())
+            var res = results[i];
+
+            var numGets = res.Count(r => r.Command == "GET");
+            var numSets = res.Count(r => r.Command == "SET");
+
+            Assert.Equal(1000, numGets);
+            Assert.Equal(1000, numSets);
+            Assert.True(res.All(cmd => cmd.Db == i));
+        }
+    }
+
+    internal class PerThreadProfiler
+    {
+        private readonly ThreadLocal<ProfilingSession> perThreadSession = new ThreadLocal<ProfilingSession>(() => new ProfilingSession());
+
+        public ProfilingSession GetSession() => perThreadSession.Value!;
+    }
+
+    internal class AsyncLocalProfiler
+    {
+        private readonly AsyncLocal<ProfilingSession> perThreadSession = new AsyncLocal<ProfilingSession>();
+
+        public ProfilingSession GetSession()
+        {
+            var val = perThreadSession.Value;
+            if (val == null)
             {
-                var profiler = new AsyncLocalProfiler();
-                var prefix = Me();
-                conn.RegisterProfiler(profiler.GetSession);
-
-                var tasks = new Task[16];
-
-                var results = new ProfiledCommandEnumerable[tasks.Length];
-
-                for (var i = 0; i < tasks.Length; i++)
-                {
-                    var ix = i;
-                    tasks[ix] = Task.Run(async () =>
-                    {
-                        var db = conn.GetDatabase(ix);
-
-                        var allTasks = new List<Task>();
-
-                        for (var j = 0; j < 1000; j++)
-                        {
-                            var g = db.StringGetAsync(prefix + ix);
-                            var s = db.StringSetAsync(prefix + ix, "world" + ix);
-                            // overlap the g+s, just for fun
-                            await g;
-                            await s;
-                        }
-
-                        results[ix] = profiler.GetSession().FinishProfiling();
-                    });
-                }
-                Task.WhenAll(tasks).Wait();
-
-                for (var i = 0; i < results.Length; i++)
-                {
-                    var res = results[i];
-
-                    var numGets = res.Count(r => r.Command == "GET");
-                    var numSets = res.Count(r => r.Command == "SET");
-
-                    Assert.Equal(1000, numGets);
-                    Assert.Equal(1000, numSets);
-                    Assert.True(res.All(cmd => cmd.Db == i));
-                }
+                perThreadSession.Value = val = new ProfilingSession();
             }
+            return val;
+        }
+    }
+
+    [Fact]
+    public void LowAllocationEnumerable()
+    {
+        using var conn = Create();
+
+        const int OuterLoop = 1000;
+        var session = new ProfilingSession();
+        conn.RegisterProfiler(() => session);
+
+        var prefix = Me();
+        var db = conn.GetDatabase(1);
+
+        var allTasks = new List<Task<string?>>();
+
+        foreach (var i in Enumerable.Range(0, OuterLoop))
+        {
+            var t =
+                db.StringSetAsync(prefix + i, "bar" + i)
+                  .ContinueWith(
+                    async _ => (string?)(await db.StringGetAsync(prefix + i).ForAwait())
+                  );
+
+            var finalResult = t.Unwrap();
+            allTasks.Add(finalResult);
         }
 
-        internal class PerThreadProfiler
-        {
-            private readonly ThreadLocal<ProfilingSession> perThreadSession = new ThreadLocal<ProfilingSession>(() => new ProfilingSession());
+        conn.WaitAll(allTasks.ToArray());
 
-            public ProfilingSession GetSession() => perThreadSession.Value!;
+        var res = session.FinishProfiling();
+        Assert.True(res.GetType().IsValueType);
+
+        using (var e = res.GetEnumerator())
+        {
+            Assert.True(e.GetType().IsValueType);
+
+            Assert.True(e.MoveNext());
+            var i = e.Current;
+
+            e.Reset();
+            Assert.True(e.MoveNext());
+            var j = e.Current;
+
+            Assert.True(ReferenceEquals(i, j));
         }
 
-        internal class AsyncLocalProfiler
-        {
-            private readonly AsyncLocal<ProfilingSession> perThreadSession = new AsyncLocal<ProfilingSession>();
+        Assert.Equal(OuterLoop, res.Count(r => r.Command == "GET" && r.Db > 0));
+        Assert.Equal(OuterLoop, res.Count(r => r.Command == "SET" && r.Db > 0));
+        Assert.Equal(OuterLoop * 2, res.Count(r => r.Db > 0));
+    }
 
-            public ProfilingSession GetSession()
+    [FactLongRunning]
+    public void ProfilingMD_Ex1()
+    {
+        using var conn = Create();
+
+        var session = new ProfilingSession();
+        var prefix = Me();
+
+        conn.RegisterProfiler(() => session);
+
+        var threads = new List<Thread>();
+
+        for (var i = 0; i < 16; i++)
+        {
+            var db = conn.GetDatabase(i);
+
+            var thread = new Thread(() =>
             {
-                var val = perThreadSession.Value;
-                if (val == null)
+                var threadTasks = new List<Task>();
+
+                for (var j = 0; j < 1000; j++)
                 {
-                    perThreadSession.Value = val = new ProfilingSession();
+                    var task = db.StringSetAsync(prefix + j, "" + j);
+                    threadTasks.Add(task);
                 }
-                return val;
-            }
+
+                Task.WaitAll(threadTasks.ToArray());
+            });
+
+            threads.Add(thread);
         }
 
-        [Fact]
-        public void LowAllocationEnumerable()
+        threads.ForEach(thread => thread.Start());
+        threads.ForEach(thread => thread.Join());
+
+        IEnumerable<IProfiledCommand> timings = session.FinishProfiling();
+
+        Assert.Equal(16000, timings.Count());
+    }
+
+    [FactLongRunning]
+    public void ProfilingMD_Ex2()
+    {
+        using var conn = Create();
+
+        var profiler = new PerThreadProfiler();
+        var prefix = Me();
+
+        conn.RegisterProfiler(profiler.GetSession);
+
+        var threads = new List<Thread>();
+
+        var perThreadTimings = new ConcurrentDictionary<Thread, List<IProfiledCommand>>();
+
+        for (var i = 0; i < 16; i++)
         {
-            const int OuterLoop = 1000;
+            var db = conn.GetDatabase(i);
 
-            using (var conn = Create())
+            var thread = new Thread(() =>
             {
-                var session = new ProfilingSession();
-                conn.RegisterProfiler(() => session);
+                var threadTasks = new List<Task>();
 
-                var prefix = Me();
-                var db = conn.GetDatabase(1);
-
-                var allTasks = new List<Task<string?>>();
-
-                foreach (var i in Enumerable.Range(0, OuterLoop))
+                for (var j = 0; j < 1000; j++)
                 {
-                    var t =
-                        db.StringSetAsync(prefix + i, "bar" + i)
-                          .ContinueWith(
-                            async _ => (string?)(await db.StringGetAsync(prefix + i).ForAwait())
-                          );
-
-                    var finalResult = t.Unwrap();
-                    allTasks.Add(finalResult);
+                    var task = db.StringSetAsync(prefix + j, "" + j);
+                    threadTasks.Add(task);
                 }
 
-                conn.WaitAll(allTasks.ToArray());
+                Task.WaitAll(threadTasks.ToArray());
 
-                var res = session.FinishProfiling();
-                Assert.True(res.GetType().IsValueType);
+                perThreadTimings[Thread.CurrentThread] = profiler.GetSession().FinishProfiling().ToList();
+            });
 
-                using (var e = res.GetEnumerator())
-                {
-                    Assert.True(e.GetType().IsValueType);
-
-                    Assert.True(e.MoveNext());
-                    var i = e.Current;
-
-                    e.Reset();
-                    Assert.True(e.MoveNext());
-                    var j = e.Current;
-
-                    Assert.True(ReferenceEquals(i, j));
-                }
-
-                Assert.Equal(OuterLoop, res.Count(r => r.Command == "GET" && r.Db > 0));
-                Assert.Equal(OuterLoop, res.Count(r => r.Command == "SET" && r.Db > 0));
-                Assert.Equal(OuterLoop * 2, res.Count(r => r.Db > 0));
-            }
+            threads.Add(thread);
         }
 
-        [FactLongRunning]
-        public void ProfilingMD_Ex1()
+        threads.ForEach(thread => thread.Start());
+        threads.ForEach(thread => thread.Join());
+
+        Assert.Equal(16, perThreadTimings.Count);
+        Assert.True(perThreadTimings.All(kv => kv.Value.Count == 1000));
+    }
+
+    [FactLongRunning]
+    public async Task ProfilingMD_Ex2_Async()
+    {
+        using var conn = Create();
+
+        var profiler = new AsyncLocalProfiler();
+        var prefix = Me();
+
+        conn.RegisterProfiler(profiler.GetSession);
+
+        var tasks = new List<Task>();
+
+        var perThreadTimings = new ConcurrentBag<List<IProfiledCommand>>();
+
+        for (var i = 0; i < 16; i++)
         {
-            using (var c = Create())
+            var db = conn.GetDatabase(i);
+
+            var task = Task.Run(async () =>
             {
-                IConnectionMultiplexer conn = c;
-                var session = new ProfilingSession();
-                var prefix = Me();
-
-                conn.RegisterProfiler(() => session);
-
-                var threads = new List<Thread>();
-
-                for (var i = 0; i < 16; i++)
+                for (var j = 0; j < 100; j++)
                 {
-                    var db = conn.GetDatabase(i);
-
-                    var thread = new Thread(() =>
-                    {
-                        var threadTasks = new List<Task>();
-
-                        for (var j = 0; j < 1000; j++)
-                        {
-                            var task = db.StringSetAsync(prefix + j, "" + j);
-                            threadTasks.Add(task);
-                        }
-
-                        Task.WaitAll(threadTasks.ToArray());
-                    });
-
-                    threads.Add(thread);
+                    await db.StringSetAsync(prefix + j, "" + j).ForAwait();
                 }
 
-                threads.ForEach(thread => thread.Start());
-                threads.ForEach(thread => thread.Join());
+                perThreadTimings.Add(profiler.GetSession().FinishProfiling().ToList());
+            });
 
-                IEnumerable<IProfiledCommand> timings = session.FinishProfiling();
-
-                Assert.Equal(16000, timings.Count());
-            }
+            tasks.Add(task);
         }
 
-        [FactLongRunning]
-        public void ProfilingMD_Ex2()
+        var timeout = Task.Delay(10000);
+        var complete = Task.WhenAll(tasks);
+        if (timeout == await Task.WhenAny(timeout, complete).ForAwait())
         {
-            using (var c = Create())
-            {
-                IConnectionMultiplexer conn = c;
-                var profiler = new PerThreadProfiler();
-                var prefix = Me();
-
-                conn.RegisterProfiler(profiler.GetSession);
-
-                var threads = new List<Thread>();
-
-                var perThreadTimings = new ConcurrentDictionary<Thread, List<IProfiledCommand>>();
-
-                for (var i = 0; i < 16; i++)
-                {
-                    var db = conn.GetDatabase(i);
-
-                    var thread = new Thread(() =>
-                    {
-                        var threadTasks = new List<Task>();
-
-                        for (var j = 0; j < 1000; j++)
-                        {
-                            var task = db.StringSetAsync(prefix + j, "" + j);
-                            threadTasks.Add(task);
-                        }
-
-                        Task.WaitAll(threadTasks.ToArray());
-
-                        perThreadTimings[Thread.CurrentThread] = profiler.GetSession().FinishProfiling().ToList();
-                    });
-
-                    threads.Add(thread);
-                }
-
-                threads.ForEach(thread => thread.Start());
-                threads.ForEach(thread => thread.Join());
-
-                Assert.Equal(16, perThreadTimings.Count);
-                Assert.True(perThreadTimings.All(kv => kv.Value.Count == 1000));
-            }
+            throw new TimeoutException();
         }
 
-        [FactLongRunning]
-        public async Task ProfilingMD_Ex2_Async()
+        Assert.Equal(16, perThreadTimings.Count);
+        foreach (var item in perThreadTimings)
         {
-            using (var c = Create())
-            {
-                IConnectionMultiplexer conn = c;
-                var profiler = new AsyncLocalProfiler();
-                var prefix = Me();
-
-                conn.RegisterProfiler(profiler.GetSession);
-
-                var tasks = new List<Task>();
-
-                var perThreadTimings = new ConcurrentBag<List<IProfiledCommand>>();
-
-                for (var i = 0; i < 16; i++)
-                {
-                    var db = conn.GetDatabase(i);
-
-                    var task = Task.Run(async () =>
-                    {
-                        for (var j = 0; j < 100; j++)
-                        {
-                            await db.StringSetAsync(prefix + j, "" + j).ForAwait();
-                        }
-
-                        perThreadTimings.Add(profiler.GetSession().FinishProfiling().ToList());
-                    });
-
-                    tasks.Add(task);
-                }
-
-                var timeout = Task.Delay(10000);
-                var complete = Task.WhenAll(tasks);
-                if (timeout == await Task.WhenAny(timeout, complete).ForAwait())
-                {
-                    throw new TimeoutException();
-                }
-
-                Assert.Equal(16, perThreadTimings.Count);
-                foreach (var item in perThreadTimings)
-                {
-                    Assert.Equal(100, item.Count);
-                }
-            }
+            Assert.Equal(100, item.Count);
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -10,854 +10,839 @@ using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable AccessToModifiedClosure
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class PubSub : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class PubSub : TestBase
+    public PubSub(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public async Task ExplicitPublishMode()
     {
-        public PubSub(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create(channelPrefix: "foo:", log: Writer);
 
-        [Fact]
-        public async Task ExplicitPublishMode()
+        var pub = conn.GetSubscriber();
+        int a = 0, b = 0, c = 0, d = 0;
+        pub.Subscribe(new RedisChannel("*bcd", RedisChannel.PatternMode.Literal), (x, y) => Interlocked.Increment(ref a));
+        pub.Subscribe(new RedisChannel("a*cd", RedisChannel.PatternMode.Pattern), (x, y) => Interlocked.Increment(ref b));
+        pub.Subscribe(new RedisChannel("ab*d", RedisChannel.PatternMode.Auto), (x, y) => Interlocked.Increment(ref c));
+        pub.Subscribe("abc*", (x, y) => Interlocked.Increment(ref d));
+
+        pub.Publish("abcd", "efg");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10),
+            () => Thread.VolatileRead(ref b) == 1
+               && Thread.VolatileRead(ref c) == 1
+               && Thread.VolatileRead(ref d) == 1);
+        Assert.Equal(0, Thread.VolatileRead(ref a));
+        Assert.Equal(1, Thread.VolatileRead(ref b));
+        Assert.Equal(1, Thread.VolatileRead(ref c));
+        Assert.Equal(1, Thread.VolatileRead(ref d));
+
+        pub.Publish("*bcd", "efg");
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => Thread.VolatileRead(ref a) == 1);
+        Assert.Equal(1, Thread.VolatileRead(ref a));
+    }
+
+    [Theory]
+    [InlineData(null, false, "a")]
+    [InlineData("", false, "b")]
+    [InlineData("Foo:", false, "c")]
+    [InlineData(null, true, "d")]
+    [InlineData("", true, "e")]
+    [InlineData("Foo:", true, "f")]
+    public async Task TestBasicPubSub(string channelPrefix, bool wildCard, string breaker)
+    {
+        using var conn = Create(channelPrefix: channelPrefix, shared: false, log: Writer);
+
+        var pub = GetAnyPrimary(conn);
+        var sub = conn.GetSubscriber();
+        await PingAsync(pub, sub).ForAwait();
+        HashSet<string?> received = new();
+        int secondHandler = 0;
+        string subChannel = (wildCard ? "a*c" : "abc") + breaker;
+        string pubChannel = "abc" + breaker;
+        Action<RedisChannel, RedisValue> handler1 = (channel, payload) =>
         {
-            using (var mx = Create(channelPrefix: "foo:", log: Writer))
+            lock (received)
             {
-                var pub = mx.GetSubscriber();
-                int a = 0, b = 0, c = 0, d = 0;
-                pub.Subscribe(new RedisChannel("*bcd", RedisChannel.PatternMode.Literal), (x, y) => Interlocked.Increment(ref a));
-                pub.Subscribe(new RedisChannel("a*cd", RedisChannel.PatternMode.Pattern), (x, y) => Interlocked.Increment(ref b));
-                pub.Subscribe(new RedisChannel("ab*d", RedisChannel.PatternMode.Auto), (x, y) => Interlocked.Increment(ref c));
-                pub.Subscribe("abc*", (x, y) => Interlocked.Increment(ref d));
-
-                pub.Publish("abcd", "efg");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10),
-                    () => Thread.VolatileRead(ref b) == 1
-                       && Thread.VolatileRead(ref c) == 1
-                       && Thread.VolatileRead(ref d) == 1);
-                Assert.Equal(0, Thread.VolatileRead(ref a));
-                Assert.Equal(1, Thread.VolatileRead(ref b));
-                Assert.Equal(1, Thread.VolatileRead(ref c));
-                Assert.Equal(1, Thread.VolatileRead(ref d));
-
-                pub.Publish("*bcd", "efg");
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => Thread.VolatileRead(ref a) == 1);
-                Assert.Equal(1, Thread.VolatileRead(ref a));
-            }
-        }
-
-        [Theory]
-        [InlineData(null, false, "a")]
-        [InlineData("", false, "b")]
-        [InlineData("Foo:", false, "c")]
-        [InlineData(null, true, "d")]
-        [InlineData("", true, "e")]
-        [InlineData("Foo:", true, "f")]
-        public async Task TestBasicPubSub(string channelPrefix, bool wildCard, string breaker)
-        {
-            using (var muxer = Create(channelPrefix: channelPrefix, shared: false, log: Writer))
-            {
-                var pub = GetAnyPrimary(muxer);
-                var sub = muxer.GetSubscriber();
-                await PingAsync(pub, sub).ForAwait();
-                HashSet<string?> received = new();
-                int secondHandler = 0;
-                string subChannel = (wildCard ? "a*c" : "abc") + breaker;
-                string pubChannel = "abc" + breaker;
-                Action<RedisChannel, RedisValue> handler1 = (channel, payload) =>
+                if (channel == pubChannel)
                 {
-                    lock (received)
-                    {
-                        if (channel == pubChannel)
-                        {
-                            received.Add(payload);
-                        }
-                        else
-                        {
-                            Log(channel);
-                        }
-                    }
+                    received.Add(payload);
                 }
-                , handler2 = (_, __) => Interlocked.Increment(ref secondHandler);
-                sub.Subscribe(subChannel, handler1);
-                sub.Subscribe(subChannel, handler2);
-
-                lock (received)
+                else
                 {
-                    Assert.Empty(received);
-                }
-                Assert.Equal(0, Thread.VolatileRead(ref secondHandler));
-                var count = sub.Publish(pubChannel, "def");
-
-                await PingAsync(pub, sub, 3).ForAwait();
-
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => received.Count == 1);
-                lock (received)
-                {
-                    Assert.Single(received);
-                }
-                // Give handler firing a moment
-                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Thread.VolatileRead(ref secondHandler) == 1);
-                Assert.Equal(1, Thread.VolatileRead(ref secondHandler));
-
-                // unsubscribe from first; should still see second
-                sub.Unsubscribe(subChannel, handler1);
-                count = sub.Publish(pubChannel, "ghi");
-                await PingAsync(pub, sub).ForAwait();
-                lock (received)
-                {
-                    Assert.Single(received);
-                }
-
-                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Thread.VolatileRead(ref secondHandler) == 2);
-
-                var secondHandlerCount = Thread.VolatileRead(ref secondHandler);
-                Log("Expecting 2 from second handler, got: " + secondHandlerCount);
-                Assert.Equal(2, secondHandlerCount);
-                Assert.Equal(1, count);
-
-                // unsubscribe from second; should see nothing this time
-                sub.Unsubscribe(subChannel, handler2);
-                count = sub.Publish(pubChannel, "ghi");
-                await PingAsync(pub, sub).ForAwait();
-                lock (received)
-                {
-                    Assert.Single(received);
-                }
-                secondHandlerCount = Thread.VolatileRead(ref secondHandler);
-                Log("Expecting 2 from second handler, got: " + secondHandlerCount);
-                Assert.Equal(2, secondHandlerCount);
-                Assert.Equal(0, count);
-            }
-        }
-
-        [Fact]
-        public async Task TestBasicPubSubFireAndForget()
-        {
-            using (var muxer = Create(shared: false, log: Writer))
-            {
-                var profiler = muxer.AddProfiler();
-                var pub = GetAnyPrimary(muxer);
-                var sub = muxer.GetSubscriber();
-
-                RedisChannel key = Me() + Guid.NewGuid();
-                HashSet<string?> received = new();
-                int secondHandler = 0;
-                await PingAsync(pub, sub).ForAwait();
-                sub.Subscribe(key, (channel, payload) =>
-                {
-                    lock (received)
-                    {
-                        if (channel == key)
-                        {
-                            received.Add(payload);
-                        }
-                    }
-                }, CommandFlags.FireAndForget);
-
-                sub.Subscribe(key, (_, __) => Interlocked.Increment(ref secondHandler), CommandFlags.FireAndForget);
-                Log(profiler);
-
-                lock (received)
-                {
-                    Assert.Empty(received);
-                }
-                Assert.Equal(0, Thread.VolatileRead(ref secondHandler));
-                await PingAsync(pub, sub).ForAwait();
-                var count = sub.Publish(key, "def", CommandFlags.FireAndForget);
-                await PingAsync(pub, sub).ForAwait();
-
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => received.Count == 1);
-                Log(profiler);
-
-                lock (received)
-                {
-                    Assert.Single(received);
-                }
-                Assert.Equal(1, Thread.VolatileRead(ref secondHandler));
-
-                sub.Unsubscribe(key);
-                count = sub.Publish(key, "ghi", CommandFlags.FireAndForget);
-
-                await PingAsync(pub, sub).ForAwait();
-                Log(profiler);
-                lock (received)
-                {
-                    Assert.Single(received);
-                }
-                Assert.Equal(0, count);
-            }
-        }
-
-        private async Task PingAsync(IServer pub, ISubscriber sub, int times = 1)
-        {
-            while (times-- > 0)
-            {
-                // both use async because we want to drain the completion managers, and the only
-                // way to prove that is to use TPL objects
-                var subTask = sub.PingAsync();
-                var pubTask = pub.PingAsync();
-                await Task.WhenAll(subTask, pubTask).ForAwait();
-
-                Log($"Sub PING time: {subTask.Result.TotalMilliseconds} ms");
-                Log($"Pub PING time: {pubTask.Result.TotalMilliseconds} ms");
-            }
-        }
-
-        [Fact]
-        public async Task TestPatternPubSub()
-        {
-            using (var muxer = Create(shared: false, log: Writer))
-            {
-                var pub = GetAnyPrimary(muxer);
-                var sub = muxer.GetSubscriber();
-
-                HashSet<string?> received = new();
-                int secondHandler = 0;
-                sub.Subscribe("a*c", (channel, payload) =>
-                {
-                    lock (received)
-                    {
-                        if (channel == "abc")
-                        {
-                            received.Add(payload);
-                        }
-                    }
-                });
-
-                sub.Subscribe("a*c", (_, __) => Interlocked.Increment(ref secondHandler));
-                lock (received)
-                {
-                    Assert.Empty(received);
-                }
-                Assert.Equal(0, Thread.VolatileRead(ref secondHandler));
-
-                await PingAsync(pub, sub).ForAwait();
-                var count = sub.Publish("abc", "def");
-                await PingAsync(pub, sub).ForAwait();
-
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => received.Count == 1);
-                lock (received)
-                {
-                    Assert.Single(received);
-                }
-
-                // Give reception a bit, the handler could be delayed under load
-                await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Thread.VolatileRead(ref secondHandler) == 1);
-                Assert.Equal(1, Thread.VolatileRead(ref secondHandler));
-
-                sub.Unsubscribe("a*c");
-                count = sub.Publish("abc", "ghi");
-
-                await PingAsync(pub, sub).ForAwait();
-
-                lock (received)
-                {
-                    Assert.Single(received);
+                    Log(channel);
                 }
             }
         }
+        , handler2 = (_, __) => Interlocked.Increment(ref secondHandler);
+        sub.Subscribe(subChannel, handler1);
+        sub.Subscribe(subChannel, handler2);
 
-        [Fact]
-        public void TestPublishWithNoSubscribers()
+        lock (received)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetSubscriber();
-                Assert.Equal(0, conn.Publish(Me() + "channel", "message"));
-            }
+            Assert.Empty(received);
+        }
+        Assert.Equal(0, Thread.VolatileRead(ref secondHandler));
+        var count = sub.Publish(pubChannel, "def");
+
+        await PingAsync(pub, sub, 3).ForAwait();
+
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => received.Count == 1);
+        lock (received)
+        {
+            Assert.Single(received);
+        }
+        // Give handler firing a moment
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Thread.VolatileRead(ref secondHandler) == 1);
+        Assert.Equal(1, Thread.VolatileRead(ref secondHandler));
+
+        // unsubscribe from first; should still see second
+        sub.Unsubscribe(subChannel, handler1);
+        count = sub.Publish(pubChannel, "ghi");
+        await PingAsync(pub, sub).ForAwait();
+        lock (received)
+        {
+            Assert.Single(received);
         }
 
-        [FactLongRunning]
-        public void TestMassivePublishWithWithoutFlush_Local()
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Thread.VolatileRead(ref secondHandler) == 2);
+
+        var secondHandlerCount = Thread.VolatileRead(ref secondHandler);
+        Log("Expecting 2 from second handler, got: " + secondHandlerCount);
+        Assert.Equal(2, secondHandlerCount);
+        Assert.Equal(1, count);
+
+        // unsubscribe from second; should see nothing this time
+        sub.Unsubscribe(subChannel, handler2);
+        count = sub.Publish(pubChannel, "ghi");
+        await PingAsync(pub, sub).ForAwait();
+        lock (received)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetSubscriber();
-                TestMassivePublish(conn, Me(), "local");
-            }
+            Assert.Single(received);
         }
+        secondHandlerCount = Thread.VolatileRead(ref secondHandler);
+        Log("Expecting 2 from second handler, got: " + secondHandlerCount);
+        Assert.Equal(2, secondHandlerCount);
+        Assert.Equal(0, count);
+    }
 
-        [FactLongRunning]
-        public void TestMassivePublishWithWithoutFlush_Remote()
+    [Fact]
+    public async Task TestBasicPubSubFireAndForget()
+    {
+        using var conn = Create(shared: false, log: Writer);
+
+        var profiler = conn.AddProfiler();
+        var pub = GetAnyPrimary(conn);
+        var sub = conn.GetSubscriber();
+
+        RedisChannel key = Me() + Guid.NewGuid();
+        HashSet<string?> received = new();
+        int secondHandler = 0;
+        await PingAsync(pub, sub).ForAwait();
+        sub.Subscribe(key, (channel, payload) =>
         {
-            using (var muxer = Create(configuration: TestConfig.Current.RemoteServerAndPort))
+            lock (received)
             {
-                var conn = muxer.GetSubscriber();
-                TestMassivePublish(conn, Me(), "remote");
-            }
-        }
-
-        private void TestMassivePublish(ISubscriber conn, string channel, string caption)
-        {
-            const int loop = 10000;
-
-            var tasks = new Task[loop];
-
-            var withFAF = Stopwatch.StartNew();
-            for (int i = 0; i < loop; i++)
-            {
-                conn.Publish(channel, "bar", CommandFlags.FireAndForget);
-            }
-            withFAF.Stop();
-
-            var withAsync = Stopwatch.StartNew();
-            for (int i = 0; i < loop; i++)
-            {
-                tasks[i] = conn.PublishAsync(channel, "bar");
-            }
-            conn.WaitAll(tasks);
-            withAsync.Stop();
-
-            Log("{2}: {0}ms (F+F) vs {1}ms (async)",
-                withFAF.ElapsedMilliseconds, withAsync.ElapsedMilliseconds, caption);
-            // We've made async so far, this test isn't really valid anymore
-            // So let's check they're at least within a few seconds.
-            Assert.True(withFAF.ElapsedMilliseconds < withAsync.ElapsedMilliseconds + 3000, caption);
-        }
-
-        [Fact]
-        public async Task PubSubGetAllAnyOrder()
-        {
-            using (var muxer = Create(syncTimeout: 20000, shared: false, log: Writer))
-            {
-                var sub = muxer.GetSubscriber();
-                RedisChannel channel = Me();
-                const int count = 1000;
-                var syncLock = new object();
-
-                Assert.True(sub.IsConnected());
-                var data = new HashSet<int>();
-                await sub.SubscribeAsync(channel, (_, val) =>
+                if (channel == key)
                 {
-                    bool pulse;
-                    lock (data)
-                    {
-                        data.Add(int.Parse(Encoding.UTF8.GetString(val!)));
-                        pulse = data.Count == count;
-                        if ((data.Count % 100) == 99) Log(data.Count.ToString());
-                    }
-                    if (pulse)
-                    {
-                        lock (syncLock)
-                        {
-                            Monitor.PulseAll(syncLock);
-                        }
-                    }
-                }).ForAwait();
+                    received.Add(payload);
+                }
+            }
+        }, CommandFlags.FireAndForget);
 
+        sub.Subscribe(key, (_, __) => Interlocked.Increment(ref secondHandler), CommandFlags.FireAndForget);
+        Log(profiler);
+
+        lock (received)
+        {
+            Assert.Empty(received);
+        }
+        Assert.Equal(0, Thread.VolatileRead(ref secondHandler));
+        await PingAsync(pub, sub).ForAwait();
+        var count = sub.Publish(key, "def", CommandFlags.FireAndForget);
+        await PingAsync(pub, sub).ForAwait();
+
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => received.Count == 1);
+        Log(profiler);
+
+        lock (received)
+        {
+            Assert.Single(received);
+        }
+        Assert.Equal(1, Thread.VolatileRead(ref secondHandler));
+
+        sub.Unsubscribe(key);
+        count = sub.Publish(key, "ghi", CommandFlags.FireAndForget);
+
+        await PingAsync(pub, sub).ForAwait();
+        Log(profiler);
+        lock (received)
+        {
+            Assert.Single(received);
+        }
+        Assert.Equal(0, count);
+    }
+
+    private async Task PingAsync(IServer pub, ISubscriber sub, int times = 1)
+    {
+        while (times-- > 0)
+        {
+            // both use async because we want to drain the completion managers, and the only
+            // way to prove that is to use TPL objects
+            var subTask = sub.PingAsync();
+            var pubTask = pub.PingAsync();
+            await Task.WhenAll(subTask, pubTask).ForAwait();
+
+            Log($"Sub PING time: {subTask.Result.TotalMilliseconds} ms");
+            Log($"Pub PING time: {pubTask.Result.TotalMilliseconds} ms");
+        }
+    }
+
+    [Fact]
+    public async Task TestPatternPubSub()
+    {
+        using var conn = Create(shared: false, log: Writer);
+
+        var pub = GetAnyPrimary(conn);
+        var sub = conn.GetSubscriber();
+
+        HashSet<string?> received = new();
+        int secondHandler = 0;
+        sub.Subscribe("a*c", (channel, payload) =>
+        {
+            lock (received)
+            {
+                if (channel == "abc")
+                {
+                    received.Add(payload);
+                }
+            }
+        });
+
+        sub.Subscribe("a*c", (_, __) => Interlocked.Increment(ref secondHandler));
+        lock (received)
+        {
+            Assert.Empty(received);
+        }
+        Assert.Equal(0, Thread.VolatileRead(ref secondHandler));
+
+        await PingAsync(pub, sub).ForAwait();
+        var count = sub.Publish("abc", "def");
+        await PingAsync(pub, sub).ForAwait();
+
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => received.Count == 1);
+        lock (received)
+        {
+            Assert.Single(received);
+        }
+
+        // Give reception a bit, the handler could be delayed under load
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Thread.VolatileRead(ref secondHandler) == 1);
+        Assert.Equal(1, Thread.VolatileRead(ref secondHandler));
+
+        sub.Unsubscribe("a*c");
+        count = sub.Publish("abc", "ghi");
+
+        await PingAsync(pub, sub).ForAwait();
+
+        lock (received)
+        {
+            Assert.Single(received);
+        }
+    }
+
+    [Fact]
+    public void TestPublishWithNoSubscribers()
+    {
+        using var conn = Create();
+
+        var sub = conn.GetSubscriber();
+        Assert.Equal(0, sub.Publish(Me() + "channel", "message"));
+    }
+
+    [FactLongRunning]
+    public void TestMassivePublishWithWithoutFlush_Local()
+    {
+        using var conn = Create();
+
+        var sub = conn.GetSubscriber();
+        TestMassivePublish(sub, Me(), "local");
+    }
+
+    [FactLongRunning]
+    public void TestMassivePublishWithWithoutFlush_Remote()
+    {
+        using var conn = Create(configuration: TestConfig.Current.RemoteServerAndPort);
+
+        var sub = conn.GetSubscriber();
+        TestMassivePublish(sub, Me(), "remote");
+    }
+
+    private void TestMassivePublish(ISubscriber sub, string channel, string caption)
+    {
+        const int loop = 10000;
+
+        var tasks = new Task[loop];
+
+        var withFAF = Stopwatch.StartNew();
+        for (int i = 0; i < loop; i++)
+        {
+            sub.Publish(channel, "bar", CommandFlags.FireAndForget);
+        }
+        withFAF.Stop();
+
+        var withAsync = Stopwatch.StartNew();
+        for (int i = 0; i < loop; i++)
+        {
+            tasks[i] = sub.PublishAsync(channel, "bar");
+        }
+        sub.WaitAll(tasks);
+        withAsync.Stop();
+
+        Log("{2}: {0}ms (F+F) vs {1}ms (async)",
+            withFAF.ElapsedMilliseconds, withAsync.ElapsedMilliseconds, caption);
+        // We've made async so far, this test isn't really valid anymore
+        // So let's check they're at least within a few seconds.
+        Assert.True(withFAF.ElapsedMilliseconds < withAsync.ElapsedMilliseconds + 3000, caption);
+    }
+
+    [Fact]
+    public async Task PubSubGetAllAnyOrder()
+    {
+        using var sonn = Create(syncTimeout: 20000, shared: false, log: Writer);
+
+        var sub = sonn.GetSubscriber();
+        RedisChannel channel = Me();
+        const int count = 1000;
+        var syncLock = new object();
+
+        Assert.True(sub.IsConnected());
+        var data = new HashSet<int>();
+        await sub.SubscribeAsync(channel, (_, val) =>
+        {
+            bool pulse;
+            lock (data)
+            {
+                data.Add(int.Parse(Encoding.UTF8.GetString(val!)));
+                pulse = data.Count == count;
+                if ((data.Count % 100) == 99) Log(data.Count.ToString());
+            }
+            if (pulse)
+            {
                 lock (syncLock)
                 {
-                    for (int i = 0; i < count; i++)
-                    {
-                        sub.Publish(channel, i.ToString(), CommandFlags.FireAndForget);
-                    }
-                    sub.Ping();
-                    if (!Monitor.Wait(syncLock, 20000))
-                    {
-                        throw new TimeoutException("Items: " + data.Count);
-                    }
-                    for (int i = 0; i < count; i++)
-                    {
-                        Assert.Contains(i, data);
-                    }
+                    Monitor.PulseAll(syncLock);
                 }
             }
-        }
+        }).ForAwait();
 
-        [Fact]
-        public async Task PubSubGetAllCorrectOrder()
+        lock (syncLock)
         {
-            using (var muxer = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
+            for (int i = 0; i < count; i++)
             {
-                var sub = muxer.GetSubscriber();
-                RedisChannel channel = Me();
-                const int count = 250;
-                var syncLock = new object();
+                sub.Publish(channel, i.ToString(), CommandFlags.FireAndForget);
+            }
+            sub.Ping();
+            if (!Monitor.Wait(syncLock, 20000))
+            {
+                throw new TimeoutException("Items: " + data.Count);
+            }
+            for (int i = 0; i < count; i++)
+            {
+                Assert.Contains(i, data);
+            }
+        }
+    }
 
-                var data = new List<int>(count);
-                var subChannel = await sub.SubscribeAsync(channel).ForAwait();
+    [Fact]
+    public async Task PubSubGetAllCorrectOrder()
+    {
+        using (var conn = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
+        {
+            var sub = conn.GetSubscriber();
+            RedisChannel channel = Me();
+            const int count = 250;
+            var syncLock = new object();
 
-                await sub.PingAsync().ForAwait();
+            var data = new List<int>(count);
+            var subChannel = await sub.SubscribeAsync(channel).ForAwait();
 
-                async Task RunLoop()
+            await sub.PingAsync().ForAwait();
+
+            async Task RunLoop()
+            {
+                while (!subChannel.Completion.IsCompleted)
                 {
-                    while (!subChannel.Completion.IsCompleted)
+                    var work = await subChannel.ReadAsync().ForAwait();
+                    int i = int.Parse(Encoding.UTF8.GetString(work.Message!));
+                    lock (data)
                     {
-                        var work = await subChannel.ReadAsync().ForAwait();
-                        int i = int.Parse(Encoding.UTF8.GetString(work.Message!));
-                        lock (data)
-                        {
-                            data.Add(i);
-                            if (data.Count == count) break;
-                            if ((data.Count % 100) == 99) Log("Received: " + data.Count.ToString());
-                        }
+                        data.Add(i);
+                        if (data.Count == count) break;
+                        if ((data.Count % 100) == 99) Log("Received: " + data.Count.ToString());
                     }
+                }
+                lock (syncLock)
+                {
+                    Log("PulseAll.");
+                    Monitor.PulseAll(syncLock);
+                }
+            }
+
+            lock (syncLock)
+            {
+                // Intentionally not awaited - running in parallel
+                _ = Task.Run(RunLoop);
+                for (int i = 0; i < count; i++)
+                {
+                    sub.Publish(channel, i.ToString());
+                    if ((i % 100) == 99) Log("Published: " + i.ToString());
+                }
+                Log("Send loop complete.");
+                if (!Monitor.Wait(syncLock, 20000))
+                {
+                    throw new TimeoutException("Items: " + data.Count);
+                }
+                Log("Unsubscribe.");
+                subChannel.Unsubscribe();
+                Log("Sub Ping.");
+                sub.Ping();
+                Log("Database Ping.");
+                conn.GetDatabase().Ping();
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(i, data[i]);
+                }
+            }
+
+            Log("Awaiting completion.");
+            await subChannel.Completion;
+            Log("Completion awaited.");
+            await Assert.ThrowsAsync<ChannelClosedException>(async delegate
+            {
+                await subChannel.ReadAsync().ForAwait();
+            }).ForAwait();
+            Log("End of muxer.");
+        }
+        Log("End of test.");
+    }
+
+    [Fact]
+    public async Task PubSubGetAllCorrectOrder_OnMessage_Sync()
+    {
+        using (var conn = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
+        {
+            var sub = conn.GetSubscriber();
+            RedisChannel channel = Me();
+            const int count = 1000;
+            var syncLock = new object();
+
+            var data = new List<int>(count);
+            var subChannel = await sub.SubscribeAsync(channel).ForAwait();
+            subChannel.OnMessage(msg =>
+            {
+                int i = int.Parse(Encoding.UTF8.GetString(msg.Message!));
+                bool pulse = false;
+                lock (data)
+                {
+                    data.Add(i);
+                    if (data.Count == count) pulse = true;
+                    if ((data.Count % 100) == 99) Log("Received: " + data.Count.ToString());
+                }
+                if (pulse)
+                {
                     lock (syncLock)
                     {
-                        Log("PulseAll.");
                         Monitor.PulseAll(syncLock);
                     }
                 }
+            });
+            await sub.PingAsync().ForAwait();
 
-                lock (syncLock)
+            lock (syncLock)
+            {
+                for (int i = 0; i < count; i++)
                 {
-                    // Intentionally not awaited - running in parallel
-                    _ = Task.Run(RunLoop);
-                    for (int i = 0; i < count; i++)
-                    {
-                        sub.Publish(channel, i.ToString());
-                        if ((i % 100) == 99) Log("Published: " + i.ToString());
-                    }
-                    Log("Send loop complete.");
-                    if (!Monitor.Wait(syncLock, 20000))
-                    {
-                        throw new TimeoutException("Items: " + data.Count);
-                    }
-                    Log("Unsubscribe.");
-                    subChannel.Unsubscribe();
-                    Log("Sub Ping.");
-                    sub.Ping();
-                    Log("Database Ping.");
-                    muxer.GetDatabase().Ping();
-                    for (int i = 0; i < count; i++)
-                    {
-                        Assert.Equal(i, data[i]);
-                    }
+                    sub.Publish(channel, i.ToString(), CommandFlags.FireAndForget);
+                    if ((i % 100) == 99) Log("Published: " + i.ToString());
                 }
-
-                Log("Awaiting completion.");
-                await subChannel.Completion;
-                Log("Completion awaited.");
-                await Assert.ThrowsAsync<ChannelClosedException>(async delegate
+                Log("Send loop complete.");
+                if (!Monitor.Wait(syncLock, 20000))
                 {
-                    await subChannel.ReadAsync().ForAwait();
-                }).ForAwait();
-                Log("End of muxer.");
-            }
-            Log("End of test.");
-        }
-
-        [Fact]
-        public async Task PubSubGetAllCorrectOrder_OnMessage_Sync()
-        {
-            using (var muxer = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
-            {
-                var sub = muxer.GetSubscriber();
-                RedisChannel channel = Me();
-                const int count = 1000;
-                var syncLock = new object();
-
-                var data = new List<int>(count);
-                var subChannel = await sub.SubscribeAsync(channel).ForAwait();
-                subChannel.OnMessage(msg =>
-                {
-                    int i = int.Parse(Encoding.UTF8.GetString(msg.Message!));
-                    bool pulse = false;
-                    lock (data)
-                    {
-                        data.Add(i);
-                        if (data.Count == count) pulse = true;
-                        if ((data.Count % 100) == 99) Log("Received: " + data.Count.ToString());
-                    }
-                    if (pulse)
-                    {
-                        lock (syncLock)
-                        {
-                            Monitor.PulseAll(syncLock);
-                        }
-                    }
-                });
-                await sub.PingAsync().ForAwait();
-
-                lock (syncLock)
-                {
-                    for (int i = 0; i < count; i++)
-                    {
-                        sub.Publish(channel, i.ToString(), CommandFlags.FireAndForget);
-                        if ((i % 100) == 99) Log("Published: " + i.ToString());
-                    }
-                    Log("Send loop complete.");
-                    if (!Monitor.Wait(syncLock, 20000))
-                    {
-                        throw new TimeoutException("Items: " + data.Count);
-                    }
-                    Log("Unsubscribe.");
-                    subChannel.Unsubscribe();
-                    Log("Sub Ping.");
-                    sub.Ping();
-                    Log("Database Ping.");
-                    muxer.GetDatabase().Ping();
-                    for (int i = 0; i < count; i++)
-                    {
-                        Assert.Equal(i, data[i]);
-                    }
+                    throw new TimeoutException("Items: " + data.Count);
                 }
-
-                Log("Awaiting completion.");
-                await subChannel.Completion;
-                Log("Completion awaited.");
-                Assert.True(subChannel.Completion.IsCompleted);
-                await Assert.ThrowsAsync<ChannelClosedException>(async delegate
-                {
-                    await subChannel.ReadAsync().ForAwait();
-                }).ForAwait();
-                Log("End of muxer.");
-            }
-            Log("End of test.");
-        }
-
-        [Fact]
-        public async Task PubSubGetAllCorrectOrder_OnMessage_Async()
-        {
-            using (var muxer = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
-            {
-                var sub = muxer.GetSubscriber();
-                RedisChannel channel = Me();
-                const int count = 1000;
-                var syncLock = new object();
-
-                var data = new List<int>(count);
-                var subChannel = await sub.SubscribeAsync(channel).ForAwait();
-                subChannel.OnMessage(msg =>
-                {
-                    int i = int.Parse(Encoding.UTF8.GetString(msg.Message!));
-                    bool pulse = false;
-                    lock (data)
-                    {
-                        data.Add(i);
-                        if (data.Count == count) pulse = true;
-                        if ((data.Count % 100) == 99) Log("Received: " + data.Count.ToString());
-                    }
-                    if (pulse)
-                    {
-                        lock (syncLock)
-                        {
-                            Monitor.PulseAll(syncLock);
-                        }
-                    }
-                    // Making sure we cope with null being returned here by a handler
-                    return i % 2 == 0 ? null! : Task.CompletedTask;
-                });
-                await sub.PingAsync().ForAwait();
-
-                // Give a delay between subscriptions and when we try to publish to be safe
-                await Task.Delay(1000).ForAwait();
-
-                lock (syncLock)
-                {
-                    for (int i = 0; i < count; i++)
-                    {
-                        sub.Publish(channel, i.ToString(), CommandFlags.FireAndForget);
-                        if ((i % 100) == 99) Log("Published: " + i.ToString());
-                    }
-                    Log("Send loop complete.");
-                    if (!Monitor.Wait(syncLock, 20000))
-                    {
-                        throw new TimeoutException("Items: " + data.Count);
-                    }
-                    Log("Unsubscribe.");
-                    subChannel.Unsubscribe();
-                    Log("Sub Ping.");
-                    sub.Ping();
-                    Log("Database Ping.");
-                    muxer.GetDatabase().Ping();
-                    for (int i = 0; i < count; i++)
-                    {
-                        Assert.Equal(i, data[i]);
-                    }
-                }
-
-                Log("Awaiting completion.");
-                await subChannel.Completion;
-                Log("Completion awaited.");
-                Assert.True(subChannel.Completion.IsCompleted);
-                await Assert.ThrowsAsync<ChannelClosedException>(async delegate
-                {
-                    await subChannel.ReadAsync().ForAwait();
-                }).ForAwait();
-                Log("End of muxer.");
-            }
-            Log("End of test.");
-        }
-
-        [Fact]
-        public async Task TestPublishWithSubscribers()
-        {
-            var channel = Me();
-            using (var muxerA = Create(shared: false, log: Writer))
-            using (var muxerB = Create(shared: false, log: Writer))
-            using (var conn = Create())
-            {
-                var listenA = muxerA.GetSubscriber();
-                var listenB = muxerB.GetSubscriber();
-                var t1 = listenA.SubscribeAsync(channel, delegate { });
-                var t2 = listenB.SubscribeAsync(channel, delegate { });
-
-                await Task.WhenAll(t1, t2).ForAwait();
-
-                // subscribe is just a thread-race-mess
-                await listenA.PingAsync();
-                await listenB.PingAsync();
-
-                var pub = conn.GetSubscriber().PublishAsync(channel, "message");
-                Assert.Equal(2, await pub); // delivery count
-            }
-        }
-
-        [Fact]
-        public async Task TestMultipleSubscribersGetMessage()
-        {
-            var channel = Me();
-            using (var muxerA = Create(shared: false, log: Writer))
-            using (var muxerB = Create(shared: false, log: Writer))
-            using (var conn = Create())
-            {
-                var listenA = muxerA.GetSubscriber();
-                var listenB = muxerB.GetSubscriber();
+                Log("Unsubscribe.");
+                subChannel.Unsubscribe();
+                Log("Sub Ping.");
+                sub.Ping();
+                Log("Database Ping.");
                 conn.GetDatabase().Ping();
-                var pub = conn.GetSubscriber();
-                int gotA = 0, gotB = 0;
-                var tA = listenA.SubscribeAsync(channel, (_, msg) => { if (msg == "message") Interlocked.Increment(ref gotA); });
-                var tB = listenB.SubscribeAsync(channel, (_, msg) => { if (msg == "message") Interlocked.Increment(ref gotB); });
-                await Task.WhenAll(tA, tB).ForAwait();
-                Assert.Equal(2, pub.Publish(channel, "message"));
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
-                Assert.Equal(1, Interlocked.CompareExchange(ref gotA, 0, 0));
-                Assert.Equal(1, Interlocked.CompareExchange(ref gotB, 0, 0));
-
-                // and unsubscibe...
-                tA = listenA.UnsubscribeAsync(channel);
-                await tA;
-                Assert.Equal(1, pub.Publish(channel, "message"));
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
-                Assert.Equal(1, Interlocked.CompareExchange(ref gotA, 0, 0));
-                Assert.Equal(2, Interlocked.CompareExchange(ref gotB, 0, 0));
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(i, data[i]);
+                }
             }
-        }
 
-        [Fact]
-        public async Task Issue38()
-        {
-            // https://code.google.com/p/booksleeve/issues/detail?id=38
-            using (var pub = Create(log: Writer))
+            Log("Awaiting completion.");
+            await subChannel.Completion;
+            Log("Completion awaited.");
+            Assert.True(subChannel.Completion.IsCompleted);
+            await Assert.ThrowsAsync<ChannelClosedException>(async delegate
             {
-                var sub = pub.GetSubscriber();
-                int count = 0;
-                var prefix = Me();
-                void handler(RedisChannel _, RedisValue __) => Interlocked.Increment(ref count);
-                var a0 = sub.SubscribeAsync(prefix + "foo", handler);
-                var a1 = sub.SubscribeAsync(prefix + "bar", handler);
-                var b0 = sub.SubscribeAsync(prefix + "f*o", handler);
-                var b1 = sub.SubscribeAsync(prefix + "b*r", handler);
-                await Task.WhenAll(a0, a1, b0, b1).ForAwait();
+                await subChannel.ReadAsync().ForAwait();
+            }).ForAwait();
+            Log("End of muxer.");
+        }
+        Log("End of test.");
+    }
 
-                var c = sub.PublishAsync(prefix + "foo", "foo");
-                var d = sub.PublishAsync(prefix + "f@o", "f@o");
-                var e = sub.PublishAsync(prefix + "bar", "bar");
-                var f = sub.PublishAsync(prefix + "b@r", "b@r");
-                await Task.WhenAll(c, d, e, f).ForAwait();
+    [Fact]
+    public async Task PubSubGetAllCorrectOrder_OnMessage_Async()
+    {
+        using (var conn = Create(configuration: TestConfig.Current.RemoteServerAndPort, syncTimeout: 20000, log: Writer))
+        {
+            var sub = conn.GetSubscriber();
+            RedisChannel channel = Me();
+            const int count = 1000;
+            var syncLock = new object();
 
-                long total = c.Result + d.Result + e.Result + f.Result;
+            var data = new List<int>(count);
+            var subChannel = await sub.SubscribeAsync(channel).ForAwait();
+            subChannel.OnMessage(msg =>
+            {
+                int i = int.Parse(Encoding.UTF8.GetString(msg.Message!));
+                bool pulse = false;
+                lock (data)
+                {
+                    data.Add(i);
+                    if (data.Count == count) pulse = true;
+                    if ((data.Count % 100) == 99) Log("Received: " + data.Count.ToString());
+                }
+                if (pulse)
+                {
+                    lock (syncLock)
+                    {
+                        Monitor.PulseAll(syncLock);
+                    }
+                }
+                // Making sure we cope with null being returned here by a handler
+                return i % 2 == 0 ? null! : Task.CompletedTask;
+            });
+            await sub.PingAsync().ForAwait();
 
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
+            // Give a delay between subscriptions and when we try to publish to be safe
+            await Task.Delay(1000).ForAwait();
 
-                Assert.Equal(6, total); // sent
-                Assert.Equal(6, Interlocked.CompareExchange(ref count, 0, 0)); // received
+            lock (syncLock)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    sub.Publish(channel, i.ToString(), CommandFlags.FireAndForget);
+                    if ((i % 100) == 99) Log("Published: " + i.ToString());
+                }
+                Log("Send loop complete.");
+                if (!Monitor.Wait(syncLock, 20000))
+                {
+                    throw new TimeoutException("Items: " + data.Count);
+                }
+                Log("Unsubscribe.");
+                subChannel.Unsubscribe();
+                Log("Sub Ping.");
+                sub.Ping();
+                Log("Database Ping.");
+                conn.GetDatabase().Ping();
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(i, data[i]);
+                }
             }
-        }
 
-        internal static Task AllowReasonableTimeToPublishAndProcess() => Task.Delay(500);
-
-        [Fact]
-        public async Task TestPartialSubscriberGetMessage()
-        {
-            using (var muxerA = Create())
-            using (var muxerB = Create())
-            using (var conn = Create())
+            Log("Awaiting completion.");
+            await subChannel.Completion;
+            Log("Completion awaited.");
+            Assert.True(subChannel.Completion.IsCompleted);
+            await Assert.ThrowsAsync<ChannelClosedException>(async delegate
             {
-                int gotA = 0, gotB = 0;
-                var listenA = muxerA.GetSubscriber();
-                var listenB = muxerB.GetSubscriber();
-                var pub = conn.GetSubscriber();
-                var prefix = Me();
-                var tA = listenA.SubscribeAsync(prefix + "channel", (s, msg) => { if (s == prefix + "channel" && msg == "message") Interlocked.Increment(ref gotA); });
-                var tB = listenB.SubscribeAsync(prefix + "chann*", (s, msg) => { if (s == prefix + "channel" && msg == "message") Interlocked.Increment(ref gotB); });
-                await Task.WhenAll(tA, tB).ForAwait();
-                Assert.Equal(2, pub.Publish(prefix + "channel", "message"));
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
-                Assert.Equal(1, Interlocked.CompareExchange(ref gotA, 0, 0));
-                Assert.Equal(1, Interlocked.CompareExchange(ref gotB, 0, 0));
-
-                // and unsubscibe...
-                tB = listenB.UnsubscribeAsync(prefix + "chann*", null);
-                await tB;
-                Assert.Equal(1, pub.Publish(prefix + "channel", "message"));
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
-                Assert.Equal(2, Interlocked.CompareExchange(ref gotA, 0, 0));
-                Assert.Equal(1, Interlocked.CompareExchange(ref gotB, 0, 0));
-            }
+                await subChannel.ReadAsync().ForAwait();
+            }).ForAwait();
+            Log("End of muxer.");
         }
+        Log("End of test.");
+    }
 
-        [Fact]
-        public async Task TestSubscribeUnsubscribeAndSubscribeAgain()
+    [Fact]
+    public async Task TestPublishWithSubscribers()
+    {
+        using var connA = Create(shared: false, log: Writer);
+        using var connB = Create(shared: false, log: Writer);
+        using var connPub = Create();
+
+        var channel = Me();
+        var listenA = connA.GetSubscriber();
+        var listenB = connB.GetSubscriber();
+        var t1 = listenA.SubscribeAsync(channel, delegate { });
+        var t2 = listenB.SubscribeAsync(channel, delegate { });
+
+        await Task.WhenAll(t1, t2).ForAwait();
+
+        // subscribe is just a thread-race-mess
+        await listenA.PingAsync();
+        await listenB.PingAsync();
+
+        var pub = connPub.GetSubscriber().PublishAsync(channel, "message");
+        Assert.Equal(2, await pub); // delivery count
+    }
+
+    [Fact]
+    public async Task TestMultipleSubscribersGetMessage()
+    {
+        using var connA = Create(shared: false, log: Writer);
+        using var connB = Create(shared: false, log: Writer);
+        using var connPub = Create();
+
+        var channel = Me();
+        var listenA = connA.GetSubscriber();
+        var listenB = connB.GetSubscriber();
+        connPub.GetDatabase().Ping();
+        var pub = connPub.GetSubscriber();
+        int gotA = 0, gotB = 0;
+        var tA = listenA.SubscribeAsync(channel, (_, msg) => { if (msg == "message") Interlocked.Increment(ref gotA); });
+        var tB = listenB.SubscribeAsync(channel, (_, msg) => { if (msg == "message") Interlocked.Increment(ref gotB); });
+        await Task.WhenAll(tA, tB).ForAwait();
+        Assert.Equal(2, pub.Publish(channel, "message"));
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+        Assert.Equal(1, Interlocked.CompareExchange(ref gotA, 0, 0));
+        Assert.Equal(1, Interlocked.CompareExchange(ref gotB, 0, 0));
+
+        // and unsubscribe...
+        tA = listenA.UnsubscribeAsync(channel);
+        await tA;
+        Assert.Equal(1, pub.Publish(channel, "message"));
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+        Assert.Equal(1, Interlocked.CompareExchange(ref gotA, 0, 0));
+        Assert.Equal(2, Interlocked.CompareExchange(ref gotB, 0, 0));
+    }
+
+    [Fact]
+    public async Task Issue38()
+    {
+        // https://code.google.com/p/booksleeve/issues/detail?id=38
+        using var conn = Create(log: Writer);
+
+        var sub = conn.GetSubscriber();
+        int count = 0;
+        var prefix = Me();
+        void handler(RedisChannel _, RedisValue __) => Interlocked.Increment(ref count);
+        var a0 = sub.SubscribeAsync(prefix + "foo", handler);
+        var a1 = sub.SubscribeAsync(prefix + "bar", handler);
+        var b0 = sub.SubscribeAsync(prefix + "f*o", handler);
+        var b1 = sub.SubscribeAsync(prefix + "b*r", handler);
+        await Task.WhenAll(a0, a1, b0, b1).ForAwait();
+
+        var c = sub.PublishAsync(prefix + "foo", "foo");
+        var d = sub.PublishAsync(prefix + "f@o", "f@o");
+        var e = sub.PublishAsync(prefix + "bar", "bar");
+        var f = sub.PublishAsync(prefix + "b@r", "b@r");
+        await Task.WhenAll(c, d, e, f).ForAwait();
+
+        long total = c.Result + d.Result + e.Result + f.Result;
+
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+
+        Assert.Equal(6, total); // sent
+        Assert.Equal(6, Interlocked.CompareExchange(ref count, 0, 0)); // received
+    }
+
+    internal static Task AllowReasonableTimeToPublishAndProcess() => Task.Delay(500);
+
+    [Fact]
+    public async Task TestPartialSubscriberGetMessage()
+    {
+        using var connA = Create();
+        using var connB = Create();
+        using var connPub = Create();
+
+        int gotA = 0, gotB = 0;
+        var listenA = connA.GetSubscriber();
+        var listenB = connB.GetSubscriber();
+        var pub = connPub.GetSubscriber();
+        var prefix = Me();
+        var tA = listenA.SubscribeAsync(prefix + "channel", (s, msg) => { if (s == prefix + "channel" && msg == "message") Interlocked.Increment(ref gotA); });
+        var tB = listenB.SubscribeAsync(prefix + "chann*", (s, msg) => { if (s == prefix + "channel" && msg == "message") Interlocked.Increment(ref gotB); });
+        await Task.WhenAll(tA, tB).ForAwait();
+        Assert.Equal(2, pub.Publish(prefix + "channel", "message"));
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+        Assert.Equal(1, Interlocked.CompareExchange(ref gotA, 0, 0));
+        Assert.Equal(1, Interlocked.CompareExchange(ref gotB, 0, 0));
+
+        // and unsubscibe...
+        tB = listenB.UnsubscribeAsync(prefix + "chann*", null);
+        await tB;
+        Assert.Equal(1, pub.Publish(prefix + "channel", "message"));
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+        Assert.Equal(2, Interlocked.CompareExchange(ref gotA, 0, 0));
+        Assert.Equal(1, Interlocked.CompareExchange(ref gotB, 0, 0));
+    }
+
+    [Fact]
+    public async Task TestSubscribeUnsubscribeAndSubscribeAgain()
+    {
+        using var connPub = Create();
+        using var connSub = Create();
+
+        var prefix = Me();
+        var pub = connPub.GetSubscriber();
+        var sub = connSub.GetSubscriber();
+        int x = 0, y = 0;
+        var t1 = sub.SubscribeAsync(prefix + "abc", delegate { Interlocked.Increment(ref x); });
+        var t2 = sub.SubscribeAsync(prefix + "ab*", delegate { Interlocked.Increment(ref y); });
+        await Task.WhenAll(t1, t2).ForAwait();
+        pub.Publish(prefix + "abc", "");
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+        Assert.Equal(1, Volatile.Read(ref x));
+        Assert.Equal(1, Volatile.Read(ref y));
+        t1 = sub.UnsubscribeAsync(prefix + "abc", null);
+        t2 = sub.UnsubscribeAsync(prefix + "ab*", null);
+        await Task.WhenAll(t1, t2).ForAwait();
+        pub.Publish(prefix + "abc", "");
+        Assert.Equal(1, Volatile.Read(ref x));
+        Assert.Equal(1, Volatile.Read(ref y));
+        t1 = sub.SubscribeAsync(prefix + "abc", delegate { Interlocked.Increment(ref x); });
+        t2 = sub.SubscribeAsync(prefix + "ab*", delegate { Interlocked.Increment(ref y); });
+        await Task.WhenAll(t1, t2).ForAwait();
+        pub.Publish(prefix + "abc", "");
+        await AllowReasonableTimeToPublishAndProcess().ForAwait();
+        Assert.Equal(2, Volatile.Read(ref x));
+        Assert.Equal(2, Volatile.Read(ref y));
+    }
+
+    [Fact]
+    public async Task AzureRedisEventsAutomaticSubscribe()
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
+
+        bool didUpdate = false;
+        var options = new ConfigurationOptions()
         {
-            using (var pubMuxer = Create())
-            using (var subMuxer = Create())
-            {
-                var prefix = Me();
-                var pub = pubMuxer.GetSubscriber();
-                var sub = subMuxer.GetSubscriber();
-                int x = 0, y = 0;
-                var t1 = sub.SubscribeAsync(prefix + "abc", delegate { Interlocked.Increment(ref x); });
-                var t2 = sub.SubscribeAsync(prefix + "ab*", delegate { Interlocked.Increment(ref y); });
-                await Task.WhenAll(t1, t2).ForAwait();
-                pub.Publish(prefix + "abc", "");
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
-                Assert.Equal(1, Volatile.Read(ref x));
-                Assert.Equal(1, Volatile.Read(ref y));
-                t1 = sub.UnsubscribeAsync(prefix + "abc", null);
-                t2 = sub.UnsubscribeAsync(prefix + "ab*", null);
-                await Task.WhenAll(t1, t2).ForAwait();
-                pub.Publish(prefix + "abc", "");
-                Assert.Equal(1, Volatile.Read(ref x));
-                Assert.Equal(1, Volatile.Read(ref y));
-                t1 = sub.SubscribeAsync(prefix + "abc", delegate { Interlocked.Increment(ref x); });
-                t2 = sub.SubscribeAsync(prefix + "ab*", delegate { Interlocked.Increment(ref y); });
-                await Task.WhenAll(t1, t2).ForAwait();
-                pub.Publish(prefix + "abc", "");
-                await AllowReasonableTimeToPublishAndProcess().ForAwait();
-                Assert.Equal(2, Volatile.Read(ref x));
-                Assert.Equal(2, Volatile.Read(ref y));
-            }
-        }
+            EndPoints = { TestConfig.Current.AzureCacheServer },
+            Password = TestConfig.Current.AzureCachePassword,
+            Ssl = true
+        };
 
-        [Fact]
-        public async Task AzureRedisEventsAutomaticSubscribe()
+        using (var connection = await ConnectionMultiplexer.ConnectAsync(options))
         {
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
-
-            bool didUpdate = false;
-            var options = new ConfigurationOptions()
+            connection.ServerMaintenanceEvent += (object? _, ServerMaintenanceEvent e) =>
             {
-                EndPoints = { TestConfig.Current.AzureCacheServer },
-                Password = TestConfig.Current.AzureCachePassword,
-                Ssl = true
+                if (e is AzureMaintenanceEvent)
+                {
+                    didUpdate = true;
+                }
             };
 
-            using (var connection = await ConnectionMultiplexer.ConnectAsync(options))
-            {
-                connection.ServerMaintenanceEvent += (object? _, ServerMaintenanceEvent e) =>
-                {
-                    if (e is AzureMaintenanceEvent)
-                    {
-                        didUpdate = true;
-                    }
-                };
+            var pubSub = connection.GetSubscriber();
+            await pubSub.PublishAsync("AzureRedisEvents", "HI");
+            await Task.Delay(100);
 
-                var pubSub = connection.GetSubscriber();
-                await pubSub.PublishAsync("AzureRedisEvents", "HI");
-                await Task.Delay(100);
+            Assert.True(didUpdate);
+        }
+    }
 
-                Assert.True(didUpdate);
-            }
+    [Fact]
+    public async Task SubscriptionsSurviveConnectionFailureAsync()
+    {
+        using var conn = (Create(allowAdmin: true, shared: false, log: Writer, syncTimeout: 1000) as ConnectionMultiplexer)!;
+
+        var profiler = conn.AddProfiler();
+        RedisChannel channel = Me();
+        var sub = conn.GetSubscriber();
+        int counter = 0;
+        Assert.True(sub.IsConnected());
+        await sub.SubscribeAsync(channel, delegate
+        {
+            Interlocked.Increment(ref counter);
+        }).ConfigureAwait(false);
+
+        var profile1 = Log(profiler);
+
+        Assert.Equal(1, conn.GetSubscriptionsCount());
+
+        await Task.Delay(200).ConfigureAwait(false);
+
+        await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
+        sub.Ping();
+        await Task.Delay(200).ConfigureAwait(false);
+
+        var counter1 = Thread.VolatileRead(ref counter);
+        Log($"Expecting 1 message, got {counter1}");
+        Assert.Equal(1, counter1);
+
+        var server = GetServer(conn);
+        var socketCount = server.GetCounters().Subscription.SocketCount;
+        Log($"Expecting 1 socket, got {socketCount}");
+        Assert.Equal(1, socketCount);
+
+        // We might fail both connections or just the primary in the time period
+        SetExpectedAmbientFailureCount(-1);
+
+        // Make sure we fail all the way
+        conn.AllowConnect = false;
+        Log("Failing connection");
+        // Fail all connections
+        server.SimulateConnectionFailure(SimulatedFailureType.All);
+        // Trigger failure (RedisTimeoutException because of backlog behavior)
+        Assert.Throws<RedisTimeoutException>(() => sub.Ping());
+        Assert.False(sub.IsConnected(channel));
+
+        // Now reconnect...
+        conn.AllowConnect = true;
+        Log("Waiting on reconnect");
+        // Wait until we're reconnected
+        await UntilConditionAsync(TimeSpan.FromSeconds(10), () => sub.IsConnected(channel));
+        Log("Reconnected");
+        // Ensure we're reconnected
+        Assert.True(sub.IsConnected(channel));
+
+        // Ensure we've sent the subscribe command after reconnecting
+        var profile2 = Log(profiler);
+        //Assert.Equal(1, profile2.Count(p => p.Command == nameof(RedisCommand.SUBSCRIBE)));
+
+        Log("Issuing ping after reconnected");
+        sub.Ping();
+
+        var muxerSubCount = conn.GetSubscriptionsCount();
+        Log($"Muxer thinks we have {muxerSubCount} subscriber(s).");
+        Assert.Equal(1, muxerSubCount);
+
+        var muxerSubs = conn.GetSubscriptions();
+        foreach (var pair in muxerSubs)
+        {
+            var muxerSub = pair.Value;
+            Log($"  Muxer Sub: {pair.Key}: (EndPoint: {muxerSub.GetCurrentServer()}, Connected: {muxerSub.IsConnected})");
         }
 
-        [Fact]
-        public async Task SubscriptionsSurviveConnectionFailureAsync()
+        Log("Publishing");
+        var published = await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
+
+        Log($"Published to {published} subscriber(s).");
+        Assert.Equal(1, published);
+
+        // Give it a few seconds to get our messages
+        Log("Waiting for 2 messages");
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => Thread.VolatileRead(ref counter) == 2);
+
+        var counter2 = Thread.VolatileRead(ref counter);
+        Log($"Expecting 2 messages, got {counter2}");
+        Assert.Equal(2, counter2);
+
+        // Log all commands at the end
+        Log("All commands since connecting:");
+        var profile3 = profiler.FinishProfiling();
+        foreach (var command in profile3)
         {
-            using (var muxer = (Create(allowAdmin: true, shared: false, log: Writer, syncTimeout: 1000) as ConnectionMultiplexer)!)
-            {
-                var profiler = muxer.AddProfiler();
-                RedisChannel channel = Me();
-                var sub = muxer.GetSubscriber();
-                int counter = 0;
-                Assert.True(sub.IsConnected());
-                await sub.SubscribeAsync(channel, delegate
-                {
-                    Interlocked.Increment(ref counter);
-                }).ConfigureAwait(false);
-
-                var profile1 = Log(profiler);
-
-                Assert.Equal(1, muxer.GetSubscriptionsCount());
-
-                await Task.Delay(200).ConfigureAwait(false);
-
-                await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
-                sub.Ping();
-                await Task.Delay(200).ConfigureAwait(false);
-
-                var counter1 = Thread.VolatileRead(ref counter);
-                Log($"Expecting 1 message, got {counter1}");
-                Assert.Equal(1, counter1);
-
-                var server = GetServer(muxer);
-                var socketCount = server.GetCounters().Subscription.SocketCount;
-                Log($"Expecting 1 socket, got {socketCount}");
-                Assert.Equal(1, socketCount);
-
-                // We might fail both connections or just the primary in the time period
-                SetExpectedAmbientFailureCount(-1);
-
-                // Make sure we fail all the way
-                muxer.AllowConnect = false;
-                Log("Failing connection");
-                // Fail all connections
-                server.SimulateConnectionFailure(SimulatedFailureType.All);
-                // Trigger failure (RedisTimeoutException because of backlog behavior)
-                Assert.Throws<RedisTimeoutException>(() => sub.Ping());
-                Assert.False(sub.IsConnected(channel));
-
-                // Now reconnect...
-                muxer.AllowConnect = true;
-                Log("Waiting on reconnect");
-                // Wait until we're reconnected
-                await UntilConditionAsync(TimeSpan.FromSeconds(10), () => sub.IsConnected(channel));
-                Log("Reconnected");
-                // Ensure we're reconnected
-                Assert.True(sub.IsConnected(channel));
-
-                // Ensure we've sent the subscribe command after reconnecting
-                var profile2 = Log(profiler);
-                //Assert.Equal(1, profile2.Count(p => p.Command == nameof(RedisCommand.SUBSCRIBE)));
-
-                Log("Issuing ping after reconnected");
-                sub.Ping();
-
-                var muxerSubCount = muxer.GetSubscriptionsCount();
-                Log($"Muxer thinks we have {muxerSubCount} subscriber(s).");
-                Assert.Equal(1, muxerSubCount);
-
-                var muxerSubs = muxer.GetSubscriptions();
-                foreach (var pair in muxerSubs)
-                {
-                    var muxerSub = pair.Value;
-                    Log($"  Muxer Sub: {pair.Key}: (EndPoint: {muxerSub.GetCurrentServer()}, Connected: {muxerSub.IsConnected})");
-                }
-
-                Log("Publishing");
-                var published = await sub.PublishAsync(channel, "abc").ConfigureAwait(false);
-
-                Log($"Published to {published} subscriber(s).");
-                Assert.Equal(1, published);
-
-                // Give it a few seconds to get our messages
-                Log("Waiting for 2 messages");
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => Thread.VolatileRead(ref counter) == 2);
-
-                var counter2 = Thread.VolatileRead(ref counter);
-                Log($"Expecting 2 messages, got {counter2}");
-                Assert.Equal(2, counter2);
-
-                // Log all commands at the end
-                Log("All commands since connecting:");
-                var profile3 = profiler.FinishProfiling();
-                foreach (var command in profile3)
-                {
-                    Log($"{command.EndPoint}: {command}");
-                }
-            }
+            Log($"{command.EndPoint}: {command}");
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/PubSubCommand.cs
+++ b/tests/StackExchange.Redis.Tests/PubSubCommand.cs
@@ -5,88 +5,85 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class PubSubCommand : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class PubSubCommand : TestBase
+    public PubSubCommand(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public void SubscriberCount()
     {
-        public PubSubCommand(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void SubscriberCount()
+        RedisChannel channel = Me() + Guid.NewGuid();
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+
+        var channels = server.SubscriptionChannels(Me() + "*");
+        Assert.DoesNotContain(channel, channels);
+
+        _ = server.SubscriptionPatternCount();
+        var count = server.SubscriptionSubscriberCount(channel);
+        Assert.Equal(0, count);
+        conn.GetSubscriber().Subscribe(channel, delegate { });
+        count = server.SubscriptionSubscriberCount(channel);
+        Assert.Equal(1, count);
+
+        channels = server.SubscriptionChannels(Me() + "*");
+        Assert.Contains(channel, channels);
+    }
+
+    [Fact]
+    public async Task SubscriberCountAsync()
+    {
+        using var conn = Create();
+
+        RedisChannel channel = Me() + Guid.NewGuid();
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+
+        var channels = await server.SubscriptionChannelsAsync(Me() + "*").WithTimeout(2000);
+        Assert.DoesNotContain(channel, channels);
+
+        _ = await server.SubscriptionPatternCountAsync().WithTimeout(2000);
+        var count = await server.SubscriptionSubscriberCountAsync(channel).WithTimeout(2000);
+        Assert.Equal(0, count);
+        await conn.GetSubscriber().SubscribeAsync(channel, delegate { }).WithTimeout(2000);
+        count = await server.SubscriptionSubscriberCountAsync(channel).WithTimeout(2000);
+        Assert.Equal(1, count);
+
+        channels = await server.SubscriptionChannelsAsync(Me() + "*").WithTimeout(2000);
+        Assert.Contains(channel, channels);
+    }
+}
+internal static class Util
+{
+    public static async Task WithTimeout(this Task task, int timeoutMs,
+        [CallerMemberName] string? caller = null, [CallerLineNumber] int line = 0)
+    {
+        var cts = new CancellationTokenSource();
+        if (task == await Task.WhenAny(task, Task.Delay(timeoutMs, cts.Token)).ForAwait())
         {
-            using (var conn = Create())
-            {
-                RedisChannel channel = Me() + Guid.NewGuid();
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-
-                var channels = server.SubscriptionChannels(Me() + "*");
-                Assert.DoesNotContain(channel, channels);
-
-                _ = server.SubscriptionPatternCount();
-                var count = server.SubscriptionSubscriberCount(channel);
-                Assert.Equal(0, count);
-                conn.GetSubscriber().Subscribe(channel, delegate { });
-                count = server.SubscriptionSubscriberCount(channel);
-                Assert.Equal(1, count);
-
-                channels = server.SubscriptionChannels(Me() + "*");
-                Assert.Contains(channel, channels);
-            }
+            cts.Cancel();
+            await task.ForAwait();
         }
-
-        [Fact]
-        public async Task SubscriberCountAsync()
+        else
         {
-            using (var conn = Create())
-            {
-                RedisChannel channel = Me() + Guid.NewGuid();
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-
-                var channels = await server.SubscriptionChannelsAsync(Me() + "*").WithTimeout(2000);
-                Assert.DoesNotContain(channel, channels);
-
-                _ = await server.SubscriptionPatternCountAsync().WithTimeout(2000);
-                var count = await server.SubscriptionSubscriberCountAsync(channel).WithTimeout(2000);
-                Assert.Equal(0, count);
-                await conn.GetSubscriber().SubscribeAsync(channel, delegate { }).WithTimeout(2000);
-                count = await server.SubscriptionSubscriberCountAsync(channel).WithTimeout(2000);
-                Assert.Equal(1, count);
-
-                channels = await server.SubscriptionChannelsAsync(Me() + "*").WithTimeout(2000);
-                Assert.Contains(channel, channels);
-            }
+            throw new TimeoutException($"timout from {caller} line {line}");
         }
     }
-    internal static class Util
+    public static async Task<T> WithTimeout<T>(this Task<T> task, int timeoutMs,
+        [CallerMemberName] string? caller = null, [CallerLineNumber] int line = 0)
     {
-        public static async Task WithTimeout(this Task task, int timeoutMs,
-            [CallerMemberName] string? caller = null, [CallerLineNumber] int line = 0)
+        var cts = new CancellationTokenSource();
+        if (task == await Task.WhenAny(task, Task.Delay(timeoutMs, cts.Token)).ForAwait())
         {
-            var cts = new CancellationTokenSource();
-            if (task == await Task.WhenAny(task, Task.Delay(timeoutMs, cts.Token)).ForAwait())
-            {
-                cts.Cancel();
-                await task.ForAwait();
-            }
-            else
-            {
-                throw new TimeoutException($"timout from {caller} line {line}");
-            }
+            cts.Cancel();
+            return await task.ForAwait();
         }
-        public static async Task<T> WithTimeout<T>(this Task<T> task, int timeoutMs,
-            [CallerMemberName] string? caller = null, [CallerLineNumber] int line = 0)
+        else
         {
-            var cts = new CancellationTokenSource();
-            if (task == await Task.WhenAny(task, Task.Delay(timeoutMs, cts.Token)).ForAwait())
-            {
-                cts.Cancel();
-                return await task.ForAwait();
-            }
-            else
-            {
-                throw new TimeoutException($"timout from {caller} line {line}");
-            }
+            throw new TimeoutException($"timout from {caller} line {line}");
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/PubSubMultiserver.cs
+++ b/tests/StackExchange.Redis.Tests/PubSubMultiserver.cs
@@ -4,75 +4,152 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class PubSubMultiserver : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class PubSubMultiserver : TestBase
+    public PubSubMultiserver(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+    protected override string GetConfiguration() => TestConfig.Current.ClusterServersAndPorts + ",connectTimeout=10000";
+
+    [Fact]
+    public void ChannelSharding()
     {
-        public PubSubMultiserver(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
-        protected override string GetConfiguration() => TestConfig.Current.ClusterServersAndPorts + ",connectTimeout=10000";
+        using var conn = (Create(channelPrefix: Me()) as ConnectionMultiplexer)!;
 
-        [Fact]
-        public void ChannelSharding()
+        var defaultSlot = conn.ServerSelectionStrategy.HashSlot(default(RedisChannel));
+        var slot1 = conn.ServerSelectionStrategy.HashSlot((RedisChannel)"hey");
+        var slot2 = conn.ServerSelectionStrategy.HashSlot((RedisChannel)"hey2");
+
+        Assert.NotEqual(defaultSlot, slot1);
+        Assert.NotEqual(ServerSelectionStrategy.NoSlot, slot1);
+        Assert.NotEqual(slot1, slot2);
+    }
+
+    [Fact]
+    public async Task ClusterNodeSubscriptionFailover()
+    {
+        Log("Connecting...");
+
+        using var conn = (Create(allowAdmin: true) as ConnectionMultiplexer)!;
+
+        var sub = conn.GetSubscriber();
+        var channel = (RedisChannel)Me();
+
+        var count = 0;
+        Log("Subscribing...");
+        await sub.SubscribeAsync(channel, (_, val) =>
         {
-            using var muxer = (Create(channelPrefix: Me()) as ConnectionMultiplexer)!;
+            Interlocked.Increment(ref count);
+            Log("Message: " + val);
+        });
+        Assert.True(sub.IsConnected(channel));
 
-            var defaultSlot = muxer.ServerSelectionStrategy.HashSlot(default(RedisChannel));
-            var slot1 = muxer.ServerSelectionStrategy.HashSlot((RedisChannel)"hey");
-            var slot2 = muxer.ServerSelectionStrategy.HashSlot((RedisChannel)"hey2");
+        Log("Publishing (1)...");
+        Assert.Equal(0, count);
+        var publishedTo = await sub.PublishAsync(channel, "message1");
+        // Client -> Redis -> Client -> handler takes just a moment
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
+        Assert.Equal(1, count);
+        Log($"  Published (1) to {publishedTo} subscriber(s).");
+        Assert.Equal(1, publishedTo);
 
-            Assert.NotEqual(defaultSlot, slot1);
-            Assert.NotEqual(ServerSelectionStrategy.NoSlot, slot1);
-            Assert.NotEqual(slot1, slot2);
-        }
+        var endpoint = sub.SubscribedEndpoint(channel);
+        var subscribedServer = conn.GetServer(endpoint);
+        var subscribedServerEndpoint = conn.GetServerEndPoint(endpoint);
 
-        [Fact]
-        public async Task ClusterNodeSubscriptionFailover()
+        Assert.True(subscribedServer.IsConnected, "subscribedServer.IsConnected");
+        Assert.NotNull(subscribedServerEndpoint);
+        Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
+        Assert.True(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
+
+        Assert.True(conn.TryGetSubscription(channel, out var subscription));
+        var initialServer = subscription.GetCurrentServer();
+        Assert.NotNull(initialServer);
+        Assert.True(initialServer.IsConnected);
+        Log("Connected to: " + initialServer);
+
+        conn.AllowConnect = false;
+        subscribedServerEndpoint.SimulateConnectionFailure(SimulatedFailureType.AllSubscription);
+
+        Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
+        Assert.False(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
+
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
+        Assert.True(subscription.IsConnected);
+
+        var newServer = subscription.GetCurrentServer();
+        Assert.NotNull(newServer);
+        Assert.NotEqual(newServer, initialServer);
+        Log("Now connected to: " + newServer);
+
+        count = 0;
+        Log("Publishing (2)...");
+        Assert.Equal(0, count);
+        publishedTo = await sub.PublishAsync(channel, "message2");
+        // Client -> Redis -> Client -> handler takes just a moment
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
+        Assert.Equal(1, count);
+        Log($"  Published (2) to {publishedTo} subscriber(s).");
+
+        ClearAmbientFailures();
+    }
+
+    [Theory]
+    [InlineData(CommandFlags.PreferMaster, true)]
+    [InlineData(CommandFlags.PreferReplica, true)]
+    [InlineData(CommandFlags.DemandMaster, false)]
+    [InlineData(CommandFlags.DemandReplica, false)]
+    public async Task PrimaryReplicaSubscriptionFailover(CommandFlags flags, bool expectSuccess)
+    {
+        var config = TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
+        Log("Connecting...");
+
+        using var muxer = (Create(configuration: config, shared: false, allowAdmin: true) as ConnectionMultiplexer)!;
+
+        var sub = muxer.GetSubscriber();
+        var channel = (RedisChannel)(Me() + flags.ToString()); // Individual channel per case to not overlap publishers
+
+        var count = 0;
+        Log("Subscribing...");
+        await sub.SubscribeAsync(channel, (_, val) =>
         {
-            Log("Connecting...");
-            using var muxer = (Create(allowAdmin: true) as ConnectionMultiplexer)!;
-            var sub = muxer.GetSubscriber();
-            var channel = (RedisChannel)Me();
+            Interlocked.Increment(ref count);
+            Log("Message: " + val);
+        }, flags);
+        Assert.True(sub.IsConnected(channel));
 
-            var count = 0;
-            Log("Subscribing...");
-            await sub.SubscribeAsync(channel, (_, val) =>
-            {
-                Interlocked.Increment(ref count);
-                Log("Message: " + val);
-            });
-            Assert.True(sub.IsConnected(channel));
+        Log("Publishing (1)...");
+        Assert.Equal(0, count);
+        var publishedTo = await sub.PublishAsync(channel, "message1");
+        // Client -> Redis -> Client -> handler takes just a moment
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
+        Assert.Equal(1, count);
+        Log($"  Published (1) to {publishedTo} subscriber(s).");
 
-            Log("Publishing (1)...");
-            Assert.Equal(0, count);
-            var publishedTo = await sub.PublishAsync(channel, "message1");
-            // Client -> Redis -> Client -> handler takes just a moment
-            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
-            Assert.Equal(1, count);
-            Log($"  Published (1) to {publishedTo} subscriber(s).");
-            Assert.Equal(1, publishedTo);
+        var endpoint = sub.SubscribedEndpoint(channel);
+        var subscribedServer = muxer.GetServer(endpoint);
+        var subscribedServerEndpoint = muxer.GetServerEndPoint(endpoint);
 
-            var endpoint = sub.SubscribedEndpoint(channel);
-            var subscribedServer = muxer.GetServer(endpoint);
-            var subscribedServerEndpoint = muxer.GetServerEndPoint(endpoint);
+        Assert.True(subscribedServer.IsConnected, "subscribedServer.IsConnected");
+        Assert.NotNull(subscribedServerEndpoint);
+        Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
+        Assert.True(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
 
-            Assert.True(subscribedServer.IsConnected, "subscribedServer.IsConnected");
-            Assert.NotNull(subscribedServerEndpoint);
-            Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
-            Assert.True(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
+        Assert.True(muxer.TryGetSubscription(channel, out var subscription));
+        var initialServer = subscription.GetCurrentServer();
+        Assert.NotNull(initialServer);
+        Assert.True(initialServer.IsConnected);
+        Log("Connected to: " + initialServer);
 
-            Assert.True(muxer.TryGetSubscription(channel, out var subscription));
-            var initialServer = subscription.GetCurrentServer();
-            Assert.NotNull(initialServer);
-            Assert.True(initialServer.IsConnected);
-            Log("Connected to: " + initialServer);
+        muxer.AllowConnect = false;
+        subscribedServerEndpoint.SimulateConnectionFailure(SimulatedFailureType.AllSubscription);
 
-            muxer.AllowConnect = false;
-            subscribedServerEndpoint.SimulateConnectionFailure(SimulatedFailureType.AllSubscription);
+        Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
+        Assert.False(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
 
-            Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
-            Assert.False(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
-
+        if (expectSuccess)
+        {
             await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
             Assert.True(subscription.IsConnected);
 
@@ -80,108 +157,34 @@ namespace StackExchange.Redis.Tests
             Assert.NotNull(newServer);
             Assert.NotEqual(newServer, initialServer);
             Log("Now connected to: " + newServer);
-
-            count = 0;
-            Log("Publishing (2)...");
-            Assert.Equal(0, count);
-            publishedTo = await sub.PublishAsync(channel, "message2");
-            // Client -> Redis -> Client -> handler takes just a moment
-            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
-            Assert.Equal(1, count);
-            Log($"  Published (2) to {publishedTo} subscriber(s).");
-
-            ClearAmbientFailures();
         }
-
-        [Theory]
-        [InlineData(CommandFlags.PreferMaster, true)]
-        [InlineData(CommandFlags.PreferReplica, true)]
-        [InlineData(CommandFlags.DemandMaster, false)]
-        [InlineData(CommandFlags.DemandReplica, false)]
-        public async Task PrimaryReplicaSubscriptionFailover(CommandFlags flags, bool expectSuccess)
+        else
         {
-            var config = TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort;
-            Log("Connecting...");
-            using var muxer = (Create(configuration: config, shared: false, allowAdmin: true) as ConnectionMultiplexer)!;
-            var sub = muxer.GetSubscriber();
-            var channel = (RedisChannel)(Me() + flags.ToString()); // Individual channel per case to not overlap publishers
+            // This subscription shouldn't be able to reconnect by flags (demanding an unavailable server)
+            await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
+            Assert.False(subscription.IsConnected);
+            Log("Unable to reconnect (as expected)");
 
-            var count = 0;
-            Log("Subscribing...");
-            await sub.SubscribeAsync(channel, (_, val) =>
-            {
-                Interlocked.Increment(ref count);
-                Log("Message: " + val);
-            }, flags);
-            Assert.True(sub.IsConnected(channel));
+            // Allow connecting back to the original
+            muxer.AllowConnect = true;
+            await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
+            Assert.True(subscription.IsConnected);
 
-            Log("Publishing (1)...");
-            Assert.Equal(0, count);
-            var publishedTo = await sub.PublishAsync(channel, "message1");
-            // Client -> Redis -> Client -> handler takes just a moment
-            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
-            Assert.Equal(1, count);
-            Log($"  Published (1) to {publishedTo} subscriber(s).");
-
-            var endpoint = sub.SubscribedEndpoint(channel);
-            var subscribedServer = muxer.GetServer(endpoint);
-            var subscribedServerEndpoint = muxer.GetServerEndPoint(endpoint);
-
-            Assert.True(subscribedServer.IsConnected, "subscribedServer.IsConnected");
-            Assert.NotNull(subscribedServerEndpoint);
-            Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
-            Assert.True(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
-
-            Assert.True(muxer.TryGetSubscription(channel, out var subscription));
-            var initialServer = subscription.GetCurrentServer();
-            Assert.NotNull(initialServer);
-            Assert.True(initialServer.IsConnected);
-            Log("Connected to: " + initialServer);
-
-            muxer.AllowConnect = false;
-            subscribedServerEndpoint.SimulateConnectionFailure(SimulatedFailureType.AllSubscription);
-
-            Assert.True(subscribedServerEndpoint.IsConnected, "subscribedServerEndpoint.IsConnected");
-            Assert.False(subscribedServerEndpoint.IsSubscriberConnected, "subscribedServerEndpoint.IsSubscriberConnected");
-
-            if (expectSuccess)
-            {
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
-                Assert.True(subscription.IsConnected);
-
-                var newServer = subscription.GetCurrentServer();
-                Assert.NotNull(newServer);
-                Assert.NotEqual(newServer, initialServer);
-                Log("Now connected to: " + newServer);
-            }
-            else
-            {
-                // This subscription shouldn't be able to reconnect by flags (demanding an unavailable server)
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
-                Assert.False(subscription.IsConnected);
-                Log("Unable to reconnect (as expected)");
-
-                // Allow connecting back to the original
-                muxer.AllowConnect = true;
-                await UntilConditionAsync(TimeSpan.FromSeconds(5), () => subscription.IsConnected);
-                Assert.True(subscription.IsConnected);
-
-                var newServer = subscription.GetCurrentServer();
-                Assert.NotNull(newServer);
-                Assert.Equal(newServer, initialServer);
-                Log("Now connected to: " + newServer);
-            }
-
-            count = 0;
-            Log("Publishing (2)...");
-            Assert.Equal(0, count);
-            publishedTo = await sub.PublishAsync(channel, "message2");
-            // Client -> Redis -> Client -> handler takes just a moment
-            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
-            Assert.Equal(1, count);
-            Log($"  Published (2) to {publishedTo} subscriber(s).");
-
-            ClearAmbientFailures();
+            var newServer = subscription.GetCurrentServer();
+            Assert.NotNull(newServer);
+            Assert.Equal(newServer, initialServer);
+            Log("Now connected to: " + newServer);
         }
+
+        count = 0;
+        Log("Publishing (2)...");
+        Assert.Equal(0, count);
+        publishedTo = await sub.PublishAsync(channel, "message2");
+        // Client -> Redis -> Client -> handler takes just a moment
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => Volatile.Read(ref count) == 1);
+        Assert.Equal(1, count);
+        Log($"  Published (2) to {publishedTo} subscriber(s).");
+
+        ClearAmbientFailures();
     }
 }

--- a/tests/StackExchange.Redis.Tests/RawResultTests.cs
+++ b/tests/StackExchange.Redis.Tests/RawResultTests.cs
@@ -1,65 +1,65 @@
 ﻿using System.Buffers;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class RawResultTests
 {
-    public class RawResultTests
+    [Fact]
+    public void TypeLoads()
     {
-        [Fact]
-        public void TypeLoads()
-        {
-            var type = typeof(RawResult);
-            Assert.Equal(nameof(RawResult), type.Name);
-        }
-        [Fact]
-        public void NullWorks()
-        {
-            var result = new RawResult(ResultType.BulkString, ReadOnlySequence<byte>.Empty, true);
-            Assert.Equal(ResultType.BulkString, result.Type);
-            Assert.True(result.IsNull);
+        var type = typeof(RawResult);
+        Assert.Equal(nameof(RawResult), type.Name);
+    }
 
-            var value = result.AsRedisValue();
+    [Fact]
+    public void NullWorks()
+    {
+        var result = new RawResult(ResultType.BulkString, ReadOnlySequence<byte>.Empty, true);
+        Assert.Equal(ResultType.BulkString, result.Type);
+        Assert.True(result.IsNull);
 
-            Assert.True(value.IsNull);
-            string? s = value;
-            Assert.Null(s);
+        var value = result.AsRedisValue();
 
-            byte[]? arr = (byte[]?)value;
-            Assert.Null(arr);
-        }
+        Assert.True(value.IsNull);
+        string? s = value;
+        Assert.Null(s);
 
-        [Fact]
-        public void DefaultWorks()
-        {
-            var result = default(RawResult);
-            Assert.Equal(ResultType.None, result.Type);
-            Assert.True(result.IsNull);
+        byte[]? arr = (byte[]?)value;
+        Assert.Null(arr);
+    }
 
-            var value = result.AsRedisValue();
+    [Fact]
+    public void DefaultWorks()
+    {
+        var result = default(RawResult);
+        Assert.Equal(ResultType.None, result.Type);
+        Assert.True(result.IsNull);
 
-            Assert.True(value.IsNull);
-            var s = (string?)value;
-            Assert.Null(s);
+        var value = result.AsRedisValue();
 
-            var arr = (byte[]?)value;
-            Assert.Null(arr);
-        }
+        Assert.True(value.IsNull);
+        var s = (string?)value;
+        Assert.Null(s);
 
-        [Fact]
-        public void NilWorks()
-        {
-            var result = RawResult.Nil;
-            Assert.Equal(ResultType.None, result.Type);
-            Assert.True(result.IsNull);
+        var arr = (byte[]?)value;
+        Assert.Null(arr);
+    }
 
-            var value = result.AsRedisValue();
+    [Fact]
+    public void NilWorks()
+    {
+        var result = RawResult.Nil;
+        Assert.Equal(ResultType.None, result.Type);
+        Assert.True(result.IsNull);
 
-            Assert.True(value.IsNull);
-            var s = (string?)value;
-            Assert.Null(s);
+        var value = result.AsRedisValue();
 
-            var arr = (byte[]?)value;
-            Assert.Null(arr);
-        }
+        Assert.True(value.IsNull);
+        var s = (string?)value;
+        Assert.Null(s);
+
+        var arr = (byte[]?)value;
+        Assert.Null(arr);
     }
 }

--- a/tests/StackExchange.Redis.Tests/RealWorld.cs
+++ b/tests/StackExchange.Redis.Tests/RealWorld.cs
@@ -2,31 +2,30 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class RealWorld : TestBase
 {
-    public class RealWorld : TestBase
+    public RealWorld(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task WhyDoesThisNotWork()
     {
-        public RealWorld(ITestOutputHelper output) : base(output) { }
+        Log("first:");
+        var config = ConfigurationOptions.Parse("localhost:6379,localhost:6380,name=Core (Q&A),tiebreaker=:RedisPrimary,abortConnect=False");
+        Assert.Equal(2, config.EndPoints.Count);
+        Log("Endpoint 0: {0} (AddressFamily: {1})", config.EndPoints[0], config.EndPoints[0].AddressFamily);
+        Log("Endpoint 1: {0} (AddressFamily: {1})", config.EndPoints[1], config.EndPoints[1].AddressFamily);
 
-        [Fact]
-        public async Task WhyDoesThisNotWork()
+        using (var conn = ConnectionMultiplexer.Connect("localhost:6379,localhost:6380,name=Core (Q&A),tiebreaker=:RedisPrimary,abortConnect=False", Writer))
         {
-            Log("first:");
-            var config = ConfigurationOptions.Parse("localhost:6379,localhost:6380,name=Core (Q&A),tiebreaker=:RedisPrimary,abortConnect=False");
-            Assert.Equal(2, config.EndPoints.Count);
-            Log("Endpoint 0: {0} (AddressFamily: {1})", config.EndPoints[0], config.EndPoints[0].AddressFamily);
-            Log("Endpoint 1: {0} (AddressFamily: {1})", config.EndPoints[1], config.EndPoints[1].AddressFamily);
+            Log("");
+            Log("pausing...");
+            await Task.Delay(200).ForAwait();
+            Log("second:");
 
-            using (var conn = ConnectionMultiplexer.Connect("localhost:6379,localhost:6380,name=Core (Q&A),tiebreaker=:RedisPrimary,abortConnect=False", Writer))
-            {
-                Log("");
-                Log("pausing...");
-                await Task.Delay(200).ForAwait();
-                Log("second:");
-
-                bool result = conn.Configure(Writer);
-                Log("Returned: {0}", result);
-            }
+            bool result = conn.Configure(Writer);
+            Log("Returned: {0}", result);
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/RedisFeaturesTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisFeaturesTests.cs
@@ -1,30 +1,29 @@
 ﻿using System;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class RedisFeaturesTests
 {
-    public class RedisFeaturesTests
+    [Fact]
+    public void ExecAbort() // a random one because it is fun
     {
-        [Fact]
-        public void ExecAbort() // a random one because it is fun
-        {
-            var features = new RedisFeatures(new Version(2, 9));
-            var s = features.ToString();
-            Assert.True(features.ExecAbort);
-            Assert.StartsWith("Features in 2.9" + Environment.NewLine, s);
-            Assert.Contains("ExecAbort: True" + Environment.NewLine, s);
+        var features = new RedisFeatures(new Version(2, 9));
+        var s = features.ToString();
+        Assert.True(features.ExecAbort);
+        Assert.StartsWith("Features in 2.9" + Environment.NewLine, s);
+        Assert.Contains("ExecAbort: True" + Environment.NewLine, s);
 
-            features = new RedisFeatures(new Version(2, 9, 5));
-            s = features.ToString();
-            Assert.False(features.ExecAbort);
-            Assert.StartsWith("Features in 2.9.5" + Environment.NewLine, s);
-            Assert.Contains("ExecAbort: False" + Environment.NewLine, s);
+        features = new RedisFeatures(new Version(2, 9, 5));
+        s = features.ToString();
+        Assert.False(features.ExecAbort);
+        Assert.StartsWith("Features in 2.9.5" + Environment.NewLine, s);
+        Assert.Contains("ExecAbort: False" + Environment.NewLine, s);
 
-            features = new RedisFeatures(new Version(3, 0));
-            s = features.ToString();
-            Assert.True(features.ExecAbort);
-            Assert.StartsWith("Features in 3.0" + Environment.NewLine, s);
-            Assert.Contains("ExecAbort: True" + Environment.NewLine, s);
-        }
+        features = new RedisFeatures(new Version(3, 0));
+        s = features.ToString();
+        Assert.True(features.ExecAbort);
+        Assert.StartsWith("Features in 3.0" + Environment.NewLine, s);
+        Assert.Contains("ExecAbort: True" + Environment.NewLine, s);
     }
 }

--- a/tests/StackExchange.Redis.Tests/RedisResultTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisResultTests.cs
@@ -2,154 +2,153 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Tests for <see cref="RedisResult"/>
+/// </summary>
+public sealed class RedisResultTests
 {
     /// <summary>
-    /// Tests for <see cref="RedisResult"/>
+    /// Tests the basic functionality of <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/>
     /// </summary>
-    public sealed class RedisResultTests
+    [Fact]
+    public void ToDictionaryWorks()
     {
-        /// <summary>
-        /// Tests the basic functionality of <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/>
-        /// </summary>
-        [Fact]
-        public void ToDictionaryWorks()
-        {
-            var redisArrayResult = RedisResult.Create(
-                new RedisValue[] { "one", 1, "two", 2, "three", 3, "four", 4 });
+        var redisArrayResult = RedisResult.Create(
+            new RedisValue[] { "one", 1, "two", 2, "three", 3, "four", 4 });
 
-            var dict = redisArrayResult.ToDictionary();
+        var dict = redisArrayResult.ToDictionary();
 
-            Assert.Equal(4, dict.Count);
-            Assert.Equal(1, (RedisValue)dict["one"]);
-            Assert.Equal(2, (RedisValue)dict["two"]);
-            Assert.Equal(3, (RedisValue)dict["three"]);
-            Assert.Equal(4, (RedisValue)dict["four"]);
-        }
+        Assert.Equal(4, dict.Count);
+        Assert.Equal(1, (RedisValue)dict["one"]);
+        Assert.Equal(2, (RedisValue)dict["two"]);
+        Assert.Equal(3, (RedisValue)dict["three"]);
+        Assert.Equal(4, (RedisValue)dict["four"]);
+    }
 
-        /// <summary>
-        /// Tests the basic functionality of <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/>
-        /// when the results contain a nested results array, which is common for lua script results
-        /// </summary>
-        [Fact]
-        public void ToDictionaryWorksWhenNested()
-        {
-            var redisArrayResult = RedisResult.Create(
-                new []
-                {
-                    RedisResult.Create((RedisValue)"one"),
-                    RedisResult.Create(new RedisValue[]{"two", 2, "three", 3}),
+    /// <summary>
+    /// Tests the basic functionality of <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/>
+    /// when the results contain a nested results array, which is common for lua script results
+    /// </summary>
+    [Fact]
+    public void ToDictionaryWorksWhenNested()
+    {
+        var redisArrayResult = RedisResult.Create(
+            new []
+            {
+                RedisResult.Create((RedisValue)"one"),
+                RedisResult.Create(new RedisValue[]{"two", 2, "three", 3}),
 
-                    RedisResult.Create((RedisValue)"four"),
-                    RedisResult.Create(new RedisValue[] { "five", 5, "six", 6 }),
-                });
+                RedisResult.Create((RedisValue)"four"),
+                RedisResult.Create(new RedisValue[] { "five", 5, "six", 6 }),
+            });
 
-            var dict = redisArrayResult.ToDictionary();
-            var nestedDict = dict["one"].ToDictionary();
+        var dict = redisArrayResult.ToDictionary();
+        var nestedDict = dict["one"].ToDictionary();
 
-            Assert.Equal(2, dict.Count);
-            Assert.Equal(2, nestedDict.Count);
-            Assert.Equal(2, (RedisValue)nestedDict["two"]);
-            Assert.Equal(3, (RedisValue)nestedDict["three"]);
-        }
+        Assert.Equal(2, dict.Count);
+        Assert.Equal(2, nestedDict.Count);
+        Assert.Equal(2, (RedisValue)nestedDict["two"]);
+        Assert.Equal(3, (RedisValue)nestedDict["three"]);
+    }
 
-        /// <summary>
-        /// Tests that <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/> fails when a duplicate key is encountered.
-        /// This also tests that the default comparator is case-insensitive.
-        /// </summary>
-        [Fact]
-        public void ToDictionaryFailsWithDuplicateKeys()
-        {
-            var redisArrayResult = RedisResult.Create(
-                new RedisValue[] { "banana", 1, "BANANA", 2, "orange", 3, "apple", 4 });
+    /// <summary>
+    /// Tests that <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/> fails when a duplicate key is encountered.
+    /// This also tests that the default comparator is case-insensitive.
+    /// </summary>
+    [Fact]
+    public void ToDictionaryFailsWithDuplicateKeys()
+    {
+        var redisArrayResult = RedisResult.Create(
+            new RedisValue[] { "banana", 1, "BANANA", 2, "orange", 3, "apple", 4 });
 
-            Assert.Throws<ArgumentException>(() => redisArrayResult.ToDictionary(/* Use default comparer, causes collision of banana */));
-        }
+        Assert.Throws<ArgumentException>(() => redisArrayResult.ToDictionary(/* Use default comparer, causes collision of banana */));
+    }
 
-        /// <summary>
-        /// Tests that <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/> correctly uses the provided comparator
-        /// </summary>
-        [Fact]
-        public void ToDictionaryWorksWithCustomComparator()
-        {
-            var redisArrayResult = RedisResult.Create(
-                new RedisValue[] { "banana", 1, "BANANA", 2, "orange", 3, "apple", 4 });
+    /// <summary>
+    /// Tests that <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/> correctly uses the provided comparator
+    /// </summary>
+    [Fact]
+    public void ToDictionaryWorksWithCustomComparator()
+    {
+        var redisArrayResult = RedisResult.Create(
+            new RedisValue[] { "banana", 1, "BANANA", 2, "orange", 3, "apple", 4 });
 
-            var dict = redisArrayResult.ToDictionary(StringComparer.Ordinal);
+        var dict = redisArrayResult.ToDictionary(StringComparer.Ordinal);
 
-            Assert.Equal(4, dict.Count);
-            Assert.Equal(1, (RedisValue)dict["banana"]);
-            Assert.Equal(2, (RedisValue)dict["BANANA"]);
-        }
+        Assert.Equal(4, dict.Count);
+        Assert.Equal(1, (RedisValue)dict["banana"]);
+        Assert.Equal(2, (RedisValue)dict["BANANA"]);
+    }
 
-        /// <summary>
-        /// Tests that <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/> fails when the redis results array contains an odd number
-        /// of elements.  In other words, it's not actually a Key,Value,Key,Value... etc. array
-        /// </summary>
-        [Fact]
-        public void ToDictionaryFailsOnMishapenResults()
-        {
-            var redisArrayResult = RedisResult.Create(
-                new RedisValue[] { "one", 1, "two", 2, "three", 3, "four" /* missing 4 */ });
+    /// <summary>
+    /// Tests that <see cref="RedisResult.ToDictionary(IEqualityComparer{string})"/> fails when the redis results array contains an odd number
+    /// of elements.  In other words, it's not actually a Key,Value,Key,Value... etc. array
+    /// </summary>
+    [Fact]
+    public void ToDictionaryFailsOnMishapenResults()
+    {
+        var redisArrayResult = RedisResult.Create(
+            new RedisValue[] { "one", 1, "two", 2, "three", 3, "four" /* missing 4 */ });
 
-            Assert.Throws<IndexOutOfRangeException>(()=>redisArrayResult.ToDictionary(StringComparer.Ordinal));
-        }
+        Assert.Throws<IndexOutOfRangeException>(()=>redisArrayResult.ToDictionary(StringComparer.Ordinal));
+    }
 
-        [Fact]
-        public void SingleResultConvertibleViaTo()
-        {
-            var value = RedisResult.Create(123);
-            Assert.StrictEqual((int)123, Convert.ToInt32(value));
-            Assert.StrictEqual((uint)123U, Convert.ToUInt32(value));
-            Assert.StrictEqual((long)123, Convert.ToInt64(value));
-            Assert.StrictEqual((ulong)123U, Convert.ToUInt64(value));
-            Assert.StrictEqual((byte)123, Convert.ToByte(value));
-            Assert.StrictEqual((sbyte)123, Convert.ToSByte(value));
-            Assert.StrictEqual((short)123, Convert.ToInt16(value));
-            Assert.StrictEqual((ushort)123, Convert.ToUInt16(value));
-            Assert.Equal("123", Convert.ToString(value));
-            Assert.StrictEqual(123M, Convert.ToDecimal(value));
-            Assert.StrictEqual((char)123, Convert.ToChar(value));
-            Assert.StrictEqual(123f, Convert.ToSingle(value));
-            Assert.StrictEqual(123d, Convert.ToDouble(value));
-        }
+    [Fact]
+    public void SingleResultConvertibleViaTo()
+    {
+        var value = RedisResult.Create(123);
+        Assert.StrictEqual((int)123, Convert.ToInt32(value));
+        Assert.StrictEqual((uint)123U, Convert.ToUInt32(value));
+        Assert.StrictEqual((long)123, Convert.ToInt64(value));
+        Assert.StrictEqual((ulong)123U, Convert.ToUInt64(value));
+        Assert.StrictEqual((byte)123, Convert.ToByte(value));
+        Assert.StrictEqual((sbyte)123, Convert.ToSByte(value));
+        Assert.StrictEqual((short)123, Convert.ToInt16(value));
+        Assert.StrictEqual((ushort)123, Convert.ToUInt16(value));
+        Assert.Equal("123", Convert.ToString(value));
+        Assert.StrictEqual(123M, Convert.ToDecimal(value));
+        Assert.StrictEqual((char)123, Convert.ToChar(value));
+        Assert.StrictEqual(123f, Convert.ToSingle(value));
+        Assert.StrictEqual(123d, Convert.ToDouble(value));
+    }
 
-        [Fact]
-        public void SingleResultConvertibleDirectViaChangeType_Type()
-        {
-            var value = RedisResult.Create(123);
-            Assert.StrictEqual((int)123, Convert.ChangeType(value, typeof(int)));
-            Assert.StrictEqual((uint)123U, Convert.ChangeType(value, typeof(uint)));
-            Assert.StrictEqual((long)123, Convert.ChangeType(value, typeof(long)));
-            Assert.StrictEqual((ulong)123U, Convert.ChangeType(value, typeof(ulong)));
-            Assert.StrictEqual((byte)123, Convert.ChangeType(value, typeof(byte)));
-            Assert.StrictEqual((sbyte)123, Convert.ChangeType(value, typeof(sbyte)));
-            Assert.StrictEqual((short)123, Convert.ChangeType(value, typeof(short)));
-            Assert.StrictEqual((ushort)123, Convert.ChangeType(value, typeof(ushort)));
-            Assert.Equal("123", Convert.ChangeType(value, typeof(string)));
-            Assert.StrictEqual(123M, Convert.ChangeType(value, typeof(decimal)));
-            Assert.StrictEqual((char)123, Convert.ChangeType(value, typeof(char)));
-            Assert.StrictEqual(123f, Convert.ChangeType(value, typeof(float)));
-            Assert.StrictEqual(123d, Convert.ChangeType(value, typeof(double)));
-        }
+    [Fact]
+    public void SingleResultConvertibleDirectViaChangeType_Type()
+    {
+        var value = RedisResult.Create(123);
+        Assert.StrictEqual((int)123, Convert.ChangeType(value, typeof(int)));
+        Assert.StrictEqual((uint)123U, Convert.ChangeType(value, typeof(uint)));
+        Assert.StrictEqual((long)123, Convert.ChangeType(value, typeof(long)));
+        Assert.StrictEqual((ulong)123U, Convert.ChangeType(value, typeof(ulong)));
+        Assert.StrictEqual((byte)123, Convert.ChangeType(value, typeof(byte)));
+        Assert.StrictEqual((sbyte)123, Convert.ChangeType(value, typeof(sbyte)));
+        Assert.StrictEqual((short)123, Convert.ChangeType(value, typeof(short)));
+        Assert.StrictEqual((ushort)123, Convert.ChangeType(value, typeof(ushort)));
+        Assert.Equal("123", Convert.ChangeType(value, typeof(string)));
+        Assert.StrictEqual(123M, Convert.ChangeType(value, typeof(decimal)));
+        Assert.StrictEqual((char)123, Convert.ChangeType(value, typeof(char)));
+        Assert.StrictEqual(123f, Convert.ChangeType(value, typeof(float)));
+        Assert.StrictEqual(123d, Convert.ChangeType(value, typeof(double)));
+    }
 
-        [Fact]
-        public void SingleResultConvertibleDirectViaChangeType_TypeCode()
-        {
-            var value = RedisResult.Create(123);
-            Assert.StrictEqual((int)123, Convert.ChangeType(value, TypeCode.Int32));
-            Assert.StrictEqual((uint)123U, Convert.ChangeType(value, TypeCode.UInt32));
-            Assert.StrictEqual((long)123, Convert.ChangeType(value, TypeCode.Int64));
-            Assert.StrictEqual((ulong)123U, Convert.ChangeType(value, TypeCode.UInt64));
-            Assert.StrictEqual((byte)123, Convert.ChangeType(value, TypeCode.Byte));
-            Assert.StrictEqual((sbyte)123, Convert.ChangeType(value, TypeCode.SByte));
-            Assert.StrictEqual((short)123, Convert.ChangeType(value, TypeCode.Int16));
-            Assert.StrictEqual((ushort)123, Convert.ChangeType(value, TypeCode.UInt16));
-            Assert.Equal("123", Convert.ChangeType(value, TypeCode.String));
-            Assert.StrictEqual(123M, Convert.ChangeType(value, TypeCode.Decimal));
-            Assert.StrictEqual((char)123, Convert.ChangeType(value, TypeCode.Char));
-            Assert.StrictEqual(123f, Convert.ChangeType(value, TypeCode.Single));
-            Assert.StrictEqual(123d, Convert.ChangeType(value, TypeCode.Double));
-        }
+    [Fact]
+    public void SingleResultConvertibleDirectViaChangeType_TypeCode()
+    {
+        var value = RedisResult.Create(123);
+        Assert.StrictEqual((int)123, Convert.ChangeType(value, TypeCode.Int32));
+        Assert.StrictEqual((uint)123U, Convert.ChangeType(value, TypeCode.UInt32));
+        Assert.StrictEqual((long)123, Convert.ChangeType(value, TypeCode.Int64));
+        Assert.StrictEqual((ulong)123U, Convert.ChangeType(value, TypeCode.UInt64));
+        Assert.StrictEqual((byte)123, Convert.ChangeType(value, TypeCode.Byte));
+        Assert.StrictEqual((sbyte)123, Convert.ChangeType(value, TypeCode.SByte));
+        Assert.StrictEqual((short)123, Convert.ChangeType(value, TypeCode.Int16));
+        Assert.StrictEqual((ushort)123, Convert.ChangeType(value, TypeCode.UInt16));
+        Assert.Equal("123", Convert.ChangeType(value, TypeCode.String));
+        Assert.StrictEqual(123M, Convert.ChangeType(value, TypeCode.Decimal));
+        Assert.StrictEqual((char)123, Convert.ChangeType(value, TypeCode.Char));
+        Assert.StrictEqual(123f, Convert.ChangeType(value, TypeCode.Single));
+        Assert.StrictEqual(123d, Convert.ChangeType(value, TypeCode.Double));
     }
 }

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalency.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalency.cs
@@ -2,281 +2,280 @@
 using System.Text;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
-{
-    public class RedisValueEquivalency
-    {
-        // internal storage types: null, integer, double, string, raw
-        // public perceived types: int, long, double, bool, memory / byte[]
+namespace StackExchange.Redis.Tests;
 
-        [Fact]
-        public void Int32_Matrix()
+public class RedisValueEquivalency
+{
+    // internal storage types: null, integer, double, string, raw
+    // public perceived types: int, long, double, bool, memory / byte[]
+
+    [Fact]
+    public void Int32_Matrix()
+    {
+        static void Check(RedisValue known, RedisValue test)
         {
-            static void Check(RedisValue known, RedisValue test)
+            KeysAndValues.CheckSame(known, test);
+            if (known.IsNull)
             {
-                KeysAndValues.CheckSame(known, test);
-                if (known.IsNull)
-                {
-                    Assert.True(test.IsNull);
-                    Assert.False(((int?)test).HasValue);
-                }
-                else
-                {
-                    Assert.False(test.IsNull);
-                    Assert.Equal((int)known, ((int?)test)!.Value);
-                    Assert.Equal((int)known, (int)test);
-                }
+                Assert.True(test.IsNull);
+                Assert.False(((int?)test).HasValue);
+            }
+            else
+            {
+                Assert.False(test.IsNull);
+                Assert.Equal((int)known, ((int?)test)!.Value);
                 Assert.Equal((int)known, (int)test);
             }
-            Check(42, 42);
-            Check(42, 42.0);
-            Check(42, "42");
-            Check(42, "42.0");
-            Check(42, Bytes("42"));
-            Check(42, Bytes("42.0"));
-            CheckString(42, "42");
-
-            Check(-42, -42);
-            Check(-42, -42.0);
-            Check(-42, "-42");
-            Check(-42, "-42.0");
-            Check(-42, Bytes("-42"));
-            Check(-42, Bytes("-42.0"));
-            CheckString(-42, "-42");
-
-            Check(1, true);
-            Check(0, false);
+            Assert.Equal((int)known, (int)test);
         }
+        Check(42, 42);
+        Check(42, 42.0);
+        Check(42, "42");
+        Check(42, "42.0");
+        Check(42, Bytes("42"));
+        Check(42, Bytes("42.0"));
+        CheckString(42, "42");
 
-        [Fact]
-        public void Int64_Matrix()
+        Check(-42, -42);
+        Check(-42, -42.0);
+        Check(-42, "-42");
+        Check(-42, "-42.0");
+        Check(-42, Bytes("-42"));
+        Check(-42, Bytes("-42.0"));
+        CheckString(-42, "-42");
+
+        Check(1, true);
+        Check(0, false);
+    }
+
+    [Fact]
+    public void Int64_Matrix()
+    {
+        static void Check(RedisValue known, RedisValue test)
         {
-            static void Check(RedisValue known, RedisValue test)
+            KeysAndValues.CheckSame(known, test);
+            if (known.IsNull)
             {
-                KeysAndValues.CheckSame(known, test);
-                if (known.IsNull)
-                {
-                    Assert.True(test.IsNull);
-                    Assert.False(((long?)test).HasValue);
-                }
-                else
-                {
-                    Assert.False(test.IsNull);
-                    Assert.Equal((long)known, ((long?)test!).Value);
-                    Assert.Equal((long)known, (long)test);
-                }
+                Assert.True(test.IsNull);
+                Assert.False(((long?)test).HasValue);
+            }
+            else
+            {
+                Assert.False(test.IsNull);
+                Assert.Equal((long)known, ((long?)test!).Value);
                 Assert.Equal((long)known, (long)test);
             }
-            Check(1099511627848, 1099511627848);
-            Check(1099511627848, 1099511627848.0);
-            Check(1099511627848, "1099511627848");
-            Check(1099511627848, "1099511627848.0");
-            Check(1099511627848, Bytes("1099511627848"));
-            Check(1099511627848, Bytes("1099511627848.0"));
-            CheckString(1099511627848, "1099511627848");
-
-            Check(-1099511627848, -1099511627848);
-            Check(-1099511627848, -1099511627848);
-            Check(-1099511627848, "-1099511627848");
-            Check(-1099511627848, "-1099511627848.0");
-            Check(-1099511627848, Bytes("-1099511627848"));
-            Check(-1099511627848, Bytes("-1099511627848.0"));
-            CheckString(-1099511627848, "-1099511627848");
-
-            Check(1L, true);
-            Check(0L, false);
+            Assert.Equal((long)known, (long)test);
         }
+        Check(1099511627848, 1099511627848);
+        Check(1099511627848, 1099511627848.0);
+        Check(1099511627848, "1099511627848");
+        Check(1099511627848, "1099511627848.0");
+        Check(1099511627848, Bytes("1099511627848"));
+        Check(1099511627848, Bytes("1099511627848.0"));
+        CheckString(1099511627848, "1099511627848");
 
-        [Fact]
-        public void Double_Matrix()
+        Check(-1099511627848, -1099511627848);
+        Check(-1099511627848, -1099511627848);
+        Check(-1099511627848, "-1099511627848");
+        Check(-1099511627848, "-1099511627848.0");
+        Check(-1099511627848, Bytes("-1099511627848"));
+        Check(-1099511627848, Bytes("-1099511627848.0"));
+        CheckString(-1099511627848, "-1099511627848");
+
+        Check(1L, true);
+        Check(0L, false);
+    }
+
+    [Fact]
+    public void Double_Matrix()
+    {
+        static void Check(RedisValue known, RedisValue test)
         {
-            static void Check(RedisValue known, RedisValue test)
+            KeysAndValues.CheckSame(known, test);
+            if (known.IsNull)
             {
-                KeysAndValues.CheckSame(known, test);
-                if (known.IsNull)
-                {
-                    Assert.True(test.IsNull);
-                    Assert.False(((double?)test).HasValue);
-                }
-                else
-                {
-                    Assert.False(test.IsNull);
-                    Assert.Equal((double)known, ((double?)test)!.Value);
-                    Assert.Equal((double)known, (double)test);
-                }
+                Assert.True(test.IsNull);
+                Assert.False(((double?)test).HasValue);
+            }
+            else
+            {
+                Assert.False(test.IsNull);
+                Assert.Equal((double)known, ((double?)test)!.Value);
                 Assert.Equal((double)known, (double)test);
             }
-            Check(1099511627848.0, 1099511627848);
-            Check(1099511627848.0, 1099511627848.0);
-            Check(1099511627848.0, "1099511627848");
-            Check(1099511627848.0, "1099511627848.0");
-            Check(1099511627848.0, Bytes("1099511627848"));
-            Check(1099511627848.0, Bytes("1099511627848.0"));
-            CheckString(1099511627848.0, "1099511627848");
-
-            Check(-1099511627848.0, -1099511627848);
-            Check(-1099511627848.0, -1099511627848);
-            Check(-1099511627848.0, "-1099511627848");
-            Check(-1099511627848.0, "-1099511627848.0");
-            Check(-1099511627848.0, Bytes("-1099511627848"));
-            Check(-1099511627848.0, Bytes("-1099511627848.0"));
-            CheckString(-1099511627848.0, "-1099511627848");
-
-            Check(1.0, true);
-            Check(0.0, false);
-
-            Check(1099511627848.6001, 1099511627848.6001);
-            Check(1099511627848.6001, "1099511627848.6001");
-            Check(1099511627848.6001, Bytes("1099511627848.6001"));
-            CheckString(1099511627848.6001, "1099511627848.6001");
-
-            Check(-1099511627848.6001, -1099511627848.6001);
-            Check(-1099511627848.6001, "-1099511627848.6001");
-            Check(-1099511627848.6001, Bytes("-1099511627848.6001"));
-            CheckString(-1099511627848.6001, "-1099511627848.6001");
-
-            Check(double.NegativeInfinity, double.NegativeInfinity);
-            Check(double.NegativeInfinity, "-inf");
-            CheckString(double.NegativeInfinity, "-inf");
-
-            Check(double.PositiveInfinity, double.PositiveInfinity);
-            Check(double.PositiveInfinity, "+inf");
-            CheckString(double.PositiveInfinity, "+inf");
+            Assert.Equal((double)known, (double)test);
         }
+        Check(1099511627848.0, 1099511627848);
+        Check(1099511627848.0, 1099511627848.0);
+        Check(1099511627848.0, "1099511627848");
+        Check(1099511627848.0, "1099511627848.0");
+        Check(1099511627848.0, Bytes("1099511627848"));
+        Check(1099511627848.0, Bytes("1099511627848.0"));
+        CheckString(1099511627848.0, "1099511627848");
 
-        private static void CheckString(RedisValue value, string expected)
-        {
-            var s = value.ToString();
-            Assert.True(s == expected, $"'{s}' vs '{expected}'");
-        }
+        Check(-1099511627848.0, -1099511627848);
+        Check(-1099511627848.0, -1099511627848);
+        Check(-1099511627848.0, "-1099511627848");
+        Check(-1099511627848.0, "-1099511627848.0");
+        Check(-1099511627848.0, Bytes("-1099511627848"));
+        Check(-1099511627848.0, Bytes("-1099511627848.0"));
+        CheckString(-1099511627848.0, "-1099511627848");
 
-        private static byte[]? Bytes(string? s) => s == null ? null : Encoding.UTF8.GetBytes(s);
+        Check(1.0, true);
+        Check(0.0, false);
 
-        private static string LineNumber([CallerLineNumber] int lineNumber = 0) => lineNumber.ToString();
+        Check(1099511627848.6001, 1099511627848.6001);
+        Check(1099511627848.6001, "1099511627848.6001");
+        Check(1099511627848.6001, Bytes("1099511627848.6001"));
+        CheckString(1099511627848.6001, "1099511627848.6001");
 
-        [Fact]
-        public void RedisValueStartsWith()
-        {
-            // test strings
-            RedisValue x = "abc";
-            Assert.True(x.StartsWith("a"), LineNumber());
-            Assert.True(x.StartsWith("ab"), LineNumber());
-            Assert.True(x.StartsWith("abc"), LineNumber());
-            Assert.False(x.StartsWith("abd"), LineNumber());
-            Assert.False(x.StartsWith("abcd"), LineNumber());
-            Assert.False(x.StartsWith(123), LineNumber());
-            Assert.False(x.StartsWith(false), LineNumber());
+        Check(-1099511627848.6001, -1099511627848.6001);
+        Check(-1099511627848.6001, "-1099511627848.6001");
+        Check(-1099511627848.6001, Bytes("-1099511627848.6001"));
+        CheckString(-1099511627848.6001, "-1099511627848.6001");
 
-            // test binary
-            x = Encoding.ASCII.GetBytes("abc");
-            Assert.True(x.StartsWith("a"), LineNumber());
-            Assert.True(x.StartsWith("ab"), LineNumber());
-            Assert.True(x.StartsWith("abc"), LineNumber());
-            Assert.False(x.StartsWith("abd"), LineNumber());
-            Assert.False(x.StartsWith("abcd"), LineNumber());
-            Assert.False(x.StartsWith(123), LineNumber());
-            Assert.False(x.StartsWith(false), LineNumber());
+        Check(double.NegativeInfinity, double.NegativeInfinity);
+        Check(double.NegativeInfinity, "-inf");
+        CheckString(double.NegativeInfinity, "-inf");
 
-            Assert.True(x.StartsWith(Encoding.ASCII.GetBytes("a")), LineNumber());
-            Assert.True(x.StartsWith(Encoding.ASCII.GetBytes("ab")), LineNumber());
-            Assert.True(x.StartsWith(Encoding.ASCII.GetBytes("abc")), LineNumber());
-            Assert.False(x.StartsWith(Encoding.ASCII.GetBytes("abd")), LineNumber());
-            Assert.False(x.StartsWith(Encoding.ASCII.GetBytes("abcd")), LineNumber());
+        Check(double.PositiveInfinity, double.PositiveInfinity);
+        Check(double.PositiveInfinity, "+inf");
+        CheckString(double.PositiveInfinity, "+inf");
+    }
 
-            x = 10; // integers are effectively strings in this context
-            Assert.True(x.StartsWith(1), LineNumber());
-            Assert.True(x.StartsWith(10), LineNumber());
-            Assert.False(x.StartsWith(100), LineNumber());
-        }
+    private static void CheckString(RedisValue value, string expected)
+    {
+        var s = value.ToString();
+        Assert.True(s == expected, $"'{s}' vs '{expected}'");
+    }
 
-        [Fact]
-        public void TryParseInt64()
-        {
-            Assert.True(((RedisValue)123).TryParse(out long l));
-            Assert.Equal(123, l);
+    private static byte[]? Bytes(string? s) => s == null ? null : Encoding.UTF8.GetBytes(s);
 
-            Assert.True(((RedisValue)123.0).TryParse(out l));
-            Assert.Equal(123, l);
+    private static string LineNumber([CallerLineNumber] int lineNumber = 0) => lineNumber.ToString();
 
-            Assert.True(((RedisValue)(int.MaxValue + 123L)).TryParse(out l));
-            Assert.Equal(int.MaxValue + 123L, l);
+    [Fact]
+    public void RedisValueStartsWith()
+    {
+        // test strings
+        RedisValue x = "abc";
+        Assert.True(x.StartsWith("a"), LineNumber());
+        Assert.True(x.StartsWith("ab"), LineNumber());
+        Assert.True(x.StartsWith("abc"), LineNumber());
+        Assert.False(x.StartsWith("abd"), LineNumber());
+        Assert.False(x.StartsWith("abcd"), LineNumber());
+        Assert.False(x.StartsWith(123), LineNumber());
+        Assert.False(x.StartsWith(false), LineNumber());
 
-            Assert.True(((RedisValue)"123").TryParse(out l));
-            Assert.Equal(123, l);
+        // test binary
+        x = Encoding.ASCII.GetBytes("abc");
+        Assert.True(x.StartsWith("a"), LineNumber());
+        Assert.True(x.StartsWith("ab"), LineNumber());
+        Assert.True(x.StartsWith("abc"), LineNumber());
+        Assert.False(x.StartsWith("abd"), LineNumber());
+        Assert.False(x.StartsWith("abcd"), LineNumber());
+        Assert.False(x.StartsWith(123), LineNumber());
+        Assert.False(x.StartsWith(false), LineNumber());
 
-            Assert.True(((RedisValue)(-123)).TryParse(out l));
-            Assert.Equal(-123, l);
+        Assert.True(x.StartsWith(Encoding.ASCII.GetBytes("a")), LineNumber());
+        Assert.True(x.StartsWith(Encoding.ASCII.GetBytes("ab")), LineNumber());
+        Assert.True(x.StartsWith(Encoding.ASCII.GetBytes("abc")), LineNumber());
+        Assert.False(x.StartsWith(Encoding.ASCII.GetBytes("abd")), LineNumber());
+        Assert.False(x.StartsWith(Encoding.ASCII.GetBytes("abcd")), LineNumber());
 
-            Assert.True(default(RedisValue).TryParse(out l));
-            Assert.Equal(0, l);
+        x = 10; // integers are effectively strings in this context
+        Assert.True(x.StartsWith(1), LineNumber());
+        Assert.True(x.StartsWith(10), LineNumber());
+        Assert.False(x.StartsWith(100), LineNumber());
+    }
 
-            Assert.True(((RedisValue)123.0).TryParse(out l));
-            Assert.Equal(123, l);
+    [Fact]
+    public void TryParseInt64()
+    {
+        Assert.True(((RedisValue)123).TryParse(out long l));
+        Assert.Equal(123, l);
 
-            Assert.False(((RedisValue)"abc").TryParse(out long _));
-            Assert.False(((RedisValue)"123.1").TryParse(out long _));
-            Assert.False(((RedisValue)123.1).TryParse(out long _));
-        }
+        Assert.True(((RedisValue)123.0).TryParse(out l));
+        Assert.Equal(123, l);
 
-        [Fact]
-        public void TryParseInt32()
-        {
-            Assert.True(((RedisValue)123).TryParse(out int i));
-            Assert.Equal(123, i);
+        Assert.True(((RedisValue)(int.MaxValue + 123L)).TryParse(out l));
+        Assert.Equal(int.MaxValue + 123L, l);
 
-            Assert.True(((RedisValue)123.0).TryParse(out i));
-            Assert.Equal(123, i);
+        Assert.True(((RedisValue)"123").TryParse(out l));
+        Assert.Equal(123, l);
 
-            Assert.False(((RedisValue)(int.MaxValue + 123L)).TryParse(out int _));
+        Assert.True(((RedisValue)(-123)).TryParse(out l));
+        Assert.Equal(-123, l);
 
-            Assert.True(((RedisValue)"123").TryParse(out i));
-            Assert.Equal(123, i);
+        Assert.True(default(RedisValue).TryParse(out l));
+        Assert.Equal(0, l);
 
-            Assert.True(((RedisValue)(-123)).TryParse(out i));
-            Assert.Equal(-123, i);
+        Assert.True(((RedisValue)123.0).TryParse(out l));
+        Assert.Equal(123, l);
 
-            Assert.True(default(RedisValue).TryParse(out i));
-            Assert.Equal(0, i);
+        Assert.False(((RedisValue)"abc").TryParse(out long _));
+        Assert.False(((RedisValue)"123.1").TryParse(out long _));
+        Assert.False(((RedisValue)123.1).TryParse(out long _));
+    }
 
-            Assert.True(((RedisValue)123.0).TryParse(out i));
-            Assert.Equal(123, i);
+    [Fact]
+    public void TryParseInt32()
+    {
+        Assert.True(((RedisValue)123).TryParse(out int i));
+        Assert.Equal(123, i);
 
-            Assert.False(((RedisValue)"abc").TryParse(out int _));
-            Assert.False(((RedisValue)"123.1").TryParse(out int _));
-            Assert.False(((RedisValue)123.1).TryParse(out int _));
-        }
+        Assert.True(((RedisValue)123.0).TryParse(out i));
+        Assert.Equal(123, i);
 
-        [Fact]
-        public void TryParseDouble()
-        {
-            Assert.True(((RedisValue)123).TryParse(out double d));
-            Assert.Equal(123, d);
+        Assert.False(((RedisValue)(int.MaxValue + 123L)).TryParse(out int _));
 
-            Assert.True(((RedisValue)123.0).TryParse(out d));
-            Assert.Equal(123.0, d);
+        Assert.True(((RedisValue)"123").TryParse(out i));
+        Assert.Equal(123, i);
 
-            Assert.True(((RedisValue)123.1).TryParse(out d));
-            Assert.Equal(123.1, d);
+        Assert.True(((RedisValue)(-123)).TryParse(out i));
+        Assert.Equal(-123, i);
 
-            Assert.True(((RedisValue)(int.MaxValue + 123L)).TryParse(out d));
-            Assert.Equal(int.MaxValue + 123L, d);
+        Assert.True(default(RedisValue).TryParse(out i));
+        Assert.Equal(0, i);
 
-            Assert.True(((RedisValue)"123").TryParse(out d));
-            Assert.Equal(123.0, d);
+        Assert.True(((RedisValue)123.0).TryParse(out i));
+        Assert.Equal(123, i);
 
-            Assert.True(((RedisValue)(-123)).TryParse(out d));
-            Assert.Equal(-123.0, d);
+        Assert.False(((RedisValue)"abc").TryParse(out int _));
+        Assert.False(((RedisValue)"123.1").TryParse(out int _));
+        Assert.False(((RedisValue)123.1).TryParse(out int _));
+    }
 
-            Assert.True(default(RedisValue).TryParse(out d));
-            Assert.Equal(0.0, d);
+    [Fact]
+    public void TryParseDouble()
+    {
+        Assert.True(((RedisValue)123).TryParse(out double d));
+        Assert.Equal(123, d);
 
-            Assert.True(((RedisValue)123.0).TryParse(out d));
-            Assert.Equal(123.0, d);
+        Assert.True(((RedisValue)123.0).TryParse(out d));
+        Assert.Equal(123.0, d);
 
-            Assert.True(((RedisValue)"123.1").TryParse(out d));
-            Assert.Equal(123.1, d);
+        Assert.True(((RedisValue)123.1).TryParse(out d));
+        Assert.Equal(123.1, d);
 
-            Assert.False(((RedisValue)"abc").TryParse(out double _));
-        }
+        Assert.True(((RedisValue)(int.MaxValue + 123L)).TryParse(out d));
+        Assert.Equal(int.MaxValue + 123L, d);
+
+        Assert.True(((RedisValue)"123").TryParse(out d));
+        Assert.Equal(123.0, d);
+
+        Assert.True(((RedisValue)(-123)).TryParse(out d));
+        Assert.Equal(-123.0, d);
+
+        Assert.True(default(RedisValue).TryParse(out d));
+        Assert.Equal(0.0, d);
+
+        Assert.True(((RedisValue)123.0).TryParse(out d));
+        Assert.Equal(123.0, d);
+
+        Assert.True(((RedisValue)"123.1").TryParse(out d));
+        Assert.Equal(123.1, d);
+
+        Assert.False(((RedisValue)"abc").TryParse(out double _));
     }
 }

--- a/tests/StackExchange.Redis.Tests/Roles.cs
+++ b/tests/StackExchange.Redis.Tests/Roles.cs
@@ -1,50 +1,43 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Roles : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Roles : TestBase
+    public Roles(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PrimaryRole(bool allowAdmin) // should work with or without admin now
     {
-        public Roles(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create(allowAdmin: allowAdmin);
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void PrimaryRole(bool allowAdmin) // should work with or without admin now
-        {
-            using var muxer = Create(allowAdmin: allowAdmin);
-            var server = muxer.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        var role = server.Role();
+        Assert.NotNull(role);
+        Assert.Equal(role.Value, RedisLiterals.master);
+        var primary = role as Role.Master;
+        Assert.NotNull(primary);
+        Assert.NotNull(primary.Replicas);
+        Assert.Contains(primary.Replicas, r =>
+            r.Ip == TestConfig.Current.ReplicaServer &&
+            r.Port == TestConfig.Current.ReplicaPort);
+    }
 
-            var role = server.Role();
-            Assert.NotNull(role);
-            Assert.Equal(role.Value, RedisLiterals.master);
-            var primary = role as Role.Master;
-            Assert.NotNull(primary);
-            Assert.NotNull(primary.Replicas);
-            Assert.Contains(primary.Replicas, r =>
-                r.Ip == TestConfig.Current.ReplicaServer &&
-                r.Port == TestConfig.Current.ReplicaPort);
-        }
+    [Fact]
+    public void ReplicaRole()
+    {
+        using var conn = ConnectionMultiplexer.Connect($"{TestConfig.Current.ReplicaServerAndPort},allowAdmin=true");
+        var server = conn.GetServer(TestConfig.Current.ReplicaServerAndPort);
 
-        [Fact]
-        public void ReplicaRole()
-        {
-            var connString = $"{TestConfig.Current.ReplicaServerAndPort},allowAdmin=true";
-            using var muxer = ConnectionMultiplexer.Connect(connString);
-            var server = muxer.GetServer(TestConfig.Current.ReplicaServerAndPort);
-
-            var role = server.Role();
-            Assert.NotNull(role);
-            var replica = role as Role.Replica;
-            Assert.NotNull(replica);
-            Assert.Equal(replica.MasterIp, TestConfig.Current.PrimaryServer);
-            Assert.Equal(replica.MasterPort, TestConfig.Current.PrimaryPort);
-        }
+        var role = server.Role();
+        Assert.NotNull(role);
+        var replica = role as Role.Replica;
+        Assert.NotNull(replica);
+        Assert.Equal(replica.MasterIp, TestConfig.Current.PrimaryServer);
+        Assert.Equal(replica.MasterPort, TestConfig.Current.PrimaryPort);
     }
 }

--- a/tests/StackExchange.Redis.Tests/SSDB.cs
+++ b/tests/StackExchange.Redis.Tests/SSDB.cs
@@ -1,31 +1,28 @@
 ﻿using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class SSDB : TestBase
 {
-    public class SSDB : TestBase
+    public SSDB(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void ConnectToSSDB()
     {
-        public SSDB(ITestOutputHelper output) : base (output) { }
+        Skip.IfNoConfig(nameof(TestConfig.Config.SSDBServer), TestConfig.Current.SSDBServer);
 
-        [Fact]
-        public void ConnectToSSDB()
+        using var conn = ConnectionMultiplexer.Connect(new ConfigurationOptions
         {
-            Skip.IfNoConfig(nameof(TestConfig.Config.SSDBServer), TestConfig.Current.SSDBServer);
+            EndPoints = { { TestConfig.Current.SSDBServer, TestConfig.Current.SSDBPort } },
+            CommandMap = CommandMap.SSDB
+        });
 
-            var config = new ConfigurationOptions
-            {
-                EndPoints = { { TestConfig.Current.SSDBServer, TestConfig.Current.SSDBPort } },
-                CommandMap = CommandMap.SSDB
-            };
-            RedisKey key = Me();
-            using (var conn = ConnectionMultiplexer.Connect(config))
-            {
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                Assert.True(db.StringGet(key).IsNull);
-                db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                Assert.Equal("abc", db.StringGet(key));
-            }
-        }
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.True(db.StringGet(key).IsNull);
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        Assert.Equal("abc", db.StringGet(key));
     }
 }

--- a/tests/StackExchange.Redis.Tests/SSL.cs
+++ b/tests/StackExchange.Redis.Tests/SSL.cs
@@ -14,180 +14,222 @@ using StackExchange.Redis.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class SSL : TestBase
 {
-    public class SSL : TestBase
+    public SSL(ITestOutputHelper output) : base(output) { }
+
+    [Theory]
+    [InlineData(null, true)] // auto-infer port (but specify 6380)
+    [InlineData(6380, true)] // all explicit
+    // (note the 6379 port is closed)
+    public void ConnectToAzure(int? port, bool ssl)
     {
-        public SSL(ITestOutputHelper output) : base (output) { }
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
 
-        [Theory]
-        [InlineData(null, true)] // auto-infer port (but specify 6380)
-        [InlineData(6380, true)] // all explicit
-        // (note the 6379 port is closed)
-        public void ConnectToAzure(int? port, bool ssl)
+        var options = new ConfigurationOptions();
+        options.CertificateValidation += ShowCertFailures(Writer);
+        if (port == null)
         {
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
+            options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
+        }
+        else
+        {
+            options.EndPoints.Add(TestConfig.Current.AzureCacheServer, port.Value);
+        }
+        options.Ssl = ssl;
+        options.Password = TestConfig.Current.AzureCachePassword;
+        Log(options.ToString());
+        using (var connection = ConnectionMultiplexer.Connect(options))
+        {
+            var ttl = connection.GetDatabase().Ping();
+            Log(ttl.ToString());
+        }
+    }
 
-            var options = new ConfigurationOptions();
-            options.CertificateValidation += ShowCertFailures(Writer);
-            if (port == null)
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ConnectToSSLServer(bool useSsl, bool specifyHost)
+    {
+        var server = TestConfig.Current.SslServer;
+        int? port = TestConfig.Current.SslPort;
+        string? password = "";
+        bool isAzure = false;
+        if (string.IsNullOrWhiteSpace(server) && useSsl)
+        {
+            // we can bounce it past azure instead?
+            server = TestConfig.Current.AzureCacheServer;
+            password = TestConfig.Current.AzureCachePassword;
+            port = null;
+            isAzure = true;
+        }
+        Skip.IfNoConfig(nameof(TestConfig.Config.SslServer), server);
+
+        var config = new ConfigurationOptions
+        {
+            AllowAdmin = true,
+            SyncTimeout = Debugger.IsAttached ? int.MaxValue : 5000,
+            Password = password,
+        };
+        var map = new Dictionary<string, string?>
+        {
+            ["config"] = null // don't rely on config working
+        };
+        if (!isAzure) map["cluster"] = null;
+        config.CommandMap = CommandMap.Create(map);
+        if (port != null) config.EndPoints.Add(server, port.Value);
+        else config.EndPoints.Add(server);
+
+        if (useSsl)
+        {
+            config.Ssl = useSsl;
+            if (specifyHost)
             {
-                options.EndPoints.Add(TestConfig.Current.AzureCacheServer);
+                config.SslHost = server;
             }
-            else
+            config.CertificateValidation += (sender, cert, chain, errors) =>
             {
-                options.EndPoints.Add(TestConfig.Current.AzureCacheServer, port.Value);
-            }
-            options.Ssl = ssl;
-            options.Password = TestConfig.Current.AzureCachePassword;
-            Log(options.ToString());
-            using (var connection = ConnectionMultiplexer.Connect(options))
-            {
-                var ttl = connection.GetDatabase().Ping();
-                Log(ttl.ToString());
-            }
+                Log("errors: " + errors);
+                Log("cert issued to: " + cert?.Subject);
+                return true; // fingers in ears, pretend we don't know this is wrong
+            };
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task ConnectToSSLServer(bool useSsl, bool specifyHost)
+        var configString = config.ToString();
+        Log("config: " + configString);
+        var clone = ConfigurationOptions.Parse(configString);
+        Assert.Equal(configString, clone.ToString());
+
+        using (var log = new StringWriter())
+        using (var muxer = ConnectionMultiplexer.Connect(config, log))
         {
-            var server = TestConfig.Current.SslServer;
-            int? port = TestConfig.Current.SslPort;
-            string? password = "";
-            bool isAzure = false;
-            if (string.IsNullOrWhiteSpace(server) && useSsl)
+            Log("Connect log:");
+            lock (log)
             {
-                // we can bounce it past azure instead?
-                server = TestConfig.Current.AzureCacheServer;
-                password = TestConfig.Current.AzureCachePassword;
-                port = null;
-                isAzure = true;
+                Log(log.ToString());
             }
-            Skip.IfNoConfig(nameof(TestConfig.Config.SslServer), server);
-
-            var config = new ConfigurationOptions
+            Log("====");
+            muxer.ConnectionFailed += OnConnectionFailed;
+            muxer.InternalError += OnInternalError;
+            var db = muxer.GetDatabase();
+            await db.PingAsync().ForAwait();
+            using (var file = File.Create("ssl-" + useSsl + "-" + specifyHost + ".zip"))
             {
-                AllowAdmin = true,
-                SyncTimeout = Debugger.IsAttached ? int.MaxValue : 5000,
-                Password = password,
-            };
-            var map = new Dictionary<string, string?>
-            {
-                ["config"] = null // don't rely on config working
-            };
-            if (!isAzure) map["cluster"] = null;
-            config.CommandMap = CommandMap.Create(map);
-            if (port != null) config.EndPoints.Add(server, port.Value);
-            else config.EndPoints.Add(server);
-
-            if (useSsl)
-            {
-                config.Ssl = useSsl;
-                if (specifyHost)
-                {
-                    config.SslHost = server;
-                }
-                config.CertificateValidation += (sender, cert, chain, errors) =>
-                {
-                    Log("errors: " + errors);
-                    Log("cert issued to: " + cert?.Subject);
-                    return true; // fingers in ears, pretend we don't know this is wrong
-                };
+                muxer.ExportConfiguration(file);
             }
+            RedisKey key = "SE.Redis";
 
-            var configString = config.ToString();
-            Log("config: " + configString);
-            var clone = ConfigurationOptions.Parse(configString);
-            Assert.Equal(configString, clone.ToString());
-
-            using (var log = new StringWriter())
-            using (var muxer = ConnectionMultiplexer.Connect(config, log))
+            const int AsyncLoop = 2000;
+            // perf; async
+            await db.KeyDeleteAsync(key).ForAwait();
+            var watch = Stopwatch.StartNew();
+            for (int i = 0; i < AsyncLoop; i++)
             {
-                Log("Connect log:");
-                lock (log)
+                try
                 {
-                    Log(log.ToString());
+                    await db.StringIncrementAsync(key, flags: CommandFlags.FireAndForget).ForAwait();
                 }
-                Log("====");
-                muxer.ConnectionFailed += OnConnectionFailed;
-                muxer.InternalError += OnInternalError;
-                var db = muxer.GetDatabase();
-                await db.PingAsync().ForAwait();
-                using (var file = File.Create("ssl-" + useSsl + "-" + specifyHost + ".zip"))
+                catch (Exception ex)
                 {
-                    muxer.ExportConfiguration(file);
+                    Log($"Failure on i={i}: {ex.Message}");
+                    throw;
                 }
-                RedisKey key = "SE.Redis";
-
-                const int AsyncLoop = 2000;
-                // perf; async
-                await db.KeyDeleteAsync(key).ForAwait();
-                var watch = Stopwatch.StartNew();
-                for (int i = 0; i < AsyncLoop; i++)
-                {
-                    try
-                    {
-                        await db.StringIncrementAsync(key, flags: CommandFlags.FireAndForget).ForAwait();
-                    }
-                    catch (Exception ex)
-                    {
-                        Log($"Failure on i={i}: {ex.Message}");
-                        throw;
-                    }
-                }
-                // need to do this inside the timer to measure the TTLB
-                long value = (long)await db.StringGetAsync(key).ForAwait();
-                watch.Stop();
-                Assert.Equal(AsyncLoop, value);
-                Log("F&F: {0} INCR, {1:###,##0}ms, {2} ops/s; final value: {3}",
-                    AsyncLoop,
-                    watch.ElapsedMilliseconds,
-                    (long)(AsyncLoop / watch.Elapsed.TotalSeconds),
-                    value);
-
-                // perf: sync/multi-threaded
-                // TestConcurrent(db, key, 30, 10);
-                //TestConcurrent(db, key, 30, 20);
-                //TestConcurrent(db, key, 30, 30);
-                //TestConcurrent(db, key, 30, 40);
-                //TestConcurrent(db, key, 30, 50);
             }
+            // need to do this inside the timer to measure the TTLB
+            long value = (long)await db.StringGetAsync(key).ForAwait();
+            watch.Stop();
+            Assert.Equal(AsyncLoop, value);
+            Log("F&F: {0} INCR, {1:###,##0}ms, {2} ops/s; final value: {3}",
+                AsyncLoop,
+                watch.ElapsedMilliseconds,
+                (long)(AsyncLoop / watch.Elapsed.TotalSeconds),
+                value);
+
+            // perf: sync/multi-threaded
+            // TestConcurrent(db, key, 30, 10);
+            //TestConcurrent(db, key, 30, 20);
+            //TestConcurrent(db, key, 30, 30);
+            //TestConcurrent(db, key, 30, 40);
+            //TestConcurrent(db, key, 30, 50);
         }
+    }
 
-        //private void TestConcurrent(IDatabase db, RedisKey key, int SyncLoop, int Threads)
-        //{
-        //    long value;
-        //    db.KeyDelete(key, CommandFlags.FireAndForget);
-        //    var time = RunConcurrent(delegate
-        //    {
-        //        for (int i = 0; i < SyncLoop; i++)
-        //        {
-        //            db.StringIncrement(key);
-        //        }
-        //    }, Threads, timeout: 45000);
-        //    value = (long)db.StringGet(key);
-        //    Assert.Equal(SyncLoop * Threads, value);
-        //    Log("Sync: {0} INCR using {1} threads, {2:###,##0}ms, {3} ops/s; final value: {4}",
-        //        SyncLoop * Threads, Threads,
-        //        (long)time.TotalMilliseconds,
-        //        (long)((SyncLoop * Threads) / time.TotalSeconds),
-        //        value);
-        //}
+    [Fact]
+    public void RedisLabsSSL()
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.RedisLabsSslServer), TestConfig.Current.RedisLabsSslServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.RedisLabsPfxPath), TestConfig.Current.RedisLabsPfxPath);
 
-        [Fact]
-        public void RedisLabsSSL()
+        var cert = new X509Certificate2(TestConfig.Current.RedisLabsPfxPath, "");
+        Assert.NotNull(cert);
+        Writer.WriteLine("Thumbprint: " + cert.Thumbprint);
+
+        int timeout = 5000;
+        if (Debugger.IsAttached) timeout *= 100;
+        var options = new ConfigurationOptions
+        {
+            EndPoints = { { TestConfig.Current.RedisLabsSslServer, TestConfig.Current.RedisLabsSslPort } },
+            ConnectTimeout = timeout,
+            AllowAdmin = true,
+            CommandMap = CommandMap.Create(new HashSet<string> {
+                "subscribe", "unsubscribe", "cluster"
+            }, false)
+        };
+
+        options.TrustIssuer("redislabs_ca.pem");
+
+        if (!Directory.Exists(Me())) Directory.CreateDirectory(Me());
+#if LOGOUTPUT
+        ConnectionMultiplexer.EchoPath = Me();
+#endif
+        options.Ssl = true;
+        options.CertificateSelection += delegate
+        {
+            return cert;
+        };
+
+        using var conn = ConnectionMultiplexer.Connect(options);
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        string? s = db.StringGet(key);
+        Assert.Null(s);
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        s = db.StringGet(key);
+        Assert.Equal("abc", s);
+
+        var latency = db.Ping();
+        Log("RedisLabs latency: {0:###,##0.##}ms", latency.TotalMilliseconds);
+
+        using (var file = File.Create("RedisLabs.zip"))
+        {
+            conn.ExportConfiguration(file);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RedisLabsEnvironmentVariableClientCertificate(bool setEnv)
+    {
+        try
         {
             Skip.IfNoConfig(nameof(TestConfig.Config.RedisLabsSslServer), TestConfig.Current.RedisLabsSslServer);
             Skip.IfNoConfig(nameof(TestConfig.Config.RedisLabsPfxPath), TestConfig.Current.RedisLabsPfxPath);
 
-            var cert = new X509Certificate2(TestConfig.Current.RedisLabsPfxPath, "");
-            Assert.NotNull(cert);
-            Writer.WriteLine("Thumbprint: " + cert.Thumbprint);
-
+            if (setEnv)
+            {
+                Environment.SetEnvironmentVariable("SERedis_ClientCertPfxPath", TestConfig.Current.RedisLabsPfxPath);
+                Environment.SetEnvironmentVariable("SERedis_IssuerCertPath", "redislabs_ca.pem");
+                // check env worked
+                Assert.Equal(TestConfig.Current.RedisLabsPfxPath, Environment.GetEnvironmentVariable("SERedis_ClientCertPfxPath"));
+                Assert.Equal("redislabs_ca.pem", Environment.GetEnvironmentVariable("SERedis_IssuerCertPath"));
+            }
             int timeout = 5000;
             if (Debugger.IsAttached) timeout *= 100;
             var options = new ConfigurationOptions
@@ -200,286 +242,223 @@ namespace StackExchange.Redis.Tests
                 }, false)
             };
 
-            options.TrustIssuer("redislabs_ca.pem");
-
             if (!Directory.Exists(Me())) Directory.CreateDirectory(Me());
 #if LOGOUTPUT
-            ConnectionMultiplexer.EchoPath = Me();
+        ConnectionMultiplexer.EchoPath = Me();
 #endif
             options.Ssl = true;
-            options.CertificateSelection += delegate
-            {
-                return cert;
-            };
+
+            using var conn = ConnectionMultiplexer.Connect(options);
+
             RedisKey key = Me();
-            using (var conn = ConnectionMultiplexer.Connect(options))
+            if (!setEnv) Assert.True(false, "Could not set environment");
+
+            var db = conn.GetDatabase();
+            db.KeyDelete(key, CommandFlags.FireAndForget);
+            string? s = db.StringGet(key);
+            Assert.Null(s);
+            db.StringSet(key, "abc");
+            s = db.StringGet(key);
+            Assert.Equal("abc", s);
+
+            var latency = db.Ping();
+            Log("RedisLabs latency: {0:###,##0.##}ms", latency.TotalMilliseconds);
+
+            using (var file = File.Create("RedisLabs.zip"))
             {
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                string? s = db.StringGet(key);
-                Assert.Null(s);
-                db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                s = db.StringGet(key);
-                Assert.Equal("abc", s);
-
-                var latency = db.Ping();
-                Log("RedisLabs latency: {0:###,##0.##}ms", latency.TotalMilliseconds);
-
-                using (var file = File.Create("RedisLabs.zip"))
-                {
-                    conn.ExportConfiguration(file);
-                }
+                conn.ExportConfiguration(file);
             }
         }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void RedisLabsEnvironmentVariableClientCertificate(bool setEnv)
+        catch (RedisConnectionException ex) when (!setEnv && ex.FailureType == ConnectionFailureType.UnableToConnect)
         {
-            try
-            {
-                Skip.IfNoConfig(nameof(TestConfig.Config.RedisLabsSslServer), TestConfig.Current.RedisLabsSslServer);
-                Skip.IfNoConfig(nameof(TestConfig.Config.RedisLabsPfxPath), TestConfig.Current.RedisLabsPfxPath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SERedis_ClientCertPfxPath", null);
+        }
+    }
 
-                if (setEnv)
+    [Fact]
+    public void SSLHostInferredFromEndpoints()
+    {
+        var options = new ConfigurationOptions()
+        {
+            EndPoints = {
+                          { "mycache.rediscache.windows.net", 15000},
+                          { "mycache.rediscache.windows.net", 15001 },
+                          { "mycache.rediscache.windows.net", 15002 },
+                        }
+        };
+        options.Ssl = true;
+        Assert.True(options.SslHost == "mycache.rediscache.windows.net");
+        options = new ConfigurationOptions()
+        {
+            EndPoints = {
+                          { "121.23.23.45", 15000},
+                        }
+        };
+        Assert.True(options.SslHost == null);
+    }
+
+    private void Check(string name, object? x, object? y)
+    {
+        Writer.WriteLine($"{name}: {(x == null ? "(null)" : x.ToString())} vs {(y == null ? "(null)" : y.ToString())}");
+        Assert.Equal(x, y);
+    }
+
+    [Fact]
+    public void Issue883_Exhaustive()
+    {
+        var old = CultureInfo.CurrentCulture;
+        try
+        {
+            var all = CultureInfo.GetCultures(CultureTypes.AllCultures);
+            Writer.WriteLine($"Checking {all.Length} cultures...");
+            foreach (var ci in all)
+            {
+                Writer.WriteLine("Testing: " + ci.Name);
+                CultureInfo.CurrentCulture = ci;
+
+                var a = ConfigurationOptions.Parse("myDNS:883,password=mypassword,connectRetry=3,connectTimeout=5000,syncTimeout=5000,defaultDatabase=0,ssl=true,abortConnect=false");
+                var b = new ConfigurationOptions
                 {
-                    Environment.SetEnvironmentVariable("SERedis_ClientCertPfxPath", TestConfig.Current.RedisLabsPfxPath);
-                    Environment.SetEnvironmentVariable("SERedis_IssuerCertPath", "redislabs_ca.pem");
-                    // check env worked
-                    Assert.Equal(TestConfig.Current.RedisLabsPfxPath, Environment.GetEnvironmentVariable("SERedis_ClientCertPfxPath"));
-                    Assert.Equal("redislabs_ca.pem", Environment.GetEnvironmentVariable("SERedis_IssuerCertPath"));
-                }
-                int timeout = 5000;
-                if (Debugger.IsAttached) timeout *= 100;
-                var options = new ConfigurationOptions
-                {
-                    EndPoints = { { TestConfig.Current.RedisLabsSslServer, TestConfig.Current.RedisLabsSslPort } },
-                    ConnectTimeout = timeout,
-                    AllowAdmin = true,
-                    CommandMap = CommandMap.Create(new HashSet<string> {
-                        "subscribe", "unsubscribe", "cluster"
-                    }, false)
+                    EndPoints = { { "myDNS", 883 } },
+                    Password = "mypassword",
+                    ConnectRetry = 3,
+                    ConnectTimeout = 5000,
+                    SyncTimeout = 5000,
+                    DefaultDatabase = 0,
+                    Ssl = true,
+                    AbortOnConnectFail = false,
                 };
+                Writer.WriteLine($"computed: {b.ToString(true)}");
 
-                if (!Directory.Exists(Me())) Directory.CreateDirectory(Me());
-#if LOGOUTPUT
-            ConnectionMultiplexer.EchoPath = Me();
-#endif
-                options.Ssl = true;
-                RedisKey key = Me();
-                using (var conn = ConnectionMultiplexer.Connect(options))
+                Writer.WriteLine("Checking endpoints...");
+                var c = a.EndPoints.Cast<DnsEndPoint>().Single();
+                var d = b.EndPoints.Cast<DnsEndPoint>().Single();
+                Check(nameof(c.Host), c.Host, d.Host);
+                Check(nameof(c.Port), c.Port, d.Port);
+                Check(nameof(c.AddressFamily), c.AddressFamily, d.AddressFamily);
+
+                var fields = typeof(ConfigurationOptions).GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                Writer.WriteLine($"Comparing {fields.Length} fields...");
+                Array.Sort(fields, (x, y) => string.CompareOrdinal(x.Name, y.Name));
+                foreach (var field in fields)
                 {
-                    if (!setEnv) Assert.True(false, "Could not set environment");
+                    Check(field.Name, field.GetValue(a), field.GetValue(b));
+                }
+            }
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = old;
+        }
+    }
 
-                    var db = conn.GetDatabase();
-                    db.KeyDelete(key, CommandFlags.FireAndForget);
-                    string? s = db.StringGet(key);
-                    Assert.Null(s);
-                    db.StringSet(key, "abc");
-                    s = db.StringGet(key);
-                    Assert.Equal("abc", s);
+    [Fact]
+    public void SSLParseViaConfig_Issue883_ConfigObject()
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
 
-                    var latency = db.Ping();
-                    Log("RedisLabs latency: {0:###,##0.##}ms", latency.TotalMilliseconds);
+        var options = new ConfigurationOptions
+        {
+            AbortOnConnectFail = false,
+            Ssl = true,
+            ConnectRetry = 3,
+            ConnectTimeout = 5000,
+            SyncTimeout = 5000,
+            DefaultDatabase = 0,
+            EndPoints = { { TestConfig.Current.AzureCacheServer, 6380 } },
+            Password = TestConfig.Current.AzureCachePassword
+        };
+        options.CertificateValidation += ShowCertFailures(Writer);
 
-                    using (var file = File.Create("RedisLabs.zip"))
+        using var conn = ConnectionMultiplexer.Connect(options);
+
+        conn.GetDatabase().Ping();
+    }
+
+    public static RemoteCertificateValidationCallback? ShowCertFailures(TextWriterOutputHelper output)
+    {
+        if (output == null)
+        {
+            return null;
+        }
+
+        return (sender, certificate, chain, sslPolicyErrors) =>
+        {
+            void WriteStatus(X509ChainStatus[] status)
+            {
+                if (status != null)
+                {
+                    for (int i = 0; i < status.Length; i++)
                     {
-                        conn.ExportConfiguration(file);
+                        var item = status[i];
+                        output.WriteLine($"\tstatus {i}: {item.Status}, {item.StatusInformation}");
                     }
                 }
             }
-            catch (RedisConnectionException ex) when (!setEnv && ex.FailureType == ConnectionFailureType.UnableToConnect)
+            lock (output)
             {
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("SERedis_ClientCertPfxPath", null);
-            }
-        }
-
-        [Fact]
-        public void SSLHostInferredFromEndpoints()
-        {
-            var options = new ConfigurationOptions()
-            {
-                EndPoints = {
-                              { "mycache.rediscache.windows.net", 15000},
-                              { "mycache.rediscache.windows.net", 15001 },
-                              { "mycache.rediscache.windows.net", 15002 },
-                            }
-            };
-            options.Ssl = true;
-            Assert.True(options.SslHost == "mycache.rediscache.windows.net");
-            options = new ConfigurationOptions()
-            {
-                EndPoints = {
-                              { "121.23.23.45", 15000},
-                            }
-            };
-            Assert.True(options.SslHost == null);
-        }
-
-        private void Check(string name, object? x, object? y)
-        {
-            Writer.WriteLine($"{name}: {(x == null ? "(null)" : x.ToString())} vs {(y == null ? "(null)" : y.ToString())}");
-            Assert.Equal(x, y);
-        }
-
-        [Fact]
-        public void Issue883_Exhaustive()
-        {
-            var old = CultureInfo.CurrentCulture;
-            try
-            {
-                var all = CultureInfo.GetCultures(CultureTypes.AllCultures);
-                Writer.WriteLine($"Checking {all.Length} cultures...");
-                foreach (var ci in all)
+                if (certificate != null)
                 {
-                    Writer.WriteLine("Testing: " + ci.Name);
-                    CultureInfo.CurrentCulture = ci;
-
-                    var a = ConfigurationOptions.Parse("myDNS:883,password=mypassword,connectRetry=3,connectTimeout=5000,syncTimeout=5000,defaultDatabase=0,ssl=true,abortConnect=false");
-                    var b = new ConfigurationOptions
-                    {
-                        EndPoints = { { "myDNS", 883 } },
-                        Password = "mypassword",
-                        ConnectRetry = 3,
-                        ConnectTimeout = 5000,
-                        SyncTimeout = 5000,
-                        DefaultDatabase = 0,
-                        Ssl = true,
-                        AbortOnConnectFail = false,
-                    };
-                    Writer.WriteLine($"computed: {b.ToString(true)}");
-
-                    Writer.WriteLine("Checking endpoints...");
-                    var c = a.EndPoints.Cast<DnsEndPoint>().Single();
-                    var d = b.EndPoints.Cast<DnsEndPoint>().Single();
-                    Check(nameof(c.Host), c.Host, d.Host);
-                    Check(nameof(c.Port), c.Port, d.Port);
-                    Check(nameof(c.AddressFamily), c.AddressFamily, d.AddressFamily);
-
-                    var fields = typeof(ConfigurationOptions).GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                    Writer.WriteLine($"Comparing {fields.Length} fields...");
-                    Array.Sort(fields, (x, y) => string.CompareOrdinal(x.Name, y.Name));
-                    foreach (var field in fields)
-                    {
-                        Check(field.Name, field.GetValue(a), field.GetValue(b));
-                    }
+                    output.WriteLine($"Subject: {certificate.Subject}");
                 }
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = old;
-            }
-        }
-
-        [Fact]
-        public void SSLParseViaConfig_Issue883_ConfigObject()
-        {
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
-
-            var options = new ConfigurationOptions
-            {
-                AbortOnConnectFail = false,
-                Ssl = true,
-                ConnectRetry = 3,
-                ConnectTimeout = 5000,
-                SyncTimeout = 5000,
-                DefaultDatabase = 0,
-                EndPoints = { { TestConfig.Current.AzureCacheServer, 6380 } },
-                Password = TestConfig.Current.AzureCachePassword
-            };
-            options.CertificateValidation += ShowCertFailures(Writer);
-            using (var conn = ConnectionMultiplexer.Connect(options))
-            {
-                conn.GetDatabase().Ping();
-            }
-        }
-
-        public static RemoteCertificateValidationCallback? ShowCertFailures(TextWriterOutputHelper output)
-        {
-            if (output == null)
-            {
-                return null;
-            }
-
-            return (sender, certificate, chain, sslPolicyErrors) =>
-            {
-                void WriteStatus(X509ChainStatus[] status)
+                output.WriteLine($"Policy errors: {sslPolicyErrors}");
+                if (chain != null)
                 {
-                    if (status != null)
+                    WriteStatus(chain.ChainStatus);
+
+                    var elements = chain.ChainElements;
+                    if (elements != null)
                     {
-                        for (int i = 0; i < status.Length; i++)
+                        int index = 0;
+                        foreach (var item in elements)
                         {
-                            var item = status[i];
-                            output.WriteLine($"\tstatus {i}: {item.Status}, {item.StatusInformation}");
+                            output.WriteLine($"{index++}: {item.Certificate.Subject}; {item.Information}");
+                            WriteStatus(item.ChainElementStatus);
                         }
                     }
                 }
-                lock (output)
-                {
-                    if (certificate != null)
-                    {
-                        output.WriteLine($"Subject: {certificate.Subject}");
-                    }
-                    output.WriteLine($"Policy errors: {sslPolicyErrors}");
-                    if (chain != null)
-                    {
-                        WriteStatus(chain.ChainStatus);
-
-                        var elements = chain.ChainElements;
-                        if (elements != null)
-                        {
-                            int index = 0;
-                            foreach (var item in elements)
-                            {
-                                output.WriteLine($"{index++}: {item.Certificate.Subject}; {item.Information}");
-                                WriteStatus(item.ChainElementStatus);
-                            }
-                        }
-                    }
-                }
-                return sslPolicyErrors == SslPolicyErrors.None;
-            };
-        }
-
-        [Fact]
-        public void SSLParseViaConfig_Issue883_ConfigString()
-        {
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
-            Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
-
-            var configString = $"{TestConfig.Current.AzureCacheServer}:6380,password={TestConfig.Current.AzureCachePassword},connectRetry=3,connectTimeout=5000,syncTimeout=5000,defaultDatabase=0,ssl=true,abortConnect=false";
-            var options = ConfigurationOptions.Parse(configString);
-            options.CertificateValidation += ShowCertFailures(Writer);
-            using (var conn = ConnectionMultiplexer.Connect(options))
-            {
-                conn.GetDatabase().Ping();
             }
-        }
+            return sslPolicyErrors == SslPolicyErrors.None;
+        };
+    }
 
-        [Fact]
-        public void ConfigObject_Issue1407_ToStringIncludesSslProtocols()
+    [Fact]
+    public void SSLParseViaConfig_Issue883_ConfigString()
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCacheServer), TestConfig.Current.AzureCacheServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.AzureCachePassword), TestConfig.Current.AzureCachePassword);
+
+        var configString = $"{TestConfig.Current.AzureCacheServer}:6380,password={TestConfig.Current.AzureCachePassword},connectRetry=3,connectTimeout=5000,syncTimeout=5000,defaultDatabase=0,ssl=true,abortConnect=false";
+        var options = ConfigurationOptions.Parse(configString);
+        options.CertificateValidation += ShowCertFailures(Writer);
+
+        using var conn = ConnectionMultiplexer.Connect(options);
+
+        conn.GetDatabase().Ping();
+    }
+
+    [Fact]
+    public void ConfigObject_Issue1407_ToStringIncludesSslProtocols()
+    {
+        const SslProtocols sslProtocols = SslProtocols.Tls12 | SslProtocols.Tls;
+        var sourceOptions = new ConfigurationOptions
         {
-            const SslProtocols sslProtocols = SslProtocols.Tls12 | SslProtocols.Tls;
-            var sourceOptions = new ConfigurationOptions
-            {
-                AbortOnConnectFail = false,
-                Ssl = true,
-                SslProtocols = sslProtocols,
-                ConnectRetry = 3,
-                ConnectTimeout = 5000,
-                SyncTimeout = 5000,
-                DefaultDatabase = 0,
-                EndPoints = { { "endpoint.test", 6380 } },
-                Password = "123456"
-            };
+            AbortOnConnectFail = false,
+            Ssl = true,
+            SslProtocols = sslProtocols,
+            ConnectRetry = 3,
+            ConnectTimeout = 5000,
+            SyncTimeout = 5000,
+            DefaultDatabase = 0,
+            EndPoints = { { "endpoint.test", 6380 } },
+            Password = "123456"
+        };
 
-            var targetOptions = ConfigurationOptions.Parse(sourceOptions.ToString());
-            Assert.Equal(sourceOptions.SslProtocols, targetOptions.SslProtocols);
-        }
+        var targetOptions = ConfigurationOptions.Parse(sourceOptions.ToString());
+        Assert.Equal(sourceOptions.SslProtocols, targetOptions.SslProtocols);
     }
 }

--- a/tests/StackExchange.Redis.Tests/SanityChecks.cs
+++ b/tests/StackExchange.Redis.Tests/SanityChecks.cs
@@ -4,32 +4,31 @@ using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
-{
-    public sealed class SanityChecks
-    {
-        /// <summary>
-        /// Ensure we don't reference System.ValueTuple as it causes issues with .NET Full Framework
-        /// </summary>
-        /// <remarks>
-        /// Modified from https://github.com/ltrzesniewski/InlineIL.Fody/blob/137e8b57f78b08cdc3abdaaf50ac01af50c58759/src/InlineIL.Tests/AssemblyTests.cs#L14
-        /// Thanks Lucas Trzesniewski!
-        /// </remarks>
-        [Fact]
-        public void ValueTupleNotReferenced()
-        {
-            using var fileStream = File.OpenRead(typeof(RedisValue).Assembly.Location);
-            using var peReader = new PEReader(fileStream);
-            var metadataReader = peReader.GetMetadataReader();
+namespace StackExchange.Redis.Tests;
 
-            foreach (var typeRefHandle in metadataReader.TypeReferences)
+public sealed class SanityChecks
+{
+    /// <summary>
+    /// Ensure we don't reference System.ValueTuple as it causes issues with .NET Full Framework
+    /// </summary>
+    /// <remarks>
+    /// Modified from https://github.com/ltrzesniewski/InlineIL.Fody/blob/137e8b57f78b08cdc3abdaaf50ac01af50c58759/src/InlineIL.Tests/AssemblyTests.cs#L14
+    /// Thanks Lucas Trzesniewski!
+    /// </remarks>
+    [Fact]
+    public void ValueTupleNotReferenced()
+    {
+        using var fileStream = File.OpenRead(typeof(RedisValue).Assembly.Location);
+        using var peReader = new PEReader(fileStream);
+        var metadataReader = peReader.GetMetadataReader();
+
+        foreach (var typeRefHandle in metadataReader.TypeReferences)
+        {
+            var typeRef = metadataReader.GetTypeReference(typeRefHandle);
+            if (metadataReader.GetString(typeRef.Namespace) == typeof(ValueTuple).Namespace)
             {
-                var typeRef = metadataReader.GetTypeReference(typeRefHandle);
-                if (metadataReader.GetString(typeRef.Namespace) == typeof(ValueTuple).Namespace)
-                {
-                    var typeName = metadataReader.GetString(typeRef.Name);
-                    Assert.DoesNotContain(nameof(ValueTuple), typeName);
-                }
+                var typeName = metadataReader.GetString(typeRef.Name);
+                Assert.DoesNotContain(nameof(ValueTuple), typeName);
             }
         }
     }

--- a/tests/StackExchange.Redis.Tests/Scans.cs
+++ b/tests/StackExchange.Redis.Tests/Scans.cs
@@ -5,418 +5,408 @@ using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable PossibleMultipleEnumeration
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Scans : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Scans : TestBase
+    public Scans(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void KeysScan(bool supported)
     {
-        public Scans(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        string[]? disabledCommands = supported ? null : new[] { "scan" };
+        using var conn = Create(disabledCommands: disabledCommands, allowAdmin: true);
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void KeysScan(bool supported)
+        var dbId = TestConfig.GetDedicatedDB(conn);
+        var db = conn.GetDatabase(dbId);
+        var prefix = Me() + ":";
+        var server = GetServer(conn);
+        server.FlushDatabase(dbId);
+        for (int i = 0; i < 100; i++)
         {
-            string[]? disabledCommands = supported ? null : new[] { "scan" };
-            using (var conn = Create(disabledCommands: disabledCommands, allowAdmin: true))
+            db.StringSet(prefix + i, Guid.NewGuid().ToString(), flags: CommandFlags.FireAndForget);
+        }
+        var seq = server.Keys(dbId, pageSize: 50);
+        var cur = seq as IScanningCursor;
+        Assert.NotNull(cur);
+        Log($"Cursor: {cur.Cursor}, PageOffset: {cur.PageOffset}, PageSize: {cur.PageSize}");
+        Assert.Equal(0, cur.PageOffset);
+        Assert.Equal(0, cur.Cursor);
+        if (supported)
+        {
+            Assert.Equal(50, cur.PageSize);
+        }
+        else
+        {
+            Assert.Equal(int.MaxValue, cur.PageSize);
+        }
+        Assert.Equal(100, seq.Distinct().Count());
+        Assert.Equal(100, seq.Distinct().Count());
+        Assert.Equal(100, server.Keys(dbId, prefix + "*").Distinct().Count());
+        // 7, 70, 71, ..., 79
+        Assert.Equal(11, server.Keys(dbId, prefix + "7*").Distinct().Count());
+    }
+
+    [Fact]
+    public void ScansIScanning()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var prefix = Me() + Guid.NewGuid();
+        var dbId = TestConfig.GetDedicatedDB(conn);
+        var db = conn.GetDatabase(dbId);
+        var server = GetServer(conn);
+        server.FlushDatabase(dbId);
+        for (int i = 0; i < 100; i++)
+        {
+            db.StringSet(prefix + i, Guid.NewGuid().ToString(), flags: CommandFlags.FireAndForget);
+        }
+        var seq = server.Keys(dbId, prefix + "*", pageSize: 15);
+        using (var iter = seq.GetEnumerator())
+        {
+            IScanningCursor s0 = (IScanningCursor)seq, s1 = (IScanningCursor)iter;
+
+            Assert.Equal(15, s0.PageSize);
+            Assert.Equal(15, s1.PageSize);
+
+            // start at zero
+            Assert.Equal(0, s0.Cursor);
+            Assert.Equal(s0.Cursor, s1.Cursor);
+
+            for (int i = 0; i < 47; i++)
             {
-                var dbId = TestConfig.GetDedicatedDB(conn);
-                var db = conn.GetDatabase(dbId);
-                var prefix = Me() + ":";
-                var server = GetServer(conn);
-                server.FlushDatabase(dbId);
-                for (int i = 0; i < 100; i++)
-                {
-                    db.StringSet(prefix + i, Guid.NewGuid().ToString(), flags: CommandFlags.FireAndForget);
-                }
-                var seq = server.Keys(dbId, pageSize: 50);
-                var cur = seq as IScanningCursor;
-                Assert.NotNull(cur);
-                Log($"Cursor: {cur.Cursor}, PageOffset: {cur.PageOffset}, PageSize: {cur.PageSize}");
-                Assert.Equal(0, cur.PageOffset);
-                Assert.Equal(0, cur.Cursor);
-                if (supported)
-                {
-                    Assert.Equal(50, cur.PageSize);
-                }
-                else
-                {
-                    Assert.Equal(int.MaxValue, cur.PageSize);
-                }
-                Assert.Equal(100, seq.Distinct().Count());
-                Assert.Equal(100, seq.Distinct().Count());
-                Assert.Equal(100, server.Keys(dbId, prefix + "*").Distinct().Count());
-                // 7, 70, 71, ..., 79
-                Assert.Equal(11, server.Keys(dbId, prefix + "7*").Distinct().Count());
+                Assert.True(iter.MoveNext());
             }
+
+            // non-zero in the middle
+            Assert.NotEqual(0, s0.Cursor);
+            Assert.Equal(s0.Cursor, s1.Cursor);
+
+            for (int i = 0; i < 53; i++)
+            {
+                Assert.True(iter.MoveNext());
+            }
+
+            // zero "next" at the end
+            Assert.False(iter.MoveNext());
+            Assert.NotEqual(0, s0.Cursor);
+            Assert.NotEqual(0, s1.Cursor);
+        }
+    }
+
+    [Fact]
+    public void ScanResume()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_8_0);
+
+        var dbId = TestConfig.GetDedicatedDB(conn);
+        var db = conn.GetDatabase(dbId);
+        var prefix = Me();
+        var server = GetServer(conn);
+        server.FlushDatabase(dbId);
+        int i;
+        for (i = 0; i < 100; i++)
+        {
+            db.StringSet(prefix + ":" + i, Guid.NewGuid().ToString());
         }
 
-        [Fact]
-        public void ScansIScanning()
+        var expected = new HashSet<string?>();
+        long snapCursor = 0;
+        int snapOffset = 0, snapPageSize = 0;
+
+        i = 0;
+        var seq = server.Keys(dbId, prefix + ":*", pageSize: 15);
+        foreach (var key in seq)
         {
-            using (var conn = Create(allowAdmin: true))
+            if (i == 57)
             {
-                var prefix = Me() + Guid.NewGuid();
-                var dbId = TestConfig.GetDedicatedDB(conn);
-                var db = conn.GetDatabase(dbId);
-                var server = GetServer(conn);
-                server.FlushDatabase(dbId);
-                for (int i = 0; i < 100; i++)
-                {
-                    db.StringSet(prefix + i, Guid.NewGuid().ToString(), flags: CommandFlags.FireAndForget);
-                }
-                var seq = server.Keys(dbId, prefix + "*", pageSize: 15);
-                using (var iter = seq.GetEnumerator())
-                {
-                    IScanningCursor s0 = (IScanningCursor)seq, s1 = (IScanningCursor)iter;
-
-                    Assert.Equal(15, s0.PageSize);
-                    Assert.Equal(15, s1.PageSize);
-
-                    // start at zero
-                    Assert.Equal(0, s0.Cursor);
-                    Assert.Equal(s0.Cursor, s1.Cursor);
-
-                    for (int i = 0; i < 47; i++)
-                    {
-                        Assert.True(iter.MoveNext());
-                    }
-
-                    // non-zero in the middle
-                    Assert.NotEqual(0, s0.Cursor);
-                    Assert.Equal(s0.Cursor, s1.Cursor);
-
-                    for (int i = 0; i < 53; i++)
-                    {
-                        Assert.True(iter.MoveNext());
-                    }
-
-                    // zero "next" at the end
-                    Assert.False(iter.MoveNext());
-                    Assert.NotEqual(0, s0.Cursor);
-                    Assert.NotEqual(0, s1.Cursor);
-                }
+                snapCursor = ((IScanningCursor)seq).Cursor;
+                snapOffset = ((IScanningCursor)seq).PageOffset;
+                snapPageSize = ((IScanningCursor)seq).PageSize;
+                Log($"i: {i}, Cursor: {snapCursor}, Offset: {snapOffset}, PageSize: {snapPageSize}");
             }
+            if (i >= 57)
+            {
+                expected.Add(key);
+            }
+            i++;
+        }
+        Log($"Expected: 43, Actual: {expected.Count}, Cursor: {snapCursor}, Offset: {snapOffset}, PageSize: {snapPageSize}");
+        Assert.Equal(43, expected.Count);
+        Assert.NotEqual(0, snapCursor);
+        Assert.Equal(15, snapPageSize);
+
+        // note: you might think that we can say "hmmm, 57 when using page-size 15 on an empty (flushed) db (so: no skipped keys); that'll be
+        // offset 12 in the 4th page; you'd be wrong, though; page size doesn't *actually* mean page size; it is a rough analogue for
+        // page size, with zero guarantees; in this particular test, the first page actually has 19 elements, for example. So: we cannot
+        // make the following assertion:
+        // Assert.Equal(12, snapOffset);
+
+        seq = server.Keys(dbId, prefix + ":*", pageSize: 15, cursor: snapCursor, pageOffset: snapOffset);
+        var seqCur = (IScanningCursor)seq;
+        Assert.Equal(snapCursor, seqCur.Cursor);
+        Assert.Equal(snapPageSize, seqCur.PageSize);
+        Assert.Equal(snapOffset, seqCur.PageOffset);
+        using (var iter = seq.GetEnumerator())
+        {
+            var iterCur = (IScanningCursor)iter;
+            Assert.Equal(snapCursor, iterCur.Cursor);
+            Assert.Equal(snapOffset, iterCur.PageOffset);
+            Assert.Equal(snapCursor, seqCur.Cursor);
+            Assert.Equal(snapOffset, seqCur.PageOffset);
+
+            Assert.True(iter.MoveNext());
+            Assert.Equal(snapCursor, iterCur.Cursor);
+            Assert.Equal(snapOffset, iterCur.PageOffset);
+            Assert.Equal(snapCursor, seqCur.Cursor);
+            Assert.Equal(snapOffset, seqCur.PageOffset);
+
+            Assert.True(iter.MoveNext());
+            Assert.Equal(snapCursor, iterCur.Cursor);
+            Assert.Equal(snapOffset + 1, iterCur.PageOffset);
+            Assert.Equal(snapCursor, seqCur.Cursor);
+            Assert.Equal(snapOffset + 1, seqCur.PageOffset);
         }
 
-        [Fact]
-        public void ScanResume()
+        int count = 0;
+        foreach (var key in seq)
         {
-            using (var conn = Create(allowAdmin: true))
+            expected.Remove(key);
+            count++;
+        }
+        Assert.Empty(expected);
+        Assert.Equal(43, count);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SetScan(bool supported)
+    {
+        string[]? disabledCommands = supported ? null : new[] { "sscan" };
+
+        using var conn = Create(disabledCommands: disabledCommands);
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.SetAdd(key, "a", CommandFlags.FireAndForget);
+        db.SetAdd(key, "b", CommandFlags.FireAndForget);
+        db.SetAdd(key, "c", CommandFlags.FireAndForget);
+        var arr = db.SetScan(key).ToArray();
+        Assert.Equal(3, arr.Length);
+        Assert.Contains((RedisValue)"a", arr);
+        Assert.Contains((RedisValue)"b", arr);
+        Assert.Contains((RedisValue)"c", arr);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SortedSetScan(bool supported)
+    {
+        string[]? disabledCommands = supported ? null : new[] { "zscan" };
+
+        using var conn = Create(disabledCommands: disabledCommands);
+
+        RedisKey key = Me() + supported;
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key, "a", 1, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, "b", 2, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, "c", 3, CommandFlags.FireAndForget);
+
+        var arr = db.SortedSetScan(key).ToArray();
+        Assert.Equal(3, arr.Length);
+        Assert.True(arr.Any(x => x.Element == "a" && x.Score == 1), "a");
+        Assert.True(arr.Any(x => x.Element == "b" && x.Score == 2), "b");
+        Assert.True(arr.Any(x => x.Element == "c" && x.Score == 3), "c");
+
+        var dictionary = arr.ToDictionary();
+        Assert.Equal(1, dictionary["a"]);
+        Assert.Equal(2, dictionary["b"]);
+        Assert.Equal(3, dictionary["c"]);
+
+        var sDictionary = arr.ToStringDictionary();
+        Assert.Equal(1, sDictionary["a"]);
+        Assert.Equal(2, sDictionary["b"]);
+        Assert.Equal(3, sDictionary["c"]);
+
+        var basic = db.SortedSetRangeByRankWithScores(key, order: Order.Ascending).ToDictionary();
+        Assert.Equal(3, basic.Count);
+        Assert.Equal(1, basic["a"]);
+        Assert.Equal(2, basic["b"]);
+        Assert.Equal(3, basic["c"]);
+
+        basic = db.SortedSetRangeByRankWithScores(key, order: Order.Descending).ToDictionary();
+        Assert.Equal(3, basic.Count);
+        Assert.Equal(1, basic["a"]);
+        Assert.Equal(2, basic["b"]);
+        Assert.Equal(3, basic["c"]);
+
+        var basicArr = db.SortedSetRangeByScoreWithScores(key, order: Order.Ascending);
+        Assert.Equal(3, basicArr.Length);
+        Assert.Equal(1, basicArr[0].Score);
+        Assert.Equal(2, basicArr[1].Score);
+        Assert.Equal(3, basicArr[2].Score);
+        basic = basicArr.ToDictionary();
+        Assert.Equal(3, basic.Count); //asc
+        Assert.Equal(1, basic["a"]);
+        Assert.Equal(2, basic["b"]);
+        Assert.Equal(3, basic["c"]);
+
+        basicArr = db.SortedSetRangeByScoreWithScores(key, order: Order.Descending);
+        Assert.Equal(3, basicArr.Length);
+        Assert.Equal(3, basicArr[0].Score);
+        Assert.Equal(2, basicArr[1].Score);
+        Assert.Equal(1, basicArr[2].Score);
+        basic = basicArr.ToDictionary();
+        Assert.Equal(3, basic.Count); // desc
+        Assert.Equal(1, basic["a"]);
+        Assert.Equal(2, basic["b"]);
+        Assert.Equal(3, basic["c"]);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HashScan(bool supported)
+    {
+        string[]? disabledCommands = supported ? null : new[] { "hscan" };
+
+        using var conn = Create(disabledCommands: disabledCommands);
+
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.HashSet(key, "a", "1", flags: CommandFlags.FireAndForget);
+        db.HashSet(key, "b", "2", flags: CommandFlags.FireAndForget);
+        db.HashSet(key, "c", "3", flags: CommandFlags.FireAndForget);
+
+        var arr = db.HashScan(key).ToArray();
+        Assert.Equal(3, arr.Length);
+        Assert.True(arr.Any(x => x.Name == "a" && x.Value == "1"), "a");
+        Assert.True(arr.Any(x => x.Name == "b" && x.Value == "2"), "b");
+        Assert.True(arr.Any(x => x.Name == "c" && x.Value == "3"), "c");
+
+        var dictionary = arr.ToDictionary();
+        Assert.Equal(1, (long)dictionary["a"]);
+        Assert.Equal(2, (long)dictionary["b"]);
+        Assert.Equal(3, (long)dictionary["c"]);
+
+        var sDictionary = arr.ToStringDictionary();
+        Assert.Equal("1", sDictionary["a"]);
+        Assert.Equal("2", sDictionary["b"]);
+        Assert.Equal("3", sDictionary["c"]);
+
+        var basic = db.HashGetAll(key).ToDictionary();
+        Assert.Equal(3, basic.Count);
+        Assert.Equal(1, (long)basic["a"]);
+        Assert.Equal(2, (long)basic["b"]);
+        Assert.Equal(3, (long)basic["c"]);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(10000)]
+    public void HashScanLarge(int pageSize)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me() + pageSize;
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        for (int i = 0; i < 2000; i++)
+            db.HashSet(key, "k" + i, "v" + i, flags: CommandFlags.FireAndForget);
+
+        int count = db.HashScan(key, pageSize: pageSize).Count();
+        Assert.Equal(2000, count);
+    }
+
+    [Fact] // See https://github.com/StackExchange/StackExchange.Redis/issues/729
+    public void HashScanThresholds()
+    {
+        using var conn = Create(allowAdmin: true);
+
+        var config = conn.GetServer(conn.GetEndPoints(true)[0]).ConfigGet("hash-max-ziplist-entries").First();
+        var threshold = int.Parse(config.Value);
+
+        RedisKey key = Me();
+        Assert.False(GotCursors(conn, key, threshold - 1));
+        Assert.True(GotCursors(conn, key, threshold + 1));
+    }
+
+    private static bool GotCursors(IConnectionMultiplexer conn, RedisKey key, int count)
+    {
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var entries = new HashEntry[count];
+        for (var i = 0; i < count; i++)
+        {
+            entries[i] = new HashEntry("Item:" + i, i);
+        }
+        db.HashSet(key, entries, CommandFlags.FireAndForget);
+
+        var found = false;
+        var response = db.HashScan(key);
+        var cursor = ((IScanningCursor)response);
+        foreach (var _ in response)
+        {
+            if (cursor.Cursor > 0)
             {
-                Skip.IfBelow(conn, RedisFeatures.v2_8_0);
-
-                var dbId = TestConfig.GetDedicatedDB(conn);
-                var db = conn.GetDatabase(dbId);
-                var prefix = Me();
-                var server = GetServer(conn);
-                server.FlushDatabase(dbId);
-                int i;
-                for (i = 0; i < 100; i++)
-                {
-                    db.StringSet(prefix + ":" + i, Guid.NewGuid().ToString());
-                }
-
-                var expected = new HashSet<string?>();
-                long snapCursor = 0;
-                int snapOffset = 0, snapPageSize = 0;
-
-                i = 0;
-                var seq = server.Keys(dbId, prefix + ":*", pageSize: 15);
-                foreach (var key in seq)
-                {
-                    if (i == 57)
-                    {
-                        snapCursor = ((IScanningCursor)seq).Cursor;
-                        snapOffset = ((IScanningCursor)seq).PageOffset;
-                        snapPageSize = ((IScanningCursor)seq).PageSize;
-                        Log($"i: {i}, Cursor: {snapCursor}, Offset: {snapOffset}, PageSize: {snapPageSize}");
-                    }
-                    if (i >= 57)
-                    {
-                        expected.Add(key);
-                    }
-                    i++;
-                }
-                Log($"Expected: 43, Actual: {expected.Count}, Cursor: {snapCursor}, Offset: {snapOffset}, PageSize: {snapPageSize}");
-                Assert.Equal(43, expected.Count);
-                Assert.NotEqual(0, snapCursor);
-                Assert.Equal(15, snapPageSize);
-
-                // note: you might think that we can say "hmmm, 57 when using page-size 15 on an empty (flushed) db (so: no skipped keys); that'll be
-                // offset 12 in the 4th page; you'd be wrong, though; page size doesn't *actually* mean page size; it is a rough analogue for
-                // page size, with zero guarantees; in this particular test, the first page actually has 19 elements, for example. So: we cannot
-                // make the following assertion:
-                // Assert.Equal(12, snapOffset);
-
-                seq = server.Keys(dbId, prefix + ":*", pageSize: 15, cursor: snapCursor, pageOffset: snapOffset);
-                var seqCur = (IScanningCursor)seq;
-                Assert.Equal(snapCursor, seqCur.Cursor);
-                Assert.Equal(snapPageSize, seqCur.PageSize);
-                Assert.Equal(snapOffset, seqCur.PageOffset);
-                using (var iter = seq.GetEnumerator())
-                {
-                    var iterCur = (IScanningCursor)iter;
-                    Assert.Equal(snapCursor, iterCur.Cursor);
-                    Assert.Equal(snapOffset, iterCur.PageOffset);
-                    Assert.Equal(snapCursor, seqCur.Cursor);
-                    Assert.Equal(snapOffset, seqCur.PageOffset);
-
-                    Assert.True(iter.MoveNext());
-                    Assert.Equal(snapCursor, iterCur.Cursor);
-                    Assert.Equal(snapOffset, iterCur.PageOffset);
-                    Assert.Equal(snapCursor, seqCur.Cursor);
-                    Assert.Equal(snapOffset, seqCur.PageOffset);
-
-                    Assert.True(iter.MoveNext());
-                    Assert.Equal(snapCursor, iterCur.Cursor);
-                    Assert.Equal(snapOffset + 1, iterCur.PageOffset);
-                    Assert.Equal(snapCursor, seqCur.Cursor);
-                    Assert.Equal(snapOffset + 1, seqCur.PageOffset);
-                }
-
-                int count = 0;
-                foreach (var key in seq)
-                {
-                    expected.Remove(key);
-                    count++;
-                }
-                Assert.Empty(expected);
-                Assert.Equal(43, count);
+                found = true;
             }
         }
+        return found;
+    }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SetScan(bool supported)
-        {
-            string[]? disabledCommands = supported ? null : new[] { "sscan" };
-            using (var conn = Create(disabledCommands: disabledCommands))
-            {
-                RedisKey key = Me();
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(10000)]
+    public void SetScanLarge(int pageSize)
+    {
+        using var conn = Create();
 
-                db.SetAdd(key, "a", CommandFlags.FireAndForget);
-                db.SetAdd(key, "b", CommandFlags.FireAndForget);
-                db.SetAdd(key, "c", CommandFlags.FireAndForget);
-                var arr = db.SetScan(key).ToArray();
-                Assert.Equal(3, arr.Length);
-                Assert.Contains((RedisValue)"a", arr);
-                Assert.Contains((RedisValue)"b", arr);
-                Assert.Contains((RedisValue)"c", arr);
-            }
-        }
+        RedisKey key = Me() + pageSize;
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SortedSetScan(bool supported)
-        {
-            string[]? disabledCommands = supported ? null : new[] { "zscan" };
-            using (var conn = Create(disabledCommands: disabledCommands))
-            {
-                RedisKey key = Me() + supported;
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 0; i < 2000; i++)
+            db.SetAdd(key, "s" + i, flags: CommandFlags.FireAndForget);
 
-                db.SortedSetAdd(key, "a", 1, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, "b", 2, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, "c", 3, CommandFlags.FireAndForget);
+        int count = db.SetScan(key, pageSize: pageSize).Count();
+        Assert.Equal(2000, count);
+    }
 
-                var arr = db.SortedSetScan(key).ToArray();
-                Assert.Equal(3, arr.Length);
-                Assert.True(arr.Any(x => x.Element == "a" && x.Score == 1), "a");
-                Assert.True(arr.Any(x => x.Element == "b" && x.Score == 2), "b");
-                Assert.True(arr.Any(x => x.Element == "c" && x.Score == 3), "c");
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(10000)]
+    public void SortedSetScanLarge(int pageSize)
+    {
+        using var conn = Create();
 
-                var dictionary = arr.ToDictionary();
-                Assert.Equal(1, dictionary["a"]);
-                Assert.Equal(2, dictionary["b"]);
-                Assert.Equal(3, dictionary["c"]);
+        RedisKey key = Me() + pageSize;
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var sDictionary = arr.ToStringDictionary();
-                Assert.Equal(1, sDictionary["a"]);
-                Assert.Equal(2, sDictionary["b"]);
-                Assert.Equal(3, sDictionary["c"]);
+        for (int i = 0; i < 2000; i++)
+            db.SortedSetAdd(key, "z" + i, i, flags: CommandFlags.FireAndForget);
 
-                var basic = db.SortedSetRangeByRankWithScores(key, order: Order.Ascending).ToDictionary();
-                Assert.Equal(3, basic.Count);
-                Assert.Equal(1, basic["a"]);
-                Assert.Equal(2, basic["b"]);
-                Assert.Equal(3, basic["c"]);
-
-                basic = db.SortedSetRangeByRankWithScores(key, order: Order.Descending).ToDictionary();
-                Assert.Equal(3, basic.Count);
-                Assert.Equal(1, basic["a"]);
-                Assert.Equal(2, basic["b"]);
-                Assert.Equal(3, basic["c"]);
-
-                var basicArr = db.SortedSetRangeByScoreWithScores(key, order: Order.Ascending);
-                Assert.Equal(3, basicArr.Length);
-                Assert.Equal(1, basicArr[0].Score);
-                Assert.Equal(2, basicArr[1].Score);
-                Assert.Equal(3, basicArr[2].Score);
-                basic = basicArr.ToDictionary();
-                Assert.Equal(3, basic.Count); //asc
-                Assert.Equal(1, basic["a"]);
-                Assert.Equal(2, basic["b"]);
-                Assert.Equal(3, basic["c"]);
-
-                basicArr = db.SortedSetRangeByScoreWithScores(key, order: Order.Descending);
-                Assert.Equal(3, basicArr.Length);
-                Assert.Equal(3, basicArr[0].Score);
-                Assert.Equal(2, basicArr[1].Score);
-                Assert.Equal(1, basicArr[2].Score);
-                basic = basicArr.ToDictionary();
-                Assert.Equal(3, basic.Count); // desc
-                Assert.Equal(1, basic["a"]);
-                Assert.Equal(2, basic["b"]);
-                Assert.Equal(3, basic["c"]);
-            }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void HashScan(bool supported)
-        {
-            string[]? disabledCommands = supported ? null : new[] { "hscan" };
-            using (var conn = Create(disabledCommands: disabledCommands))
-            {
-                RedisKey key = Me();
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                db.HashSet(key, "a", "1", flags: CommandFlags.FireAndForget);
-                db.HashSet(key, "b", "2", flags: CommandFlags.FireAndForget);
-                db.HashSet(key, "c", "3", flags: CommandFlags.FireAndForget);
-
-                var arr = db.HashScan(key).ToArray();
-                Assert.Equal(3, arr.Length);
-                Assert.True(arr.Any(x => x.Name == "a" && x.Value == "1"), "a");
-                Assert.True(arr.Any(x => x.Name == "b" && x.Value == "2"), "b");
-                Assert.True(arr.Any(x => x.Name == "c" && x.Value == "3"), "c");
-
-                var dictionary = arr.ToDictionary();
-                Assert.Equal(1, (long)dictionary["a"]);
-                Assert.Equal(2, (long)dictionary["b"]);
-                Assert.Equal(3, (long)dictionary["c"]);
-
-                var sDictionary = arr.ToStringDictionary();
-                Assert.Equal("1", sDictionary["a"]);
-                Assert.Equal("2", sDictionary["b"]);
-                Assert.Equal("3", sDictionary["c"]);
-
-                var basic = db.HashGetAll(key).ToDictionary();
-                Assert.Equal(3, basic.Count);
-                Assert.Equal(1, (long)basic["a"]);
-                Assert.Equal(2, (long)basic["b"]);
-                Assert.Equal(3, (long)basic["c"]);
-            }
-        }
-
-        [Theory]
-        [InlineData(10)]
-        [InlineData(100)]
-        [InlineData(1000)]
-        [InlineData(10000)]
-        public void HashScanLarge(int pageSize)
-        {
-            using (var conn = Create())
-            {
-                RedisKey key = Me() + pageSize;
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                for (int i = 0; i < 2000; i++)
-                    db.HashSet(key, "k" + i, "v" + i, flags: CommandFlags.FireAndForget);
-
-                int count = db.HashScan(key, pageSize: pageSize).Count();
-                Assert.Equal(2000, count);
-            }
-        }
-
-        [Fact] // See https://github.com/StackExchange/StackExchange.Redis/issues/729
-        public void HashScanThresholds()
-        {
-            using (var conn = Create(allowAdmin: true))
-            {
-                var config = conn.GetServer(conn.GetEndPoints(true)[0]).ConfigGet("hash-max-ziplist-entries").First();
-                var threshold = int.Parse(config.Value);
-
-                RedisKey key = Me();
-                Assert.False(GotCursors(conn, key, threshold - 1));
-                Assert.True(GotCursors(conn, key, threshold + 1));
-            }
-        }
-
-        private static bool GotCursors(IConnectionMultiplexer conn, RedisKey key, int count)
-        {
-            var db = conn.GetDatabase();
-            db.KeyDelete(key, CommandFlags.FireAndForget);
-
-            var entries = new HashEntry[count];
-            for (var i = 0; i < count; i++)
-            {
-                entries[i] = new HashEntry("Item:" + i, i);
-            }
-            db.HashSet(key, entries, CommandFlags.FireAndForget);
-
-            var found = false;
-            var response = db.HashScan(key);
-            var cursor = ((IScanningCursor)response);
-            foreach (var _ in response)
-            {
-                if (cursor.Cursor > 0)
-                {
-                    found = true;
-                }
-            }
-            return found;
-        }
-
-        [Theory]
-        [InlineData(10)]
-        [InlineData(100)]
-        [InlineData(1000)]
-        [InlineData(10000)]
-        public void SetScanLarge(int pageSize)
-        {
-            using (var conn = Create())
-            {
-                RedisKey key = Me() + pageSize;
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                for (int i = 0; i < 2000; i++)
-                    db.SetAdd(key, "s" + i, flags: CommandFlags.FireAndForget);
-
-                int count = db.SetScan(key, pageSize: pageSize).Count();
-                Assert.Equal(2000, count);
-            }
-        }
-
-        [Theory]
-        [InlineData(10)]
-        [InlineData(100)]
-        [InlineData(1000)]
-        [InlineData(10000)]
-        public void SortedSetScanLarge(int pageSize)
-        {
-            using (var conn = Create())
-            {
-                RedisKey key = Me() + pageSize;
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                for (int i = 0; i < 2000; i++)
-                    db.SortedSetAdd(key, "z" + i, i, flags: CommandFlags.FireAndForget);
-
-                int count = db.SortedSetScan(key, pageSize: pageSize).Count();
-                Assert.Equal(2000, count);
-            }
-        }
+        int count = db.SortedSetScan(key, pageSize: pageSize).Count();
+        Assert.Equal(2000, count);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Scripting.cs
+++ b/tests/StackExchange.Redis.Tests/Scripting.cs
@@ -7,112 +7,104 @@ using StackExchange.Redis.KeyspaceIsolation;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Scripting : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Scripting : TestBase
+    public Scripting(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    private IConnectionMultiplexer GetScriptConn(bool allowAdmin = false)
     {
-        public Scripting(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        int syncTimeout = 5000;
+        if (Debugger.IsAttached) syncTimeout = 500000;
+        return Create(allowAdmin: allowAdmin, syncTimeout: syncTimeout, require: RedisFeatures.v2_6_0);
+    }
 
-        private IConnectionMultiplexer GetScriptConn(bool allowAdmin = false)
-        {
-            int syncTimeout = 5000;
-            if (Debugger.IsAttached) syncTimeout = 500000;
-            var muxer = Create(allowAdmin: allowAdmin, syncTimeout: syncTimeout);
+    [Fact]
+    public void ClientScripting()
+    {
+        using var conn = GetScriptConn();
+        _ = conn.GetDatabase().ScriptEvaluate("return redis.call('info','server')", null, null);
+    }
 
-            Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
-            return muxer;
-        }
+    [Fact]
+    public async Task BasicScripting()
+    {
+        using var conn = GetScriptConn();
 
-        [Fact]
-        public void ClientScripting()
-        {
-            using (var conn = GetScriptConn())
-            {
-                _ = conn.GetDatabase().ScriptEvaluate("return redis.call('info','server')", null, null);
-            }
-        }
+        var db = conn.GetDatabase();
+        var noCache = db.ScriptEvaluateAsync("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
+            new RedisKey[] { "key1", "key2" }, new RedisValue[] { "first", "second" });
+        var cache = db.ScriptEvaluateAsync("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
+            new RedisKey[] { "key1", "key2" }, new RedisValue[] { "first", "second" });
+        var results = (string[]?)await noCache;
+        Assert.NotNull(results);
+        Assert.Equal(4, results.Length);
+        Assert.Equal("key1", results[0]);
+        Assert.Equal("key2", results[1]);
+        Assert.Equal("first", results[2]);
+        Assert.Equal("second", results[3]);
 
-        [Fact]
-        public async Task BasicScripting()
-        {
-            using (var muxer = GetScriptConn())
-            {
-                var conn = muxer.GetDatabase();
-                var noCache = conn.ScriptEvaluateAsync("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
-                    new RedisKey[] { "key1", "key2" }, new RedisValue[] { "first", "second" });
-                var cache = conn.ScriptEvaluateAsync("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
-                    new RedisKey[] { "key1", "key2" }, new RedisValue[] { "first", "second" });
-                var results = (string[]?)await noCache;
-                Assert.NotNull(results);
-                Assert.Equal(4, results.Length);
-                Assert.Equal("key1", results[0]);
-                Assert.Equal("key2", results[1]);
-                Assert.Equal("first", results[2]);
-                Assert.Equal("second", results[3]);
+        results = (string[]?)await cache;
+        Assert.NotNull(results);
+        Assert.Equal(4, results.Length);
+        Assert.Equal("key1", results[0]);
+        Assert.Equal("key2", results[1]);
+        Assert.Equal("first", results[2]);
+        Assert.Equal("second", results[3]);
+    }
 
-                results = (string[]?)await cache;
-                Assert.NotNull(results);
-                Assert.Equal(4, results.Length);
-                Assert.Equal("key1", results[0]);
-                Assert.Equal("key2", results[1]);
-                Assert.Equal("first", results[2]);
-                Assert.Equal("second", results[3]);
-            }
-        }
+    [Fact]
+    public void KeysScripting()
+    {
+        using var conn = GetScriptConn();
 
-        [Fact]
-        public void KeysScripting()
-        {
-            using (var muxer = GetScriptConn())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.StringSet(key, "bar", flags: CommandFlags.FireAndForget);
-                var result = (string?)conn.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
-                Assert.Equal("bar", result);
-            }
-        }
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.StringSet(key, "bar", flags: CommandFlags.FireAndForget);
+        var result = (string?)db.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
+        Assert.Equal("bar", result);
+    }
 
-        [Fact]
-        public async Task TestRandomThingFromForum()
-        {
-            const string script = @"local currentVal = tonumber(redis.call('GET', KEYS[1]));
+    [Fact]
+    public async Task TestRandomThingFromForum()
+    {
+        const string script = @"local currentVal = tonumber(redis.call('GET', KEYS[1]));
                 if (currentVal <= 0 ) then return 1 elseif (currentVal - (tonumber(ARGV[1])) < 0 ) then return 0 end;
                 return redis.call('INCRBY', KEYS[1], -tonumber(ARGV[1]));";
 
-            using (var muxer = GetScriptConn())
-            {
-                var prefix = Me();
-                var conn = muxer.GetDatabase();
-                conn.StringSet(prefix + "A", "0", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "B", "5", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "C", "10", flags: CommandFlags.FireAndForget);
+        using var conn = GetScriptConn();
 
-                var a = conn.ScriptEvaluateAsync(script, new RedisKey[] { prefix + "A" }, new RedisValue[] { 6 }).ForAwait();
-                var b = conn.ScriptEvaluateAsync(script, new RedisKey[] { prefix + "B" }, new RedisValue[] { 6 }).ForAwait();
-                var c = conn.ScriptEvaluateAsync(script, new RedisKey[] { prefix + "C" }, new RedisValue[] { 6 }).ForAwait();
+        var prefix = Me();
+        var db = conn.GetDatabase();
+        db.StringSet(prefix + "A", "0", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "B", "5", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "C", "10", flags: CommandFlags.FireAndForget);
 
-                var vals = await conn.StringGetAsync(new RedisKey[] { prefix + "A", prefix + "B", prefix + "C" }).ForAwait();
+        var a = db.ScriptEvaluateAsync(script, new RedisKey[] { prefix + "A" }, new RedisValue[] { 6 }).ForAwait();
+        var b = db.ScriptEvaluateAsync(script, new RedisKey[] { prefix + "B" }, new RedisValue[] { 6 }).ForAwait();
+        var c = db.ScriptEvaluateAsync(script, new RedisKey[] { prefix + "C" }, new RedisValue[] { 6 }).ForAwait();
 
-                Assert.Equal(1, (long)await a); // exit code when current val is non-positive
-                Assert.Equal(0, (long)await b); // exit code when result would be negative
-                Assert.Equal(4, (long)await c); // 10 - 6 = 4
-                Assert.Equal("0", vals[0]);
-                Assert.Equal("5", vals[1]);
-                Assert.Equal("4", vals[2]);
-            }
-        }
+        var vals = await db.StringGetAsync(new RedisKey[] { prefix + "A", prefix + "B", prefix + "C" }).ForAwait();
 
-        [Fact]
-        public void HackyGetPerf()
-        {
-            using (var muxer = GetScriptConn())
-            {
-                var key = Me();
-                var conn = muxer.GetDatabase();
-                conn.StringSet(key + "foo", "bar", flags: CommandFlags.FireAndForget);
-                var result = (long)conn.ScriptEvaluate(@"
+        Assert.Equal(1, (long)await a); // exit code when current val is non-positive
+        Assert.Equal(0, (long)await b); // exit code when result would be negative
+        Assert.Equal(4, (long)await c); // 10 - 6 = 4
+        Assert.Equal("0", vals[0]);
+        Assert.Equal("5", vals[1]);
+        Assert.Equal("4", vals[2]);
+    }
+
+    [Fact]
+    public void HackyGetPerf()
+    {
+        using var conn = GetScriptConn();
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.StringSet(key + "foo", "bar", flags: CommandFlags.FireAndForget);
+        var result = (long)db.ScriptEvaluate(@"
 redis.call('psetex', KEYS[1], 60000, 'timing')
 for i = 1,5000 do
     redis.call('set', 'ignore','abc')
@@ -121,1018 +113,944 @@ local timeTaken = 60000 - redis.call('pttl', KEYS[1])
 redis.call('del', KEYS[1])
 return timeTaken
 ", new RedisKey[] { key }, null);
-                Log(result.ToString());
-                Assert.True(result > 0);
-            }
-        }
+        Log(result.ToString());
+        Assert.True(result > 0);
+    }
 
-        [Fact]
-        public async Task MultiIncrWithoutReplies()
+    [Fact]
+    public async Task MultiIncrWithoutReplies()
+    {
+        using var conn = GetScriptConn();
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        // prime some initial values
+        db.KeyDelete(new RedisKey[] { prefix + "a", prefix + "b", prefix + "c" }, CommandFlags.FireAndForget);
+        db.StringIncrement(prefix + "b", flags: CommandFlags.FireAndForget);
+        db.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
+        db.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
+
+        // run the script, passing "a", "b", "c", "c" to
+        // increment a & b by 1, c twice
+        var result = db.ScriptEvaluateAsync(
+            "for i,key in ipairs(KEYS) do redis.call('incr', key) end",
+            new RedisKey[] { prefix + "a", prefix + "b", prefix + "c", prefix + "c" }, // <== aka "KEYS" in the script
+            null).ForAwait(); // <== aka "ARGV" in the script
+
+        // check the incremented values
+        var a = db.StringGetAsync(prefix + "a").ForAwait();
+        var b = db.StringGetAsync(prefix + "b").ForAwait();
+        var c = db.StringGetAsync(prefix + "c").ForAwait();
+
+        var r = await result;
+        Assert.NotNull(r);
+        Assert.True(r.IsNull, "result");
+        Assert.Equal(1, (long)await a);
+        Assert.Equal(2, (long)await b);
+        Assert.Equal(4, (long)await c);
+    }
+
+    [Fact]
+    public async Task MultiIncrByWithoutReplies()
+    {
+        using var conn = GetScriptConn();
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        // prime some initial values
+        db.KeyDelete(new RedisKey[] { prefix + "a", prefix + "b", prefix + "c" }, CommandFlags.FireAndForget);
+        db.StringIncrement(prefix + "b", flags: CommandFlags.FireAndForget);
+        db.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
+        db.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
+
+        //run the script, passing "a", "b", "c" and 1,2,3
+        // increment a &b by 1, c twice
+        var result = db.ScriptEvaluateAsync(
+            "for i,key in ipairs(KEYS) do redis.call('incrby', key, ARGV[i]) end",
+            new RedisKey[] { prefix + "a", prefix + "b", prefix + "c" }, // <== aka "KEYS" in the script
+            new RedisValue[] { 1, 1, 2 }).ForAwait(); // <== aka "ARGV" in the script
+
+        // check the incremented values
+        var a = db.StringGetAsync(prefix + "a").ForAwait();
+        var b = db.StringGetAsync(prefix + "b").ForAwait();
+        var c = db.StringGetAsync(prefix + "c").ForAwait();
+
+        Assert.True((await result).IsNull, "result");
+        Assert.Equal(1, (long)await a);
+        Assert.Equal(2, (long)await b);
+        Assert.Equal(4, (long)await c);
+    }
+
+    [Fact]
+    public void DisableStringInference()
+    {
+        using var conn = GetScriptConn();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.StringSet(key, "bar", flags: CommandFlags.FireAndForget);
+        var result = (byte[]?)db.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key });
+        Assert.NotNull(result);
+        Assert.Equal("bar", Encoding.UTF8.GetString(result));
+    }
+
+    [Fact]
+    public void FlushDetection()
+    {
+        // we don't expect this to handle everything; we just expect it to be predictable
+        using var conn = GetScriptConn(allowAdmin: true);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.StringSet(key, "bar", flags: CommandFlags.FireAndForget);
+        var result = (string?)db.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
+        Assert.Equal("bar", result);
+
+        // now cause all kinds of problems
+        GetServer(conn).ScriptFlush();
+
+        //expect this one to <strike>fail</strike> just work fine (self-fix)
+        db.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
+
+        result = (string?)db.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
+        Assert.Equal("bar", result);
+    }
+
+    [Fact]
+    public void PrepareScript()
+    {
+        string[] scripts = { "return redis.call('get', KEYS[1])", "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}" };
+        using (var conn = GetScriptConn(allowAdmin: true))
         {
-            using (var muxer = GetScriptConn())
-            {
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                // prime some initial values
-                conn.KeyDelete(new RedisKey[] { prefix + "a", prefix + "b", prefix + "c" }, CommandFlags.FireAndForget);
-                conn.StringIncrement(prefix + "b", flags: CommandFlags.FireAndForget);
-                conn.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
-                conn.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
+            var server = GetServer(conn);
+            server.ScriptFlush();
 
-                // run the script, passing "a", "b", "c", "c" to
-                // increment a & b by 1, c twice
-                var result = conn.ScriptEvaluateAsync(
-                    "for i,key in ipairs(KEYS) do redis.call('incr', key) end",
-                    new RedisKey[] { prefix + "a", prefix + "b", prefix + "c", prefix + "c" }, // <== aka "KEYS" in the script
-                    null).ForAwait(); // <== aka "ARGV" in the script
+            // when vanilla
+            server.ScriptLoad(scripts[0]);
+            server.ScriptLoad(scripts[1]);
 
-                // check the incremented values
-                var a = conn.StringGetAsync(prefix + "a").ForAwait();
-                var b = conn.StringGetAsync(prefix + "b").ForAwait();
-                var c = conn.StringGetAsync(prefix + "c").ForAwait();
-
-                var r = await result;
-                Assert.NotNull(r);
-                Assert.True(r.IsNull, "result");
-                Assert.Equal(1, (long)await a);
-                Assert.Equal(2, (long)await b);
-                Assert.Equal(4, (long)await c);
-            }
+            //when known to exist
+            server.ScriptLoad(scripts[0]);
+            server.ScriptLoad(scripts[1]);
         }
-
-        [Fact]
-        public async Task MultiIncrByWithoutReplies()
+        using (var conn = GetScriptConn())
         {
-            using (var muxer = GetScriptConn())
-            {
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                // prime some initial values
-                conn.KeyDelete(new RedisKey[] { prefix + "a", prefix + "b", prefix + "c" }, CommandFlags.FireAndForget);
-                conn.StringIncrement(prefix + "b", flags: CommandFlags.FireAndForget);
-                conn.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
-                conn.StringIncrement(prefix + "c", flags: CommandFlags.FireAndForget);
+            var server = GetServer(conn);
 
-                //run the script, passing "a", "b", "c" and 1,2,3
-                // increment a &b by 1, c twice
-                var result = conn.ScriptEvaluateAsync(
-                    "for i,key in ipairs(KEYS) do redis.call('incrby', key, ARGV[i]) end",
-                    new RedisKey[] { prefix + "a", prefix + "b", prefix + "c" }, // <== aka "KEYS" in the script
-                    new RedisValue[] { 1, 1, 2 }).ForAwait(); // <== aka "ARGV" in the script
+            //when vanilla
+            server.ScriptLoad(scripts[0]);
+            server.ScriptLoad(scripts[1]);
 
-                // check the incremented values
-                var a = conn.StringGetAsync(prefix + "a").ForAwait();
-                var b = conn.StringGetAsync(prefix + "b").ForAwait();
-                var c = conn.StringGetAsync(prefix + "c").ForAwait();
+            //when known to exist
+            server.ScriptLoad(scripts[0]);
+            server.ScriptLoad(scripts[1]);
 
-                Assert.True((await result).IsNull, "result");
-                Assert.Equal(1, (long)await a);
-                Assert.Equal(2, (long)await b);
-                Assert.Equal(4, (long)await c);
-            }
+            //when known to exist
+            server.ScriptLoad(scripts[0]);
+            server.ScriptLoad(scripts[1]);
         }
+    }
 
-        [Fact]
-        public void DisableStringInference()
+    [Fact]
+    public void NonAsciiScripts()
+    {
+        using var conn = GetScriptConn();
+
+        const string evil = "return '僕'";
+        var db = conn.GetDatabase();
+        GetServer(conn).ScriptLoad(evil);
+
+        var result = (string?)db.ScriptEvaluate(evil, null, null);
+        Assert.Equal("僕", result);
+    }
+
+    [Fact]
+    public async Task ScriptThrowsError()
+    {
+        await Assert.ThrowsAsync<RedisServerException>(async () =>
         {
-            using (var muxer = GetScriptConn())
+            using var conn = GetScriptConn();
+
+            var db = conn.GetDatabase();
+            try
             {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.StringSet(key, "bar", flags: CommandFlags.FireAndForget);
-                var result = (byte[]?)conn.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key });
-                Assert.NotNull(result);
-                Assert.Equal("bar", Encoding.UTF8.GetString(result));
+                await db.ScriptEvaluateAsync("return redis.error_reply('oops')", null, null).ForAwait();
             }
-        }
-
-        [Fact]
-        public void FlushDetection()
-        { // we don't expect this to handle everything; we just expect it to be predictable
-            using (var muxer = GetScriptConn(allowAdmin: true))
+            catch (AggregateException ex)
             {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.StringSet(key, "bar", flags: CommandFlags.FireAndForget);
-                var result = (string?)conn.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
-                Assert.Equal("bar", result);
-
-                // now cause all kinds of problems
-                GetServer(muxer).ScriptFlush();
-
-                //expect this one to <strike>fail</strike> just work fine (self-fix)
-                conn.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
-
-                result = (string?)conn.ScriptEvaluate("return redis.call('get', KEYS[1])", new RedisKey[] { key }, null);
-                Assert.Equal("bar", result);
+                throw ex.InnerExceptions[0];
             }
-        }
+        }).ForAwait();
+    }
 
-        [Fact]
-        public void PrepareScript()
+    [Fact]
+    public void ScriptThrowsErrorInsideTransaction()
+    {
+        using var conn = GetScriptConn();
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var beforeTran = (string?)db.StringGet(key);
+        Assert.Null(beforeTran);
+        var tran = db.CreateTransaction();
         {
-            string[] scripts = { "return redis.call('get', KEYS[1])", "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}" };
-            using (var muxer = GetScriptConn(allowAdmin: true))
-            {
-                var server = GetServer(muxer);
-                server.ScriptFlush();
+            var a = tran.StringIncrementAsync(key);
+            var b = tran.ScriptEvaluateAsync("return redis.error_reply('oops')", null, null);
+            var c = tran.StringIncrementAsync(key);
+            var complete = tran.ExecuteAsync();
 
-                // when vanilla
-                server.ScriptLoad(scripts[0]);
-                server.ScriptLoad(scripts[1]);
+            Assert.True(conn.Wait(complete));
+            Assert.True(QuickWait(a).IsCompleted, a.Status.ToString());
+            Assert.True(QuickWait(c).IsCompleted, "State: " + c.Status);
+            Assert.Equal(1L, a.Result);
+            Assert.Equal(2L, c.Result);
 
-                //when known to exist
-                server.ScriptLoad(scripts[0]);
-                server.ScriptLoad(scripts[1]);
-            }
-            using (var muxer = GetScriptConn())
-            {
-                var server = GetServer(muxer);
-
-                //when vanilla
-                server.ScriptLoad(scripts[0]);
-                server.ScriptLoad(scripts[1]);
-
-                //when known to exist
-                server.ScriptLoad(scripts[0]);
-                server.ScriptLoad(scripts[1]);
-
-                //when known to exist
-                server.ScriptLoad(scripts[0]);
-                server.ScriptLoad(scripts[1]);
-            }
+            Assert.True(QuickWait(b).IsFaulted, "should be faulted");
+            Assert.NotNull(b.Exception);
+            Assert.Single(b.Exception.InnerExceptions);
+            var ex = b.Exception.InnerExceptions.Single();
+            Assert.IsType<RedisServerException>(ex);
+            // 7.0 slightly changes the error format, accept either.
+            Assert.Contains(ex.Message, new[] { "ERR oops", "oops" });
         }
-
-        [Fact]
-        public void NonAsciiScripts()
+        var afterTran = db.StringGetAsync(key);
+        Assert.Equal(2L, (long)db.Wait(afterTran));
+    }
+    private static Task<T> QuickWait<T>(Task<T> task)
+    {
+        if (!task.IsCompleted)
         {
-            using (var muxer = GetScriptConn())
-            {
-                const string evil = "return '僕'";
-                var conn = muxer.GetDatabase();
-                GetServer(muxer).ScriptLoad(evil);
-
-                var result = (string?)conn.ScriptEvaluate(evil, null, null);
-                Assert.Equal("僕", result);
-            }
+            try { task.Wait(200); } catch { /* But don't error */ }
         }
+        return task;
+    }
 
-        [Fact]
-        public async Task ScriptThrowsError()
-        {
-            await Assert.ThrowsAsync<RedisServerException>(async () =>
-            {
-                using (var muxer = GetScriptConn())
-                {
-                    var conn = muxer.GetDatabase();
-                    try
-                    {
-                        await conn.ScriptEvaluateAsync("return redis.error_reply('oops')", null, null).ForAwait();
-                    }
-                    catch (AggregateException ex)
-                    {
-                        throw ex.InnerExceptions[0];
-                    }
-                }
-            }).ForAwait();
-        }
+    [Fact]
+    public async Task ChangeDbInScript()
+    {
+        using var conn = GetScriptConn();
 
-        [Fact]
-        public void ScriptThrowsErrorInsideTransaction()
-        {
-            using (var muxer = GetScriptConn())
-            {
-                var key = Me();
-                var conn = muxer.GetDatabase();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var beforeTran = (string?)conn.StringGet(key);
-                Assert.Null(beforeTran);
-                var tran = conn.CreateTransaction();
-                {
-                    var a = tran.StringIncrementAsync(key);
-                    var b = tran.ScriptEvaluateAsync("return redis.error_reply('oops')", null, null);
-                    var c = tran.StringIncrementAsync(key);
-                    var complete = tran.ExecuteAsync();
+        var key = Me();
+        conn.GetDatabase(1).StringSet(key, "db 1", flags: CommandFlags.FireAndForget);
+        conn.GetDatabase(2).StringSet(key, "db 2", flags: CommandFlags.FireAndForget);
 
-                    Assert.True(muxer.Wait(complete));
-                    Assert.True(QuickWait(a).IsCompleted, a.Status.ToString());
-                    Assert.True(QuickWait(c).IsCompleted, "State: " + c.Status);
-                    Assert.Equal(1L, a.Result);
-                    Assert.Equal(2L, c.Result);
-
-                    Assert.True(QuickWait(b).IsFaulted, "should be faulted");
-                    Assert.NotNull(b.Exception);
-                    Assert.Single(b.Exception.InnerExceptions);
-                    var ex = b.Exception.InnerExceptions.Single();
-                    Assert.IsType<RedisServerException>(ex);
-                    // 7.0 slightly changes the error format, accept either.
-                    Assert.Contains(ex.Message, new[] { "ERR oops", "oops" });
-                }
-                var afterTran = conn.StringGetAsync(key);
-                Assert.Equal(2L, (long)conn.Wait(afterTran));
-            }
-        }
-        private static Task<T> QuickWait<T>(Task<T> task)
-        {
-            if (!task.IsCompleted)
-            {
-                try { task.Wait(200); } catch { /* But don't error */ }
-            }
-            return task;
-        }
-
-        [Fact]
-        public async Task ChangeDbInScript()
-        {
-            using (var muxer = GetScriptConn())
-            {
-                var key = Me();
-                muxer.GetDatabase(1).StringSet(key, "db 1", flags: CommandFlags.FireAndForget);
-                muxer.GetDatabase(2).StringSet(key, "db 2", flags: CommandFlags.FireAndForget);
-
-                Log("Key: " + key);
-                var conn = muxer.GetDatabase(2);
-                var evalResult = conn.ScriptEvaluateAsync(@"redis.call('select', 1)
+        Log("Key: " + key);
+        var db = conn.GetDatabase(2);
+        var evalResult = db.ScriptEvaluateAsync(@"redis.call('select', 1)
         return redis.call('get','" + key + "')", null, null);
-                var getResult = conn.StringGetAsync(key);
+        var getResult = db.StringGetAsync(key);
 
-                Assert.Equal("db 1", (string?)await evalResult);
-                // now, our connection thought it was in db 2, but the script changed to db 1
-                Assert.Equal("db 2", await getResult);
-            }
-        }
+        Assert.Equal("db 1", (string?)await evalResult);
+        // now, our connection thought it was in db 2, but the script changed to db 1
+        Assert.Equal("db 2", await getResult);
+    }
 
-        [Fact]
-        public async Task ChangeDbInTranScript()
-        {
-            using (var muxer = GetScriptConn())
-            {
-                var key = Me();
-                muxer.GetDatabase(1).StringSet(key, "db 1", flags: CommandFlags.FireAndForget);
-                muxer.GetDatabase(2).StringSet(key, "db 2", flags: CommandFlags.FireAndForget);
+    [Fact]
+    public async Task ChangeDbInTranScript()
+    {
+        using var conn = GetScriptConn();
 
-                var conn = muxer.GetDatabase(2);
-                var tran = conn.CreateTransaction();
-                var evalResult = tran.ScriptEvaluateAsync(@"redis.call('select', 1)
+        var key = Me();
+        conn.GetDatabase(1).StringSet(key, "db 1", flags: CommandFlags.FireAndForget);
+        conn.GetDatabase(2).StringSet(key, "db 2", flags: CommandFlags.FireAndForget);
+
+        var db = conn.GetDatabase(2);
+        var tran = db.CreateTransaction();
+        var evalResult = tran.ScriptEvaluateAsync(@"redis.call('select', 1)
         return redis.call('get','" + key + "')", null, null);
-                var getResult = tran.StringGetAsync(key);
-                Assert.True(tran.Execute());
+        var getResult = tran.StringGetAsync(key);
+        Assert.True(tran.Execute());
 
-                Assert.Equal("db 1", (string?)await evalResult);
-                // now, our connection thought it was in db 2, but the script changed to db 1
-                Assert.Equal("db 2", await getResult);
-            }
+        Assert.Equal("db 1", (string?)await evalResult);
+        // now, our connection thought it was in db 2, but the script changed to db 1
+        Assert.Equal("db 2", await getResult);
+    }
+
+    [Fact]
+    public void TestBasicScripting()
+    {
+        using var conn = Create(require: RedisFeatures.v2_6_0);
+
+        RedisValue newId = Guid.NewGuid().ToString();
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.HashSet(key, "id", 123, flags: CommandFlags.FireAndForget);
+
+        var wasSet = (bool)db.ScriptEvaluate("if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end",
+            new[] { key }, new[] { newId });
+
+        Assert.True(wasSet);
+
+        wasSet = (bool)db.ScriptEvaluate("if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end",
+            new[] { key }, new[] { newId });
+        Assert.False(wasSet);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CheckLoads(bool async)
+    {
+        using var conn0 = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+        using var conn1 = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        // note that these are on different connections (so we wouldn't expect
+        // the flush to drop the local cache - assume it is a surprise!)
+        var server = conn0.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        var db = conn1.GetDatabase();
+        const string script = "return 1;";
+
+        // start empty
+        server.ScriptFlush();
+        Assert.False(server.ScriptExists(script));
+
+        // run once, causes to be cached
+        Assert.True((bool)db.ScriptEvaluate(script));
+        Assert.True(server.ScriptExists(script));
+
+        // can run again
+        Assert.True((bool)db.ScriptEvaluate(script));
+
+        // ditch the scripts; should no longer exist
+        db.Ping();
+        server.ScriptFlush();
+        Assert.False(server.ScriptExists(script));
+        db.Ping();
+
+        if (async)
+        {
+            // now: fails the first time
+            var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.ScriptEvaluateAsync(script).ForAwait()).ForAwait();
+            Assert.Equal("NOSCRIPT No matching script. Please use EVAL.", ex.Message);
+        }
+        else
+        {
+            // just works; magic
+            Assert.True((bool)db.ScriptEvaluate(script));
         }
 
-        [Fact]
-        public void TestBasicScripting()
+        // but gets marked as unloaded, so we can use it again...
+        Assert.True((bool)db.ScriptEvaluate(script));
+
+        // which will cause it to be cached
+        Assert.True(server.ScriptExists(script));
+    }
+
+    [Fact]
+    public void CompareScriptToDirect()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "return redis.call('incr', KEYS[1])";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
+
+        server.ScriptLoad(Script);
+        var db = conn.GetDatabase();
+        db.Ping(); // k, we're all up to date now; clean db, minimal script cache
+
+        // we're using a pipeline here, so send 1000 messages, but for timing: only care about the last
+        const int LOOP = 5000;
+        RedisKey key = Me();
+        RedisKey[] keys = new[] { key }; // script takes an array
+
+        // run via script
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var watch = Stopwatch.StartNew();
+        for (int i = 1; i < LOOP; i++) // the i=1 is to do all-but-one
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+            db.ScriptEvaluate(Script, keys, flags: CommandFlags.FireAndForget);
+        }
+        var scriptResult = db.ScriptEvaluate(Script, keys); // last one we wait for (no F+F)
+        watch.Stop();
+        TimeSpan scriptTime = watch.Elapsed;
 
-                RedisValue newId = Guid.NewGuid().ToString();
-                RedisKey key = Me();
-                var db = conn.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.HashSet(key, "id", 123, flags: CommandFlags.FireAndForget);
+        // run via raw op
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        watch = Stopwatch.StartNew();
+        for (int i = 1; i < LOOP; i++) // the i=1 is to do all-but-one
+        {
+            db.StringIncrement(key, flags: CommandFlags.FireAndForget);
+        }
+        var directResult = db.StringIncrement(key); // last one we wait for (no F+F)
+        watch.Stop();
+        TimeSpan directTime = watch.Elapsed;
 
-                var wasSet = (bool)db.ScriptEvaluate("if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end",
-                    new [] { key }, new [] { newId });
+        Assert.Equal(LOOP, (long)scriptResult);
+        Assert.Equal(LOOP, directResult);
 
-                Assert.True(wasSet);
+        Log("script: {0}ms; direct: {1}ms",
+            scriptTime.TotalMilliseconds,
+            directTime.TotalMilliseconds);
+    }
 
-                wasSet = (bool)db.ScriptEvaluate("if redis.call('hexists', KEYS[1], 'UniqueId') then return redis.call('hset', KEYS[1], 'UniqueId', ARGV[1]) else return 0 end",
-                    new [] { key }, new [] { newId });
-                Assert.False(wasSet);
-            }
+    [Fact]
+    public void TestCallByHash()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "return redis.call('incr', KEYS[1])";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
+
+        byte[]? hash = server.ScriptLoad(Script);
+        Assert.NotNull(hash);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        RedisKey[] keys = { key };
+
+        string hexHash = string.Concat(hash.Select(x => x.ToString("X2")));
+        Assert.Equal("2BAB3B661081DB58BD2341920E0BA7CF5DC77B25", hexHash);
+
+        db.ScriptEvaluate(hexHash, keys, flags: CommandFlags.FireAndForget);
+        db.ScriptEvaluate(hash, keys, flags: CommandFlags.FireAndForget);
+
+        var count = (int)db.StringGet(keys)[0];
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void SimpleLuaScript()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "return @ident";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
+
+        var prepared = LuaScript.Prepare(Script);
+
+        var db = conn.GetDatabase();
+
+        {
+            var val = prepared.Evaluate(db, new { ident = "hello" });
+            Assert.Equal("hello", (string?)val);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task CheckLoads(bool async)
         {
-            using (var conn0 = Create(allowAdmin: true))
-            using (var conn1 = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn0, RedisFeatures.v2_6_0);
-
-                // note that these are on different connections (so we wouldn't expect
-                // the flush to drop the local cache - assume it is a surprise!)
-                var server = conn0.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                var db = conn1.GetDatabase();
-                const string script = "return 1;";
-
-                // start empty
-                server.ScriptFlush();
-                Assert.False(server.ScriptExists(script));
-
-                // run once, causes to be cached
-                Assert.True((bool)db.ScriptEvaluate(script));
-                Assert.True(server.ScriptExists(script));
-
-                // can run again
-                Assert.True((bool)db.ScriptEvaluate(script));
-
-                // ditch the scripts; should no longer exist
-                db.Ping();
-                server.ScriptFlush();
-                Assert.False(server.ScriptExists(script));
-                db.Ping();
-
-                if (async)
-                {
-                    // now: fails the first time
-                    var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.ScriptEvaluateAsync(script).ForAwait()).ForAwait();
-                    Assert.Equal("NOSCRIPT No matching script. Please use EVAL.", ex.Message);
-                }
-                else
-                {
-                    // just works; magic
-                    Assert.True((bool)db.ScriptEvaluate(script));
-                }
-
-                // but gets marked as unloaded, so we can use it again...
-                Assert.True((bool)db.ScriptEvaluate(script));
-
-                // which will cause it to be cached
-                Assert.True(server.ScriptExists(script));
-            }
+            var val = prepared.Evaluate(db, new { ident = 123 });
+            Assert.Equal(123, (int)val);
         }
 
-        [Fact]
-        public void CompareScriptToDirect()
         {
-            const string Script = "return redis.call('incr', KEYS[1])";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                server.ScriptLoad(Script);
-                var db = conn.GetDatabase();
-                db.Ping(); // k, we're all up to date now; clean db, minimal script cache
-
-                // we're using a pipeline here, so send 1000 messages, but for timing: only care about the last
-                const int LOOP = 5000;
-                RedisKey key = Me();
-                RedisKey[] keys = new[] { key }; // script takes an array
-
-                // run via script
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                var watch = Stopwatch.StartNew();
-                for (int i = 1; i < LOOP; i++) // the i=1 is to do all-but-one
-                {
-                    db.ScriptEvaluate(Script, keys, flags: CommandFlags.FireAndForget);
-                }
-                var scriptResult = db.ScriptEvaluate(Script, keys); // last one we wait for (no F+F)
-                watch.Stop();
-                TimeSpan scriptTime = watch.Elapsed;
-
-                // run via raw op
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                watch = Stopwatch.StartNew();
-                for (int i = 1; i < LOOP; i++) // the i=1 is to do all-but-one
-                {
-                    db.StringIncrement(key, flags: CommandFlags.FireAndForget);
-                }
-                var directResult = db.StringIncrement(key); // last one we wait for (no F+F)
-                watch.Stop();
-                TimeSpan directTime = watch.Elapsed;
-
-                Assert.Equal(LOOP, (long)scriptResult);
-                Assert.Equal(LOOP, directResult);
-
-                Log("script: {0}ms; direct: {1}ms",
-                    scriptTime.TotalMilliseconds,
-                    directTime.TotalMilliseconds);
-            }
+            var val = prepared.Evaluate(db, new { ident = 123L });
+            Assert.Equal(123L, (long)val);
         }
 
-        [Fact]
-        public void TestCallByHash()
         {
-            const string Script = "return redis.call('incr', KEYS[1])";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                byte[]? hash = server.ScriptLoad(Script);
-                Assert.NotNull(hash);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                RedisKey[] keys = { key };
-
-                string hexHash = string.Concat(hash.Select(x => x.ToString("X2")));
-                Assert.Equal("2BAB3B661081DB58BD2341920E0BA7CF5DC77B25", hexHash);
-
-                db.ScriptEvaluate(hexHash, keys, flags: CommandFlags.FireAndForget);
-                db.ScriptEvaluate(hash, keys, flags: CommandFlags.FireAndForget);
-
-                var count = (int)db.StringGet(keys)[0];
-                Assert.Equal(2, count);
-            }
+            var val = prepared.Evaluate(db, new { ident = 1.1 });
+            Assert.Equal(1.1, (double)val);
         }
 
-        [Fact]
-        public void SimpleLuaScript()
         {
-            const string Script = "return @ident";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                var prepared = LuaScript.Prepare(Script);
-
-                var db = conn.GetDatabase();
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = "hello" });
-                    Assert.Equal("hello", (string?)val);
-                }
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = 123 });
-                    Assert.Equal(123, (int)val);
-                }
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = 123L });
-                    Assert.Equal(123L, (long)val);
-                }
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = 1.1 });
-                    Assert.Equal(1.1, (double)val);
-                }
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = true });
-                    Assert.True((bool)val);
-                }
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = new byte[] { 4, 5, 6 } });
-                    var valArray = (byte[]?)val;
-                    Assert.NotNull(valArray);
-                    Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
-                }
-
-                {
-                    var val = prepared.Evaluate(db, new { ident = new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 }) });
-                    var valArray = (byte[]?)val;
-                    Assert.NotNull(valArray);
-                    Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
-                }
-            }
+            var val = prepared.Evaluate(db, new { ident = true });
+            Assert.True((bool)val);
         }
 
-        [Fact]
-        public void SimpleRawScriptEvaluate()
         {
-            const string Script = "return ARGV[1]";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                var db = conn.GetDatabase();
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { "hello" });
-                    Assert.Equal("hello", (string?)val);
-                }
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { 123 });
-                    Assert.Equal(123, (int)val);
-                }
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { 123L });
-                    Assert.Equal(123L, (long)val);
-                }
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { 1.1 });
-                    Assert.Equal(1.1, (double)val);
-                }
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { true });
-                    Assert.True((bool)val);
-                }
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { new byte[] { 4, 5, 6 } });
-                    var valArray = (byte[]?)val;
-                    Assert.NotNull(valArray);
-                    Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
-                }
-
-                {
-                    var val = db.ScriptEvaluate(Script, values: new RedisValue[] { new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 }) });
-                    var valArray = (byte[]?)val;
-                    Assert.NotNull(valArray);
-                    Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
-                }
-            }
+            var val = prepared.Evaluate(db, new { ident = new byte[] { 4, 5, 6 } });
+            var valArray = (byte[]?)val;
+            Assert.NotNull(valArray);
+            Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
         }
 
-        [Fact]
-        public void LuaScriptWithKeys()
         {
-            const string Script = "redis.call('set', @key, @value)";
+            var val = prepared.Evaluate(db, new { ident = new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 }) });
+            var valArray = (byte[]?)val;
+            Assert.NotNull(valArray);
+            Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
+        }
+    }
 
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+    [Fact]
+    public void SimpleRawScriptEvaluate()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
+        const string Script = "return ARGV[1]";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
 
-                var script = LuaScript.Prepare(Script);
+        var db = conn.GetDatabase();
 
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var p = new { key = (RedisKey)key, value = 123 };
-
-                script.Evaluate(db, p);
-                var val = db.StringGet(key);
-                Assert.Equal(123, (int)val);
-
-                // no super clean way to extract this; so just abuse InternalsVisibleTo
-                script.ExtractParameters(p, null, out RedisKey[]? keys, out _);
-                Assert.NotNull(keys);
-                Assert.Single(keys);
-                Assert.Equal(key, keys[0]);
-            }
+        {
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { "hello" });
+            Assert.Equal("hello", (string?)val);
         }
 
-        [Fact]
-        public void NoInlineReplacement()
         {
-            const string Script = "redis.call('set', @key, 'hello@example')";
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                var script = LuaScript.Prepare(Script);
-
-                Assert.Equal("redis.call('set', ARGV[1], 'hello@example')", script.ExecutableScript);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var p = new { key };
-
-                script.Evaluate(db, p, flags: CommandFlags.FireAndForget);
-                var val = db.StringGet(key);
-                Assert.Equal("hello@example", val);
-            }
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { 123 });
+            Assert.Equal(123, (int)val);
         }
 
-        [Fact]
-        public void EscapeReplacement()
         {
-            const string Script = "redis.call('set', @key, @@escapeMe)";
-            var script = LuaScript.Prepare(Script);
-
-            Assert.Equal("redis.call('set', ARGV[1], @escapeMe)", script.ExecutableScript);
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { 123L });
+            Assert.Equal(123L, (long)val);
         }
 
-        [Fact]
-        public void SimpleLoadedLuaScript()
         {
-            const string Script = "return @ident";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                var prepared = LuaScript.Prepare(Script);
-                var loaded = prepared.Load(server);
-
-                var db = conn.GetDatabase();
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = "hello" });
-                    Assert.Equal("hello", (string?)val);
-                }
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = 123 });
-                    Assert.Equal(123, (int)val);
-                }
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = 123L });
-                    Assert.Equal(123L, (long)val);
-                }
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = 1.1 });
-                    Assert.Equal(1.1, (double)val);
-                }
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = true });
-                    Assert.True((bool)val);
-                }
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = new byte[] { 4, 5, 6 } });
-                    var valArray = (byte[]?)val;
-                    Assert.NotNull(valArray);
-                    Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
-                }
-
-                {
-                    var val = loaded.Evaluate(db, new { ident = new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 }) });
-                    var valArray = (byte[]?)val;
-                    Assert.NotNull(valArray);
-                    Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
-                }
-            }
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { 1.1 });
+            Assert.Equal(1.1, (double)val);
         }
 
-        [Fact]
-        public void LoadedLuaScriptWithKeys()
         {
-            const string Script = "redis.call('set', @key, @value)";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
-                server.ScriptFlush();
-
-                var script = LuaScript.Prepare(Script);
-                var prepared = script.Load(server);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var p = new { key = (RedisKey)key, value = 123 };
-
-                prepared.Evaluate(db, p, flags: CommandFlags.FireAndForget);
-                var val = db.StringGet(key);
-                Assert.Equal(123, (int)val);
-
-                // no super clean way to extract this; so just abuse InternalsVisibleTo
-                prepared.Original.ExtractParameters(p, null, out RedisKey[]? keys, out _);
-                Assert.NotNull(keys);
-                Assert.Single(keys);
-                Assert.Equal(key, keys[0]);
-            }
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { true });
+            Assert.True((bool)val);
         }
 
-        [Fact]
-        public void PurgeLuaScriptCache()
         {
-            const string Script = "redis.call('set', @PurgeLuaScriptCacheKey, @PurgeLuaScriptCacheValue)";
-            var first = LuaScript.Prepare(Script);
-            var fromCache = LuaScript.Prepare(Script);
-
-            Assert.True(ReferenceEquals(first, fromCache));
-
-            LuaScript.PurgeCache();
-            var shouldBeNew = LuaScript.Prepare(Script);
-
-            Assert.False(ReferenceEquals(first, shouldBeNew));
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { new byte[] { 4, 5, 6 } });
+            var valArray = (byte[]?)val;
+            Assert.NotNull(valArray);
+            Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
         }
 
-        private static void PurgeLuaScriptOnFinalizeImpl(string script)
         {
-            var first = LuaScript.Prepare(script);
-            var fromCache = LuaScript.Prepare(script);
-            Assert.True(ReferenceEquals(first, fromCache));
-            Assert.Equal(1, LuaScript.GetCachedScriptCount());
+            var val = db.ScriptEvaluate(Script, values: new RedisValue[] { new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 }) });
+            var valArray = (byte[]?)val;
+            Assert.NotNull(valArray);
+            Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
+        }
+    }
+
+    [Fact]
+    public void LuaScriptWithKeys()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
+
+        var script = LuaScript.Prepare(Script);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var p = new { key = (RedisKey)key, value = 123 };
+
+        script.Evaluate(db, p);
+        var val = db.StringGet(key);
+        Assert.Equal(123, (int)val);
+
+        // no super clean way to extract this; so just abuse InternalsVisibleTo
+        script.ExtractParameters(p, null, out RedisKey[]? keys, out _);
+        Assert.NotNull(keys);
+        Assert.Single(keys);
+        Assert.Equal(key, keys[0]);
+    }
+
+    [Fact]
+    public void NoInlineReplacement()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, 'hello@example')";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
+
+        var script = LuaScript.Prepare(Script);
+
+        Assert.Equal("redis.call('set', ARGV[1], 'hello@example')", script.ExecutableScript);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var p = new { key };
+
+        script.Evaluate(db, p, flags: CommandFlags.FireAndForget);
+        var val = db.StringGet(key);
+        Assert.Equal("hello@example", val);
+    }
+
+    [Fact]
+    public void EscapeReplacement()
+    {
+        const string Script = "redis.call('set', @key, @@escapeMe)";
+        var script = LuaScript.Prepare(Script);
+
+        Assert.Equal("redis.call('set', ARGV[1], @escapeMe)", script.ExecutableScript);
+    }
+
+    [Fact]
+    public void SimpleLoadedLuaScript()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "return @ident";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
+
+        var prepared = LuaScript.Prepare(Script);
+        var loaded = prepared.Load(server);
+
+        var db = conn.GetDatabase();
+
+        {
+            var val = loaded.Evaluate(db, new { ident = "hello" });
+            Assert.Equal("hello", (string?)val);
         }
 
-        [FactLongRunning]
-        public void PurgeLuaScriptOnFinalize()
         {
-            const string Script = "redis.call('set', @PurgeLuaScriptOnFinalizeKey, @PurgeLuaScriptOnFinalizeValue)";
-            LuaScript.PurgeCache();
-            Assert.Equal(0, LuaScript.GetCachedScriptCount());
-
-            // This has to be a separate method to guarantee that the created LuaScript objects go out of scope,
-            //   and are thus available to be GC'd
-            PurgeLuaScriptOnFinalizeImpl(Script);
-            CollectGarbage();
-
-            Assert.Equal(0, LuaScript.GetCachedScriptCount());
-
-            LuaScript.Prepare(Script);
-            Assert.Equal(1, LuaScript.GetCachedScriptCount());
+            var val = loaded.Evaluate(db, new { ident = 123 });
+            Assert.Equal(123, (int)val);
         }
 
-        [Fact]
-        public void IDatabaseLuaScriptConvenienceMethods()
         {
-            const string Script = "redis.call('set', @key, @value)";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var script = LuaScript.Prepare(Script);
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.ScriptEvaluate(script, new { key = (RedisKey)key, value = "value" }, flags: CommandFlags.FireAndForget);
-                var val = db.StringGet(key);
-                Assert.Equal("value", val);
-
-                var prepared = script.Load(conn.GetServer(conn.GetEndPoints()[0]));
-
-                db.ScriptEvaluate(prepared, new { key = (RedisKey)(key + "2"), value = "value2" }, flags: CommandFlags.FireAndForget);
-                var val2 = db.StringGet(key + "2");
-                Assert.Equal("value2", val2);
-            }
+            var val = loaded.Evaluate(db, new { ident = 123L });
+            Assert.Equal(123L, (long)val);
         }
 
-        [Fact]
-        public void IServerLuaScriptConvenienceMethods()
         {
-            const string Script = "redis.call('set', @key, @value)";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var script = LuaScript.Prepare(Script);
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                var db = conn.GetDatabase();
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var prepared = server.ScriptLoad(script);
-
-                db.ScriptEvaluate(prepared, new { key = (RedisKey)key, value = "value3" });
-                var val = db.StringGet(key);
-                Assert.Equal("value3", val);
-            }
+            var val = loaded.Evaluate(db, new { ident = 1.1 });
+            Assert.Equal(1.1, (double)val);
         }
 
-        [Fact]
-        public void LuaScriptPrefixedKeys()
         {
-            const string Script = "redis.call('set', @key, @value)";
-            var prepared = LuaScript.Prepare(Script);
-            var key = Me();
-            var p = new { key = (RedisKey)key, value = "hello" };
-
-            // no super clean way to extract this; so just abuse InternalsVisibleTo
-            prepared.ExtractParameters(p, "prefix-", out RedisKey[]? keys, out RedisValue[]? args);
-            Assert.NotNull(keys);
-            Assert.Single(keys);
-            Assert.Equal("prefix-" + key, keys[0]);
-            Assert.NotNull(args);
-            Assert.Equal(2, args.Length);
-            Assert.Equal("prefix-" +  key, args[0]);
-            Assert.Equal("hello", args[1]);
+            var val = loaded.Evaluate(db, new { ident = true });
+            Assert.True((bool)val);
         }
 
-        [Fact]
-        public void LuaScriptWithWrappedDatabase()
         {
-            const string Script = "redis.call('set', @key, @value)";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var db = conn.GetDatabase();
-                var wrappedDb = db.WithKeyPrefix("prefix-");
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var prepared = LuaScript.Prepare(Script);
-                wrappedDb.ScriptEvaluate(prepared, new { key = (RedisKey)key, value = 123 });
-                var val1 = wrappedDb.StringGet(key);
-                Assert.Equal(123, (int)val1);
-
-                var val2 = db.StringGet("prefix-" + key);
-                Assert.Equal(123, (int)val2);
-
-                var val3 = db.StringGet(key);
-                Assert.True(val3.IsNull);
-            }
+            var val = loaded.Evaluate(db, new { ident = new byte[] { 4, 5, 6 } });
+            var valArray = (byte[]?)val;
+            Assert.NotNull(valArray);
+            Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
         }
 
-        [Fact]
-        public async Task AsyncLuaScriptWithWrappedDatabase()
         {
-            const string Script = "redis.call('set', @key, @value)";
-
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
-
-                var db = conn.GetDatabase();
-                var wrappedDb = db.WithKeyPrefix("prefix-");
-                var key = Me();
-                await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
-
-                var prepared = LuaScript.Prepare(Script);
-                await wrappedDb.ScriptEvaluateAsync(prepared, new { key = (RedisKey)key, value = 123 });
-                var val1 = await wrappedDb.StringGetAsync(key);
-                Assert.Equal(123, (int)val1);
-
-                var val2 = await db.StringGetAsync("prefix-" + key);
-                Assert.Equal(123, (int)val2);
-
-                var val3 = await db.StringGetAsync(key);
-                Assert.True(val3.IsNull);
-            }
+            var val = loaded.Evaluate(db, new { ident = new ReadOnlyMemory<byte>(new byte[] { 4, 5, 6 }) });
+            var valArray = (byte[]?)val;
+            Assert.NotNull(valArray);
+            Assert.True(new byte[] { 4, 5, 6 }.SequenceEqual(valArray));
         }
+    }
 
-        [Fact]
-        public void LoadedLuaScriptWithWrappedDatabase()
-        {
-            const string Script = "redis.call('set', @key, @value)";
+    [Fact]
+    public void LoadedLuaScriptWithKeys()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+        const string Script = "redis.call('set', @key, @value)";
+        var server = conn.GetServer(TestConfig.Current.PrimaryServerAndPort);
+        server.ScriptFlush();
 
-                var db = conn.GetDatabase();
-                var wrappedDb = db.WithKeyPrefix("prefix2-");
-                var key = Me();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
+        var script = LuaScript.Prepare(Script);
+        var prepared = script.Load(server);
 
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                var prepared = LuaScript.Prepare(Script).Load(server);
-                wrappedDb.ScriptEvaluate(prepared, new { key = (RedisKey)key, value = 123 }, flags: CommandFlags.FireAndForget);
-                var val1 = wrappedDb.StringGet(key);
-                Assert.Equal(123, (int)val1);
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var val2 = db.StringGet("prefix2-" + key);
-                Assert.Equal(123, (int)val2);
+        var p = new { key = (RedisKey)key, value = 123 };
 
-                var val3 = db.StringGet(key);
-                Assert.True(val3.IsNull);
-            }
-        }
+        prepared.Evaluate(db, p, flags: CommandFlags.FireAndForget);
+        var val = db.StringGet(key);
+        Assert.Equal(123, (int)val);
 
-        [Fact]
-        public async Task AsyncLoadedLuaScriptWithWrappedDatabase()
-        {
-            const string Script = "redis.call('set', @key, @value)";
+        // no super clean way to extract this; so just abuse InternalsVisibleTo
+        prepared.Original.ExtractParameters(p, null, out RedisKey[]? keys, out _);
+        Assert.NotNull(keys);
+        Assert.Single(keys);
+        Assert.Equal(key, keys[0]);
+    }
 
-            using (var conn = Create(allowAdmin: true))
-            {
-                Skip.IfBelow(conn, RedisFeatures.v2_6_0);
+    [Fact]
+    public void PurgeLuaScriptCache()
+    {
+        const string Script = "redis.call('set', @PurgeLuaScriptCacheKey, @PurgeLuaScriptCacheValue)";
+        var first = LuaScript.Prepare(Script);
+        var fromCache = LuaScript.Prepare(Script);
 
-                var db = conn.GetDatabase();
-                var wrappedDb = db.WithKeyPrefix("prefix2-");
-                var key = Me();
-                await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
+        Assert.True(ReferenceEquals(first, fromCache));
 
-                var server = conn.GetServer(conn.GetEndPoints()[0]);
-                var prepared = await LuaScript.Prepare(Script).LoadAsync(server);
-                await wrappedDb.ScriptEvaluateAsync(prepared, new { key = (RedisKey)key, value = 123 }, flags: CommandFlags.FireAndForget);
-                var val1 = await wrappedDb.StringGetAsync(key);
-                Assert.Equal(123, (int)val1);
+        LuaScript.PurgeCache();
+        var shouldBeNew = LuaScript.Prepare(Script);
 
-                var val2 = await db.StringGetAsync("prefix2-" + key);
-                Assert.Equal(123, (int)val2);
+        Assert.False(ReferenceEquals(first, shouldBeNew));
+    }
 
-                var val3 = await db.StringGetAsync(key);
-                Assert.True(val3.IsNull);
-            }
-        }
+    private static void PurgeLuaScriptOnFinalizeImpl(string script)
+    {
+        var first = LuaScript.Prepare(script);
+        var fromCache = LuaScript.Prepare(script);
+        Assert.True(ReferenceEquals(first, fromCache));
+        Assert.Equal(1, LuaScript.GetCachedScriptCount());
+    }
 
-        [Fact]
-        public void ScriptWithKeyPrefixViaTokens()
-        {
-            using (var conn = Create())
-            {
-                var p = conn.GetDatabase().WithKeyPrefix("prefix/");
+    [FactLongRunning]
+    public void PurgeLuaScriptOnFinalize()
+    {
+        const string Script = "redis.call('set', @PurgeLuaScriptOnFinalizeKey, @PurgeLuaScriptOnFinalizeValue)";
+        LuaScript.PurgeCache();
+        Assert.Equal(0, LuaScript.GetCachedScriptCount());
 
-                var args = new { x = "abc", y = (RedisKey)"def", z = 123 };
-                var script = LuaScript.Prepare(@"
+        // This has to be a separate method to guarantee that the created LuaScript objects go out of scope,
+        //   and are thus available to be GC'd
+        PurgeLuaScriptOnFinalizeImpl(Script);
+        CollectGarbage();
+
+        Assert.Equal(0, LuaScript.GetCachedScriptCount());
+
+        LuaScript.Prepare(Script);
+        Assert.Equal(1, LuaScript.GetCachedScriptCount());
+    }
+
+    [Fact]
+    public void IDatabaseLuaScriptConvenienceMethods()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var script = LuaScript.Prepare(Script);
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.ScriptEvaluate(script, new { key = (RedisKey)key, value = "value" }, flags: CommandFlags.FireAndForget);
+        var val = db.StringGet(key);
+        Assert.Equal("value", val);
+
+        var prepared = script.Load(conn.GetServer(conn.GetEndPoints()[0]));
+
+        db.ScriptEvaluate(prepared, new { key = (RedisKey)(key + "2"), value = "value2" }, flags: CommandFlags.FireAndForget);
+        var val2 = db.StringGet(key + "2");
+        Assert.Equal("value2", val2);
+    }
+
+    [Fact]
+    public void IServerLuaScriptConvenienceMethods()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var script = LuaScript.Prepare(Script);
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var prepared = server.ScriptLoad(script);
+
+        db.ScriptEvaluate(prepared, new { key = (RedisKey)key, value = "value3" });
+        var val = db.StringGet(key);
+        Assert.Equal("value3", val);
+    }
+
+    [Fact]
+    public void LuaScriptPrefixedKeys()
+    {
+        const string Script = "redis.call('set', @key, @value)";
+        var prepared = LuaScript.Prepare(Script);
+        var key = Me();
+        var p = new { key = (RedisKey)key, value = "hello" };
+
+        // no super clean way to extract this; so just abuse InternalsVisibleTo
+        prepared.ExtractParameters(p, "prefix-", out RedisKey[]? keys, out RedisValue[]? args);
+        Assert.NotNull(keys);
+        Assert.Single(keys);
+        Assert.Equal("prefix-" + key, keys[0]);
+        Assert.NotNull(args);
+        Assert.Equal(2, args.Length);
+        Assert.Equal("prefix-" +  key, args[0]);
+        Assert.Equal("hello", args[1]);
+    }
+
+    [Fact]
+    public void LuaScriptWithWrappedDatabase()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var db = conn.GetDatabase();
+        var wrappedDb = db.WithKeyPrefix("prefix-");
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var prepared = LuaScript.Prepare(Script);
+        wrappedDb.ScriptEvaluate(prepared, new { key = (RedisKey)key, value = 123 });
+        var val1 = wrappedDb.StringGet(key);
+        Assert.Equal(123, (int)val1);
+
+        var val2 = db.StringGet("prefix-" + key);
+        Assert.Equal(123, (int)val2);
+
+        var val3 = db.StringGet(key);
+        Assert.True(val3.IsNull);
+    }
+
+    [Fact]
+    public async Task AsyncLuaScriptWithWrappedDatabase()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var db = conn.GetDatabase();
+        var wrappedDb = db.WithKeyPrefix("prefix-");
+        var key = Me();
+        await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
+
+        var prepared = LuaScript.Prepare(Script);
+        await wrappedDb.ScriptEvaluateAsync(prepared, new { key = (RedisKey)key, value = 123 });
+        var val1 = await wrappedDb.StringGetAsync(key);
+        Assert.Equal(123, (int)val1);
+
+        var val2 = await db.StringGetAsync("prefix-" + key);
+        Assert.Equal(123, (int)val2);
+
+        var val3 = await db.StringGetAsync(key);
+        Assert.True(val3.IsNull);
+    }
+
+    [Fact]
+    public void LoadedLuaScriptWithWrappedDatabase()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var db = conn.GetDatabase();
+        var wrappedDb = db.WithKeyPrefix("prefix2-");
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        var prepared = LuaScript.Prepare(Script).Load(server);
+        wrappedDb.ScriptEvaluate(prepared, new { key = (RedisKey)key, value = 123 }, flags: CommandFlags.FireAndForget);
+        var val1 = wrappedDb.StringGet(key);
+        Assert.Equal(123, (int)val1);
+
+        var val2 = db.StringGet("prefix2-" + key);
+        Assert.Equal(123, (int)val2);
+
+        var val3 = db.StringGet(key);
+        Assert.True(val3.IsNull);
+    }
+
+    [Fact]
+    public async Task AsyncLoadedLuaScriptWithWrappedDatabase()
+    {
+        using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
+
+        const string Script = "redis.call('set', @key, @value)";
+        var db = conn.GetDatabase();
+        var wrappedDb = db.WithKeyPrefix("prefix2-");
+        var key = Me();
+        await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
+
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        var prepared = await LuaScript.Prepare(Script).LoadAsync(server);
+        await wrappedDb.ScriptEvaluateAsync(prepared, new { key = (RedisKey)key, value = 123 }, flags: CommandFlags.FireAndForget);
+        var val1 = await wrappedDb.StringGetAsync(key);
+        Assert.Equal(123, (int)val1);
+
+        var val2 = await db.StringGetAsync("prefix2-" + key);
+        Assert.Equal(123, (int)val2);
+
+        var val3 = await db.StringGetAsync(key);
+        Assert.True(val3.IsNull);
+    }
+
+    [Fact]
+    public void ScriptWithKeyPrefixViaTokens()
+    {
+        using var conn = Create();
+
+        var p = conn.GetDatabase().WithKeyPrefix("prefix/");
+
+        var args = new { x = "abc", y = (RedisKey)"def", z = 123 };
+        var script = LuaScript.Prepare(@"
 local arr = {};
 arr[1] = @x;
 arr[2] = @y;
 arr[3] = @z;
 return arr;
 ");
-                var result = (RedisValue[]?)p.ScriptEvaluate(script, args);
-                Assert.NotNull(result);
-                Assert.Equal("abc", result[0]);
-                Assert.Equal("prefix/def", result[1]);
-                Assert.Equal("123", result[2]);
-            }
-        }
+        var result = (RedisValue[]?)p.ScriptEvaluate(script, args);
+        Assert.NotNull(result);
+        Assert.Equal("abc", result[0]);
+        Assert.Equal("prefix/def", result[1]);
+        Assert.Equal("123", result[2]);
+    }
 
-        [Fact]
-        public void ScriptWithKeyPrefixViaArrays()
-        {
-            using (var conn = Create())
-            {
-                var p = conn.GetDatabase().WithKeyPrefix("prefix/");
+    [Fact]
+    public void ScriptWithKeyPrefixViaArrays()
+    {
+        using var conn = Create();
 
-                const string script = @"
+        var p = conn.GetDatabase().WithKeyPrefix("prefix/");
+
+        const string script = @"
 local arr = {};
 arr[1] = ARGV[1];
 arr[2] = KEYS[1];
 arr[3] = ARGV[2];
 return arr;
 ";
-                var result = (RedisValue[]?)p.ScriptEvaluate(script, new RedisKey[] { "def" }, new RedisValue[] { "abc", 123 });
-                Assert.NotNull(result);
-                Assert.Equal("abc", result[0]);
-                Assert.Equal("prefix/def", result[1]);
-                Assert.Equal("123", result[2]);
-            }
-        }
+        var result = (RedisValue[]?)p.ScriptEvaluate(script, new RedisKey[] { "def" }, new RedisValue[] { "abc", 123 });
+        Assert.NotNull(result);
+        Assert.Equal("abc", result[0]);
+        Assert.Equal("prefix/def", result[1]);
+        Assert.Equal("123", result[2]);
+    }
 
-        [Fact]
-        public void ScriptWithKeyPrefixCompare()
-        {
-            using (var conn = Create())
-            {
-                var p = conn.GetDatabase().WithKeyPrefix("prefix/");
-                var args = new { k = (RedisKey)"key", s = "str", v = 123 };
-                LuaScript lua = LuaScript.Prepare("return {@k, @s, @v}");
-                var viaArgs = (RedisValue[]?)p.ScriptEvaluate(lua, args);
+    [Fact]
+    public void ScriptWithKeyPrefixCompare()
+    {
+        using var conn = Create();
 
-                var viaArr = (RedisValue[]?)p.ScriptEvaluate("return {KEYS[1], ARGV[1], ARGV[2]}", new[] { args.k }, new RedisValue[] { args.s, args.v });
-                Assert.NotNull(viaArr);
-                Assert.NotNull(viaArgs);
-                Assert.Equal(string.Join(",", viaArr), string.Join(",", viaArgs));
-            }
-        }
+        var p = conn.GetDatabase().WithKeyPrefix("prefix/");
+        var args = new { k = (RedisKey)"key", s = "str", v = 123 };
+        LuaScript lua = LuaScript.Prepare("return {@k, @s, @v}");
+        var viaArgs = (RedisValue[]?)p.ScriptEvaluate(lua, args);
 
-        [Fact]
-        public void RedisResultUnderstandsNullArrayArray() => TestNullArray(RedisResult.NullArray);
-        [Fact]
-        public void RedisResultUnderstandsNullArrayNull() => TestNullArray(null);
+        var viaArr = (RedisValue[]?)p.ScriptEvaluate("return {KEYS[1], ARGV[1], ARGV[2]}", new[] { args.k }, new RedisValue[] { args.s, args.v });
+        Assert.NotNull(viaArr);
+        Assert.NotNull(viaArgs);
+        Assert.Equal(string.Join(",", viaArr), string.Join(",", viaArgs));
+    }
 
-        private static void TestNullArray(RedisResult? value)
-        {
-            Assert.True(value == null || value.IsNull);
+    [Fact]
+    public void RedisResultUnderstandsNullArrayArray() => TestNullArray(RedisResult.NullArray);
+    [Fact]
+    public void RedisResultUnderstandsNullArrayNull() => TestNullArray(null);
 
-            Assert.Null((RedisValue[]?)value);
-            Assert.Null((RedisKey[]?)value);
-            Assert.Null((bool[]?)value);
-            Assert.Null((long[]?)value);
-            Assert.Null((ulong[]?)value);
-            Assert.Null((string[]?)value);
-            Assert.Null((int[]?)value);
-            Assert.Null((double[]?)value);
-            Assert.Null((byte[][]?)value);
-            Assert.Null((RedisResult[]?)value);
-        }
+    private static void TestNullArray(RedisResult? value)
+    {
+        Assert.True(value == null || value.IsNull);
 
-        [Fact]
-        public void RedisResultUnderstandsNullNull() => TestNullValue(null);
-        [Fact]
-        public void RedisResultUnderstandsNullValue() => TestNullValue(RedisResult.Create(RedisValue.Null, ResultType.None));
+        Assert.Null((RedisValue[]?)value);
+        Assert.Null((RedisKey[]?)value);
+        Assert.Null((bool[]?)value);
+        Assert.Null((long[]?)value);
+        Assert.Null((ulong[]?)value);
+        Assert.Null((string[]?)value);
+        Assert.Null((int[]?)value);
+        Assert.Null((double[]?)value);
+        Assert.Null((byte[][]?)value);
+        Assert.Null((RedisResult[]?)value);
+    }
 
-        private static void TestNullValue(RedisResult? value)
-        {
-            Assert.True(value == null || value.IsNull);
+    [Fact]
+    public void RedisResultUnderstandsNullNull() => TestNullValue(null);
+    [Fact]
+    public void RedisResultUnderstandsNullValue() => TestNullValue(RedisResult.Create(RedisValue.Null, ResultType.None));
 
-            Assert.True(((RedisValue)value).IsNull);
-            Assert.True(((RedisKey)value).IsNull);
-            Assert.Null((bool?)value);
-            Assert.Null((long?)value);
-            Assert.Null((ulong?)value);
-            Assert.Null((string?)value);
-            Assert.Null((double?)value);
-            Assert.Null((byte[]?)value);
-        }
+    private static void TestNullValue(RedisResult? value)
+    {
+        Assert.True(value == null || value.IsNull);
+
+        Assert.True(((RedisValue)value).IsNull);
+        Assert.True(((RedisKey)value).IsNull);
+        Assert.Null((bool?)value);
+        Assert.Null((long?)value);
+        Assert.Null((ulong?)value);
+        Assert.Null((string?)value);
+        Assert.Null((double?)value);
+        Assert.Null((byte[]?)value);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Secure.cs
+++ b/tests/StackExchange.Redis.Tests/Secure.cs
@@ -3,80 +3,77 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(NonParallelCollection.Name)]
+public class Secure : TestBase
 {
-    [Collection(NonParallelCollection.Name)]
-    public class Secure : TestBase
+    protected override string GetConfiguration() =>
+        TestConfig.Current.SecureServerAndPort + ",password=" + TestConfig.Current.SecurePassword + ",name=MyClient";
+
+    public Secure(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void MassiveBulkOpsFireAndForgetSecure()
     {
-        protected override string GetConfiguration() =>
-            TestConfig.Current.SecureServerAndPort + ",password=" + TestConfig.Current.SecurePassword + ",name=MyClient";
+        using var conn = Create();
 
-        public Secure(ITestOutputHelper output) : base (output) { }
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.Ping();
 
-        [Fact]
-        public void MassiveBulkOpsFireAndForgetSecure()
+        var watch = Stopwatch.StartNew();
+
+        for (int i = 0; i <= AsyncOpsQty; i++)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me();
-                var conn = muxer.GetDatabase();
-                conn.Ping();
-
-                var watch = Stopwatch.StartNew();
-
-                for (int i = 0; i <= AsyncOpsQty; i++)
-                {
-                    conn.StringSet(key, i, flags: CommandFlags.FireAndForget);
-                }
-                int val = (int)conn.StringGet(key);
-                Assert.Equal(AsyncOpsQty, val);
-                watch.Stop();
-                Log("{2}: Time for {0} ops: {1}ms (any order); ops/s: {3}", AsyncOpsQty, watch.ElapsedMilliseconds, Me(),
-                    AsyncOpsQty / watch.Elapsed.TotalSeconds);
-            }
+            db.StringSet(key, i, flags: CommandFlags.FireAndForget);
         }
+        int val = (int)db.StringGet(key);
+        Assert.Equal(AsyncOpsQty, val);
+        watch.Stop();
+        Log("{2}: Time for {0} ops: {1}ms (any order); ops/s: {3}", AsyncOpsQty, watch.ElapsedMilliseconds, Me(),
+            AsyncOpsQty / watch.Elapsed.TotalSeconds);
+    }
 
-        [Fact]
-        public void CheckConfig()
+    [Fact]
+    public void CheckConfig()
+    {
+        var config = ConfigurationOptions.Parse(GetConfiguration());
+        foreach (var ep in config.EndPoints)
         {
-            var config = ConfigurationOptions.Parse(GetConfiguration());
-            foreach (var ep in config.EndPoints)
-            {
-                Log(ep.ToString());
-            }
-            Assert.Single(config.EndPoints);
-            Assert.Equal("changeme", config.Password);
+            Log(ep.ToString());
         }
+        Assert.Single(config.EndPoints);
+        Assert.Equal("changeme", config.Password);
+    }
 
-        [Fact]
-        public void Connect()
+    [Fact]
+    public void Connect()
+    {
+        using var server = Create();
+
+        server.GetDatabase().Ping();
+    }
+
+    [Theory]
+    [InlineData("wrong")]
+    [InlineData("")]
+    public async Task ConnectWithWrongPassword(string password)
+    {
+        var config = ConfigurationOptions.Parse(GetConfiguration());
+        config.Password = password;
+        config.ConnectRetry = 0; // we don't want to retry on closed sockets in this case.
+        config.BacklogPolicy = BacklogPolicy.FailFast;
+
+        var ex = await Assert.ThrowsAsync<RedisConnectionException>(async () =>
         {
-            using (var server = Create())
-            {
-                server.GetDatabase().Ping();
-            }
-        }
+            SetExpectedAmbientFailureCount(-1);
 
-        [Theory]
-        [InlineData("wrong")]
-        [InlineData("")]
-        public async Task ConnectWithWrongPassword(string password)
-        {
-            var config = ConfigurationOptions.Parse(GetConfiguration());
-            config.Password = password;
-            config.ConnectRetry = 0; // we don't want to retry on closed sockets in this case.
-            config.BacklogPolicy = BacklogPolicy.FailFast;
+            using var conn = await ConnectionMultiplexer.ConnectAsync(config, Writer).ConfigureAwait(false);
 
-            var ex = await Assert.ThrowsAsync<RedisConnectionException>(async () =>
-            {
-                SetExpectedAmbientFailureCount(-1);
-                using (var conn = await ConnectionMultiplexer.ConnectAsync(config, Writer).ConfigureAwait(false))
-                {
-                    conn.GetDatabase().Ping();
-                }
-            }).ConfigureAwait(false);
-            Log("Exception: " + ex.Message);
-            Assert.StartsWith("It was not possible to connect to the redis server(s). There was an authentication failure; check that passwords (or client certificates) are configured correctly.", ex.Message);
-        }
+            conn.GetDatabase().Ping();
+        }).ConfigureAwait(false);
+        Log("Exception: " + ex.Message);
+        Assert.StartsWith("It was not possible to connect to the redis server(s). There was an authentication failure; check that passwords (or client certificates) are configured correctly.", ex.Message);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Sentinel.cs
+++ b/tests/StackExchange.Redis.Tests/Sentinel.cs
@@ -6,434 +6,432 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Sentinel : SentinelBase
 {
-    public class Sentinel : SentinelBase
+    public Sentinel(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task PrimaryConnectTest()
     {
-        public Sentinel(ITestOutputHelper output) : base(output) { }
+        var connectionString = $"{TestConfig.Current.SentinelServer},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
 
-        [Fact]
-        public async Task PrimaryConnectTest()
+        var conn = ConnectionMultiplexer.Connect(connectionString);
+
+        var db = conn.GetDatabase();
+        db.Ping();
+
+        var endpoints = conn.GetEndPoints();
+        Assert.Equal(2, endpoints.Length);
+
+        var servers = endpoints.Select(e => conn.GetServer(e)).ToArray();
+        Assert.Equal(2, servers.Length);
+
+        var primary = servers.FirstOrDefault(s => !s.IsReplica);
+        Assert.NotNull(primary);
+        var replica = servers.FirstOrDefault(s => s.IsReplica);
+        Assert.NotNull(replica);
+        Assert.NotEqual(primary.EndPoint.ToString(), replica.EndPoint.ToString());
+
+        var expected = DateTime.Now.Ticks.ToString();
+        Log("Tick Key: " + expected);
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.StringSet(key, expected);
+
+        var value = db.StringGet(key);
+        Assert.Equal(expected, value);
+
+        // force read from replica, replication has some lag
+        await WaitForReplicationAsync(servers[0], TimeSpan.FromSeconds(10)).ForAwait();
+        value = db.StringGet(key, CommandFlags.DemandReplica);
+        Assert.Equal(expected, value);
+    }
+
+    [Fact]
+    public async Task PrimaryConnectAsyncTest()
+    {
+        var connectionString = $"{TestConfig.Current.SentinelServer},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
+        var conn = await ConnectionMultiplexer.ConnectAsync(connectionString);
+
+        var db = conn.GetDatabase();
+        await db.PingAsync();
+
+        var endpoints = conn.GetEndPoints();
+        Assert.Equal(2, endpoints.Length);
+
+        var servers = endpoints.Select(e => conn.GetServer(e)).ToArray();
+        Assert.Equal(2, servers.Length);
+
+        var primary = servers.FirstOrDefault(s => !s.IsReplica);
+        Assert.NotNull(primary);
+        var replica = servers.FirstOrDefault(s => s.IsReplica);
+        Assert.NotNull(replica);
+        Assert.NotEqual(primary.EndPoint.ToString(), replica.EndPoint.ToString());
+
+        var expected = DateTime.Now.Ticks.ToString();
+        Log("Tick Key: " + expected);
+        var key = Me();
+        await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
+        await db.StringSetAsync(key, expected);
+
+        var value = await db.StringGetAsync(key);
+        Assert.Equal(expected, value);
+
+        // force read from replica, replication has some lag
+        await WaitForReplicationAsync(servers[0], TimeSpan.FromSeconds(10)).ForAwait();
+        value = await db.StringGetAsync(key, CommandFlags.DemandReplica);
+        Assert.Equal(expected, value);
+    }
+
+    [Fact]
+    public void SentinelConnectTest()
+    {
+        var options = ServiceOptions.Clone();
+        options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA);
+        var conn = ConnectionMultiplexer.SentinelConnect(options);
+
+        var db = conn.GetDatabase();
+        var test = db.Ping();
+        Log("ping to sentinel {0}:{1} took {2} ms", TestConfig.Current.SentinelServer,
+            TestConfig.Current.SentinelPortA, test.TotalMilliseconds);
+    }
+
+    [Fact]
+    public async Task SentinelConnectAsyncTest()
+    {
+        var options = ServiceOptions.Clone();
+        options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA);
+        var conn = await ConnectionMultiplexer.SentinelConnectAsync(options);
+
+        var db = conn.GetDatabase();
+        var test = await db.PingAsync();
+        Log("ping to sentinel {0}:{1} took {2} ms", TestConfig.Current.SentinelServer,
+            TestConfig.Current.SentinelPortA, test.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SentinelRole()
+    {
+        foreach (var server in SentinelsServers)
         {
-            var connectionString = $"{TestConfig.Current.SentinelServer},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
-            var conn = ConnectionMultiplexer.Connect(connectionString);
-
-            var db = conn.GetDatabase();
-            db.Ping();
-
-            var endpoints = conn.GetEndPoints();
-            Assert.Equal(2, endpoints.Length);
-
-            var servers = endpoints.Select(e => conn.GetServer(e)).ToArray();
-            Assert.Equal(2, servers.Length);
-
-            var primary = servers.FirstOrDefault(s => !s.IsReplica);
-            Assert.NotNull(primary);
-            var replica = servers.FirstOrDefault(s => s.IsReplica);
-            Assert.NotNull(replica);
-            Assert.NotEqual(primary.EndPoint.ToString(), replica.EndPoint.ToString());
-
-            var expected = DateTime.Now.Ticks.ToString();
-            Log("Tick Key: " + expected);
-            var key = Me();
-            db.KeyDelete(key, CommandFlags.FireAndForget);
-            db.StringSet(key, expected);
-
-            var value = db.StringGet(key);
-            Assert.Equal(expected, value);
-
-            // force read from replica, replication has some lag
-            await WaitForReplicationAsync(servers[0], TimeSpan.FromSeconds(10)).ForAwait();
-            value = db.StringGet(key, CommandFlags.DemandReplica);
-            Assert.Equal(expected, value);
+            var role = server.Role();
+            Assert.NotNull(role);
+            Assert.Equal(role.Value, RedisLiterals.sentinel);
+            var sentinel = role as Role.Sentinel;
+            Assert.NotNull(sentinel);
         }
+    }
 
-        [Fact]
-        public async Task PrimaryConnectAsyncTest()
+    [Fact]
+    public void PingTest()
+    {
+        var test = SentinelServerA.Ping();
+        Log("ping to sentinel {0}:{1} took {2} ms", TestConfig.Current.SentinelServer,
+            TestConfig.Current.SentinelPortA, test.TotalMilliseconds);
+        test = SentinelServerB.Ping();
+        Log("ping to sentinel {0}:{1} took {1} ms", TestConfig.Current.SentinelServer,
+            TestConfig.Current.SentinelPortB, test.TotalMilliseconds);
+        test = SentinelServerC.Ping();
+        Log("ping to sentinel {0}:{1} took {1} ms", TestConfig.Current.SentinelServer,
+            TestConfig.Current.SentinelPortC, test.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SentinelGetPrimaryAddressByNameTest()
+    {
+        foreach (var server in SentinelsServers)
         {
-            var connectionString = $"{TestConfig.Current.SentinelServer},serviceName={ServiceOptions.ServiceName},allowAdmin=true";
-            var conn = await ConnectionMultiplexer.ConnectAsync(connectionString);
-
-            var db = conn.GetDatabase();
-            await db.PingAsync();
-
-            var endpoints = conn.GetEndPoints();
-            Assert.Equal(2, endpoints.Length);
-
-            var servers = endpoints.Select(e => conn.GetServer(e)).ToArray();
-            Assert.Equal(2, servers.Length);
-
-            var primary = servers.FirstOrDefault(s => !s.IsReplica);
-            Assert.NotNull(primary);
-            var replica = servers.FirstOrDefault(s => s.IsReplica);
-            Assert.NotNull(replica);
-            Assert.NotEqual(primary.EndPoint.ToString(), replica.EndPoint.ToString());
-
-            var expected = DateTime.Now.Ticks.ToString();
-            Log("Tick Key: " + expected);
-            var key = Me();
-            await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
-            await db.StringSetAsync(key, expected);
-
-            var value = await db.StringGetAsync(key);
-            Assert.Equal(expected, value);
-
-            // force read from replica, replication has some lag
-            await WaitForReplicationAsync(servers[0], TimeSpan.FromSeconds(10)).ForAwait();
-            value = await db.StringGetAsync(key, CommandFlags.DemandReplica);
-            Assert.Equal(expected, value);
+            var primary = server.SentinelMaster(ServiceName);
+            var endpoint = server.SentinelGetMasterAddressByName(ServiceName);
+            Assert.NotNull(endpoint);
+            var ipEndPoint = endpoint as IPEndPoint;
+            Assert.NotNull(ipEndPoint);
+            Assert.Equal(primary.ToDictionary()["ip"], ipEndPoint.Address.ToString());
+            Assert.Equal(primary.ToDictionary()["port"], ipEndPoint.Port.ToString());
+            Log("{0}:{1}", ipEndPoint.Address, ipEndPoint.Port);
         }
+    }
 
-        [Fact]
-        public void SentinelConnectTest()
+    [Fact]
+    public async Task SentinelGetPrimaryAddressByNameAsyncTest()
+    {
+        foreach (var server in SentinelsServers)
         {
-            var options = ServiceOptions.Clone();
-            options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA);
-
-            var conn = ConnectionMultiplexer.SentinelConnect(options);
-            var db = conn.GetDatabase();
-
-            var test = db.Ping();
-            Log("ping to sentinel {0}:{1} took {2} ms", TestConfig.Current.SentinelServer,
-                TestConfig.Current.SentinelPortA, test.TotalMilliseconds);
+            var primary = server.SentinelMaster(ServiceName);
+            var endpoint = await server.SentinelGetMasterAddressByNameAsync(ServiceName).ForAwait();
+            Assert.NotNull(endpoint);
+            var ipEndPoint = endpoint as IPEndPoint;
+            Assert.NotNull(ipEndPoint);
+            Assert.Equal(primary.ToDictionary()["ip"], ipEndPoint.Address.ToString());
+            Assert.Equal(primary.ToDictionary()["port"], ipEndPoint.Port.ToString());
+            Log("{0}:{1}", ipEndPoint.Address, ipEndPoint.Port);
         }
+    }
 
-        [Fact]
-        public async Task SentinelConnectAsyncTest()
+    [Fact]
+    public void SentinelGetMasterAddressByNameNegativeTest()
+    {
+        foreach (var server in SentinelsServers)
         {
-            var options = ServiceOptions.Clone();
-            options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA);
-
-            var conn = await ConnectionMultiplexer.SentinelConnectAsync(options);
-            var db = conn.GetDatabase();
-
-            var test = await db.PingAsync();
-            Log("ping to sentinel {0}:{1} took {2} ms", TestConfig.Current.SentinelServer,
-                TestConfig.Current.SentinelPortA, test.TotalMilliseconds);
+            var endpoint = server.SentinelGetMasterAddressByName("FakeServiceName");
+            Assert.Null(endpoint);
         }
+    }
 
-        [Fact]
-        public void SentinelRole()
+    [Fact]
+    public async Task SentinelGetMasterAddressByNameAsyncNegativeTest()
+    {
+        foreach (var server in SentinelsServers)
         {
-            foreach (var server in SentinelsServers)
+            var endpoint = await server.SentinelGetMasterAddressByNameAsync("FakeServiceName").ForAwait();
+            Assert.Null(endpoint);
+        }
+    }
+
+    [Fact]
+    public void SentinelPrimaryTest()
+    {
+        foreach (var server in SentinelsServers)
+        {
+            var dict = server.SentinelMaster(ServiceName).ToDictionary();
+            Assert.Equal(ServiceName, dict["name"]);
+            Assert.StartsWith("master", dict["flags"]);
+            foreach (var kvp in dict)
             {
-                var role = server.Role();
-                Assert.NotNull(role);
-                Assert.Equal(role.Value, RedisLiterals.sentinel);
-                var sentinel = role as Role.Sentinel;
-                Assert.NotNull(sentinel);
+                Log("{0}:{1}", kvp.Key, kvp.Value);
             }
         }
+    }
 
-        [Fact]
-        public void PingTest()
+    [Fact]
+    public async Task SentinelPrimaryAsyncTest()
+    {
+        foreach (var server in SentinelsServers)
         {
-            var test = SentinelServerA.Ping();
-            Log("ping to sentinel {0}:{1} took {2} ms", TestConfig.Current.SentinelServer,
-                TestConfig.Current.SentinelPortA, test.TotalMilliseconds);
-            test = SentinelServerB.Ping();
-            Log("ping to sentinel {0}:{1} took {1} ms", TestConfig.Current.SentinelServer,
-                TestConfig.Current.SentinelPortB, test.TotalMilliseconds);
-            test = SentinelServerC.Ping();
-            Log("ping to sentinel {0}:{1} took {1} ms", TestConfig.Current.SentinelServer,
-                TestConfig.Current.SentinelPortC, test.TotalMilliseconds);
-        }
-
-        [Fact]
-        public void SentinelGetPrimaryAddressByNameTest()
-        {
-            foreach (var server in SentinelsServers)
+            var results = await server.SentinelMasterAsync(ServiceName).ForAwait();
+            Assert.Equal(ServiceName, results.ToDictionary()["name"]);
+            Assert.StartsWith("master", results.ToDictionary()["flags"]);
+            foreach (var kvp in results)
             {
-                var primary = server.SentinelMaster(ServiceName);
-                var endpoint = server.SentinelGetMasterAddressByName(ServiceName);
-                Assert.NotNull(endpoint);
-                var ipEndPoint = endpoint as IPEndPoint;
-                Assert.NotNull(ipEndPoint);
-                Assert.Equal(primary.ToDictionary()["ip"], ipEndPoint.Address.ToString());
-                Assert.Equal(primary.ToDictionary()["port"], ipEndPoint.Port.ToString());
-                Log("{0}:{1}", ipEndPoint.Address, ipEndPoint.Port);
+                Log("{0}:{1}", kvp.Key, kvp.Value);
             }
         }
+    }
 
-        [Fact]
-        public async Task SentinelGetPrimaryAddressByNameAsyncTest()
+    [Fact]
+    public void SentinelSentinelsTest()
+    {
+        var sentinels = SentinelServerA.SentinelSentinels(ServiceName);
+
+        var expected = new List<string?> {
+            SentinelServerB.EndPoint.ToString(),
+            SentinelServerC.EndPoint.ToString()
+        };
+
+        var actual = new List<string>();
+        foreach (var kv in sentinels)
         {
-            foreach (var server in SentinelsServers)
-            {
-                var primary = server.SentinelMaster(ServiceName);
-                var endpoint = await server.SentinelGetMasterAddressByNameAsync(ServiceName).ForAwait();
-                Assert.NotNull(endpoint);
-                var ipEndPoint = endpoint as IPEndPoint;
-                Assert.NotNull(ipEndPoint);
-                Assert.Equal(primary.ToDictionary()["ip"], ipEndPoint.Address.ToString());
-                Assert.Equal(primary.ToDictionary()["port"], ipEndPoint.Port.ToString());
-                Log("{0}:{1}", ipEndPoint.Address, ipEndPoint.Port);
-            }
+            var data = kv.ToDictionary();
+            actual.Add(data["ip"] + ":" + data["port"]);
         }
 
-        [Fact]
-        public void SentinelGetMasterAddressByNameNegativeTest()
+        Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerA.EndPoint.ToString()));
+        Assert.True(sentinels.Length == 2);
+        Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+
+        sentinels = SentinelServerB.SentinelSentinels(ServiceName);
+        foreach (var kv in sentinels)
         {
-            foreach (var server in SentinelsServers)
+            var data = kv.ToDictionary();
+            actual.Add(data["ip"] + ":" + data["port"]);
+        }
+        expected = new List<string?> {
+            SentinelServerA.EndPoint.ToString(),
+            SentinelServerC.EndPoint.ToString()
+        };
+
+        Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerB.EndPoint.ToString()));
+        Assert.True(sentinels.Length == 2);
+        Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+
+        sentinels = SentinelServerC.SentinelSentinels(ServiceName);
+        foreach (var kv in sentinels)
+        {
+            var data = kv.ToDictionary();
+            actual.Add(data["ip"] + ":" + data["port"]);
+        }
+        expected = new List<string?> {
+            SentinelServerA.EndPoint.ToString(),
+            SentinelServerB.EndPoint.ToString()
+        };
+
+        Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerC.EndPoint.ToString()));
+        Assert.True(sentinels.Length == 2);
+        Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+    }
+
+    [Fact]
+    public async Task SentinelSentinelsAsyncTest()
+    {
+        var sentinels = await SentinelServerA.SentinelSentinelsAsync(ServiceName).ForAwait();
+        var expected = new List<string?> {
+            SentinelServerB.EndPoint.ToString(),
+            SentinelServerC.EndPoint.ToString()
+        };
+
+        var actual = new List<string>();
+        foreach (var kv in sentinels)
+        {
+            var data = kv.ToDictionary();
+            actual.Add(data["ip"] + ":" + data["port"]);
+        }
+        Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerA.EndPoint.ToString()));
+        Assert.True(sentinels.Length == 2);
+        Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+
+        sentinels = await SentinelServerB.SentinelSentinelsAsync(ServiceName).ForAwait();
+
+        expected = new List<string?> {
+            SentinelServerA.EndPoint.ToString(),
+            SentinelServerC.EndPoint.ToString()
+        };
+
+        actual = new List<string>();
+        foreach (var kv in sentinels)
+        {
+            var data = kv.ToDictionary();
+            actual.Add(data["ip"] + ":" + data["port"]);
+        }
+        Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerB.EndPoint.ToString()));
+        Assert.True(sentinels.Length == 2);
+        Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+
+        sentinels = await SentinelServerC.SentinelSentinelsAsync(ServiceName).ForAwait();
+        expected = new List<string?> {
+            SentinelServerA.EndPoint.ToString(),
+            SentinelServerB.EndPoint.ToString()
+        };
+        actual = new List<string>();
+        foreach (var kv in sentinels)
+        {
+            var data = kv.ToDictionary();
+            actual.Add(data["ip"] + ":" + data["port"]);
+        }
+        Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerC.EndPoint.ToString()));
+        Assert.True(sentinels.Length == 2);
+        Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+    }
+
+    [Fact]
+    public void SentinelPrimariesTest()
+    {
+        var primaryConfigs = SentinelServerA.SentinelMasters();
+        Assert.Single(primaryConfigs);
+        Assert.True(primaryConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
+        Assert.Equal(ServiceName, primaryConfigs[0].ToDictionary()["name"]);
+        Assert.StartsWith("master", primaryConfigs[0].ToDictionary()["flags"]);
+        foreach (var config in primaryConfigs)
+        {
+            foreach (var kvp in config)
             {
-                var endpoint = server.SentinelGetMasterAddressByName("FakeServiceName");
-                Assert.Null(endpoint);
+                Log("{0}:{1}", kvp.Key, kvp.Value);
             }
         }
+    }
 
-        [Fact]
-        public async Task SentinelGetMasterAddressByNameAsyncNegativeTest()
+    [Fact]
+    public async Task SentinelPrimariesAsyncTest()
+    {
+        var primaryConfigs = await SentinelServerA.SentinelMastersAsync().ForAwait();
+        Assert.Single(primaryConfigs);
+        Assert.True(primaryConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
+        Assert.Equal(ServiceName, primaryConfigs[0].ToDictionary()["name"]);
+        Assert.StartsWith("master", primaryConfigs[0].ToDictionary()["flags"]);
+        foreach (var config in primaryConfigs)
         {
-            foreach (var server in SentinelsServers)
+            foreach (var kvp in config)
             {
-                var endpoint = await server.SentinelGetMasterAddressByNameAsync("FakeServiceName").ForAwait();
-                Assert.Null(endpoint);
+                Log("{0}:{1}", kvp.Key, kvp.Value);
             }
         }
+    }
 
-        [Fact]
-        public void SentinelPrimaryTest()
+    [Fact]
+    public async Task SentinelReplicasTest()
+    {
+        // Give previous test run a moment to reset when multi-framework failover is in play.
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => SentinelServerA.SentinelReplicas(ServiceName).Length > 0);
+
+        var replicaConfigs = SentinelServerA.SentinelReplicas(ServiceName);
+        Assert.True(replicaConfigs.Length > 0, "Has replicaConfigs");
+        Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
+        Assert.StartsWith("slave", replicaConfigs[0].ToDictionary()["flags"]);
+
+        foreach (var config in replicaConfigs)
         {
-            foreach (var server in SentinelsServers)
+            foreach (var kvp in config)
             {
-                var dict = server.SentinelMaster(ServiceName).ToDictionary();
-                Assert.Equal(ServiceName, dict["name"]);
-                Assert.StartsWith("master", dict["flags"]);
-                foreach (var kvp in dict)
-                {
-                    Log("{0}:{1}", kvp.Key, kvp.Value);
-                }
+                Log("{0}:{1}", kvp.Key, kvp.Value);
             }
         }
+    }
 
-        [Fact]
-        public async Task SentinelPrimaryAsyncTest()
+    [Fact]
+    public async Task SentinelReplicasAsyncTest()
+    {
+        // Give previous test run a moment to reset when multi-framework failover is in play.
+        await UntilConditionAsync(TimeSpan.FromSeconds(5), () => SentinelServerA.SentinelReplicas(ServiceName).Length > 0);
+
+        var replicaConfigs = await SentinelServerA.SentinelReplicasAsync(ServiceName).ForAwait();
+        Assert.True(replicaConfigs.Length > 0, "Has replicaConfigs");
+        Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
+        Assert.StartsWith("slave", replicaConfigs[0].ToDictionary()["flags"]);
+        foreach (var config in replicaConfigs)
         {
-            foreach (var server in SentinelsServers)
+            foreach (var kvp in config)
             {
-                var results = await server.SentinelMasterAsync(ServiceName).ForAwait();
-                Assert.Equal(ServiceName, results.ToDictionary()["name"]);
-                Assert.StartsWith("master", results.ToDictionary()["flags"]);
-                foreach (var kvp in results)
-                {
-                    Log("{0}:{1}", kvp.Key, kvp.Value);
-                }
+                Log("{0}:{1}", kvp.Key, kvp.Value);
             }
         }
+    }
 
-        [Fact]
-        public void SentinelSentinelsTest()
+    [Fact]
+    public async Task SentinelGetSentinelAddressesTest()
+    {
+        var addresses = await SentinelServerA.SentinelGetSentinelAddressesAsync(ServiceName).ForAwait();
+        Assert.Contains(SentinelServerB.EndPoint, addresses);
+        Assert.Contains(SentinelServerC.EndPoint, addresses);
+
+        addresses = await SentinelServerB.SentinelGetSentinelAddressesAsync(ServiceName).ForAwait();
+        Assert.Contains(SentinelServerA.EndPoint, addresses);
+        Assert.Contains(SentinelServerC.EndPoint, addresses);
+
+        addresses = await SentinelServerC.SentinelGetSentinelAddressesAsync(ServiceName).ForAwait();
+        Assert.Contains(SentinelServerA.EndPoint, addresses);
+        Assert.Contains(SentinelServerB.EndPoint, addresses);
+    }
+
+    [Fact]
+    public async Task ReadOnlyConnectionReplicasTest()
+    {
+        var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
+        var config = new ConfigurationOptions();
+
+        foreach (var replica in replicas)
         {
-            var sentinels = SentinelServerA.SentinelSentinels(ServiceName);
-
-            var expected = new List<string?> {
-                SentinelServerB.EndPoint.ToString(),
-                SentinelServerC.EndPoint.ToString()
-            };
-
-            var actual = new List<string>();
-            foreach (var kv in sentinels)
-            {
-                var data = kv.ToDictionary();
-                actual.Add(data["ip"] + ":" + data["port"]);
-            }
-
-            Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerA.EndPoint.ToString()));
-            Assert.True(sentinels.Length == 2);
-            Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
-
-            sentinels = SentinelServerB.SentinelSentinels(ServiceName);
-            foreach (var kv in sentinels)
-            {
-                var data = kv.ToDictionary();
-                actual.Add(data["ip"] + ":" + data["port"]);
-            }
-            expected = new List<string?> {
-                SentinelServerA.EndPoint.ToString(),
-                SentinelServerC.EndPoint.ToString()
-            };
-
-            Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerB.EndPoint.ToString()));
-            Assert.True(sentinels.Length == 2);
-            Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
-
-            sentinels = SentinelServerC.SentinelSentinels(ServiceName);
-            foreach (var kv in sentinels)
-            {
-                var data = kv.ToDictionary();
-                actual.Add(data["ip"] + ":" + data["port"]);
-            }
-            expected = new List<string?> {
-                SentinelServerA.EndPoint.ToString(),
-                SentinelServerB.EndPoint.ToString()
-            };
-
-            Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerC.EndPoint.ToString()));
-            Assert.True(sentinels.Length == 2);
-            Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
+            config.EndPoints.Add(replica);
         }
 
-        [Fact]
-        public async Task SentinelSentinelsAsyncTest()
-        {
-            var sentinels = await SentinelServerA.SentinelSentinelsAsync(ServiceName).ForAwait();
-            var expected = new List<string?> {
-                SentinelServerB.EndPoint.ToString(),
-                SentinelServerC.EndPoint.ToString()
-            };
+        var readonlyConn = await ConnectionMultiplexer.ConnectAsync(config);
 
-            var actual = new List<string>();
-            foreach (var kv in sentinels)
-            {
-                var data = kv.ToDictionary();
-                actual.Add(data["ip"] + ":" + data["port"]);
-            }
-            Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerA.EndPoint.ToString()));
-            Assert.True(sentinels.Length == 2);
-            Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
-
-            sentinels = await SentinelServerB.SentinelSentinelsAsync(ServiceName).ForAwait();
-
-            expected = new List<string?> {
-                SentinelServerA.EndPoint.ToString(),
-                SentinelServerC.EndPoint.ToString()
-            };
-
-            actual = new List<string>();
-            foreach (var kv in sentinels)
-            {
-                var data = kv.ToDictionary();
-                actual.Add(data["ip"] + ":" + data["port"]);
-            }
-            Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerB.EndPoint.ToString()));
-            Assert.True(sentinels.Length == 2);
-            Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
-
-            sentinels = await SentinelServerC.SentinelSentinelsAsync(ServiceName).ForAwait();
-            expected = new List<string?> {
-                SentinelServerA.EndPoint.ToString(),
-                SentinelServerB.EndPoint.ToString()
-            };
-            actual = new List<string>();
-            foreach (var kv in sentinels)
-            {
-                var data = kv.ToDictionary();
-                actual.Add(data["ip"] + ":" + data["port"]);
-            }
-            Assert.All(expected, ep => Assert.NotEqual(ep, SentinelServerC.EndPoint.ToString()));
-            Assert.True(sentinels.Length == 2);
-            Assert.All(expected, ep => Assert.Contains(ep, actual, _ipComparer));
-        }
-
-        [Fact]
-        public void SentinelPrimariesTest()
-        {
-            var primaryConfigs = SentinelServerA.SentinelMasters();
-            Assert.Single(primaryConfigs);
-            Assert.True(primaryConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
-            Assert.Equal(ServiceName, primaryConfigs[0].ToDictionary()["name"]);
-            Assert.StartsWith("master", primaryConfigs[0].ToDictionary()["flags"]);
-            foreach (var config in primaryConfigs)
-            {
-                foreach (var kvp in config)
-                {
-                    Log("{0}:{1}", kvp.Key, kvp.Value);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task SentinelPrimariesAsyncTest()
-        {
-            var primaryConfigs = await SentinelServerA.SentinelMastersAsync().ForAwait();
-            Assert.Single(primaryConfigs);
-            Assert.True(primaryConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
-            Assert.Equal(ServiceName, primaryConfigs[0].ToDictionary()["name"]);
-            Assert.StartsWith("master", primaryConfigs[0].ToDictionary()["flags"]);
-            foreach (var config in primaryConfigs)
-            {
-                foreach (var kvp in config)
-                {
-                    Log("{0}:{1}", kvp.Key, kvp.Value);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task SentinelReplicasTest()
-        {
-            // Give previous test run a moment to reset when multi-framework failover is in play.
-            await UntilConditionAsync(TimeSpan.FromSeconds(5), () => SentinelServerA.SentinelReplicas(ServiceName).Length > 0);
-
-            var replicaConfigs = SentinelServerA.SentinelReplicas(ServiceName);
-            Assert.True(replicaConfigs.Length > 0, "Has replicaConfigs");
-            Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
-            Assert.StartsWith("slave", replicaConfigs[0].ToDictionary()["flags"]);
-
-            foreach (var config in replicaConfigs)
-            {
-                foreach (var kvp in config)
-                {
-                    Log("{0}:{1}", kvp.Key, kvp.Value);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task SentinelReplicasAsyncTest()
-        {
-            // Give previous test run a moment to reset when multi-framework failover is in play.
-            await UntilConditionAsync(TimeSpan.FromSeconds(5), () => SentinelServerA.SentinelReplicas(ServiceName).Length > 0);
-
-            var replicaConfigs = await SentinelServerA.SentinelReplicasAsync(ServiceName).ForAwait();
-            Assert.True(replicaConfigs.Length > 0, "Has replicaConfigs");
-            Assert.True(replicaConfigs[0].ToDictionary().ContainsKey("name"), "replicaConfigs contains 'name'");
-            Assert.StartsWith("slave", replicaConfigs[0].ToDictionary()["flags"]);
-            foreach (var config in replicaConfigs)
-            {
-                foreach (var kvp in config)
-                {
-                    Log("{0}:{1}", kvp.Key, kvp.Value);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task SentinelGetSentinelAddressesTest()
-        {
-            var addresses = await SentinelServerA.SentinelGetSentinelAddressesAsync(ServiceName).ForAwait();
-            Assert.Contains(SentinelServerB.EndPoint, addresses);
-            Assert.Contains(SentinelServerC.EndPoint, addresses);
-
-            addresses = await SentinelServerB.SentinelGetSentinelAddressesAsync(ServiceName).ForAwait();
-            Assert.Contains(SentinelServerA.EndPoint, addresses);
-            Assert.Contains(SentinelServerC.EndPoint, addresses);
-
-            addresses = await SentinelServerC.SentinelGetSentinelAddressesAsync(ServiceName).ForAwait();
-            Assert.Contains(SentinelServerA.EndPoint, addresses);
-            Assert.Contains(SentinelServerB.EndPoint, addresses);
-        }
-
-        [Fact]
-        public async Task ReadOnlyConnectionReplicasTest()
-        {
-            var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
-            var config = new ConfigurationOptions();
-
-            foreach (var replica in replicas)
-            {
-                config.EndPoints.Add(replica);
-            }
-
-            var readonlyConn = await ConnectionMultiplexer.ConnectAsync(config);
-
-            await UntilConditionAsync(TimeSpan.FromSeconds(2), () => readonlyConn.IsConnected);
-            Assert.True(readonlyConn.IsConnected);
-            var db = readonlyConn.GetDatabase();
-            var s = db.StringGet("test");
-            Assert.True(s.IsNullOrEmpty);
-            //var ex = Assert.Throws<RedisConnectionException>(() => db.StringSet("test", "try write to read only instance"));
-            //Assert.StartsWith("No connection is available to service this operation", ex.Message);
-        }
+        await UntilConditionAsync(TimeSpan.FromSeconds(2), () => readonlyConn.IsConnected);
+        Assert.True(readonlyConn.IsConnected);
+        var db = readonlyConn.GetDatabase();
+        var s = db.StringGet("test");
+        Assert.True(s.IsNullOrEmpty);
+        //var ex = Assert.Throws<RedisConnectionException>(() => db.StringSet("test", "try write to read only instance"));
+        //Assert.StartsWith("No connection is available to service this operation", ex.Message);
     }
 }

--- a/tests/StackExchange.Redis.Tests/SentinelBase.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelBase.cs
@@ -1,192 +1,190 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
-{
-    public class SentinelBase : TestBase, IAsyncLifetime
-    {
-        protected static string ServiceName => TestConfig.Current.SentinelSeviceName;
-        protected static ConfigurationOptions ServiceOptions => new ConfigurationOptions { ServiceName = ServiceName, AllowAdmin = true };
+namespace StackExchange.Redis.Tests;
 
-        protected ConnectionMultiplexer Conn { get; set; }
-        protected IServer SentinelServerA { get; set; }
-        protected IServer SentinelServerB { get; set; }
-        protected IServer SentinelServerC { get; set; }
-        public IServer[] SentinelsServers { get; set; }
+public class SentinelBase : TestBase, IAsyncLifetime
+{
+    protected static string ServiceName => TestConfig.Current.SentinelSeviceName;
+    protected static ConfigurationOptions ServiceOptions => new ConfigurationOptions { ServiceName = ServiceName, AllowAdmin = true };
+
+    protected ConnectionMultiplexer Conn { get; set; }
+    protected IServer SentinelServerA { get; set; }
+    protected IServer SentinelServerB { get; set; }
+    protected IServer SentinelServerC { get; set; }
+    public IServer[] SentinelsServers { get; set; }
 
 #nullable disable
-        public SentinelBase(ITestOutputHelper output) : base(output)
-        {
-            Skip.IfNoConfig(nameof(TestConfig.Config.SentinelServer), TestConfig.Current.SentinelServer);
-            Skip.IfNoConfig(nameof(TestConfig.Config.SentinelSeviceName), TestConfig.Current.SentinelSeviceName);
-        }
+    public SentinelBase(ITestOutputHelper output) : base(output)
+    {
+        Skip.IfNoConfig(nameof(TestConfig.Config.SentinelServer), TestConfig.Current.SentinelServer);
+        Skip.IfNoConfig(nameof(TestConfig.Config.SentinelSeviceName), TestConfig.Current.SentinelSeviceName);
+    }
 #nullable enable
 
-        public Task DisposeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => Task.CompletedTask;
 
-        public async Task InitializeAsync()
+    public async Task InitializeAsync()
+    {
+        var options = ServiceOptions.Clone();
+        options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA);
+        options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortB);
+        options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortC);
+        Conn = ConnectionMultiplexer.SentinelConnect(options, Writer);
+
+        for (var i = 0; i < 150; i++)
         {
-            var options = ServiceOptions.Clone();
-            options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA);
-            options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortB);
-            options.EndPoints.Add(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortC);
-            Conn = ConnectionMultiplexer.SentinelConnect(options, Writer);
-
-            for (var i = 0; i < 150; i++)
+            await Task.Delay(100).ForAwait();
+            if (Conn.IsConnected)
             {
-                await Task.Delay(100).ForAwait();
-                if (Conn.IsConnected)
+                using var checkConn = Conn.GetSentinelMasterConnection(options, Writer);
+                if (checkConn.IsConnected)
                 {
-                    using var checkConn = Conn.GetSentinelMasterConnection(options, Writer);
-                    if (checkConn.IsConnected)
-                    {
-                        break;
-                    }
+                    break;
                 }
             }
-            Assert.True(Conn.IsConnected);
-            SentinelServerA = Conn.GetServer(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA)!;
-            SentinelServerB = Conn.GetServer(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortB)!;
-            SentinelServerC = Conn.GetServer(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortC)!;
-            SentinelsServers = new[] { SentinelServerA, SentinelServerB, SentinelServerC };
-
-            SentinelServerA.AllowReplicaWrites = true;
-            // Wait until we are in a state of a single primary and replica
-            await WaitForReadyAsync();
         }
+        Assert.True(Conn.IsConnected);
+        SentinelServerA = Conn.GetServer(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortA)!;
+        SentinelServerB = Conn.GetServer(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortB)!;
+        SentinelServerC = Conn.GetServer(TestConfig.Current.SentinelServer, TestConfig.Current.SentinelPortC)!;
+        SentinelsServers = new[] { SentinelServerA, SentinelServerB, SentinelServerC };
 
-        // Sometimes it's global, sometimes it's local
-        // Depends what mood Redis is in but they're equal and not the point of our tests
-        protected static readonly IpComparer _ipComparer = new IpComparer();
-        protected class IpComparer : IEqualityComparer<string?>
+        SentinelServerA.AllowReplicaWrites = true;
+        // Wait until we are in a state of a single primary and replica
+        await WaitForReadyAsync();
+    }
+
+    // Sometimes it's global, sometimes it's local
+    // Depends what mood Redis is in but they're equal and not the point of our tests
+    protected static readonly IpComparer _ipComparer = new IpComparer();
+    protected class IpComparer : IEqualityComparer<string?>
+    {
+        public bool Equals(string? x, string? y) => x == y || x?.Replace("0.0.0.0", "127.0.0.1") == y?.Replace("0.0.0.0", "127.0.0.1");
+        public int GetHashCode(string? obj) => obj?.GetHashCode() ?? 0;
+    }
+
+    protected async Task WaitForReadyAsync(EndPoint? expectedPrimary = null, bool waitForReplication = false, TimeSpan? duration = null)
+    {
+        duration ??= TimeSpan.FromSeconds(30);
+
+        var sw = Stopwatch.StartNew();
+
+        // wait until we have 1 primary and 1 replica and have verified their roles
+        var primary = SentinelServerA.SentinelGetMasterAddressByName(ServiceName);
+        if (expectedPrimary != null && expectedPrimary.ToString() != primary?.ToString())
         {
-            public bool Equals(string? x, string? y) => x == y || x?.Replace("0.0.0.0", "127.0.0.1") == y?.Replace("0.0.0.0", "127.0.0.1");
-            public int GetHashCode(string? obj) => obj?.GetHashCode() ?? 0;
-        }
-
-        protected async Task WaitForReadyAsync(EndPoint? expectedPrimary = null, bool waitForReplication = false, TimeSpan? duration = null)
-        {
-            duration ??= TimeSpan.FromSeconds(30);
-
-            var sw = Stopwatch.StartNew();
-
-            // wait until we have 1 primary and 1 replica and have verified their roles
-            var primary = SentinelServerA.SentinelGetMasterAddressByName(ServiceName);
-            if (expectedPrimary != null && expectedPrimary.ToString() != primary?.ToString())
-            {
-                while (sw.Elapsed < duration.Value)
-                {
-                    await Task.Delay(1000).ForAwait();
-                    try
-                    {
-                        primary = SentinelServerA.SentinelGetMasterAddressByName(ServiceName);
-                        if (expectedPrimary.ToString() == primary?.ToString())
-                            break;
-                    }
-                    catch (Exception)
-                    {
-                        // ignore
-                    }
-                }
-            }
-            if (expectedPrimary != null && expectedPrimary.ToString() != primary?.ToString())
-                throw new RedisException($"Primary was expected to be {expectedPrimary}");
-            Log($"Primary is {primary}");
-
-            using var checkConn = Conn.GetSentinelMasterConnection(ServiceOptions);
-
-            await WaitForRoleAsync(checkConn.GetServer(primary), "master", duration.Value.Subtract(sw.Elapsed)).ForAwait();
-
-            var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
-            if (replicas?.Length > 0)
-            {
-                await Task.Delay(1000).ForAwait();
-                replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
-                await WaitForRoleAsync(checkConn.GetServer(replicas[0]), "slave", duration.Value.Subtract(sw.Elapsed)).ForAwait();
-            }
-
-            if (waitForReplication)
-            {
-                await WaitForReplicationAsync(checkConn.GetServer(primary), duration.Value.Subtract(sw.Elapsed)).ForAwait();
-            }
-        }
-
-        protected async Task WaitForRoleAsync(IServer server, string role, TimeSpan? duration = null)
-        {
-            duration ??= TimeSpan.FromSeconds(30);
-
-            Log($"Waiting for server ({server.EndPoint}) role to be \"{role}\"...");
-            var sw = Stopwatch.StartNew();
             while (sw.Elapsed < duration.Value)
             {
+                await Task.Delay(1000).ForAwait();
                 try
                 {
-                    if (server.Role()?.Value == role)
-                    {
-                        Log($"Done waiting for server ({server.EndPoint}) role to be \"{role}\"");
-                        return;
-                    }
+                    primary = SentinelServerA.SentinelGetMasterAddressByName(ServiceName);
+                    if (expectedPrimary.ToString() == primary?.ToString())
+                        break;
                 }
                 catch (Exception)
                 {
                     // ignore
                 }
-
-                await Task.Delay(500).ForAwait();
             }
+        }
+        if (expectedPrimary != null && expectedPrimary.ToString() != primary?.ToString())
+            throw new RedisException($"Primary was expected to be {expectedPrimary}");
+        Log($"Primary is {primary}");
 
-            throw new RedisException($"Timeout waiting for server ({server.EndPoint}) to have expected role (\"{role}\") assigned");
+        using var checkConn = Conn.GetSentinelMasterConnection(ServiceOptions);
+
+        await WaitForRoleAsync(checkConn.GetServer(primary), "master", duration.Value.Subtract(sw.Elapsed)).ForAwait();
+
+        var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
+        if (replicas?.Length > 0)
+        {
+            await Task.Delay(1000).ForAwait();
+            replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
+            await WaitForRoleAsync(checkConn.GetServer(replicas[0]), "slave", duration.Value.Subtract(sw.Elapsed)).ForAwait();
         }
 
-        protected async Task WaitForReplicationAsync(IServer primary, TimeSpan? duration = null)
+        if (waitForReplication)
         {
-            duration ??= TimeSpan.FromSeconds(10);
+            await WaitForReplicationAsync(checkConn.GetServer(primary), duration.Value.Subtract(sw.Elapsed)).ForAwait();
+        }
+    }
 
-            static void LogEndpoints(IServer primary, Action<string> log)
+    protected async Task WaitForRoleAsync(IServer server, string role, TimeSpan? duration = null)
+    {
+        duration ??= TimeSpan.FromSeconds(30);
+
+        Log($"Waiting for server ({server.EndPoint}) role to be \"{role}\"...");
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < duration.Value)
+        {
+            try
             {
-                if (primary.Multiplexer is ConnectionMultiplexer muxer)
+                if (server.Role()?.Value == role)
                 {
-                    var serverEndpoints = muxer.GetServerSnapshot();
-                    log("Endpoints:");
-                    foreach (var serverEndpoint in serverEndpoints)
-                    {
-                        log($"  {serverEndpoint}:");
-                        var server = primary.Multiplexer.GetServer(serverEndpoint.EndPoint);
-                        log($"     Server: (Connected={server.IsConnected}, Type={server.ServerType}, IsReplica={server.IsReplica}, Unselectable={serverEndpoint.GetUnselectableFlags()})");
-                    }
-                }
-            }
-
-            Log("Waiting for primary/replica replication to be in sync...");
-            var sw = Stopwatch.StartNew();
-            while (sw.Elapsed < duration.Value)
-            {
-                var info = primary.Info("replication");
-                var replicationInfo = info.FirstOrDefault(f => f.Key == "Replication")?.ToArray().ToDictionary();
-                var replicaInfo = replicationInfo?.FirstOrDefault(i => i.Key.StartsWith("slave")).Value?.Split(',').ToDictionary(i => i.Split('=').First(), i => i.Split('=').Last());
-                var replicaOffset = replicaInfo?["offset"];
-                var primaryOffset = replicationInfo?["master_repl_offset"];
-
-                if (replicaOffset == primaryOffset)
-                {
-                    Log($"Done waiting for primary ({primaryOffset}) / replica ({replicaOffset}) replication to be in sync");
-                    LogEndpoints(primary, Log);
+                    Log($"Done waiting for server ({server.EndPoint}) role to be \"{role}\"");
                     return;
                 }
-
-                Log($"Waiting for primary ({primaryOffset}) / replica ({replicaOffset}) replication to be in sync...");
-
-                await Task.Delay(250).ForAwait();
+            }
+            catch (Exception)
+            {
+                // ignore
             }
 
-            throw new RedisException("Timeout waiting for test servers primary/replica replication to be in sync.");
+            await Task.Delay(500).ForAwait();
         }
+
+        throw new RedisException($"Timeout waiting for server ({server.EndPoint}) to have expected role (\"{role}\") assigned");
+    }
+
+    protected async Task WaitForReplicationAsync(IServer primary, TimeSpan? duration = null)
+    {
+        duration ??= TimeSpan.FromSeconds(10);
+
+        static void LogEndpoints(IServer primary, Action<string> log)
+        {
+            if (primary.Multiplexer is ConnectionMultiplexer muxer)
+            {
+                var serverEndpoints = muxer.GetServerSnapshot();
+                log("Endpoints:");
+                foreach (var serverEndpoint in serverEndpoints)
+                {
+                    log($"  {serverEndpoint}:");
+                    var server = primary.Multiplexer.GetServer(serverEndpoint.EndPoint);
+                    log($"     Server: (Connected={server.IsConnected}, Type={server.ServerType}, IsReplica={server.IsReplica}, Unselectable={serverEndpoint.GetUnselectableFlags()})");
+                }
+            }
+        }
+
+        Log("Waiting for primary/replica replication to be in sync...");
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < duration.Value)
+        {
+            var info = primary.Info("replication");
+            var replicationInfo = info.FirstOrDefault(f => f.Key == "Replication")?.ToArray().ToDictionary();
+            var replicaInfo = replicationInfo?.FirstOrDefault(i => i.Key.StartsWith("slave")).Value?.Split(',').ToDictionary(i => i.Split('=').First(), i => i.Split('=').Last());
+            var replicaOffset = replicaInfo?["offset"];
+            var primaryOffset = replicationInfo?["master_repl_offset"];
+
+            if (replicaOffset == primaryOffset)
+            {
+                Log($"Done waiting for primary ({primaryOffset}) / replica ({replicaOffset}) replication to be in sync");
+                LogEndpoints(primary, Log);
+                return;
+            }
+
+            Log($"Waiting for primary ({primaryOffset}) / replica ({replicaOffset}) replication to be in sync...");
+
+            await Task.Delay(250).ForAwait();
+        }
+
+        throw new RedisException("Timeout waiting for test servers primary/replica replication to be in sync.");
     }
 }

--- a/tests/StackExchange.Redis.Tests/Sets.cs
+++ b/tests/StackExchange.Redis.Tests/Sets.cs
@@ -4,362 +4,343 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Sets : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Sets : TestBase
+    public Sets(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+
+    [Fact]
+    public void SetContains()
     {
-        public Sets(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+        using var conn = Create(require: RedisFeatures.v6_2_0);
 
-        [Fact]
-        public void SetContains()
+        var key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key);
+        for (int i = 1; i < 1001; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            db.KeyDelete(key);
-            for (int i = 1; i < 1001; i++)
-            {
-                db.SetAdd(key, i, CommandFlags.FireAndForget);
-            }
-
-            // Single member
-            var isMemeber = db.SetContains(key, 1);
-            Assert.True(isMemeber);
-
-            // Multi members
-            var areMemebers = db.SetContains(key, new RedisValue[] { 0, 1, 2 });
-            Assert.Equal(3, areMemebers.Length);
-            Assert.False(areMemebers[0]);
-            Assert.True(areMemebers[1]);
-
-            // key not exists
-            db.KeyDelete(key);
-            isMemeber = db.SetContains(key, 1);
-            Assert.False(isMemeber);
-            areMemebers = db.SetContains(key, new RedisValue[] { 0, 1, 2 });
-            Assert.Equal(3, areMemebers.Length);
-            Assert.True(areMemebers.All(i => !i)); // Check that all the elements are False
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public async Task SetContainsAsync()
+        // Single member
+        var isMemeber = db.SetContains(key, 1);
+        Assert.True(isMemeber);
+
+        // Multi members
+        var areMemebers = db.SetContains(key, new RedisValue[] { 0, 1, 2 });
+        Assert.Equal(3, areMemebers.Length);
+        Assert.False(areMemebers[0]);
+        Assert.True(areMemebers[1]);
+
+        // key not exists
+        db.KeyDelete(key);
+        isMemeber = db.SetContains(key, 1);
+        Assert.False(isMemeber);
+        areMemebers = db.SetContains(key, new RedisValue[] { 0, 1, 2 });
+        Assert.Equal(3, areMemebers.Length);
+        Assert.True(areMemebers.All(i => !i)); // Check that all the elements are False
+    }
+
+    [Fact]
+    public async Task SetContainsAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        await db.KeyDeleteAsync(key);
+        for (int i = 1; i < 1001; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var key = Me();
-            var db = conn.GetDatabase();
-            await db.KeyDeleteAsync(key);
-            for (int i = 1; i < 1001; i++)
-            {
-                db.SetAdd(key, i, CommandFlags.FireAndForget);
-            }
-
-            // Single member
-            var isMemeber = await db.SetContainsAsync(key, 1);
-            Assert.True(isMemeber);
-
-            // Multi members
-            var areMemebers = await db.SetContainsAsync(key, new RedisValue[] { 0, 1, 2 });
-            Assert.Equal(3, areMemebers.Length);
-            Assert.False(areMemebers[0]);
-            Assert.True(areMemebers[1]);
-
-            // key not exists
-            await db.KeyDeleteAsync(key);
-            isMemeber = await db.SetContainsAsync(key, 1);
-            Assert.False(isMemeber);
-            areMemebers = await db.SetContainsAsync(key, new RedisValue[] { 0, 1, 2 });
-            Assert.Equal(3, areMemebers.Length);
-            Assert.True(areMemebers.All(i => !i)); // Check that all the elements are False
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public void SetIntersectionLength()
+        // Single member
+        var isMemeber = await db.SetContainsAsync(key, 1);
+        Assert.True(isMemeber);
+
+        // Multi members
+        var areMemebers = await db.SetContainsAsync(key, new RedisValue[] { 0, 1, 2 });
+        Assert.Equal(3, areMemebers.Length);
+        Assert.False(areMemebers[0]);
+        Assert.True(areMemebers[1]);
+
+        // key not exists
+        await db.KeyDeleteAsync(key);
+        isMemeber = await db.SetContainsAsync(key, 1);
+        Assert.False(isMemeber);
+        areMemebers = await db.SetContainsAsync(key, new RedisValue[] { 0, 1, 2 });
+        Assert.Equal(3, areMemebers.Length);
+        Assert.True(areMemebers.All(i => !i)); // Check that all the elements are False
+    }
+
+    [Fact]
+    public void SetIntersectionLength()
+    {
+        using var conn = Create(require: RedisFeatures.v7_0_0_rc1);
+
+        var db = conn.GetDatabase();
+
+        var key1 = Me() + "1";
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        db.SetAdd(key1, new RedisValue[] { 0, 1, 2, 3, 4 }, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        db.SetAdd(key2, new RedisValue[] { 1, 2, 3, 4, 5 }, CommandFlags.FireAndForget);
+
+        Assert.Equal(4, db.SetIntersectionLength(new RedisKey[]{ key1, key2}));
+        // with limit
+        Assert.Equal(3, db.SetIntersectionLength(new RedisKey[]{ key1, key2}, 3));
+
+        // Missing keys should be 0
+        var key3 = Me() + "3";
+        var key4 = Me() + "4";
+        db.KeyDelete(key3, CommandFlags.FireAndForget);
+        Assert.Equal(0, db.SetIntersectionLength(new RedisKey[] { key1, key3 }));
+        Assert.Equal(0, db.SetIntersectionLength(new RedisKey[] { key3, key4 }));
+    }
+
+    [Fact]
+    public async Task SetIntersectionLengthAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v7_0_0_rc1);
+
+        var db = conn.GetDatabase();
+
+        var key1 = Me() + "1";
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        db.SetAdd(key1, new RedisValue[] { 0, 1, 2, 3, 4 }, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        db.SetAdd(key2, new RedisValue[] { 1, 2, 3, 4, 5 }, CommandFlags.FireAndForget);
+
+        Assert.Equal(4, await db.SetIntersectionLengthAsync(new RedisKey[]{ key1, key2}));
+        // with limit
+        Assert.Equal(3, await db.SetIntersectionLengthAsync(new RedisKey[]{ key1, key2}, 3));
+
+        // Missing keys should be 0
+        var key3 = Me() + "3";
+        var key4 = Me() + "4";
+        db.KeyDelete(key3, CommandFlags.FireAndForget);
+        Assert.Equal(0, await db.SetIntersectionLengthAsync(new RedisKey[] { key1, key3 }));
+        Assert.Equal(0, await db.SetIntersectionLengthAsync(new RedisKey[] { key3, key4 }));
+    }
+
+    [Fact]
+    public void SScan()
+    {
+        using var conn = Create();
+
+        var server = GetAnyPrimary(conn);
+
+        var key = Me();
+        var db = conn.GetDatabase();
+        int totalUnfiltered = 0, totalFiltered = 0;
+        for (int i = 1; i < 1001; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v7_0_0_rc1);
-            var db = conn.GetDatabase();
-
-            var key1 = Me() + "1";
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            db.SetAdd(key1, new RedisValue[] { 0, 1, 2, 3, 4 }, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-            db.SetAdd(key2, new RedisValue[] { 1, 2, 3, 4, 5 }, CommandFlags.FireAndForget);
-
-            Assert.Equal(4, db.SetIntersectionLength(new RedisKey[]{ key1, key2}));
-            // with limit
-            Assert.Equal(3, db.SetIntersectionLength(new RedisKey[]{ key1, key2}, 3));
-
-            // Missing keys should be 0
-            var key3 = Me() + "3";
-            var key4 = Me() + "4";
-            db.KeyDelete(key3, CommandFlags.FireAndForget);
-            Assert.Equal(0, db.SetIntersectionLength(new RedisKey[] { key1, key3 }));
-            Assert.Equal(0, db.SetIntersectionLength(new RedisKey[] { key3, key4 }));
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
+            totalUnfiltered += i;
+            if (i.ToString().Contains('3')) totalFiltered += i;
         }
 
-        [Fact]
-        public async Task SetIntersectionLengthAsync()
+        var unfilteredActual = db.SetScan(key).Select(x => (int)x).Sum();
+        Assert.Equal(totalUnfiltered, unfilteredActual);
+        if (server.Features.Scan)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v7_0_0_rc1);
-            var db = conn.GetDatabase();
+            var filteredActual = db.SetScan(key, "*3*").Select(x => (int)x).Sum();
+            Assert.Equal(totalFiltered, filteredActual);
+        }
+    }
 
-            var key1 = Me() + "1";
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            db.SetAdd(key1, new RedisValue[] { 0, 1, 2, 3, 4 }, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-            db.SetAdd(key2, new RedisValue[] { 1, 2, 3, 4, 5 }, CommandFlags.FireAndForget);
+    [Fact]
+    public async Task SetRemoveArgTests()
+    {
+        using var conn = Create();
 
-            Assert.Equal(4, await db.SetIntersectionLengthAsync(new RedisKey[]{ key1, key2}));
-            // with limit
-            Assert.Equal(3, await db.SetIntersectionLengthAsync(new RedisKey[]{ key1, key2}, 3));
+        var db = conn.GetDatabase();
+        var key = Me();
 
-            // Missing keys should be 0
-            var key3 = Me() + "3";
-            var key4 = Me() + "4";
-            db.KeyDelete(key3, CommandFlags.FireAndForget);
-            Assert.Equal(0, await db.SetIntersectionLengthAsync(new RedisKey[] { key1, key3 }));
-            Assert.Equal(0, await db.SetIntersectionLengthAsync(new RedisKey[] { key3, key4 }));
+        RedisValue[]? values = null;
+        Assert.Throws<ArgumentNullException>(() => db.SetRemove(key, values!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await db.SetRemoveAsync(key, values!).ForAwait()).ForAwait();
+
+        values = Array.Empty<RedisValue>();
+        Assert.Equal(0, db.SetRemove(key, values));
+        Assert.Equal(0, await db.SetRemoveAsync(key, values).ForAwait());
+    }
+
+    [Fact]
+    public void SetPopMulti_Multi()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 1; i < 11; i++)
+        {
+            db.SetAddAsync(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public void SScan()
+        var random = db.SetPop(key);
+        Assert.False(random.IsNull);
+        Assert.True((int)random > 0);
+        Assert.True((int)random <= 10);
+        Assert.Equal(9, db.SetLength(key));
+
+        var moreRandoms = db.SetPop(key, 2);
+        Assert.Equal(2, moreRandoms.Length);
+        Assert.False(moreRandoms[0].IsNull);
+        Assert.Equal(7, db.SetLength(key));
+    }
+
+    [Fact]
+    public void SetPopMulti_Single()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 1; i < 11; i++)
         {
-            using (var conn = Create())
-            {
-                var server = GetAnyPrimary(conn);
-
-                var key = Me();
-                var db = conn.GetDatabase();
-                int totalUnfiltered = 0, totalFiltered = 0;
-                for (int i = 1; i < 1001; i++)
-                {
-                    db.SetAdd(key, i, CommandFlags.FireAndForget);
-                    totalUnfiltered += i;
-                    if (i.ToString().Contains('3')) totalFiltered += i;
-                }
-
-                var unfilteredActual = db.SetScan(key).Select(x => (int)x).Sum();
-                Assert.Equal(totalUnfiltered, unfilteredActual);
-                if (server.Features.Scan)
-                {
-                    var filteredActual = db.SetScan(key, "*3*").Select(x => (int)x).Sum();
-                    Assert.Equal(totalFiltered, filteredActual);
-                }
-            }
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public async Task SetRemoveArgTests()
+        var random = db.SetPop(key);
+        Assert.False(random.IsNull);
+        Assert.True((int)random > 0);
+        Assert.True((int)random <= 10);
+        Assert.Equal(9, db.SetLength(key));
+
+        var moreRandoms = db.SetPop(key, 1);
+        Assert.Single(moreRandoms);
+        Assert.False(moreRandoms[0].IsNull);
+        Assert.Equal(8, db.SetLength(key));
+    }
+
+    [Fact]
+    public async Task SetPopMulti_Multi_Async()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 1; i < 11; i++)
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                RedisValue[]? values = null;
-                Assert.Throws<ArgumentNullException>(() => db.SetRemove(key, values!));
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await db.SetRemoveAsync(key, values!).ForAwait()).ForAwait();
-
-                values = Array.Empty<RedisValue>();
-                Assert.Equal(0, db.SetRemove(key, values));
-                Assert.Equal(0, await db.SetRemoveAsync(key, values).ForAwait());
-            }
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public void SetPopMulti_Multi()
+        var random = await db.SetPopAsync(key).ForAwait();
+        Assert.False(random.IsNull);
+        Assert.True((int)random > 0);
+        Assert.True((int)random <= 10);
+        Assert.Equal(9, db.SetLength(key));
+
+        var moreRandoms = await db.SetPopAsync(key, 2).ForAwait();
+        Assert.Equal(2, moreRandoms.Length);
+        Assert.False(moreRandoms[0].IsNull);
+        Assert.Equal(7, db.SetLength(key));
+    }
+
+    [Fact]
+    public async Task SetPopMulti_Single_Async()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 1; i < 11; i++)
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                for (int i = 1; i < 11; i++)
-                {
-                    db.SetAddAsync(key, i, CommandFlags.FireAndForget);
-                }
-
-                var random = db.SetPop(key);
-                Assert.False(random.IsNull);
-                Assert.True((int)random > 0);
-                Assert.True((int)random <= 10);
-                Assert.Equal(9, db.SetLength(key));
-
-                var moreRandoms = db.SetPop(key, 2);
-                Assert.Equal(2, moreRandoms.Length);
-                Assert.False(moreRandoms[0].IsNull);
-                Assert.Equal(7, db.SetLength(key));
-            }
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public void SetPopMulti_Single()
+        var random = await db.SetPopAsync(key).ForAwait();
+        Assert.False(random.IsNull);
+        Assert.True((int)random > 0);
+        Assert.True((int)random <= 10);
+        Assert.Equal(9, db.SetLength(key));
+
+        var moreRandoms = db.SetPop(key, 1);
+        Assert.Single(moreRandoms);
+        Assert.False(moreRandoms[0].IsNull);
+        Assert.Equal(8, db.SetLength(key));
+    }
+
+    [Fact]
+    public async Task SetPopMulti_Zero_Async()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 1; i < 11; i++)
         {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                for (int i = 1; i < 11; i++)
-                {
-                    db.SetAdd(key, i, CommandFlags.FireAndForget);
-                }
-
-                var random = db.SetPop(key);
-                Assert.False(random.IsNull);
-                Assert.True((int)random > 0);
-                Assert.True((int)random <= 10);
-                Assert.Equal(9, db.SetLength(key));
-
-                var moreRandoms = db.SetPop(key, 1);
-                Assert.Single(moreRandoms);
-                Assert.False(moreRandoms[0].IsNull);
-                Assert.Equal(8, db.SetLength(key));
-            }
+            db.SetAdd(key, i, CommandFlags.FireAndForget);
         }
 
-        [Fact]
-        public async Task SetPopMulti_Multi_Async()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
+        var t = db.SetPopAsync(key, count: 0);
+        Assert.True(t.IsCompleted); // sync
+        var arr = await t;
+        Assert.Empty(arr);
 
-                var db = conn.GetDatabase();
-                var key = Me();
+        Assert.Equal(10, db.SetLength(key));
+    }
 
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                for (int i = 1; i < 11; i++)
-                {
-                    db.SetAdd(key, i, CommandFlags.FireAndForget);
-                }
+    [Fact]
+    public void SetAdd_Zero()
+    {
+        using var conn = Create();
 
-                var random = await db.SetPopAsync(key).ForAwait();
-                Assert.False(random.IsNull);
-                Assert.True((int)random > 0);
-                Assert.True((int)random <= 10);
-                Assert.Equal(9, db.SetLength(key));
+        var db = conn.GetDatabase();
+        var key = Me();
 
-                var moreRandoms = await db.SetPopAsync(key, 2).ForAwait();
-                Assert.Equal(2, moreRandoms.Length);
-                Assert.False(moreRandoms[0].IsNull);
-                Assert.Equal(7, db.SetLength(key));
-            }
-        }
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-        [Fact]
-        public async Task SetPopMulti_Single_Async()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
+        var result = db.SetAdd(key, Array.Empty<RedisValue>());
+        Assert.Equal(0, result);
 
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                for (int i = 1; i < 11; i++)
-                {
-                    db.SetAdd(key, i, CommandFlags.FireAndForget);
-                }
+        Assert.Equal(0, db.SetLength(key));
+    }
 
-                var random = await db.SetPopAsync(key).ForAwait();
-                Assert.False(random.IsNull);
-                Assert.True((int)random > 0);
-                Assert.True((int)random <= 10);
-                Assert.Equal(9, db.SetLength(key));
+    [Fact]
+    public async Task SetAdd_Zero_Async()
+    {
+        using var conn = Create();
 
-                var moreRandoms = db.SetPop(key, 1);
-                Assert.Single(moreRandoms);
-                Assert.False(moreRandoms[0].IsNull);
-                Assert.Equal(8, db.SetLength(key));
-            }
-        }
+        var db = conn.GetDatabase();
+        var key = Me();
 
-        [Fact]
-        public async Task SetPopMulti_Zero_Async()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                for (int i = 1; i < 11; i++)
-                {
-                    db.SetAdd(key, i, CommandFlags.FireAndForget);
-                }
+        var t = db.SetAddAsync(key, Array.Empty<RedisValue>());
+        Assert.True(t.IsCompleted); // sync
+        var count = await t;
+        Assert.Equal(0, count);
 
-                var t = db.SetPopAsync(key, count: 0);
-                Assert.True(t.IsCompleted); // sync
-                var arr = await t;
-                Assert.Empty(arr);
+        Assert.Equal(0, db.SetLength(key));
+    }
 
-                Assert.Equal(10, db.SetLength(key));
-            }
-        }
+    [Fact]
+    public void SetPopMulti_Nil()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
 
-        [Fact]
-        public void SetAdd_Zero()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
+        var db = conn.GetDatabase();
+        var key = Me();
 
-                db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key, CommandFlags.FireAndForget);
 
-                var result = db.SetAdd(key, Array.Empty<RedisValue>());
-                Assert.Equal(0, result);
-
-                Assert.Equal(0, db.SetLength(key));
-            }
-        }
-
-        [Fact]
-        public async Task SetAdd_Zero_Async()
-        {
-            using (var conn = Create())
-            {
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var t = db.SetAddAsync(key, Array.Empty<RedisValue>());
-                Assert.True(t.IsCompleted); // sync
-                var count = await t;
-                Assert.Equal(0, count);
-
-                Assert.Equal(0, db.SetLength(key));
-            }
-        }
-
-        [Fact]
-        public void SetPopMulti_Nil()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-
-                var arr = db.SetPop(key, 1);
-                Assert.Empty(arr);
-            }
-        }
+        var arr = db.SetPop(key, 1);
+        Assert.Empty(arr);
     }
 }

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -8,234 +8,233 @@ using System.Threading.Tasks;
 using StackExchange.Redis.Profiling;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class SharedConnectionFixture : IDisposable
 {
-    public class SharedConnectionFixture : IDisposable
+    public bool IsEnabled { get; }
+
+    public const string Key = "Shared Muxer";
+    private readonly ConnectionMultiplexer _actualConnection;
+    internal IInternalConnectionMultiplexer Connection { get; }
+    public string Configuration { get; }
+
+    public SharedConnectionFixture()
     {
-        public bool IsEnabled { get; }
+        IsEnabled = TestConfig.Current.UseSharedConnection;
+        Configuration = TestBase.GetDefaultConfiguration();
+        _actualConnection = TestBase.CreateDefault(
+            output: null,
+            clientName: nameof(SharedConnectionFixture),
+            configuration: Configuration,
+            allowAdmin: true
+        );
+        _actualConnection.InternalError += OnInternalError;
+        _actualConnection.ConnectionFailed += OnConnectionFailed;
 
-        public const string Key = "Shared Muxer";
-        private readonly ConnectionMultiplexer _actualConnection;
-        internal IInternalConnectionMultiplexer Connection { get; }
-        public string Configuration { get; }
+        Connection = new NonDisposingConnection(_actualConnection);
+    }
 
-        public SharedConnectionFixture()
+    private class NonDisposingConnection : IInternalConnectionMultiplexer
+    {
+        public bool AllowConnect
         {
-            IsEnabled = TestConfig.Current.UseSharedConnection;
-            Configuration = TestBase.GetDefaultConfiguration();
-            _actualConnection = TestBase.CreateDefault(
-                output: null,
-                clientName: nameof(SharedConnectionFixture),
-                configuration: Configuration,
-                allowAdmin: true
-            );
-            _actualConnection.InternalError += OnInternalError;
-            _actualConnection.ConnectionFailed += OnConnectionFailed;
-
-            Connection = new NonDisposingConnection(_actualConnection);
+            get => _inner.AllowConnect;
+            set => _inner.AllowConnect = value;
         }
 
-        private class NonDisposingConnection : IInternalConnectionMultiplexer
+        public bool IgnoreConnect
         {
-            public bool AllowConnect
-            {
-                get => _inner.AllowConnect;
-                set => _inner.AllowConnect = value;
-            }
+            get => _inner.IgnoreConnect;
+            set => _inner.IgnoreConnect = value;
+        }
 
-            public bool IgnoreConnect
-            {
-                get => _inner.IgnoreConnect;
-                set => _inner.IgnoreConnect = value;
-            }
+        public ReadOnlySpan<ServerEndPoint> GetServerSnapshot() => _inner.GetServerSnapshot();
 
-            public ReadOnlySpan<ServerEndPoint> GetServerSnapshot() => _inner.GetServerSnapshot();
+        private readonly IInternalConnectionMultiplexer _inner;
+        public NonDisposingConnection(IInternalConnectionMultiplexer inner) => _inner = inner;
 
-            private readonly IInternalConnectionMultiplexer _inner;
-            public NonDisposingConnection(IInternalConnectionMultiplexer inner) => _inner = inner;
+        public string ClientName => _inner.ClientName;
 
-            public string ClientName => _inner.ClientName;
+        public string Configuration => _inner.Configuration;
 
-            public string Configuration => _inner.Configuration;
+        public int TimeoutMilliseconds => _inner.TimeoutMilliseconds;
 
-            public int TimeoutMilliseconds => _inner.TimeoutMilliseconds;
-
-            public long OperationCount => _inner.OperationCount;
+        public long OperationCount => _inner.OperationCount;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            public bool PreserveAsyncOrder { get => false; set { } }
+        public bool PreserveAsyncOrder { get => false; set { } }
 #pragma warning restore CS0618
 
-            public bool IsConnected => _inner.IsConnected;
+        public bool IsConnected => _inner.IsConnected;
 
-            public bool IsConnecting => _inner.IsConnecting;
+        public bool IsConnecting => _inner.IsConnecting;
 
-            public ConfigurationOptions RawConfig => _inner.RawConfig;
+        public ConfigurationOptions RawConfig => _inner.RawConfig;
 
-            public bool IncludeDetailInExceptions { get => _inner.RawConfig.IncludeDetailInExceptions; set => _inner.RawConfig.IncludeDetailInExceptions = value; }
+        public bool IncludeDetailInExceptions { get => _inner.RawConfig.IncludeDetailInExceptions; set => _inner.RawConfig.IncludeDetailInExceptions = value; }
 
-            public int StormLogThreshold { get => _inner.StormLogThreshold; set => _inner.StormLogThreshold = value; }
+        public int StormLogThreshold { get => _inner.StormLogThreshold; set => _inner.StormLogThreshold = value; }
 
-            public event EventHandler<RedisErrorEventArgs> ErrorMessage
-            {
-                add => _inner.ErrorMessage += value;
-                remove => _inner.ErrorMessage -= value;
-            }
-
-            public event EventHandler<ConnectionFailedEventArgs> ConnectionFailed
-            {
-                add => _inner.ConnectionFailed += value;
-                remove => _inner.ConnectionFailed -= value;
-            }
-
-            public event EventHandler<InternalErrorEventArgs> InternalError
-            {
-                add => _inner.InternalError += value;
-                remove => _inner.InternalError -= value;
-            }
-
-            public event EventHandler<ConnectionFailedEventArgs> ConnectionRestored
-            {
-                add => _inner.ConnectionRestored += value;
-                remove => _inner.ConnectionRestored -= value;
-            }
-
-            public event EventHandler<EndPointEventArgs> ConfigurationChanged
-            {
-                add => _inner.ConfigurationChanged += value;
-                remove => _inner.ConfigurationChanged -= value;
-            }
-
-            public event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast
-            {
-                add => _inner.ConfigurationChangedBroadcast += value;
-                remove => _inner.ConfigurationChangedBroadcast -= value;
-            }
-
-            public event EventHandler<HashSlotMovedEventArgs> HashSlotMoved
-            {
-                add => _inner.HashSlotMoved += value;
-                remove => _inner.HashSlotMoved -= value;
-            }
-
-            public void Close(bool allowCommandsToComplete = true) => _inner.Close(allowCommandsToComplete);
-
-            public Task CloseAsync(bool allowCommandsToComplete = true) => _inner.CloseAsync(allowCommandsToComplete);
-
-            public bool Configure(TextWriter? log = null) => _inner.Configure(log);
-
-            public Task<bool> ConfigureAsync(TextWriter? log = null) => _inner.ConfigureAsync(log);
-
-            public void Dispose() { } // DO NOT call _inner.Dispose();
-
-            public ServerCounters GetCounters() => _inner.GetCounters();
-
-            public IDatabase GetDatabase(int db = -1, object? asyncState = null) => _inner.GetDatabase(db, asyncState);
-
-            public EndPoint[] GetEndPoints(bool configuredOnly = false) => _inner.GetEndPoints(configuredOnly);
-
-            public int GetHashSlot(RedisKey key) => _inner.GetHashSlot(key);
-
-            public IServer GetServer(string host, int port, object? asyncState = null) => _inner.GetServer(host, port, asyncState);
-
-            public IServer GetServer(string hostAndPort, object? asyncState = null) => _inner.GetServer(hostAndPort, asyncState);
-
-            public IServer GetServer(IPAddress host, int port) => _inner.GetServer(host, port);
-
-            public IServer GetServer(EndPoint endpoint, object? asyncState = null) => _inner.GetServer(endpoint, asyncState);
-
-            public string GetStatus() => _inner.GetStatus();
-
-            public void GetStatus(TextWriter log) => _inner.GetStatus(log);
-
-            public string? GetStormLog() => _inner.GetStormLog();
-
-            public ISubscriber GetSubscriber(object? asyncState = null) => _inner.GetSubscriber(asyncState);
-
-            public int HashSlot(RedisKey key) => _inner.HashSlot(key);
-
-            public long PublishReconfigure(CommandFlags flags = CommandFlags.None) => _inner.PublishReconfigure(flags);
-
-            public Task<long> PublishReconfigureAsync(CommandFlags flags = CommandFlags.None) => _inner.PublishReconfigureAsync(flags);
-
-            public void RegisterProfiler(Func<ProfilingSession> profilingSessionProvider) => _inner.RegisterProfiler(profilingSessionProvider);
-
-            public void ResetStormLog() => _inner.ResetStormLog();
-
-            public void Wait(Task task) => _inner.Wait(task);
-
-            public T Wait<T>(Task<T> task) => _inner.Wait(task);
-
-            public void WaitAll(params Task[] tasks) => _inner.WaitAll(tasks);
-
-            public void ExportConfiguration(Stream destination, ExportOptions options = ExportOptions.All)
-                => _inner.ExportConfiguration(destination, options);
-
-            public override string ToString() => _inner.ToString();
-        }
-
-        public void Dispose()
+        public event EventHandler<RedisErrorEventArgs> ErrorMessage
         {
-            _actualConnection.Dispose();
-            GC.SuppressFinalize(this);
+            add => _inner.ErrorMessage += value;
+            remove => _inner.ErrorMessage -= value;
         }
 
-        protected void OnInternalError(object? sender, InternalErrorEventArgs e)
+        public event EventHandler<ConnectionFailedEventArgs> ConnectionFailed
         {
-            Interlocked.Increment(ref privateFailCount);
-            lock (privateExceptions)
-            {
-                privateExceptions.Add(TestBase.Time() + ": Internal error: " + e.Origin + ", " + EndPointCollection.ToString(e.EndPoint) + "/" + e.ConnectionType);
-            }
+            add => _inner.ConnectionFailed += value;
+            remove => _inner.ConnectionFailed -= value;
         }
-        protected void OnConnectionFailed(object? sender, ConnectionFailedEventArgs e)
+
+        public event EventHandler<InternalErrorEventArgs> InternalError
         {
-            Interlocked.Increment(ref privateFailCount);
-            lock (privateExceptions)
-            {
-                privateExceptions.Add($"{TestBase.Time()}: Connection failed ({e.FailureType}): {EndPointCollection.ToString(e.EndPoint)}/{e.ConnectionType}: {e.Exception}");
-            }
+            add => _inner.InternalError += value;
+            remove => _inner.InternalError -= value;
         }
-        private readonly List<string> privateExceptions = new List<string>();
-        private int privateFailCount;
 
-        public void Teardown(TextWriter output)
+        public event EventHandler<ConnectionFailedEventArgs> ConnectionRestored
         {
-            var innerPrivateFailCount = Interlocked.Exchange(ref privateFailCount, 0);
-            if (innerPrivateFailCount != 0)
-            {
-                lock (privateExceptions)
-                {
-                    foreach (var item in privateExceptions.Take(5))
-                    {
-                        TestBase.LogNoTime(output, item);
-                    }
-                    privateExceptions.Clear();
-                }
-                //Assert.True(false, $"There were {privateFailCount} private ambient exceptions.");
-            }
-
-            if (_actualConnection != null)
-            {
-                TestBase.Log(output, "Connection Counts: " + _actualConnection.GetCounters().ToString());
-                foreach (var ep in _actualConnection.GetServerSnapshot())
-                {
-                    var interactive = ep.GetBridge(ConnectionType.Interactive);
-                    TestBase.Log(output, $"  {Format.ToString(interactive)}: " + interactive?.GetStatus());
-
-                    var subscription = ep.GetBridge(ConnectionType.Subscription);
-                    TestBase.Log(output, $"  {Format.ToString(subscription)}: " + subscription?.GetStatus());
-                }
-            }
+            add => _inner.ConnectionRestored += value;
+            remove => _inner.ConnectionRestored -= value;
         }
+
+        public event EventHandler<EndPointEventArgs> ConfigurationChanged
+        {
+            add => _inner.ConfigurationChanged += value;
+            remove => _inner.ConfigurationChanged -= value;
+        }
+
+        public event EventHandler<EndPointEventArgs> ConfigurationChangedBroadcast
+        {
+            add => _inner.ConfigurationChangedBroadcast += value;
+            remove => _inner.ConfigurationChangedBroadcast -= value;
+        }
+
+        public event EventHandler<HashSlotMovedEventArgs> HashSlotMoved
+        {
+            add => _inner.HashSlotMoved += value;
+            remove => _inner.HashSlotMoved -= value;
+        }
+
+        public void Close(bool allowCommandsToComplete = true) => _inner.Close(allowCommandsToComplete);
+
+        public Task CloseAsync(bool allowCommandsToComplete = true) => _inner.CloseAsync(allowCommandsToComplete);
+
+        public bool Configure(TextWriter? log = null) => _inner.Configure(log);
+
+        public Task<bool> ConfigureAsync(TextWriter? log = null) => _inner.ConfigureAsync(log);
+
+        public void Dispose() { } // DO NOT call _inner.Dispose();
+
+        public ServerCounters GetCounters() => _inner.GetCounters();
+
+        public IDatabase GetDatabase(int db = -1, object? asyncState = null) => _inner.GetDatabase(db, asyncState);
+
+        public EndPoint[] GetEndPoints(bool configuredOnly = false) => _inner.GetEndPoints(configuredOnly);
+
+        public int GetHashSlot(RedisKey key) => _inner.GetHashSlot(key);
+
+        public IServer GetServer(string host, int port, object? asyncState = null) => _inner.GetServer(host, port, asyncState);
+
+        public IServer GetServer(string hostAndPort, object? asyncState = null) => _inner.GetServer(hostAndPort, asyncState);
+
+        public IServer GetServer(IPAddress host, int port) => _inner.GetServer(host, port);
+
+        public IServer GetServer(EndPoint endpoint, object? asyncState = null) => _inner.GetServer(endpoint, asyncState);
+
+        public string GetStatus() => _inner.GetStatus();
+
+        public void GetStatus(TextWriter log) => _inner.GetStatus(log);
+
+        public string? GetStormLog() => _inner.GetStormLog();
+
+        public ISubscriber GetSubscriber(object? asyncState = null) => _inner.GetSubscriber(asyncState);
+
+        public int HashSlot(RedisKey key) => _inner.HashSlot(key);
+
+        public long PublishReconfigure(CommandFlags flags = CommandFlags.None) => _inner.PublishReconfigure(flags);
+
+        public Task<long> PublishReconfigureAsync(CommandFlags flags = CommandFlags.None) => _inner.PublishReconfigureAsync(flags);
+
+        public void RegisterProfiler(Func<ProfilingSession> profilingSessionProvider) => _inner.RegisterProfiler(profilingSessionProvider);
+
+        public void ResetStormLog() => _inner.ResetStormLog();
+
+        public void Wait(Task task) => _inner.Wait(task);
+
+        public T Wait<T>(Task<T> task) => _inner.Wait(task);
+
+        public void WaitAll(params Task[] tasks) => _inner.WaitAll(tasks);
+
+        public void ExportConfiguration(Stream destination, ExportOptions options = ExportOptions.All)
+            => _inner.ExportConfiguration(destination, options);
+
+        public override string ToString() => _inner.ToString();
     }
 
-    // https://stackoverflow.com/questions/13829737/xunit-net-run-code-once-before-and-after-all-tests
-    [CollectionDefinition(SharedConnectionFixture.Key)]
-    public class ConnectionCollection : ICollectionFixture<SharedConnectionFixture>
+    public void Dispose()
     {
-        // This class has no code, and is never created. Its purpose is simply
-        // to be the place to apply [CollectionDefinition] and all the
-        // ICollectionFixture<> interfaces.
+        _actualConnection.Dispose();
+        GC.SuppressFinalize(this);
     }
+
+    protected void OnInternalError(object? sender, InternalErrorEventArgs e)
+    {
+        Interlocked.Increment(ref privateFailCount);
+        lock (privateExceptions)
+        {
+            privateExceptions.Add(TestBase.Time() + ": Internal error: " + e.Origin + ", " + EndPointCollection.ToString(e.EndPoint) + "/" + e.ConnectionType);
+        }
+    }
+    protected void OnConnectionFailed(object? sender, ConnectionFailedEventArgs e)
+    {
+        Interlocked.Increment(ref privateFailCount);
+        lock (privateExceptions)
+        {
+            privateExceptions.Add($"{TestBase.Time()}: Connection failed ({e.FailureType}): {EndPointCollection.ToString(e.EndPoint)}/{e.ConnectionType}: {e.Exception}");
+        }
+    }
+    private readonly List<string> privateExceptions = new List<string>();
+    private int privateFailCount;
+
+    public void Teardown(TextWriter output)
+    {
+        var innerPrivateFailCount = Interlocked.Exchange(ref privateFailCount, 0);
+        if (innerPrivateFailCount != 0)
+        {
+            lock (privateExceptions)
+            {
+                foreach (var item in privateExceptions.Take(5))
+                {
+                    TestBase.LogNoTime(output, item);
+                }
+                privateExceptions.Clear();
+            }
+            //Assert.True(false, $"There were {privateFailCount} private ambient exceptions.");
+        }
+
+        if (_actualConnection != null)
+        {
+            TestBase.Log(output, "Connection Counts: " + _actualConnection.GetCounters().ToString());
+            foreach (var ep in _actualConnection.GetServerSnapshot())
+            {
+                var interactive = ep.GetBridge(ConnectionType.Interactive);
+                TestBase.Log(output, $"  {Format.ToString(interactive)}: " + interactive?.GetStatus());
+
+                var subscription = ep.GetBridge(ConnectionType.Subscription);
+                TestBase.Log(output, $"  {Format.ToString(subscription)}: " + subscription?.GetStatus());
+            }
+        }
+    }
+}
+
+// https://stackoverflow.com/questions/13829737/xunit-net-run-code-once-before-and-after-all-tests
+[CollectionDefinition(SharedConnectionFixture.Key)]
+public class ConnectionCollection : ICollectionFixture<SharedConnectionFixture>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
 }

--- a/tests/StackExchange.Redis.Tests/Sockets.cs
+++ b/tests/StackExchange.Redis.Tests/Sockets.cs
@@ -1,32 +1,29 @@
 ﻿using System.Diagnostics;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Sockets : TestBase
 {
-    public class Sockets : TestBase
+    protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+    public Sockets(ITestOutputHelper output) : base (output) { }
+
+    [FactLongRunning]
+    public void CheckForSocketLeaks()
     {
-        protected override string GetConfiguration() => TestConfig.Current.PrimaryServerAndPort;
-        public Sockets(ITestOutputHelper output) : base (output) { }
-
-        [FactLongRunning]
-        public void CheckForSocketLeaks()
+        const int count = 2000;
+        for (var i = 0; i < count; i++)
         {
-            const int count = 2000;
-            for (var i = 0; i < count; i++)
-            {
-                using (var _ = Create(clientName: "Test: " + i))
-                {
-                    // Intentionally just creating and disposing to leak sockets here
-                    // ...so we can figure out what's happening.
-                }
-            }
-            // Force GC before memory dump in debug below...
-            CollectGarbage();
+            using var _ = Create(clientName: "Test: " + i);
+            // Intentionally just creating and disposing to leak sockets here
+            // ...so we can figure out what's happening.
+        }
+        // Force GC before memory dump in debug below...
+        CollectGarbage();
 
-            if (Debugger.IsAttached)
-            {
-                Debugger.Break();
-            }
+        if (Debugger.IsAttached)
+        {
+            Debugger.Break();
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/SortedSets.cs
+++ b/tests/StackExchange.Redis.Tests/SortedSets.cs
@@ -3,1277 +3,1214 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class SortedSets : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class SortedSets : TestBase
+    public SortedSets(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    private static readonly SortedSetEntry[] entries = new SortedSetEntry[]
     {
-        public SortedSets(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        new SortedSetEntry("a", 1),
+        new SortedSetEntry("b", 2),
+        new SortedSetEntry("c", 3),
+        new SortedSetEntry("d", 4),
+        new SortedSetEntry("e", 5),
+        new SortedSetEntry("f", 6),
+        new SortedSetEntry("g", 7),
+        new SortedSetEntry("h", 8),
+        new SortedSetEntry("i", 9),
+        new SortedSetEntry("j", 10)
+    };
 
-        private static readonly SortedSetEntry[] entries = new SortedSetEntry[]
+    private static readonly SortedSetEntry[] entriesPow2 = new SortedSetEntry[]
+    {
+        new SortedSetEntry("a", 1),
+        new SortedSetEntry("b", 2),
+        new SortedSetEntry("c", 4),
+        new SortedSetEntry("d", 8),
+        new SortedSetEntry("e", 16),
+        new SortedSetEntry("f", 32),
+        new SortedSetEntry("g", 64),
+        new SortedSetEntry("h", 128),
+        new SortedSetEntry("i", 256),
+        new SortedSetEntry("j", 512)
+    };
+
+    private static readonly SortedSetEntry[] entriesPow3 = new SortedSetEntry[]
+    {
+        new SortedSetEntry("a", 1),
+        new SortedSetEntry("c", 4),
+        new SortedSetEntry("e", 16),
+        new SortedSetEntry("g", 64),
+        new SortedSetEntry("i", 256),
+    };
+
+    private static readonly SortedSetEntry[] lexEntries = new SortedSetEntry[]
+    {
+        new SortedSetEntry("a", 0),
+        new SortedSetEntry("b", 0),
+        new SortedSetEntry("c", 0),
+        new SortedSetEntry("d", 0),
+        new SortedSetEntry("e", 0),
+        new SortedSetEntry("f", 0),
+        new SortedSetEntry("g", 0),
+        new SortedSetEntry("h", 0),
+        new SortedSetEntry("i", 0),
+        new SortedSetEntry("j", 0)
+    };
+
+    [Fact]
+    public void SortedSetCombine()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var diff = db.SortedSetCombine(SetOperation.Difference, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, diff.Length);
+        Assert.Equal("b", diff[0]);
+
+        var inter = db.SortedSetCombine(SetOperation.Intersect, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter.Length);
+        Assert.Equal("a", inter[0]);
+
+        var union = db.SortedSetCombine(SetOperation.Union, new RedisKey[] { key1, key2 });
+        Assert.Equal(10, union.Length);
+        Assert.Equal("a", union[0]);
+    }
+
+    [Fact]
+    public async Task SortedSetCombineAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var diff = await db.SortedSetCombineAsync(SetOperation.Difference, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, diff.Length);
+        Assert.Equal("b", diff[0]);
+
+        var inter = await db.SortedSetCombineAsync(SetOperation.Intersect, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter.Length);
+        Assert.Equal("a", inter[0]);
+
+        var union = await db.SortedSetCombineAsync(SetOperation.Union, new RedisKey[] { key1, key2 });
+        Assert.Equal(10, union.Length);
+        Assert.Equal("a", union[0]);
+    }
+
+    [Fact]
+    public void SortedSetCombineWithScores()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var diff = db.SortedSetCombineWithScores(SetOperation.Difference, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, diff.Length);
+        Assert.Equal(new SortedSetEntry("b", 2), diff[0]);
+
+        var inter = db.SortedSetCombineWithScores(SetOperation.Intersect, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter.Length);
+        Assert.Equal(new SortedSetEntry("a", 2), inter[0]);
+
+        var union = db.SortedSetCombineWithScores(SetOperation.Union, new RedisKey[] { key1, key2 });
+        Assert.Equal(10, union.Length);
+        Assert.Equal(new SortedSetEntry("a", 2), union[0]);
+    }
+
+    [Fact]
+    public async Task SortedSetCombineWithScoresAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var diff = await db.SortedSetCombineWithScoresAsync(SetOperation.Difference, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, diff.Length);
+        Assert.Equal(new SortedSetEntry("b", 2), diff[0]);
+
+        var inter = await db.SortedSetCombineWithScoresAsync(SetOperation.Intersect, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter.Length);
+        Assert.Equal(new SortedSetEntry("a", 2), inter[0]);
+
+        var union = await db.SortedSetCombineWithScoresAsync(SetOperation.Union, new RedisKey[] { key1, key2 });
+        Assert.Equal(10, union.Length);
+        Assert.Equal(new SortedSetEntry("a", 2), union[0]);
+    }
+
+    [Fact]
+    public void SortedSetCombineAndStore()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        var destination = Me() + "dest";
+        db.KeyDelete(destination, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var diff = db.SortedSetCombineAndStore(SetOperation.Difference, destination, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, diff);
+
+        var inter = db.SortedSetCombineAndStore(SetOperation.Intersect, destination, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter);
+
+        var union = db.SortedSetCombineAndStore(SetOperation.Union, destination, new RedisKey[] { key1, key2 });
+        Assert.Equal(10, union);
+    }
+
+    [Fact]
+    public async Task SortedSetCombineAndStoreAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        var destination = Me() + "dest";
+        db.KeyDelete(destination, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var diff = await db.SortedSetCombineAndStoreAsync(SetOperation.Difference, destination, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, diff);
+
+        var inter = await db.SortedSetCombineAndStoreAsync(SetOperation.Intersect, destination, new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter);
+
+        var union = await db.SortedSetCombineAndStoreAsync(SetOperation.Union, destination, new RedisKey[] { key1, key2 });
+        Assert.Equal(10, union);
+    }
+
+    [Fact]
+    public async Task SortedSetCombineErrors()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        var destination = Me() + "dest";
+        db.KeyDelete(destination, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        // ZDIFF can't be used with weights
+        var ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombine(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineWithScores(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineAndStore(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
+        Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
+        // and Async...
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineWithScoresAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAndStoreAsync(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
+        Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
+
+        // ZDIFF can't be used with aggregation
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombine(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineWithScores(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineAndStore(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
+        Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
+        // and Async...
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineWithScoresAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
+        Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAndStoreAsync(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
+        Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
+
+        // Too many weights
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombine(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
+        Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineWithScores(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
+        Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+        ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineAndStore(SetOperation.Union, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
+        Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+        // and Async...
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAsync(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
+        Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineWithScoresAsync(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
+        Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+        ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAndStoreAsync(SetOperation.Union, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
+        Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+    }
+
+    [Fact]
+    public void SortedSetIntersectionLength()
+    {
+        using var conn = Create(require: RedisFeatures.v7_0_0_rc1);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var inter = db.SortedSetIntersectionLength(new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter);
+
+        // with limit
+        inter = db.SortedSetIntersectionLength(new RedisKey[] { key1, key2 }, 3);
+        Assert.Equal(3, inter);
+    }
+
+    [Fact]
+    public async Task SortedSetIntersectionLengthAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v7_0_0_rc1);
+
+        var db = conn.GetDatabase();
+        var key1 = Me();
+        db.KeyDelete(key1, CommandFlags.FireAndForget);
+        var key2 = Me() + "2";
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        db.SortedSetAdd(key1, entries);
+        db.SortedSetAdd(key2, entriesPow3);
+
+        var inter = await db.SortedSetIntersectionLengthAsync(new RedisKey[] { key1, key2 });
+        Assert.Equal(5, inter);
+
+        // with limit
+        inter = await db.SortedSetIntersectionLengthAsync(new RedisKey[] { key1, key2 }, 3);
+        Assert.Equal(3, inter);
+    }
+
+    [Fact]
+    public void SortedSetPopMulti_Multi()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        var first = db.SortedSetPop(key, Order.Ascending);
+        Assert.True(first.HasValue);
+        Assert.Equal(entries[0], first.Value);
+        Assert.Equal(9, db.SortedSetLength(key));
+
+        var lasts = db.SortedSetPop(key, 2, Order.Descending);
+        Assert.Equal(2, lasts.Length);
+        Assert.Equal(entries[9], lasts[0]);
+        Assert.Equal(entries[8], lasts[1]);
+        Assert.Equal(7, db.SortedSetLength(key));
+    }
+
+    [Fact]
+    public void SortedSetPopMulti_Single()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        var last = db.SortedSetPop(key, Order.Descending);
+        Assert.True(last.HasValue);
+        Assert.Equal(entries[9], last.Value);
+        Assert.Equal(9, db.SortedSetLength(key));
+
+        var firsts = db.SortedSetPop(key, 1, Order.Ascending);
+        Assert.Single(firsts);
+        Assert.Equal(entries[0], firsts[0]);
+        Assert.Equal(8, db.SortedSetLength(key));
+    }
+
+    [Fact]
+    public async Task SortedSetPopMulti_Multi_Async()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        var last = await db.SortedSetPopAsync(key, Order.Descending).ForAwait();
+        Assert.True(last.HasValue);
+        Assert.Equal(entries[9], last.Value);
+        Assert.Equal(9, db.SortedSetLength(key));
+
+        var moreLasts = await db.SortedSetPopAsync(key, 2, Order.Descending).ForAwait();
+        Assert.Equal(2, moreLasts.Length);
+        Assert.Equal(entries[8], moreLasts[0]);
+        Assert.Equal(entries[7], moreLasts[1]);
+        Assert.Equal(7, db.SortedSetLength(key));
+    }
+
+    [Fact]
+    public async Task SortedSetPopMulti_Single_Async()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        var first = await db.SortedSetPopAsync(key).ForAwait();
+        Assert.True(first.HasValue);
+        Assert.Equal(entries[0], first.Value);
+        Assert.Equal(9, db.SortedSetLength(key));
+
+        var moreFirsts = await db.SortedSetPopAsync(key, 1).ForAwait();
+        Assert.Single(moreFirsts);
+        Assert.Equal(entries[1], moreFirsts[0]);
+        Assert.Equal(8, db.SortedSetLength(key));
+    }
+
+    [Fact]
+    public async Task SortedSetPopMulti_Zero_Async()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        var t = db.SortedSetPopAsync(key, count: 0);
+        Assert.True(t.IsCompleted); // sync
+        var arr = await t;
+        Assert.NotNull(arr);
+        Assert.Empty(arr);
+
+        Assert.Equal(10, db.SortedSetLength(key));
+    }
+
+    [Fact]
+    public void SortedSetRandomMembers()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        var key0 = Me() + "non-existing";
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key0, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        // single member
+        var randMember = db.SortedSetRandomMember(key);
+        Assert.True(Array.Exists(entries, element => element.Element.Equals(randMember)));
+
+        // with count
+        var randMemberArray = db.SortedSetRandomMembers(key, 5);
+        Assert.Equal(5, randMemberArray.Length);
+        randMemberArray = db.SortedSetRandomMembers(key, 15);
+        Assert.Equal(10, randMemberArray.Length);
+        randMemberArray = db.SortedSetRandomMembers(key, -5);
+        Assert.Equal(5, randMemberArray.Length);
+        randMemberArray = db.SortedSetRandomMembers(key, -15);
+        Assert.Equal(15, randMemberArray.Length);
+
+        // with scores
+        var randMemberArray2 = db.SortedSetRandomMembersWithScores(key, 2);
+        Assert.Equal(2, randMemberArray2.Length);
+        foreach (var member in randMemberArray2)
         {
-            new SortedSetEntry("a", 1),
-            new SortedSetEntry("b", 2),
-            new SortedSetEntry("c", 3),
-            new SortedSetEntry("d", 4),
-            new SortedSetEntry("e", 5),
-            new SortedSetEntry("f", 6),
-            new SortedSetEntry("g", 7),
-            new SortedSetEntry("h", 8),
-            new SortedSetEntry("i", 9),
-            new SortedSetEntry("j", 10)
-        };
-
-        private static readonly SortedSetEntry[] entriesPow2 = new SortedSetEntry[]
-        {
-            new SortedSetEntry("a", 1),
-            new SortedSetEntry("b", 2),
-            new SortedSetEntry("c", 4),
-            new SortedSetEntry("d", 8),
-            new SortedSetEntry("e", 16),
-            new SortedSetEntry("f", 32),
-            new SortedSetEntry("g", 64),
-            new SortedSetEntry("h", 128),
-            new SortedSetEntry("i", 256),
-            new SortedSetEntry("j", 512)
-        };
-
-        private static readonly SortedSetEntry[] entriesPow3 = new SortedSetEntry[]
-        {
-            new SortedSetEntry("a", 1),
-            new SortedSetEntry("c", 4),
-            new SortedSetEntry("e", 16),
-            new SortedSetEntry("g", 64),
-            new SortedSetEntry("i", 256),
-        };
-
-        private static readonly SortedSetEntry[] lexEntries = new SortedSetEntry[]
-        {
-            new SortedSetEntry("a", 0),
-            new SortedSetEntry("b", 0),
-            new SortedSetEntry("c", 0),
-            new SortedSetEntry("d", 0),
-            new SortedSetEntry("e", 0),
-            new SortedSetEntry("f", 0),
-            new SortedSetEntry("g", 0),
-            new SortedSetEntry("h", 0),
-            new SortedSetEntry("i", 0),
-            new SortedSetEntry("j", 0)
-        };
-
-        [Fact]
-        public void SortedSetCombine()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var diff = db.SortedSetCombine(SetOperation.Difference, new RedisKey[]{ key1, key2});
-            Assert.Equal(5, diff.Length);
-            Assert.Equal("b", diff[0]);
-
-            var inter = db.SortedSetCombine(SetOperation.Intersect, new RedisKey[]{ key1, key2});
-            Assert.Equal(5, inter.Length);
-            Assert.Equal("a", inter[0]);
-
-            var union = db.SortedSetCombine(SetOperation.Union, new RedisKey[]{ key1, key2});
-            Assert.Equal(10, union.Length);
-            Assert.Equal("a", union[0]);
+            Assert.Contains(member, entries);
         }
 
+        // check missing key case
+        randMember = db.SortedSetRandomMember(key0);
+        Assert.True(randMember.IsNull);
+        randMemberArray = db.SortedSetRandomMembers(key0, 2);
+        Assert.True(randMemberArray.Length == 0);
+        randMemberArray2 = db.SortedSetRandomMembersWithScores(key0, 2);
+        Assert.True(randMemberArray2.Length == 0);
+    }
 
-        [Fact]
-        public async Task SortedSetCombineAsync()
+    [Fact]
+    public async Task SortedSetRandomMembersAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        var key0 = Me() + "non-existing";
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key0, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
+
+        var randMember = await db.SortedSetRandomMemberAsync(key);
+        Assert.True(Array.Exists(entries, element => element.Element.Equals(randMember)));
+
+        // with count
+        var randMemberArray = await db.SortedSetRandomMembersAsync(key, 5);
+        Assert.Equal(5, randMemberArray.Length);
+        randMemberArray = await db.SortedSetRandomMembersAsync(key, 15);
+        Assert.Equal(10, randMemberArray.Length);
+        randMemberArray = await db.SortedSetRandomMembersAsync(key, -5);
+        Assert.Equal(5, randMemberArray.Length);
+        randMemberArray = await db.SortedSetRandomMembersAsync(key, -15);
+        Assert.Equal(15, randMemberArray.Length);
+
+        // with scores
+        var randMemberArray2 = await db.SortedSetRandomMembersWithScoresAsync(key, 2);
+        Assert.Equal(2, randMemberArray2.Length);
+        foreach (var member in randMemberArray2)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var diff = await db.SortedSetCombineAsync(SetOperation.Difference, new RedisKey[] { key1, key2 });
-            Assert.Equal(5, diff.Length);
-            Assert.Equal("b", diff[0]);
-
-            var inter = await db.SortedSetCombineAsync(SetOperation.Intersect, new RedisKey[] { key1, key2 });
-            Assert.Equal(5, inter.Length);
-            Assert.Equal("a", inter[0]);
-
-            var union = await db.SortedSetCombineAsync(SetOperation.Union, new RedisKey[] { key1, key2 });
-            Assert.Equal(10, union.Length);
-            Assert.Equal("a", union[0]);
+            Assert.Contains(member, entries);
         }
 
-        [Fact]
-        public void SortedSetCombineWithScores()
+        // check missing key case
+        randMember = await db.SortedSetRandomMemberAsync(key0);
+        Assert.True(randMember.IsNull);
+        randMemberArray = await db.SortedSetRandomMembersAsync(key0, 2);
+        Assert.True(randMemberArray.Length == 0);
+        randMemberArray2 = await db.SortedSetRandomMembersWithScoresAsync(key0, 2);
+        Assert.True(randMemberArray2.Length == 0);
+    }
+
+    [Fact]
+    public async Task SortedSetRangeStoreByRankAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entries, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 0, -1);
+        Assert.Equal(entries.Length, res);
+    }
+
+    [Fact]
+    public async Task SortedSetRangeStoreByRankLimitedAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entries, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 1, 4);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(4, res);
+        for (var i = 1; i < 5; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var diff = db.SortedSetCombineWithScores(SetOperation.Difference, new RedisKey[]{ key1, key2});
-            Assert.Equal(5, diff.Length);
-            Assert.Equal(new SortedSetEntry("b", 2), diff[0]);
-
-            var inter = db.SortedSetCombineWithScores(SetOperation.Intersect, new RedisKey[]{ key1, key2});
-            Assert.Equal(5, inter.Length);
-            Assert.Equal(new SortedSetEntry("a", 2), inter[0]);
-
-            var union = db.SortedSetCombineWithScores(SetOperation.Union, new RedisKey[]{ key1, key2});
-            Assert.Equal(10, union.Length);
-            Assert.Equal(new SortedSetEntry("a", 2), union[0]);
+            Assert.Equal(entries[i], range[i - 1]);
         }
+    }
 
+    [Fact]
+    public async Task SortedSetRangeStoreByScoreAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
 
-        [Fact]
-        public async Task SortedSetCombineWithScoresAsync()
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 64, 128, SortedSetOrder.ByScore);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(2, res);
+        for (var i = 6; i < 8; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var diff = await db.SortedSetCombineWithScoresAsync(SetOperation.Difference, new RedisKey[] { key1, key2 });
-            Assert.Equal(5, diff.Length);
-            Assert.Equal(new SortedSetEntry("b", 2), diff[0]);
-
-            var inter = await db.SortedSetCombineWithScoresAsync(SetOperation.Intersect, new RedisKey[] { key1, key2 });
-            Assert.Equal(5, inter.Length);
-            Assert.Equal(new SortedSetEntry("a", 2), inter[0]);
-
-            var union = await db.SortedSetCombineWithScoresAsync(SetOperation.Union, new RedisKey[] { key1, key2 });
-            Assert.Equal(10, union.Length);
-            Assert.Equal(new SortedSetEntry("a", 2), union[0]);
+            Assert.Equal(entriesPow2[i], range[i - 6]);
         }
+    }
 
-        [Fact]
-        public void SortedSetCombineAndStore()
+    [Fact]
+    public async Task SortedSetRangeStoreByScoreAsyncDefault()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < entriesPow2.Length; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-            var destination = Me() + "dest";
-            db.KeyDelete(destination, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var diff = db.SortedSetCombineAndStore(SetOperation.Difference, destination, new RedisKey[]{ key1, key2});
-            Assert.Equal(5, diff);
-
-            var inter = db.SortedSetCombineAndStore(SetOperation.Intersect, destination, new RedisKey[]{ key1, key2});
-            Assert.Equal(5, inter);
-
-            var union = db.SortedSetCombineAndStore(SetOperation.Union, destination, new RedisKey[]{ key1, key2});
-            Assert.Equal(10, union);
+            Assert.Equal(entriesPow2[i], range[i]);
         }
+    }
 
+    [Fact]
+    public async Task SortedSetRangeStoreByScoreAsyncLimited()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
 
-        [Fact]
-        public async Task SortedSetCombineAndStoreAsync()
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore, skip: 1, take: 6);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(6, res);
+        for (var i = 1; i < 7; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-            var destination = Me() + "dest";
-            db.KeyDelete(destination, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var diff = await db.SortedSetCombineAndStoreAsync(SetOperation.Difference, destination, new RedisKey[] { key1, key2 });
-            Assert.Equal(5, diff);
-
-            var inter = await db.SortedSetCombineAndStoreAsync(SetOperation.Intersect, destination, new RedisKey[] { key1, key2 });
-            Assert.Equal(5, inter);
-
-            var union = await db.SortedSetCombineAndStoreAsync(SetOperation.Union, destination, new RedisKey[] { key1, key2 });
-            Assert.Equal(10, union);
+            Assert.Equal(entriesPow2[i], range[i - 1]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetCombineErrors()
+    [Fact]
+    public async Task SortedSetRangeStoreByScoreAsyncExclusiveRange()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 32, 256, SortedSetOrder.ByScore, exclude: Exclude.Both);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(2, res);
+        for (var i = 6; i < 8; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-            var destination = Me() + "dest";
-            db.KeyDelete(destination, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            // ZDIFF can't be used with weights
-            var ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombine(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineWithScores(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineAndStore(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
-            Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
-            // and Async...
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineWithScoresAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAndStoreAsync(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2 }));
-            Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
-
-            // ZDIFF can't be used with aggregation
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombine(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineWithScores(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineAndStore(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
-            Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
-            // and Async...
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineWithScoresAsync(SetOperation.Difference, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
-            Assert.Equal("ZDIFF cannot be used with weights or aggregation.", ex.Message);
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAndStoreAsync(SetOperation.Difference, destination, new RedisKey[] { key1, key2 }, aggregate: Aggregate.Max));
-            Assert.Equal("ZDIFFSTORE cannot be used with weights or aggregation.", ex.Message);
-
-            // Too many weights
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombine(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
-            Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineWithScores(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
-            Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
-            ex = Assert.Throws<ArgumentException>(() => db.SortedSetCombineAndStore(SetOperation.Union, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
-            Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
-            // and Async...
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAsync(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
-            Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineWithScoresAsync(SetOperation.Union, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
-            Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
-            ex = await Assert.ThrowsAsync<ArgumentException>(() => db.SortedSetCombineAndStoreAsync(SetOperation.Union, destination, new RedisKey[] { key1, key2 }, new double[] { 1, 2, 3 }));
-            Assert.StartsWith("Keys and weights should have the same number of elements.", ex.Message);
+            Assert.Equal(entriesPow2[i], range[i - 6]);
         }
+    }
 
-        [Fact]
-        public void SortedSetIntersectionLength()
+    [Fact]
+    public async Task SortedSetRangeStoreByScoreAsyncReverse()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, start: double.PositiveInfinity, double.NegativeInfinity, SortedSetOrder.ByScore, order: Order.Descending);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < entriesPow2.Length; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v7_0_0_rc1);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var inter = db.SortedSetIntersectionLength(new RedisKey[]{ key1, key2});
-            Assert.Equal(5, inter);
-
-            // with limit
-            inter = db.SortedSetIntersectionLength(new RedisKey[]{ key1, key2}, 3);
-            Assert.Equal(3, inter);
+            Assert.Equal(entriesPow2[i], range[i]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetIntersectionLengthAsync()
+    [Fact]
+    public async Task SortedSetRangeStoreByLexAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < lexEntries.Length; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v7_0_0_rc1);
-
-            var db = conn.GetDatabase();
-            var key1 = Me();
-            db.KeyDelete(key1, CommandFlags.FireAndForget);
-            var key2 = Me() + "2";
-            db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-            db.SortedSetAdd(key1, entries);
-            db.SortedSetAdd(key2, entriesPow3);
-
-            var inter = await db.SortedSetIntersectionLengthAsync(new RedisKey[] { key1, key2 });
-            Assert.Equal(5, inter);
-
-            // with limit
-            inter = await db.SortedSetIntersectionLengthAsync(new RedisKey[] { key1, key2 }, 3);
-            Assert.Equal(3, inter);
+            Assert.Equal(lexEntries[i], range[i]);
         }
+    }
 
-        [Fact]
-        public void SortedSetPopMulti_Multi()
+    [Fact]
+    public async Task SortedSetRangeStoreByLexExclusiveRangeAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex, Exclude.Both);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(8, res);
+        for (var i = 1; i < lexEntries.Length - 1; i++)
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-                var first = db.SortedSetPop(key, Order.Ascending);
-                Assert.True(first.HasValue);
-                Assert.Equal(entries[0], first.Value);
-                Assert.Equal(9, db.SortedSetLength(key));
-
-                var lasts = db.SortedSetPop(key, 2, Order.Descending);
-                Assert.Equal(2, lasts.Length);
-                Assert.Equal(entries[9], lasts[0]);
-                Assert.Equal(entries[8], lasts[1]);
-                Assert.Equal(7, db.SortedSetLength(key));
-            }
+            Assert.Equal(lexEntries[i], range[i - 1]);
         }
+    }
 
-        [Fact]
-        public void SortedSetPopMulti_Single()
+    [Fact]
+    public async Task SortedSetRangeStoreByLexRevRangeAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        await db.SortedSetAddAsync(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, "j", "a", SortedSetOrder.ByLex, exclude: Exclude.None, order: Order.Descending);
+        var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < lexEntries.Length; i++)
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-                var last = db.SortedSetPop(key, Order.Descending);
-                Assert.True(last.HasValue);
-                Assert.Equal(entries[9], last.Value);
-                Assert.Equal(9, db.SortedSetLength(key));
-
-                var firsts = db.SortedSetPop(key, 1, Order.Ascending);
-                Assert.Single(firsts);
-                Assert.Equal(entries[0], firsts[0]);
-                Assert.Equal(8, db.SortedSetLength(key));
-            }
+            Assert.Equal(lexEntries[i], range[i]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetPopMulti_Multi_Async()
+    [Fact]
+    public void SortedSetRangeStoreByRank()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entries, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 0, -1);
+        Assert.Equal(entries.Length, res);
+    }
+
+    [Fact]
+    public void SortedSetRangeStoreByRankLimited()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entries, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 1, 4);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(4, res);
+        for (var i = 1; i < 5; i++)
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-                var last = await db.SortedSetPopAsync(key, Order.Descending).ForAwait();
-                Assert.True(last.HasValue);
-                Assert.Equal(entries[9], last.Value);
-                Assert.Equal(9, db.SortedSetLength(key));
-
-                var moreLasts = await db.SortedSetPopAsync(key, 2, Order.Descending).ForAwait();
-                Assert.Equal(2, moreLasts.Length);
-                Assert.Equal(entries[8], moreLasts[0]);
-                Assert.Equal(entries[7], moreLasts[1]);
-                Assert.Equal(7, db.SortedSetLength(key));
-            }
+            Assert.Equal(entries[i], range[i - 1]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetPopMulti_Single_Async()
+    [Fact]
+    public void SortedSetRangeStoreByScore()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 64, 128, SortedSetOrder.ByScore);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(2, res);
+        for (var i = 6; i < 8; i++)
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-                var first = await db.SortedSetPopAsync(key).ForAwait();
-                Assert.True(first.HasValue);
-                Assert.Equal(entries[0], first.Value);
-                Assert.Equal(9, db.SortedSetLength(key));
-
-                var moreFirsts = await db.SortedSetPopAsync(key, 1).ForAwait();
-                Assert.Single(moreFirsts);
-                Assert.Equal(entries[1], moreFirsts[0]);
-                Assert.Equal(8, db.SortedSetLength(key));
-            }
+            Assert.Equal(entriesPow2[i], range[i - 6]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetPopMulti_Zero_Async()
+    [Fact]
+    public void SortedSetRangeStoreByScoreDefault()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < entriesPow2.Length; i++)
         {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var key = Me();
-
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-                var t = db.SortedSetPopAsync(key, count: 0);
-                Assert.True(t.IsCompleted); // sync
-                var arr = await t;
-                Assert.NotNull(arr);
-                Assert.Empty(arr);
-
-                Assert.Equal(10, db.SortedSetLength(key));
-            }
+            Assert.Equal(entriesPow2[i], range[i]);
         }
+    }
 
-        [Fact]
-        public void SortedSetRandomMembers()
+    [Fact]
+    public void SortedSetRangeStoreByScoreLimited()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore, skip: 1, take: 6);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(6, res);
+        for (var i = 1; i < 7; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var key0 = Me() + "non-existing";
-
-            db.KeyDelete(key, CommandFlags.FireAndForget);
-            db.KeyDelete(key0, CommandFlags.FireAndForget);
-            db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-            // single member
-            var randMember = db.SortedSetRandomMember(key);
-            Assert.True(Array.Exists(entries, element => element.Element.Equals(randMember)));
-
-            // with count
-            var randMemberArray = db.SortedSetRandomMembers(key, 5);
-            Assert.Equal(5, randMemberArray.Length);
-            randMemberArray = db.SortedSetRandomMembers(key, 15);
-            Assert.Equal(10, randMemberArray.Length);
-            randMemberArray = db.SortedSetRandomMembers(key, -5);
-            Assert.Equal(5, randMemberArray.Length);
-            randMemberArray = db.SortedSetRandomMembers(key, -15);
-            Assert.Equal(15, randMemberArray.Length);
-
-            // with scores
-            var randMemberArray2 = db.SortedSetRandomMembersWithScores(key, 2);
-            Assert.Equal(2, randMemberArray2.Length);
-            foreach (var member in randMemberArray2)
-            {
-                Assert.Contains(member, entries);
-            }
-
-            // check missing key case
-            randMember = db.SortedSetRandomMember(key0);
-            Assert.True(randMember.IsNull);
-            randMemberArray = db.SortedSetRandomMembers(key0, 2);
-            Assert.True(randMemberArray.Length == 0);
-            randMemberArray2 = db.SortedSetRandomMembersWithScores(key0, 2);
-            Assert.True(randMemberArray2.Length == 0);
+            Assert.Equal(entriesPow2[i], range[i - 1]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetRandomMembersAsync()
+    [Fact]
+    public void SortedSetRangeStoreByScoreExclusiveRange()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 32, 256, SortedSetOrder.ByScore, exclude: Exclude.Both);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(2, res);
+        for (var i = 6; i < 8; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var key0 = Me() + "non-existing";
-
-            db.KeyDelete(key, CommandFlags.FireAndForget);
-            db.KeyDelete(key0, CommandFlags.FireAndForget);
-            db.SortedSetAdd(key, entries, CommandFlags.FireAndForget);
-
-            var randMember = await db.SortedSetRandomMemberAsync(key);
-            Assert.True(Array.Exists(entries, element => element.Element.Equals(randMember)));
-
-            // with count
-            var randMemberArray = await db.SortedSetRandomMembersAsync(key, 5);
-            Assert.Equal(5, randMemberArray.Length);
-            randMemberArray = await db.SortedSetRandomMembersAsync(key, 15);
-            Assert.Equal(10, randMemberArray.Length);
-            randMemberArray = await db.SortedSetRandomMembersAsync(key, -5);
-            Assert.Equal(5, randMemberArray.Length);
-            randMemberArray = await db.SortedSetRandomMembersAsync(key, -15);
-            Assert.Equal(15, randMemberArray.Length);
-
-            // with scores
-            var randMemberArray2 = await db.SortedSetRandomMembersWithScoresAsync(key, 2);
-            Assert.Equal(2, randMemberArray2.Length);
-            foreach (var member in randMemberArray2)
-            {
-                Assert.Contains(member, entries);
-            }
-
-            // check missing key case
-            randMember = await db.SortedSetRandomMemberAsync(key0);
-            Assert.True(randMember.IsNull);
-            randMemberArray = await db.SortedSetRandomMembersAsync(key0, 2);
-            Assert.True(randMemberArray.Length == 0);
-            randMemberArray2 = await db.SortedSetRandomMembersWithScoresAsync(key0, 2);
-            Assert.True(randMemberArray2.Length == 0);
+            Assert.Equal(entriesPow2[i], range[i - 6]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetRangeStoreByRankAsync()
+    [Fact]
+    public void SortedSetRangeStoreByScoreReverse()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, start: double.PositiveInfinity, double.NegativeInfinity, SortedSetOrder.ByScore, order: Order.Descending);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < entriesPow2.Length; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entries, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 0, -1);
-            Assert.Equal(entries.Length, res);
+            Assert.Equal(entriesPow2[i], range[i]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetRangeStoreByRankLimitedAsync()
+    [Fact]
+    public void SortedSetRangeStoreByLex()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < lexEntries.Length; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entries, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 1, 4);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(4, res);
-            for (var i = 1; i < 5; i++)
-            {
-                Assert.Equal(entries[i], range[i-1]);
-            }
+            Assert.Equal(lexEntries[i], range[i]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetRangeStoreByScoreAsync()
+    [Fact]
+    public void SortedSetRangeStoreByLexExclusiveRange()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex, Exclude.Both);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(8, res);
+        for (var i = 1; i < lexEntries.Length - 1; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 64, 128, SortedSetOrder.ByScore);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(2, res);
-            for (var i = 6; i < 8; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i-6]);
-            }
+            Assert.Equal(lexEntries[i], range[i - 1]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetRangeStoreByScoreAsyncDefault()
+    [Fact]
+    public void SortedSetRangeStoreByLexRevRange()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, "j", "a", SortedSetOrder.ByLex, Exclude.None, Order.Descending);
+        var range = db.SortedSetRangeByRankWithScores(destinationKey);
+        Assert.Equal(10, res);
+        for (var i = 0; i < lexEntries.Length; i++)
         {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i < entriesPow2.Length; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i]);
-            }
+            Assert.Equal(lexEntries[i], range[i]);
         }
+    }
 
-        [Fact]
-        public async Task SortedSetRangeStoreByScoreAsyncLimited()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore, skip: 1, take: 6);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(6, res);
-            for (var i = 1; i < 7; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i-1]);
-            }
-        }
-
-        [Fact]
-        public async Task SortedSetRangeStoreByScoreAsyncExclusiveRange()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, 32, 256, SortedSetOrder.ByScore, exclude: Exclude.Both);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(2, res);
-            for (var i = 6; i < 8; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i-6]);
-            }
-        }
-
-        [Fact]
-        public async Task SortedSetRangeStoreByScoreAsyncReverse()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, start: double.PositiveInfinity, double.NegativeInfinity, SortedSetOrder.ByScore, order: Order.Descending);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i < entriesPow2.Length; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public async Task SortedSetRangeStoreByLexAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i <lexEntries.Length; i++)
-            {
-                Assert.Equal(lexEntries[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public async Task SortedSetRangeStoreByLexExclusiveRangeAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex, Exclude.Both);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(8, res);
-            for (var i = 1; i <lexEntries.Length-1; i++)
-            {
-                Assert.Equal(lexEntries[i], range[i-1]);
-            }
-        }
-
-        [Fact]
-        public async Task SortedSetRangeStoreByLexRevRangeAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            await db.SortedSetAddAsync(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var res = await db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, "j", "a", SortedSetOrder.ByLex, exclude:Exclude.None, order: Order.Descending);
-            var range = await db.SortedSetRangeByRankWithScoresAsync(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i < lexEntries.Length; i++)
-            {
-                Assert.Equal(lexEntries[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByRank()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entries, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 0, -1);
-            Assert.Equal(entries.Length, res);
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByRankLimited()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entries, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 1, 4);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(4, res);
-            for (var i = 1; i < 5; i++)
-            {
-                Assert.Equal(entries[i], range[i-1]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByScore()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 64, 128, SortedSetOrder.ByScore);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(2, res);
-            for (var i = 6; i < 8; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i-6]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByScoreDefault()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i < entriesPow2.Length; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByScoreLimited()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey,double.NegativeInfinity, double.PositiveInfinity, SortedSetOrder.ByScore, skip: 1, take: 6);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(6, res);
-            for (var i = 1; i < 7; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i-1]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByScoreExclusiveRange()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, 32, 256, SortedSetOrder.ByScore, exclude: Exclude.Both);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(2, res);
-            for (var i = 6; i < 8; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i-6]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByScoreReverse()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, entriesPow2, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, start: double.PositiveInfinity, double.NegativeInfinity, SortedSetOrder.ByScore, order: Order.Descending);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i < entriesPow2.Length; i++)
-            {
-                Assert.Equal(entriesPow2[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByLex()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i <lexEntries.Length; i++)
-            {
-                Assert.Equal(lexEntries[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByLexExclusiveRange()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, "a", "j", SortedSetOrder.ByLex, Exclude.Both);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(8, res);
-            for (var i = 1; i <lexEntries.Length-1; i++)
-            {
-                Assert.Equal(lexEntries[i], range[i-1]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreByLexRevRange()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var res = db.SortedSetRangeAndStore(sourceKey, destinationKey, "j", "a", SortedSetOrder.ByLex, Exclude.None, Order.Descending);
-            var range = db.SortedSetRangeByRankWithScores(destinationKey);
-            Assert.Equal(10, res);
-            for (var i = 0; i < lexEntries.Length; i++)
-            {
-                Assert.Equal(lexEntries[i], range[i]);
-            }
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreFailErroneousTake()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var exception = Assert.Throws<ArgumentException>(()=>db.SortedSetRangeAndStore(sourceKey, destinationKey,0,-1, take:5));
-            Assert.Equal("take", exception.ParamName);
-        }
-
-        [Fact]
-        public void SortedSetRangeStoreFailExclude()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var me = Me();
-            var sourceKey = $"{me}:ZSetSource";
-            var destinationKey = $"{me}:ZSetDestination";
-
-            db.KeyDelete(new RedisKey[] {sourceKey, destinationKey}, CommandFlags.FireAndForget);
-            db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
-            var exception = Assert.Throws<ArgumentException>(()=>db.SortedSetRangeAndStore(sourceKey, destinationKey,0,-1, exclude: Exclude.Both));
-            Assert.Equal("exclude", exception.ParamName);
-        }
-
-        [Fact]
-        public void SortedSetScoresSingle()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v2_1_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var memberName = "member";
-
-            db.KeyDelete(key);
-            db.SortedSetAdd(key, memberName, 1.5);
-
-            var score = db.SortedSetScore(key, memberName);
-
-            Assert.NotNull(score);
-            Assert.Equal((double)1.5, score.Value);
-        }
-
-        [Fact]
-        public async Task SortedSetScoresSingleAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v2_1_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var memberName = "member";
-
-            await db.KeyDeleteAsync(key);
-            await db.SortedSetAddAsync(key, memberName, 1.5);
-
-            var score = await db.SortedSetScoreAsync(key, memberName);
-
-            Assert.NotNull(score);
-            Assert.Equal((double)1.5, score.Value);
-        }
-
-        [Fact]
-        public void SortedSetScoresSingle_MissingSetStillReturnsNull()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v2_1_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-
-            db.KeyDelete(key);
-
-            // Attempt to retrieve score for a missing set, should still return null.
-            var score = db.SortedSetScore(key, "bogusMemberName");
-
-            Assert.Null(score);
-        }
-
-        [Fact]
-        public async Task SortedSetScoresSingle_MissingSetStillReturnsNullAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v2_1_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-
-            await db.KeyDeleteAsync(key);
-
-            // Attempt to retrieve score for a missing set, should still return null.
-            var score = await db.SortedSetScoreAsync(key, "bogusMemberName");
-
-            Assert.Null(score);
-        }
-
-        [Fact]
-        public void SortedSetScoresSingle_ReturnsNullForMissingMember()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v2_1_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-
-            db.KeyDelete(key);
-            db.SortedSetAdd(key, "member1", 1.5);
-
-            // Attempt to retrieve score for a missing member, should return null.
-            var score = db.SortedSetScore(key, "bogusMemberName");
-
-            Assert.Null(score);
-        }
-
-        [Fact]
-        public async Task SortedSetScoresSingle_ReturnsNullForMissingMemberAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v2_1_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-
-            await db.KeyDeleteAsync(key);
-            await db.SortedSetAddAsync(key, "member1", 1.5);
-
-            // Attempt to retrieve score for a missing member, should return null.
-            var score = await db.SortedSetScoreAsync(key, "bogusMemberName");
-
-            Assert.Null(score);
-        }
-
-        [Fact]
-        public void SortedSetScoresMultiple()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var member1 = "member1";
-            var member2 = "member2";
-            var member3 = "member3";
-
-            db.KeyDelete(key);
-            db.SortedSetAdd(key, member1, 1.5);
-            db.SortedSetAdd(key, member2, 1.75);
-            db.SortedSetAdd(key, member3, 2);
-
-            var scores = db.SortedSetScores(key, new RedisValue[] { member1, member2, member3 });
-
-            Assert.NotNull(scores);
-            Assert.Equal(3, scores.Length);
-            Assert.Equal((double)1.5, scores[0]);
-            Assert.Equal((double)1.75, scores[1]);
-            Assert.Equal(2, scores[2]);
-        }
-
-        [Fact]
-        public async Task SortedSetScoresMultipleAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var member1 = "member1";
-            var member2 = "member2";
-            var member3 = "member3";
-
-            await db.KeyDeleteAsync(key);
-            await db.SortedSetAddAsync(key, member1, 1.5);
-            await db.SortedSetAddAsync(key, member2, 1.75);
-            await db.SortedSetAddAsync(key, member3, 2);
-
-            var scores = await db.SortedSetScoresAsync(key, new RedisValue[] { member1, member2, member3 });
-
-            Assert.NotNull(scores);
-            Assert.Equal(3, scores.Length);
-            Assert.Equal((double)1.5, scores[0]);
-            Assert.Equal((double)1.75, scores[1]);
-            Assert.Equal(2, scores[2]);
-        }
-
-        [Fact]
-        public void SortedSetScoresMultiple_ReturnsNullItemsForMissingSet()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-
-            db.KeyDelete(key);
-
-            // Missing set but should still return an array of nulls.
-            var scores = db.SortedSetScores(key, new RedisValue[] { "bogus1", "bogus2", "bogus3" });
-
-            Assert.NotNull(scores);
-            Assert.Equal(3, scores.Length);
-            Assert.Null(scores[0]);
-            Assert.Null(scores[1]);
-            Assert.Null(scores[2]);
-        }
-
-        [Fact]
-        public async Task SortedSetScoresMultiple_ReturnsNullItemsForMissingSetAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-
-            await db.KeyDeleteAsync(key);
-
-            // Missing set but should still return an array of nulls.
-            var scores = await db.SortedSetScoresAsync(key, new RedisValue[] { "bogus1", "bogus2", "bogus3" });
-
-            Assert.NotNull(scores);
-            Assert.Equal(3, scores.Length);
-            Assert.Null(scores[0]);
-            Assert.Null(scores[1]);
-            Assert.Null(scores[2]);
-        }
-
-        [Fact]
-        public void SortedSetScoresMultiple_ReturnsScoresAndNullItems()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var member1 = "member1";
-            var member2 = "member2";
-            var member3 = "member3";
-            var bogusMember = "bogusMember";
-
-            db.KeyDelete(key);
-
-            db.SortedSetAdd(key, member1, 1.5);
-            db.SortedSetAdd(key, member2, 1.75);
-            db.SortedSetAdd(key, member3, 2);
-
-            var scores = db.SortedSetScores(key, new RedisValue[] { member1, bogusMember, member2, member3 });
-
-            Assert.NotNull(scores);
-            Assert.Equal(4, scores.Length);
-            Assert.Null(scores[1]);
-            Assert.Equal((double)1.5, scores[0]);
-            Assert.Equal((double)1.75, scores[2]);
-            Assert.Equal(2, scores[3]);
-        }
-
-        [Fact]
-        public async Task SortedSetScoresMultiple_ReturnsScoresAndNullItemsAsync()
-        {
-            using var conn = Create();
-            Skip.IfBelow(conn, RedisFeatures.v6_2_0);
-
-            var db = conn.GetDatabase();
-            var key = Me();
-            var member1 = "member1";
-            var member2 = "member2";
-            var member3 = "member3";
-            var bogusMember = "bogusMember";
-
-            await db.KeyDeleteAsync(key);
-
-            await db.SortedSetAddAsync(key, member1, 1.5);
-            await db.SortedSetAddAsync(key, member2, 1.75);
-            await db.SortedSetAddAsync(key, member3, 2);
-
-            var scores = await db.SortedSetScoresAsync(key, new RedisValue[] { member1, bogusMember, member2, member3 });
-
-            Assert.NotNull(scores);
-            Assert.Equal(4, scores.Length);
-            Assert.Null(scores[1]);
-            Assert.Equal((double)1.5, scores[0]);
-            Assert.Equal((double)1.75, scores[2]);
-            Assert.Equal(2, scores[3]);
-        }
+    [Fact]
+    public void SortedSetRangeStoreFailErroneousTake()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var exception = Assert.Throws<ArgumentException>(() => db.SortedSetRangeAndStore(sourceKey, destinationKey, 0, -1, take: 5));
+        Assert.Equal("take", exception.ParamName);
+    }
+
+    [Fact]
+    public void SortedSetRangeStoreFailExclude()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var me = Me();
+        var sourceKey = $"{me}:ZSetSource";
+        var destinationKey = $"{me}:ZSetDestination";
+
+        db.KeyDelete(new RedisKey[] { sourceKey, destinationKey }, CommandFlags.FireAndForget);
+        db.SortedSetAdd(sourceKey, lexEntries, CommandFlags.FireAndForget);
+        var exception = Assert.Throws<ArgumentException>(() => db.SortedSetRangeAndStore(sourceKey, destinationKey, 0, -1, exclude: Exclude.Both));
+        Assert.Equal("exclude", exception.ParamName);
+    }
+
+    [Fact]
+    public void SortedSetScoresSingle()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string memberName = "member";
+
+        db.KeyDelete(key);
+        db.SortedSetAdd(key, memberName, 1.5);
+
+        var score = db.SortedSetScore(key, memberName);
+
+        Assert.NotNull(score);
+        Assert.Equal((double)1.5, score.Value);
+    }
+
+    [Fact]
+    public async Task SortedSetScoresSingleAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string memberName = "member";
+
+        await db.KeyDeleteAsync(key);
+        await db.SortedSetAddAsync(key, memberName, 1.5);
+
+        var score = await db.SortedSetScoreAsync(key, memberName);
+
+        Assert.NotNull(score);
+        Assert.Equal((double)1.5, score.Value);
+    }
+
+    [Fact]
+    public void SortedSetScoresSingle_MissingSetStillReturnsNull()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key);
+
+        // Attempt to retrieve score for a missing set, should still return null.
+        var score = db.SortedSetScore(key, "bogusMemberName");
+
+        Assert.Null(score);
+    }
+
+    [Fact]
+    public async Task SortedSetScoresSingle_MissingSetStillReturnsNullAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        await db.KeyDeleteAsync(key);
+
+        // Attempt to retrieve score for a missing set, should still return null.
+        var score = await db.SortedSetScoreAsync(key, "bogusMemberName");
+
+        Assert.Null(score);
+    }
+
+    [Fact]
+    public void SortedSetScoresSingle_ReturnsNullForMissingMember()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key);
+        db.SortedSetAdd(key, "member1", 1.5);
+
+        // Attempt to retrieve score for a missing member, should return null.
+        var score = db.SortedSetScore(key, "bogusMemberName");
+
+        Assert.Null(score);
+    }
+
+    [Fact]
+    public async Task SortedSetScoresSingle_ReturnsNullForMissingMemberAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        await db.KeyDeleteAsync(key);
+        await db.SortedSetAddAsync(key, "member1", 1.5);
+
+        // Attempt to retrieve score for a missing member, should return null.
+        var score = await db.SortedSetScoreAsync(key, "bogusMemberName");
+
+        Assert.Null(score);
+    }
+
+    [Fact]
+    public void SortedSetScoresMultiple()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string member1 = "member1",
+                     member2 = "member2",
+                     member3 = "member3";
+
+        db.KeyDelete(key);
+        db.SortedSetAdd(key, member1, 1.5);
+        db.SortedSetAdd(key, member2, 1.75);
+        db.SortedSetAdd(key, member3, 2);
+
+        var scores = db.SortedSetScores(key, new RedisValue[] { member1, member2, member3 });
+
+        Assert.NotNull(scores);
+        Assert.Equal(3, scores.Length);
+        Assert.Equal((double)1.5, scores[0]);
+        Assert.Equal((double)1.75, scores[1]);
+        Assert.Equal(2, scores[2]);
+    }
+
+    [Fact]
+    public async Task SortedSetScoresMultipleAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string member1 = "member1",
+                     member2 = "member2",
+                     member3 = "member3";
+
+        await db.KeyDeleteAsync(key);
+        await db.SortedSetAddAsync(key, member1, 1.5);
+        await db.SortedSetAddAsync(key, member2, 1.75);
+        await db.SortedSetAddAsync(key, member3, 2);
+
+        var scores = await db.SortedSetScoresAsync(key, new RedisValue[] { member1, member2, member3 });
+
+        Assert.NotNull(scores);
+        Assert.Equal(3, scores.Length);
+        Assert.Equal((double)1.5, scores[0]);
+        Assert.Equal((double)1.75, scores[1]);
+        Assert.Equal(2, scores[2]);
+    }
+
+    [Fact]
+    public void SortedSetScoresMultiple_ReturnsNullItemsForMissingSet()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key);
+
+        // Missing set but should still return an array of nulls.
+        var scores = db.SortedSetScores(key, new RedisValue[] { "bogus1", "bogus2", "bogus3" });
+
+        Assert.NotNull(scores);
+        Assert.Equal(3, scores.Length);
+        Assert.Null(scores[0]);
+        Assert.Null(scores[1]);
+        Assert.Null(scores[2]);
+    }
+
+    [Fact]
+    public async Task SortedSetScoresMultiple_ReturnsNullItemsForMissingSetAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        await db.KeyDeleteAsync(key);
+
+        // Missing set but should still return an array of nulls.
+        var scores = await db.SortedSetScoresAsync(key, new RedisValue[] { "bogus1", "bogus2", "bogus3" });
+
+        Assert.NotNull(scores);
+        Assert.Equal(3, scores.Length);
+        Assert.Null(scores[0]);
+        Assert.Null(scores[1]);
+        Assert.Null(scores[2]);
+    }
+
+    [Fact]
+    public void SortedSetScoresMultiple_ReturnsScoresAndNullItems()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string member1 = "member1",
+                     member2 = "member2",
+                     member3 = "member3",
+                     bogusMember = "bogusMember";
+
+        db.KeyDelete(key);
+
+        db.SortedSetAdd(key, member1, 1.5);
+        db.SortedSetAdd(key, member2, 1.75);
+        db.SortedSetAdd(key, member3, 2);
+
+        var scores = db.SortedSetScores(key, new RedisValue[] { member1, bogusMember, member2, member3 });
+
+        Assert.NotNull(scores);
+        Assert.Equal(4, scores.Length);
+        Assert.Null(scores[1]);
+        Assert.Equal((double)1.5, scores[0]);
+        Assert.Equal((double)1.75, scores[2]);
+        Assert.Equal(2, scores[3]);
+    }
+
+    [Fact]
+    public async Task SortedSetScoresMultiple_ReturnsScoresAndNullItemsAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        const string member1 = "member1",
+                     member2 = "member2",
+                     member3 = "member3",
+                     bogusMember = "bogusMember";
+
+        await db.KeyDeleteAsync(key);
+
+        await db.SortedSetAddAsync(key, member1, 1.5);
+        await db.SortedSetAddAsync(key, member2, 1.75);
+        await db.SortedSetAddAsync(key, member3, 2);
+
+        var scores = await db.SortedSetScoresAsync(key, new RedisValue[] { member1, bogusMember, member2, member3 });
+
+        Assert.NotNull(scores);
+        Assert.Equal(4, scores.Length);
+        Assert.Null(scores[1]);
+        Assert.Equal((double)1.5, scores[0]);
+        Assert.Equal((double)1.75, scores[2]);
+        Assert.Equal(2, scores[3]);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Streams.cs
+++ b/tests/StackExchange.Redis.Tests/Streams.cs
@@ -5,1818 +5,1574 @@ using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Streams : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Streams : TestBase
+    public Streams(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void IsStreamType()
     {
-        public Streams(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create(require: RedisFeatures.v5_0_0);
 
-        [Fact]
-        public void IsStreamType()
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("type_check");
+        db.StreamAdd(key, "field1", "value1");
+
+        var keyType = db.KeyType(key);
+
+        Assert.Equal(RedisType.Stream, keyType);
+    }
+
+    [Fact]
+    public void StreamAddSinglePairWithAutoId()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var messageId = db.StreamAdd(GetUniqueKey("auto_id"), "field1", "value1");
+
+        Assert.True(messageId != RedisValue.Null && ((string?)messageId)?.Length > 0);
+    }
+
+    [Fact]
+    public void StreamAddMultipleValuePairsWithAutoId()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("multiple_value_pairs");
+        var fields = new[]
         {
-            using (var conn = Create())
+            new NameValueEntry("field1", "value1"),
+            new NameValueEntry("field2", "value2"),
+        };
+
+        var messageId = db.StreamAdd(key, fields);
+
+        var entries = db.StreamRange(key);
+
+        Assert.Single(entries);
+        Assert.Equal(messageId, entries[0].Id);
+        var vals = entries[0].Values;
+        Assert.NotNull(vals);
+        Assert.Equal(2, vals.Length);
+        Assert.Equal("field1", vals[0].Name);
+        Assert.Equal("value1", vals[0].Value);
+        Assert.Equal("field2", vals[1].Name);
+        Assert.Equal("value2", vals[1].Value);
+    }
+
+    [Fact]
+    public void StreamAddWithManualId()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        const string id = "42-0";
+        var key = GetUniqueKey("manual_id");
+
+        var messageId = db.StreamAdd(key, "field1", "value1", id);
+
+        Assert.Equal(id, messageId);
+    }
+
+    [Fact]
+    public void StreamAddMultipleValuePairsWithManualId()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        const string id = "42-0";
+        var key = GetUniqueKey("manual_id_multiple_values");
+
+        var fields = new[]
+        {
+                new NameValueEntry("field1", "value1"),
+                new NameValueEntry("field2", "value2")
+            };
+
+        var messageId = db.StreamAdd(key, fields, id);
+        var entries = db.StreamRange(key);
+
+        Assert.Equal(id, messageId);
+        Assert.NotNull(entries);
+        Assert.Single(entries);
+        Assert.Equal(id, entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupSetId()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_set_id");
+        const string groupName = "test_group",
+                     consumer = "consumer";
+
+        // Create a stream
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+
+        // Create a group and set the position to deliver new messages only.
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.NewMessages);
+
+        // Read into the group, expect nothing
+        var firstRead = db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
+
+        // Reset the ID back to read from the beginning.
+        db.StreamConsumerGroupSetPosition(key, groupName, StreamPosition.Beginning);
+
+        var secondRead = db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
+
+        Assert.NotNull(firstRead);
+        Assert.NotNull(secondRead);
+        Assert.Empty(firstRead);
+        Assert.Equal(2, secondRead.Length);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupWithNoConsumers()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_with_no_consumers");
+        const string groupName = "test_group";
+
+        // Create a stream
+        db.StreamAdd(key, "field1", "value1");
+
+        // Create a group
+        db.StreamCreateConsumerGroup(key, groupName, "0-0");
+
+        // Query redis for the group consumers, expect an empty list in response.
+        var consumers = db.StreamConsumerInfo(key, groupName);
+
+        Assert.Empty(consumers);
+    }
+
+    [Fact]
+    public void StreamCreateConsumerGroup()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_create");
+        const string groupName = "test_group";
+
+        // Create a stream
+        db.StreamAdd(key, "field1", "value1");
+
+        // Create a group
+        var result = db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void StreamCreateConsumerGroupBeforeCreatingStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_create_before_stream");
+
+        // Ensure the key doesn't exist.
+        var keyExistsBeforeCreate = db.KeyExists(key);
+
+        // The 'createStream' parameter is 'true' by default.
+        var groupCreated = db.StreamCreateConsumerGroup(key, "consumerGroup", StreamPosition.NewMessages);
+
+        var keyExistsAfterCreate = db.KeyExists(key);
+
+        Assert.False(keyExistsBeforeCreate);
+        Assert.True(groupCreated);
+        Assert.True(keyExistsAfterCreate);
+    }
+
+    [Fact]
+    public void StreamCreateConsumerGroupFailsIfKeyDoesntExist()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_create_before_stream_should_fail");
+
+        // Pass 'false' for 'createStream' to ensure that an
+        // exception is thrown when the stream doesn't exist.
+        Assert.ThrowsAny<RedisServerException>(() => db.StreamCreateConsumerGroup(
+                key,
+                "consumerGroup",
+                StreamPosition.NewMessages,
+                createStream: false));
+    }
+
+    [Fact]
+    public void StreamCreateConsumerGroupSucceedsWhenKeyExists()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_create_after_stream");
+
+        db.StreamAdd(key, "f1", "v1");
+
+        // Pass 'false' for 'createStream', should create the consumer group
+        // without issue since the stream already exists.
+        var groupCreated = db.StreamCreateConsumerGroup(
+            key,
+            "consumerGroup",
+            StreamPosition.NewMessages,
+            createStream: false);
+
+        Assert.True(groupCreated);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadOnlyNewMessagesWithEmptyResponse()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_read");
+        const string groupName = "test_group";
+
+        // Create a stream
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+
+        // Create a group.
+        db.StreamCreateConsumerGroup(key, groupName);
+
+        // Read, expect no messages
+        var entries = db.StreamReadGroup(key, groupName, "test_consumer", "0-0");
+
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadFromStreamBeginning()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_read_beginning");
+        const string groupName = "test_group";
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        var entries = db.StreamReadGroup(key, groupName, "test_consumer", StreamPosition.NewMessages);
+
+        Assert.Equal(2, entries.Length);
+        Assert.True(id1 == entries[0].Id);
+        Assert.True(id2 == entries[1].Id);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadFromStreamBeginningWithCount()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_read_with_count");
+        const string groupName = "test_group";
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+        _ = db.StreamAdd(key, "field4", "value4");
+
+        // Start reading after id1.
+        db.StreamCreateConsumerGroup(key, groupName, id1);
+
+        var entries = db.StreamReadGroup(key, groupName, "test_consumer", StreamPosition.NewMessages, 2);
+
+        // Ensure we only received the requested count and that the IDs match the expected values.
+        Assert.Equal(2, entries.Length);
+        Assert.True(id2 == entries[0].Id);
+        Assert.True(id3 == entries[1].Id);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupAcknowledgeMessage()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_ack");
+        const string groupName = "test_group",
+                     consumer = "test_consumer";
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+        var id4 = db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        // Read all 4 messages, they will be assigned to the consumer
+        var entries = db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
+
+        // Send XACK for 3 of the messages
+
+        // Single message Id overload.
+        var oneAck = db.StreamAcknowledge(key, groupName, id1);
+
+        // Multiple message Id overload.
+        var twoAck = db.StreamAcknowledge(key, groupName, new[] { id3, id4 });
+
+        // Read the group again, it should only return the unacknowledged message.
+        var notAcknowledged = db.StreamReadGroup(key, groupName, consumer, "0-0");
+
+        Assert.Equal(4, entries.Length);
+        Assert.Equal(1, oneAck);
+        Assert.Equal(2, twoAck);
+        Assert.Single(notAcknowledged);
+        Assert.Equal(id2, notAcknowledged[0].Id);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupClaimMessages()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_claim");
+        const string groupName = "test_group",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        _ = db.StreamAdd(key, "field1", "value1");
+        _ = db.StreamAdd(key, "field2", "value2");
+        _ = db.StreamAdd(key, "field3", "value3");
+        _ = db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, groupName, "0-0");
+
+        // Read a single message into the first consumer.
+        db.StreamReadGroup(key, groupName, consumer1, count: 1);
+
+        // Read the remaining messages into the second consumer.
+        db.StreamReadGroup(key, groupName, consumer2);
+
+        // Claim the 3 messages consumed by consumer2 for consumer1.
+
+        // Get the pending messages for consumer2.
+        var pendingMessages = db.StreamPendingMessages(key, groupName,
+            10,
+            consumer2);
+
+        // Claim the messages for consumer1.
+        var messages = db.StreamClaim(key,
+                            groupName,
+                            consumer1,
+                            0, // Min message idle time
+                            messageIds: pendingMessages.Select(pm => pm.MessageId).ToArray());
+
+        // Now see how many messages are pending for each consumer
+        var pendingSummary = db.StreamPending(key, groupName);
+
+        Assert.NotNull(pendingSummary.Consumers);
+        Assert.Single(pendingSummary.Consumers);
+        Assert.Equal(4, pendingSummary.Consumers[0].PendingMessageCount);
+        Assert.Equal(pendingMessages.Length, messages.Length);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupClaimMessagesReturningIds()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_claim_view_ids");
+        const string groupName = "test_group",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        _ = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+        var id4 = db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        // Read a single message into the first consumer.
+        _ = db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
+
+        // Read the remaining messages into the second consumer.
+        _ = db.StreamReadGroup(key, groupName, consumer2);
+
+        // Claim the 3 messages consumed by consumer2 for consumer1.
+
+        // Get the pending messages for consumer2.
+        var pendingMessages = db.StreamPendingMessages(key, groupName,
+            10,
+            consumer2);
+
+        // Claim the messages for consumer1.
+        var messageIds = db.StreamClaimIdsOnly(key,
+                            groupName,
+                            consumer1,
+                            0, // Min message idle time
+                            messageIds: pendingMessages.Select(pm => pm.MessageId).ToArray());
+
+        // We should get an array of 3 message IDs.
+        Assert.Equal(3, messageIds.Length);
+        Assert.Equal(id2, messageIds[0]);
+        Assert.Equal(id3, messageIds[1]);
+        Assert.Equal(id4, messageIds[2]);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadMultipleOneReadBeginningOneReadNew()
+    {
+        // Create a group for each stream. One set to read from the beginning of the
+        // stream and the other to begin reading only new messages.
+
+        // Ask redis to read from the beginning of both stream, expect messages
+        // for only the stream set to read from the beginning.
+
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        const string groupName = "test_group";
+        var stream1 = GetUniqueKey("stream1a");
+        var stream2 = GetUniqueKey("stream2a");
+
+        db.StreamAdd(stream1, "field1-1", "value1-1");
+        db.StreamAdd(stream1, "field1-2", "value1-2");
+
+        db.StreamAdd(stream2, "field2-1", "value2-1");
+        db.StreamAdd(stream2, "field2-2", "value2-2");
+        db.StreamAdd(stream2, "field2-3", "value2-3");
+
+        // stream1 set up to read only new messages.
+        db.StreamCreateConsumerGroup(stream1, groupName, StreamPosition.NewMessages);
+
+        // stream2 set up to read from the beginning of the stream
+        db.StreamCreateConsumerGroup(stream2, groupName, StreamPosition.Beginning);
+
+        // Read for both streams from the beginning. We shouldn't get anything back for stream1.
+        var pairs = new[]
+        {
+                // StreamPosition.NewMessages will send ">" which indicates "Undelivered" messages.
+                new StreamPosition(stream1, StreamPosition.NewMessages),
+                new StreamPosition(stream2, StreamPosition.NewMessages)
+            };
+
+        var streams = db.StreamReadGroup(pairs, groupName, "test_consumer");
+
+        Assert.NotNull(streams);
+        Assert.Single(streams);
+        Assert.Equal(stream2, streams[0].Key);
+        Assert.Equal(3, streams[0].Entries.Length);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadMultipleOnlyNewMessagesExpectNoResult()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        const string groupName = "test_group";
+        var stream1 = GetUniqueKey("stream1b");
+        var stream2 = GetUniqueKey("stream2b");
+
+        db.StreamAdd(stream1, "field1-1", "value1-1");
+        db.StreamAdd(stream2, "field2-1", "value2-1");
+
+        // set both streams to read only new messages (default behavior).
+        db.StreamCreateConsumerGroup(stream1, groupName);
+        db.StreamCreateConsumerGroup(stream2, groupName);
+
+        // We shouldn't get anything for either stream.
+        var pairs = new[]
+        {
+                new StreamPosition(stream1, StreamPosition.Beginning),
+                new StreamPosition(stream2, StreamPosition.Beginning)
+            };
+
+        var streams = db.StreamReadGroup(pairs, groupName, "test_consumer");
+
+        Assert.NotNull(streams);
+        Assert.Equal(2, streams.Length);
+        Assert.Empty(streams[0].Entries);
+        Assert.Empty(streams[1].Entries);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadMultipleOnlyNewMessagesExpect1Result()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        const string groupName = "test_group";
+        var stream1 = GetUniqueKey("stream1c");
+        var stream2 = GetUniqueKey("stream2c");
+
+        // These messages won't be read.
+        db.StreamAdd(stream1, "field1-1", "value1-1");
+        db.StreamAdd(stream2, "field2-1", "value2-1");
+
+        // set both streams to read only new messages (default behavior).
+        db.StreamCreateConsumerGroup(stream1, groupName);
+        db.StreamCreateConsumerGroup(stream2, groupName);
+
+        // We should read these though.
+        var id1 = db.StreamAdd(stream1, "field1-2", "value1-2");
+        var id2 = db.StreamAdd(stream2, "field2-2", "value2-2");
+
+        // Read the new messages (messages created after the group was created).
+        var pairs = new[]
+        {
+                new StreamPosition(stream1, StreamPosition.NewMessages),
+                new StreamPosition(stream2, StreamPosition.NewMessages)
+            };
+
+        var streams = db.StreamReadGroup(pairs, groupName, "test_consumer");
+
+        Assert.NotNull(streams);
+        Assert.Equal(2, streams.Length);
+        Assert.Single(streams[0].Entries);
+        Assert.Single(streams[1].Entries);
+        Assert.Equal(id1, streams[0].Entries[0].Id);
+        Assert.Equal(id2, streams[1].Entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupReadMultipleRestrictCount()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        const string groupName = "test_group";
+        var stream1 = GetUniqueKey("stream1d");
+        var stream2 = GetUniqueKey("stream2d");
+
+        var id1_1 = db.StreamAdd(stream1, "field1-1", "value1-1");
+        var id1_2 = db.StreamAdd(stream1, "field1-2", "value1-2");
+
+        var id2_1 = db.StreamAdd(stream2, "field2-1", "value2-1");
+        _ = db.StreamAdd(stream2, "field2-2", "value2-2");
+        _ = db.StreamAdd(stream2, "field2-3", "value2-3");
+
+        // Set the initial read point in each stream, *after* the first ID in both streams.
+        db.StreamCreateConsumerGroup(stream1, groupName, id1_1);
+        db.StreamCreateConsumerGroup(stream2, groupName, id2_1);
+
+        var pairs = new[]
+        {
+                // Read after the first id in both streams
+                new StreamPosition(stream1, StreamPosition.NewMessages),
+                new StreamPosition(stream2, StreamPosition.NewMessages)
+            };
+
+        // Restrict the count to 2 (expect only 1 message from first stream, 2 from the second).
+        var streams = db.StreamReadGroup(pairs, groupName, "test_consumer", 2);
+
+        Assert.NotNull(streams);
+        Assert.Equal(2, streams.Length);
+        Assert.Single(streams[0].Entries);
+        Assert.Equal(2, streams[1].Entries.Length);
+        Assert.Equal(id1_2, streams[0].Entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupViewPendingInfoNoConsumers()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_pending_info_no_consumers");
+        const string groupName = "test_group";
+
+        db.StreamAdd(key, "field1", "value1");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        var pendingInfo = db.StreamPending(key, groupName);
+
+        Assert.Equal(0, pendingInfo.PendingMessageCount);
+        Assert.Equal(RedisValue.Null, pendingInfo.LowestPendingMessageId);
+        Assert.Equal(RedisValue.Null, pendingInfo.HighestPendingMessageId);
+        Assert.NotNull(pendingInfo.Consumers);
+        Assert.Empty(pendingInfo.Consumers);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupViewPendingInfoWhenNothingPending()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_pending_info_nothing_pending");
+        const string groupName = "test_group";
+
+        db.StreamAdd(key, "field1", "value1");
+
+        db.StreamCreateConsumerGroup(key, groupName, "0-0");
+
+        var pendingMessages = db.StreamPendingMessages(key,
+            groupName,
+            10,
+            consumerName: RedisValue.Null);
+
+        Assert.NotNull(pendingMessages);
+        Assert.Empty(pendingMessages);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupViewPendingInfoSummary()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_pending_info");
+        const string groupName = "test_group",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+        var id4 = db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        // Read a single message into the first consumer.
+        db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
+
+        // Read the remaining messages into the second consumer.
+        db.StreamReadGroup(key, groupName, consumer2);
+
+        var pendingInfo = db.StreamPending(key, groupName);
+
+        Assert.Equal(4, pendingInfo.PendingMessageCount);
+        Assert.Equal(id1, pendingInfo.LowestPendingMessageId);
+        Assert.Equal(id4, pendingInfo.HighestPendingMessageId);
+        Assert.True(pendingInfo.Consumers.Length == 2);
+
+        var consumer1Count = pendingInfo.Consumers.First(c => c.Name == consumer1).PendingMessageCount;
+        var consumer2Count = pendingInfo.Consumers.First(c => c.Name == consumer2).PendingMessageCount;
+
+        Assert.Equal(1, consumer1Count);
+        Assert.Equal(3, consumer2Count);
+    }
+
+    [Fact]
+    public async Task StreamConsumerGroupViewPendingMessageInfo()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_pending_messages");
+        const string groupName = "test_group",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        // Read a single message into the first consumer.
+        db.StreamReadGroup(key, groupName, consumer1, count: 1);
+
+        // Read the remaining messages into the second consumer.
+        _ = db.StreamReadGroup(key, groupName, consumer2) ?? throw new ArgumentNullException(nameof(consumer2), "db.StreamReadGroup(key, groupName, consumer2)");
+
+        await Task.Delay(10).ForAwait();
+
+        // Get the pending info about the messages themselves.
+        var pendingMessageInfoList = db.StreamPendingMessages(key, groupName, 10, RedisValue.Null);
+
+        Assert.NotNull(pendingMessageInfoList);
+        Assert.Equal(4, pendingMessageInfoList.Length);
+        Assert.Equal(consumer1, pendingMessageInfoList[0].ConsumerName);
+        Assert.Equal(1, pendingMessageInfoList[0].DeliveryCount);
+        Assert.True((int)pendingMessageInfoList[0].IdleTimeInMilliseconds > 0);
+        Assert.Equal(id1, pendingMessageInfoList[0].MessageId);
+    }
+
+    [Fact]
+    public void StreamConsumerGroupViewPendingMessageInfoForConsumer()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_pending_for_consumer");
+        const string groupName = "test_group",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+
+        // Read a single message into the first consumer.
+        db.StreamReadGroup(key, groupName, consumer1, count: 1);
+
+        // Read the remaining messages into the second consumer.
+        db.StreamReadGroup(key, groupName, consumer2);
+
+        // Get the pending info about the messages themselves.
+        var pendingMessageInfoList = db.StreamPendingMessages(key,
+            groupName,
+            10,
+            consumer2);
+
+        Assert.NotNull(pendingMessageInfoList);
+        Assert.Equal(3, pendingMessageInfoList.Length);
+    }
+
+    [Fact]
+    public void StreamDeleteConsumer()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("delete_consumer");
+        const string groupName = "test_group",
+                     consumer = "test_consumer";
+
+        // Add a message to create the stream.
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+
+        // Create a consumer group and read the message.
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+        db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
+
+        var preDeleteConsumers = db.StreamConsumerInfo(key, groupName);
+
+        // Delete the consumer.
+        var deleteResult = db.StreamDeleteConsumer(key, groupName, consumer);
+
+        // Should get 2 messages in the deleteResult.
+        var postDeleteConsumers = db.StreamConsumerInfo(key, groupName);
+
+        Assert.Equal(2, deleteResult);
+        Assert.Single(preDeleteConsumers);
+        Assert.Empty(postDeleteConsumers);
+    }
+
+    [Fact]
+    public void StreamDeleteConsumerGroup()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("delete_consumer_group");
+        const string groupName = "test_group",
+                     consumer = "test_consumer";
+
+        // Add a message to create the stream.
+        db.StreamAdd(key, "field1", "value1");
+
+        // Create a consumer group and read the messages.
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
+        db.StreamReadGroup(key, groupName, consumer, StreamPosition.Beginning);
+
+        var preDeleteInfo = db.StreamInfo(key);
+
+        // Now delete the group.
+        var deleteResult = db.StreamDeleteConsumerGroup(key, groupName);
+
+        var postDeleteInfo = db.StreamInfo(key);
+
+        Assert.True(deleteResult);
+        Assert.Equal(1, preDeleteInfo.ConsumerGroupCount);
+        Assert.Equal(0, postDeleteInfo.ConsumerGroupCount);
+    }
+
+    [Fact]
+    public void StreamDeleteMessage()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("delete_msg");
+
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        var deletedCount = db.StreamDelete(key, new[] { id3 });
+        var messages = db.StreamRange(key);
+
+        Assert.Equal(1, deletedCount);
+        Assert.Equal(3, messages.Length);
+    }
+
+    [Fact]
+    public void StreamDeleteMessages()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("delete_msgs");
+
+        db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        var deletedCount = db.StreamDelete(key, new[] { id2, id3 }, CommandFlags.None);
+        var messages = db.StreamRange(key);
+
+        Assert.Equal(2, deletedCount);
+        Assert.Equal(2, messages.Length);
+    }
+
+    [Fact]
+    public void StreamGroupInfoGet()
+    {
+        var key = GetUniqueKey("group_info");
+        const string group1 = "test_group_1",
+                     group2 = "test_group_2",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        using (var conn = Create(require: RedisFeatures.v5_0_0))
+        {
+            var db = conn.GetDatabase();
+            db.KeyDelete(key);
+
+            db.StreamAdd(key, "field1", "value1");
+            db.StreamAdd(key, "field2", "value2");
+            db.StreamAdd(key, "field3", "value3");
+            db.StreamAdd(key, "field4", "value4");
+
+            db.StreamCreateConsumerGroup(key, group1, StreamPosition.Beginning);
+            db.StreamCreateConsumerGroup(key, group2, StreamPosition.Beginning);
+
+            // Read a single message into the first consumer.
+            db.StreamReadGroup(key, group1, consumer1, count: 1);
+
+            // Read the remaining messages into the second consumer.
+            db.StreamReadGroup(key, group2, consumer2);
+
+            var groupInfoList = db.StreamGroupInfo(key);
+
+            Assert.NotNull(groupInfoList);
+            Assert.Equal(2, groupInfoList.Length);
+
+            Assert.Equal(group1, groupInfoList[0].Name);
+            Assert.Equal(1, groupInfoList[0].PendingMessageCount);
+            Assert.True(IsMessageId(groupInfoList[0].LastDeliveredId)); // can't test actual - will vary
+
+            Assert.Equal(group2, groupInfoList[1].Name);
+            Assert.Equal(4, groupInfoList[1].PendingMessageCount);
+            Assert.True(IsMessageId(groupInfoList[1].LastDeliveredId)); // can't test actual - will vary
+        }
+
+        static bool IsMessageId(string? value)
+        {
+            if (value.IsNullOrWhiteSpace()) return false;
+            return value.Length >= 3 && value.Contains('-');
+        }
+    }
+
+    [Fact]
+    public void StreamGroupConsumerInfoGet()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("group_consumer_info");
+        const string group = "test_group",
+                     consumer1 = "test_consumer_1",
+                     consumer2 = "test_consumer_2";
+
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key, group, StreamPosition.Beginning);
+        db.StreamReadGroup(key, group, consumer1, count: 1);
+        db.StreamReadGroup(key, group, consumer2);
+
+        var consumerInfoList = db.StreamConsumerInfo(key, group);
+
+        Assert.NotNull(consumerInfoList);
+        Assert.Equal(2, consumerInfoList.Length);
+
+        Assert.Equal(consumer1, consumerInfoList[0].Name);
+        Assert.Equal(consumer2, consumerInfoList[1].Name);
+
+        Assert.Equal(1, consumerInfoList[0].PendingMessageCount);
+        Assert.Equal(3, consumerInfoList[1].PendingMessageCount);
+    }
+
+    [Fact]
+    public void StreamInfoGet()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("stream_info");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+        var id4 = db.StreamAdd(key, "field4", "value4");
+
+        var streamInfo = db.StreamInfo(key);
+
+        Assert.Equal(4, streamInfo.Length);
+        Assert.True(streamInfo.RadixTreeKeys > 0);
+        Assert.True(streamInfo.RadixTreeNodes > 0);
+        Assert.Equal(id1, streamInfo.FirstEntry.Id);
+        Assert.Equal(id4, streamInfo.LastEntry.Id);
+    }
+
+    [Fact]
+    public void StreamInfoGetWithEmptyStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("stream_info_empty");
+
+        // Add an entry and then delete it so the stream is empty, then run streaminfo
+        // to ensure it functions properly on an empty stream. Namely, the first-entry
+        // and last-entry messages should be null.
+
+        var id = db.StreamAdd(key, "field1", "value1");
+        db.StreamDelete(key, new[] { id });
+
+        Assert.Equal(0, db.StreamLength(key));
+
+        var streamInfo = db.StreamInfo(key);
+
+        Assert.True(streamInfo.FirstEntry.IsNull);
+        Assert.True(streamInfo.LastEntry.IsNull);
+    }
+
+    [Fact]
+    public void StreamNoConsumerGroups()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("stream_with_no_consumers");
+
+        db.StreamAdd(key, "field1", "value1");
+
+        var groups = db.StreamGroupInfo(key);
+
+        Assert.NotNull(groups);
+        Assert.Empty(groups);
+    }
+
+    [Fact]
+    public void StreamPendingNoMessagesOrConsumers()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("stream_pending_empty");
+        const string groupName = "test_group";
+
+        var id = db.StreamAdd(key, "field1", "value1");
+        db.StreamDelete(key, new[] { id });
+
+        db.StreamCreateConsumerGroup(key, groupName, "0-0");
+
+        var pendingInfo = db.StreamPending(key, "test_group");
+
+        Assert.Equal(0, pendingInfo.PendingMessageCount);
+        Assert.Equal(RedisValue.Null, pendingInfo.LowestPendingMessageId);
+        Assert.Equal(RedisValue.Null, pendingInfo.HighestPendingMessageId);
+        Assert.NotNull(pendingInfo.Consumers);
+        Assert.Empty(pendingInfo.Consumers);
+    }
+
+    [Fact]
+    public void StreamPositionDefaultValueIsBeginning()
+    {
+        RedisValue position = StreamPosition.Beginning;
+        Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XREAD));
+        Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XREADGROUP));
+        Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XGROUP));
+    }
+
+    [Fact]
+    public void StreamPositionValidateBeginning()
+    {
+        var position = StreamPosition.Beginning;
+
+        Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XREAD));
+    }
+
+    [Fact]
+    public void StreamPositionValidateExplicit()
+    {
+        const string explicitValue = "1-0";
+        const string position = explicitValue;
+
+        Assert.Equal(explicitValue, StreamPosition.Resolve(position, RedisCommand.XREAD));
+    }
+
+    [Fact]
+    public void StreamPositionValidateNew()
+    {
+        var position = StreamPosition.NewMessages;
+
+        Assert.Equal(StreamConstants.NewMessages, StreamPosition.Resolve(position, RedisCommand.XGROUP));
+        Assert.Equal(StreamConstants.UndeliveredMessages, StreamPosition.Resolve(position, RedisCommand.XREADGROUP));
+        Assert.ThrowsAny<InvalidOperationException>(() => StreamPosition.Resolve(position, RedisCommand.XREAD));
+    }
+
+    [Fact]
+    public void StreamRead()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+
+        // Read the entire stream from the beginning.
+        var entries = db.StreamRead(key, "0-0");
+
+        Assert.Equal(3, entries.Length);
+        Assert.Equal(id1, entries[0].Id);
+        Assert.Equal(id2, entries[1].Id);
+        Assert.Equal(id3, entries[2].Id);
+    }
+
+    [Fact]
+    public void StreamReadEmptyStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read_empty_stream");
+
+        // Write to a stream to create the key.
+        var id1 = db.StreamAdd(key, "field1", "value1");
+
+        // Delete the key to empty the stream.
+        db.StreamDelete(key, new[] { id1 });
+        var len = db.StreamLength(key);
+
+        // Read the entire stream from the beginning.
+        var entries = db.StreamRead(key, "0-0");
+
+        Assert.Empty(entries);
+        Assert.Equal(0, len);
+    }
+
+    [Fact]
+    public void StreamReadEmptyStreams()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key1 = GetUniqueKey("read_empty_stream_1");
+        var key2 = GetUniqueKey("read_empty_stream_2");
+
+        // Write to a stream to create the key.
+        var id1 = db.StreamAdd(key1, "field1", "value1");
+        var id2 = db.StreamAdd(key2, "field2", "value2");
+
+        // Delete the key to empty the stream.
+        db.StreamDelete(key1, new[] { id1 });
+        db.StreamDelete(key2, new[] { id2 });
+
+        var len1 = db.StreamLength(key1);
+        var len2 = db.StreamLength(key2);
+
+        // Read the entire stream from the beginning.
+        var entries1 = db.StreamRead(key1, "0-0");
+        var entries2 = db.StreamRead(key2, "0-0");
+
+        Assert.Empty(entries1);
+        Assert.Empty(entries2);
+
+        Assert.Equal(0, len1);
+        Assert.Equal(0, len2);
+    }
+
+    [Fact]
+    public void StreamReadExpectedExceptionInvalidCountMultipleStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var streamPositions = new[]
+        {
+            new StreamPosition("key1", "0-0"),
+            new StreamPosition("key2", "0-0")
+        };
+        Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(streamPositions, 0));
+    }
+
+    [Fact]
+    public void StreamReadExpectedExceptionInvalidCountSingleStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read_exception_invalid_count_single");
+        Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(key, "0-0", 0));
+    }
+
+    [Fact]
+    public void StreamReadExpectedExceptionNullStreamList()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        Assert.Throws<ArgumentNullException>(() => db.StreamRead(null!));
+    }
+
+    [Fact]
+    public void StreamReadExpectedExceptionEmptyStreamList()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var emptyList = Array.Empty<StreamPosition>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(emptyList));
+    }
+
+    [Fact]
+    public void StreamReadMultipleStreams()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key1 = GetUniqueKey("read_multi_1a");
+        var key2 = GetUniqueKey("read_multi_2a");
+
+        var id1 = db.StreamAdd(key1, "field1", "value1");
+        var id2 = db.StreamAdd(key1, "field2", "value2");
+        var id3 = db.StreamAdd(key2, "field3", "value3");
+        var id4 = db.StreamAdd(key2, "field4", "value4");
+
+        // Read from both streams at the same time.
+        var streamList = new[]
+        {
+                new StreamPosition(key1, "0-0"),
+                new StreamPosition(key2, "0-0")
+            };
+
+        var streams = db.StreamRead(streamList);
+
+        Assert.True(streams.Length == 2);
+
+        Assert.Equal(key1, streams[0].Key);
+        Assert.Equal(2, streams[0].Entries.Length);
+        Assert.Equal(id1, streams[0].Entries[0].Id);
+        Assert.Equal(id2, streams[0].Entries[1].Id);
+
+        Assert.Equal(key2, streams[1].Key);
+        Assert.Equal(2, streams[1].Entries.Length);
+        Assert.Equal(id3, streams[1].Entries[0].Id);
+        Assert.Equal(id4, streams[1].Entries[1].Id);
+    }
+
+    [Fact]
+    public void StreamReadMultipleStreamsWithCount()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key1 = GetUniqueKey("read_multi_count_1");
+        var key2 = GetUniqueKey("read_multi_count_2");
+
+        var id1 = db.StreamAdd(key1, "field1", "value1");
+        db.StreamAdd(key1, "field2", "value2");
+        var id3 = db.StreamAdd(key2, "field3", "value3");
+        db.StreamAdd(key2, "field4", "value4");
+
+        var streamList = new[]
+        {
+                new StreamPosition(key1, "0-0"),
+                new StreamPosition(key2, "0-0")
+            };
+
+        var streams = db.StreamRead(streamList, countPerStream: 1);
+
+        // We should get both streams back.
+        Assert.Equal(2, streams.Length);
+
+        // Ensure we only got one message per stream.
+        Assert.Single(streams[0].Entries);
+        Assert.Single(streams[1].Entries);
+
+        // Check the message IDs as well.
+        Assert.Equal(id1, streams[0].Entries[0].Id);
+        Assert.Equal(id3, streams[1].Entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamReadMultipleStreamsWithReadPastSecondStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key1 = GetUniqueKey("read_multi_1b");
+        var key2 = GetUniqueKey("read_multi_2b");
+
+        db.StreamAdd(key1, "field1", "value1");
+        db.StreamAdd(key1, "field2", "value2");
+        db.StreamAdd(key2, "field3", "value3");
+        var id4 = db.StreamAdd(key2, "field4", "value4");
+
+        var streamList = new[]
+        {
+                new StreamPosition(key1, "0-0"),
+
+                // read past the end of stream # 2
+                new StreamPosition(key2, id4)
+            };
+
+        var streams = db.StreamRead(streamList);
+
+        // We should only get the first stream back.
+        Assert.Single(streams);
+
+        Assert.Equal(key1, streams[0].Key);
+        Assert.Equal(2, streams[0].Entries.Length);
+    }
+
+    [Fact]
+    public void StreamReadMultipleStreamsWithEmptyResponse()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key1 = GetUniqueKey("read_multi_1c");
+        var key2 = GetUniqueKey("read_multi_2c");
+
+        db.StreamAdd(key1, "field1", "value1");
+        var id2 = db.StreamAdd(key1, "field2", "value2");
+        db.StreamAdd(key2, "field3", "value3");
+        var id4 = db.StreamAdd(key2, "field4", "value4");
+
+        var streamList = new[]
+        {
+                // Read past the end of both streams.
+                new StreamPosition(key1, id2),
+                new StreamPosition(key2, id4)
+            };
+
+        var streams = db.StreamRead(streamList);
+
+        // We expect an empty response.
+        Assert.Empty(streams);
+    }
+
+    [Fact]
+    public void StreamReadPastEndOfStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read_empty");
+
+        db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+
+        // Read after the final ID in the stream, we expect an empty array as a response.
+
+        var entries = db.StreamRead(key, id2);
+
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public void StreamReadRange()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("range");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+
+        var entries = db.StreamRange(key);
+
+        Assert.Equal(2, entries.Length);
+        Assert.Equal(id1, entries[0].Id);
+        Assert.Equal(id2, entries[1].Id);
+    }
+
+    [Fact]
+    public void StreamReadRangeOfEmptyStream()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("range_empty");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+
+        var deleted = db.StreamDelete(key, new[] { id1, id2 });
+
+        var entries = db.StreamRange(key);
+
+        Assert.Equal(2, deleted);
+        Assert.NotNull(entries);
+        Assert.Empty(entries);
+    }
+
+    [Fact]
+    public void StreamReadRangeWithCount()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("range_count");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+
+        var entries = db.StreamRange(key, count: 1);
+
+        Assert.Single(entries);
+        Assert.Equal(id1, entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamReadRangeReverse()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("rangerev");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+
+        var entries = db.StreamRange(key, messageOrder: Order.Descending);
+
+        Assert.Equal(2, entries.Length);
+        Assert.Equal(id2, entries[0].Id);
+        Assert.Equal(id1, entries[1].Id);
+    }
+
+    [Fact]
+    public void StreamReadRangeReverseWithCount()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("rangerev_count");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+
+        var entries = db.StreamRange(key, id1, id2, 1, Order.Descending);
+
+        Assert.Single(entries);
+        Assert.Equal(id2, entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamReadWithAfterIdAndCount_1()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read1");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+
+        // Only read a single item from the stream.
+        var entries = db.StreamRead(key, id1, 1);
+
+        Assert.Single(entries);
+        Assert.Equal(id2, entries[0].Id);
+    }
+
+    [Fact]
+    public void StreamReadWithAfterIdAndCount_2()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read2");
+
+        var id1 = db.StreamAdd(key, "field1", "value1");
+        var id2 = db.StreamAdd(key, "field2", "value2");
+        var id3 = db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        // Read multiple items from the stream.
+        var entries = db.StreamRead(key, id1, 2);
+
+        Assert.Equal(2, entries.Length);
+        Assert.Equal(id2, entries[0].Id);
+        Assert.Equal(id3, entries[1].Id);
+    }
+
+    [Fact]
+    public void StreamTrimLength()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("trimlen");
+
+        // Add a couple items and check length.
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+        db.StreamAdd(key, "field3", "value3");
+        db.StreamAdd(key, "field4", "value4");
+
+        var numRemoved = db.StreamTrim(key, 1);
+        var len = db.StreamLength(key);
+
+        Assert.Equal(3, numRemoved);
+        Assert.Equal(1, len);
+    }
+
+    [Fact]
+    public void StreamVerifyLength()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("len");
+
+        // Add a couple items and check length.
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+
+        var len = db.StreamLength(key);
+
+        Assert.Equal(2, len);
+    }
+
+    [Fact]
+    public async Task AddWithApproxCountAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("approx-async");
+        await db.StreamAddAsync(key, "field", "value", maxLength: 10, useApproximateMaxLength: true, flags: CommandFlags.None).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void AddWithApproxCount()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("approx");
+        db.StreamAdd(key, "field", "value", maxLength: 10, useApproximateMaxLength: true, flags: CommandFlags.None);
+    }
+
+    [Fact]
+    public void StreamReadGroupWithNoAckShowsNoPendingMessages()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = GetUniqueKey("read_group_noack");
+        const string groupName = "test_group",
+                     consumer = "consumer";
+
+        db.StreamAdd(key, "field1", "value1");
+        db.StreamAdd(key, "field2", "value2");
+
+        db.StreamCreateConsumerGroup(key, groupName, StreamPosition.NewMessages);
+
+        db.StreamReadGroup(key,
+            groupName,
+            consumer,
+            StreamPosition.NewMessages,
+            noAck: true);
+
+        var pendingInfo = db.StreamPending(key, groupName);
+
+        Assert.Equal(0, pendingInfo.PendingMessageCount);
+    }
+
+    [Fact]
+    public void StreamReadGroupMultiStreamWithNoAckShowsNoPendingMessages()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key1 = GetUniqueKey("read_group_noack1");
+        var key2 = GetUniqueKey("read_group_noack2");
+        const string groupName = "test_group",
+                     consumer = "consumer";
+
+        db.StreamAdd(key1, "field1", "value1");
+        db.StreamAdd(key1, "field2", "value2");
+
+        db.StreamAdd(key2, "field3", "value3");
+        db.StreamAdd(key2, "field4", "value4");
+
+        db.StreamCreateConsumerGroup(key1, groupName, StreamPosition.NewMessages);
+        db.StreamCreateConsumerGroup(key2, groupName, StreamPosition.NewMessages);
+
+        db.StreamReadGroup(new[]
             {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-                var key = GetUniqueKey("type_check");
-
-                var db = conn.GetDatabase();
-                db.StreamAdd(key, "field1", "value1");
-
-                var keyType = db.KeyType(key);
-
-                Assert.Equal(RedisType.Stream, keyType);
-            }
-        }
-
-        [Fact]
-        public void StreamAddSinglePairWithAutoId()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var messageId = db.StreamAdd(GetUniqueKey("auto_id"), "field1", "value1");
-
-                Assert.True(messageId != RedisValue.Null && ((string?)messageId)?.Length > 0);
-            }
-        }
-
-        [Fact]
-        public void StreamAddMultipleValuePairsWithAutoId()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var key = GetUniqueKey("multiple_value_pairs");
-
-                var fields = new []
-                {
-                    new NameValueEntry("field1", "value1"),
-                    new NameValueEntry("field2", "value2")
-                };
-
-                var db = conn.GetDatabase();
-                var messageId = db.StreamAdd(key, fields);
-
-                var entries = db.StreamRange(key);
-
-                Assert.Single(entries);
-                Assert.Equal(messageId, entries[0].Id);
-                var vals = entries[0].Values;
-                Assert.NotNull(vals);
-                Assert.Equal(2, vals.Length);
-                Assert.Equal("field1", vals[0].Name);
-                Assert.Equal("value1", vals[0].Value);
-                Assert.Equal("field2", vals[1].Name);
-                Assert.Equal("value2", vals[1].Value);
-            }
-        }
-
-        [Fact]
-        public void StreamAddWithManualId()
-        {
-            const string id = "42-0";
-            var key = GetUniqueKey("manual_id");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                var messageId = db.StreamAdd(key, "field1", "value1", id);
-
-                Assert.Equal(id, messageId);
-            }
-        }
-
-        [Fact]
-        public void StreamAddMultipleValuePairsWithManualId()
-        {
-            const string id = "42-0";
-            var key = GetUniqueKey("manual_id_multiple_values");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var fields = new []
-                {
-                    new NameValueEntry("field1", "value1"),
-                    new NameValueEntry("field2", "value2")
-                };
-
-                var messageId = db.StreamAdd(key, fields, id);
-                var entries = db.StreamRange(key);
-
-                Assert.Equal(id, messageId);
-                Assert.NotNull(entries);
-                Assert.Single(entries);
-                Assert.Equal(id, entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupSetId()
-        {
-            var key = GetUniqueKey("group_set_id");
-            const string groupName = "test_group";
-            const string consumer = "consumer";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Create a stream
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-
-                // Create a group and set the position to deliver new messages only.
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.NewMessages);
-
-                // Read into the group, expect nothing
-                var firstRead = db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
-
-                // Reset the ID back to read from the beginning.
-                db.StreamConsumerGroupSetPosition(key, groupName, StreamPosition.Beginning);
-
-                var secondRead = db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
-
-                Assert.NotNull(firstRead);
-                Assert.NotNull(secondRead);
-                Assert.Empty(firstRead);
-                Assert.Equal(2, secondRead.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupWithNoConsumers()
-        {
-            var key = GetUniqueKey("group_with_no_consumers");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Create a stream
-                db.StreamAdd(key, "field1", "value1");
-
-                // Create a group
-                db.StreamCreateConsumerGroup(key, groupName, "0-0");
-
-                // Query redis for the group consumers, expect an empty list in response.
-                var consumers = db.StreamConsumerInfo(key, groupName);
-
-                Assert.Empty(consumers);
-            }
-        }
-
-        [Fact]
-        public void StreamCreateConsumerGroup()
-        {
-            var key = GetUniqueKey("group_create");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Create a stream
-                db.StreamAdd(key, "field1", "value1");
-
-                // Create a group
-                var result = db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                Assert.True(result);
-            }
-        }
-
-        [Fact]
-        public void StreamCreateConsumerGroupBeforeCreatingStream()
-        {
-            var key = GetUniqueKey("group_create_before_stream");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Ensure the key doesn't exist.
-                var keyExistsBeforeCreate = db.KeyExists(key);
-
-                // The 'createStream' parameter is 'true' by default.
-                var groupCreated = db.StreamCreateConsumerGroup(key, "consumerGroup", StreamPosition.NewMessages);
-
-                var keyExistsAfterCreate = db.KeyExists(key);
-
-                Assert.False(keyExistsBeforeCreate);
-                Assert.True(groupCreated);
-                Assert.True(keyExistsAfterCreate);
-            }
-        }
-
-        [Fact]
-        public void StreamCreateConsumerGroupFailsIfKeyDoesntExist()
-        {
-            var key = GetUniqueKey("group_create_before_stream_should_fail");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Pass 'false' for 'createStream' to ensure that an
-                // exception is thrown when the stream doesn't exist.
-                Assert.ThrowsAny<RedisServerException>(() => db.StreamCreateConsumerGroup(
-                        key,
-                        "consumerGroup",
-                        StreamPosition.NewMessages,
-                        createStream: false));
-            }
-        }
-
-        [Fact]
-        public void StreamCreateConsumerGroupSucceedsWhenKeyExists()
-        {
-            var key = GetUniqueKey("group_create_after_stream");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "f1", "v1");
-
-                // Pass 'false' for 'createStream', should create the consumer group
-                // without issue since the stream already exists.
-                var groupCreated = db.StreamCreateConsumerGroup(
-                    key,
-                    "consumerGroup",
-                    StreamPosition.NewMessages,
-                    createStream: false);
-
-                Assert.True(groupCreated);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadOnlyNewMessagesWithEmptyResponse()
-        {
-            var key = GetUniqueKey("group_read");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Create a stream
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-
-                // Create a group.
-                db.StreamCreateConsumerGroup(key, groupName);
-
-                // Read, expect no messages
-                var entries = db.StreamReadGroup(key, groupName, "test_consumer", "0-0");
-
-                Assert.Empty(entries);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadFromStreamBeginning()
-        {
-            var key = GetUniqueKey("group_read_beginning");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                var entries = db.StreamReadGroup(key, groupName, "test_consumer", StreamPosition.NewMessages);
-
-                Assert.Equal(2, entries.Length);
-                Assert.True(id1 == entries[0].Id);
-                Assert.True(id2 == entries[1].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadFromStreamBeginningWithCount()
-        {
-            var key = GetUniqueKey("group_read_with_count");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                _ = db.StreamAdd(key, "field4", "value4");
-
-                // Start reading after id1.
-                db.StreamCreateConsumerGroup(key, groupName, id1);
-
-                var entries = db.StreamReadGroup(key, groupName, "test_consumer", StreamPosition.NewMessages, 2);
-
-                // Ensure we only received the requested count and that the IDs match the expected values.
-                Assert.Equal(2, entries.Length);
-                Assert.True(id2 == entries[0].Id);
-                Assert.True(id3 == entries[1].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupAcknowledgeMessage()
-        {
-            var key = GetUniqueKey("group_ack");
-            const string groupName = "test_group";
-            const string consumer = "test_consumer";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                // Read all 4 messages, they will be assigned to the consumer
-                var entries = db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
-
-                // Send XACK for 3 of the messages
-
-                // Single message Id overload.
-                var oneAck = db.StreamAcknowledge(key, groupName, id1);
-
-                // Multiple message Id overload.
-                var twoAck = db.StreamAcknowledge(key, groupName, new [] { id3, id4 });
-
-                // Read the group again, it should only return the unacknowledged message.
-                var notAcknowledged = db.StreamReadGroup(key, groupName, consumer, "0-0");
-
-                Assert.Equal(4, entries.Length);
-                Assert.Equal(1, oneAck);
-                Assert.Equal(2, twoAck);
-                Assert.Single(notAcknowledged);
-                Assert.Equal(id2, notAcknowledged[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupClaimMessages()
-        {
-            var key = GetUniqueKey("group_claim");
-            const string groupName = "test_group";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                _ = db.StreamAdd(key, "field1", "value1");
-                _ = db.StreamAdd(key, "field2", "value2");
-                _ = db.StreamAdd(key, "field3", "value3");
-                _ = db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, groupName, "0-0");
-
-                // Read a single message into the first consumer.
-                db.StreamReadGroup(key, groupName, consumer1, count: 1);
-
-                // Read the remaining messages into the second consumer.
-                db.StreamReadGroup(key, groupName, consumer2);
-
-                // Claim the 3 messages consumed by consumer2 for consumer1.
-
-                // Get the pending messages for consumer2.
-                var pendingMessages = db.StreamPendingMessages(key, groupName,
-                    10,
-                    consumer2);
-
-                // Claim the messages for consumer1.
-                var messages = db.StreamClaim(key,
-                                    groupName,
-                                    consumer1,
-                                    0, // Min message idle time
-                                    messageIds: pendingMessages.Select(pm => pm.MessageId).ToArray());
-
-                // Now see how many messages are pending for each consumer
-                var pendingSummary = db.StreamPending(key, groupName);
-
-                Assert.NotNull(pendingSummary.Consumers);
-                Assert.Single(pendingSummary.Consumers);
-                Assert.Equal(4, pendingSummary.Consumers[0].PendingMessageCount);
-                Assert.Equal(pendingMessages.Length, messages.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupClaimMessagesReturningIds()
-        {
-            var key = GetUniqueKey("group_claim_view_ids");
-            const string groupName = "test_group";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                _ = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                // Read a single message into the first consumer.
-                _ = db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
-
-                // Read the remaining messages into the second consumer.
-                _ = db.StreamReadGroup(key, groupName, consumer2);
-
-                // Claim the 3 messages consumed by consumer2 for consumer1.
-
-                // Get the pending messages for consumer2.
-                var pendingMessages = db.StreamPendingMessages(key, groupName,
-                    10,
-                    consumer2);
-
-                // Claim the messages for consumer1.
-                var messageIds = db.StreamClaimIdsOnly(key,
-                                    groupName,
-                                    consumer1,
-                                    0, // Min message idle time
-                                    messageIds: pendingMessages.Select(pm => pm.MessageId).ToArray());
-
-                // We should get an array of 3 message IDs.
-                Assert.Equal(3, messageIds.Length);
-                Assert.Equal(id2, messageIds[0]);
-                Assert.Equal(id3, messageIds[1]);
-                Assert.Equal(id4, messageIds[2]);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadMultipleOneReadBeginningOneReadNew()
-        {
-            // Create a group for each stream. One set to read from the beginning of the
-            // stream and the other to begin reading only new messages.
-
-            // Ask redis to read from the beginning of both stream, expect messages
-            // for only the stream set to read from the beginning.
-
-            const string groupName = "test_group";
-            var stream1 = GetUniqueKey("stream1a");
-            var stream2 = GetUniqueKey("stream2a");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(stream1, "field1-1", "value1-1");
-                db.StreamAdd(stream1, "field1-2", "value1-2");
-
-                db.StreamAdd(stream2, "field2-1", "value2-1");
-                db.StreamAdd(stream2, "field2-2", "value2-2");
-                db.StreamAdd(stream2, "field2-3", "value2-3");
-
-                // stream1 set up to read only new messages.
-                db.StreamCreateConsumerGroup(stream1, groupName, StreamPosition.NewMessages);
-
-                // stream2 set up to read from the beginning of the stream
-                db.StreamCreateConsumerGroup(stream2, groupName, StreamPosition.Beginning);
-
-                // Read for both streams from the beginning. We shouldn't get anything back for stream1.
-                var pairs = new []
-                {
-                    // StreamPosition.NewMessages will send ">" which indicates "Undelivered" messages.
-                    new StreamPosition(stream1, StreamPosition.NewMessages),
-                    new StreamPosition(stream2, StreamPosition.NewMessages)
-                };
-
-                var streams = db.StreamReadGroup(pairs, groupName, "test_consumer");
-
-                Assert.NotNull(streams);
-                Assert.Single(streams);
-                Assert.Equal(stream2, streams[0].Key);
-                Assert.Equal(3, streams[0].Entries.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadMultipleOnlyNewMessagesExpectNoResult()
-        {
-            const string groupName = "test_group";
-            var stream1 = GetUniqueKey("stream1b");
-            var stream2 = GetUniqueKey("stream2b");
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(stream1, "field1-1", "value1-1");
-                db.StreamAdd(stream2, "field2-1", "value2-1");
-
-                // set both streams to read only new messages (default behavior).
-                db.StreamCreateConsumerGroup(stream1, groupName);
-                db.StreamCreateConsumerGroup(stream2, groupName);
-
-                // We shouldn't get anything for either stream.
-                var pairs = new []
-                {
-                    new StreamPosition(stream1, StreamPosition.Beginning),
-                    new StreamPosition(stream2, StreamPosition.Beginning)
-                };
-
-                var streams = db.StreamReadGroup(pairs, groupName, "test_consumer");
-
-                Assert.NotNull(streams);
-                Assert.Equal(2, streams.Length);
-                Assert.Empty(streams[0].Entries);
-                Assert.Empty(streams[1].Entries);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadMultipleOnlyNewMessagesExpect1Result()
-        {
-            const string groupName = "test_group";
-            var stream1 = GetUniqueKey("stream1c");
-            var stream2 = GetUniqueKey("stream2c");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // These messages won't be read.
-                db.StreamAdd(stream1, "field1-1", "value1-1");
-                db.StreamAdd(stream2, "field2-1", "value2-1");
-
-                // set both streams to read only new messages (default behavior).
-                db.StreamCreateConsumerGroup(stream1, groupName);
-                db.StreamCreateConsumerGroup(stream2, groupName);
-
-                // We should read these though.
-                var id1 = db.StreamAdd(stream1, "field1-2", "value1-2");
-                var id2 = db.StreamAdd(stream2, "field2-2", "value2-2");
-
-                // Read the new messages (messages created after the group was created).
-                var pairs = new []
-                {
-                    new StreamPosition(stream1, StreamPosition.NewMessages),
-                    new StreamPosition(stream2, StreamPosition.NewMessages)
-                };
-
-                var streams = db.StreamReadGroup(pairs, groupName, "test_consumer");
-
-                Assert.NotNull(streams);
-                Assert.Equal(2, streams.Length);
-                Assert.Single(streams[0].Entries);
-                Assert.Single(streams[1].Entries);
-                Assert.Equal(id1, streams[0].Entries[0].Id);
-                Assert.Equal(id2, streams[1].Entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupReadMultipleRestrictCount()
-        {
-            const string groupName = "test_group";
-            var stream1 = GetUniqueKey("stream1d");
-            var stream2 = GetUniqueKey("stream2d");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1_1 = db.StreamAdd(stream1, "field1-1", "value1-1");
-                var id1_2 = db.StreamAdd(stream1, "field1-2", "value1-2");
-
-                var id2_1 = db.StreamAdd(stream2, "field2-1", "value2-1");
-                _ = db.StreamAdd(stream2, "field2-2", "value2-2");
-                _ = db.StreamAdd(stream2, "field2-3", "value2-3");
-
-                // Set the initial read point in each stream, *after* the first ID in both streams.
-                db.StreamCreateConsumerGroup(stream1, groupName, id1_1);
-                db.StreamCreateConsumerGroup(stream2, groupName, id2_1);
-
-                var pairs = new []
-                {
-                    // Read after the first id in both streams
-                    new StreamPosition(stream1, StreamPosition.NewMessages),
-                    new StreamPosition(stream2, StreamPosition.NewMessages)
-                };
-
-                // Restrict the count to 2 (expect only 1 message from first stream, 2 from the second).
-                var streams = db.StreamReadGroup(pairs, groupName, "test_consumer", 2);
-
-                Assert.NotNull(streams);
-                Assert.Equal(2, streams.Length);
-                Assert.Single(streams[0].Entries);
-                Assert.Equal(2, streams[1].Entries.Length);
-                Assert.Equal(id1_2, streams[0].Entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupViewPendingInfoNoConsumers()
-        {
-            var key = GetUniqueKey("group_pending_info_no_consumers");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                var pendingInfo = db.StreamPending(key, groupName);
-
-                Assert.Equal(0, pendingInfo.PendingMessageCount);
-                Assert.Equal(RedisValue.Null, pendingInfo.LowestPendingMessageId);
-                Assert.Equal(RedisValue.Null, pendingInfo.HighestPendingMessageId);
-                Assert.NotNull(pendingInfo.Consumers);
-                Assert.Empty(pendingInfo.Consumers);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupViewPendingInfoWhenNothingPending()
-        {
-            var key = GetUniqueKey("group_pending_info_nothing_pending");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-
-                db.StreamCreateConsumerGroup(key, groupName, "0-0");
-
-                var pendingMessages = db.StreamPendingMessages(key,
-                    groupName,
-                    10,
-                    consumerName: RedisValue.Null);
-
-                Assert.NotNull(pendingMessages);
-                Assert.Empty(pendingMessages);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupViewPendingInfoSummary()
-        {
-            var key = GetUniqueKey("group_pending_info");
-            const string groupName = "test_group";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                // Read a single message into the first consumer.
-                db.StreamReadGroup(key, groupName, consumer1, StreamPosition.NewMessages, 1);
-
-                // Read the remaining messages into the second consumer.
-                db.StreamReadGroup(key, groupName, consumer2);
-
-                var pendingInfo = db.StreamPending(key, groupName);
-
-                Assert.Equal(4, pendingInfo.PendingMessageCount);
-                Assert.Equal(id1, pendingInfo.LowestPendingMessageId);
-                Assert.Equal(id4, pendingInfo.HighestPendingMessageId);
-                Assert.True(pendingInfo.Consumers.Length == 2);
-
-                var consumer1Count = pendingInfo.Consumers.First(c => c.Name == consumer1).PendingMessageCount;
-                var consumer2Count = pendingInfo.Consumers.First(c => c.Name == consumer2).PendingMessageCount;
-
-                Assert.Equal(1, consumer1Count);
-                Assert.Equal(3, consumer2Count);
-            }
-        }
-
-        [Fact]
-        public async Task StreamConsumerGroupViewPendingMessageInfo()
-        {
-            var key = GetUniqueKey("group_pending_messages");
-            const string groupName = "test_group";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                // Read a single message into the first consumer.
-                db.StreamReadGroup(key, groupName, consumer1, count: 1);
-
-                // Read the remaining messages into the second consumer.
-                _ = db.StreamReadGroup(key, groupName, consumer2) ?? throw new ArgumentNullException(nameof(consumer2), "db.StreamReadGroup(key, groupName, consumer2)");
-
-                await Task.Delay(10).ForAwait();
-
-                // Get the pending info about the messages themselves.
-                var pendingMessageInfoList = db.StreamPendingMessages(key, groupName, 10, RedisValue.Null);
-
-                Assert.NotNull(pendingMessageInfoList);
-                Assert.Equal(4, pendingMessageInfoList.Length);
-                Assert.Equal(consumer1, pendingMessageInfoList[0].ConsumerName);
-                Assert.Equal(1, pendingMessageInfoList[0].DeliveryCount);
-                Assert.True((int)pendingMessageInfoList[0].IdleTimeInMilliseconds > 0);
-                Assert.Equal(id1, pendingMessageInfoList[0].MessageId);
-            }
-        }
-
-        [Fact]
-        public void StreamConsumerGroupViewPendingMessageInfoForConsumer()
-        {
-            var key = GetUniqueKey("group_pending_for_consumer");
-            const string groupName = "test_group";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-
-                // Read a single message into the first consumer.
-                db.StreamReadGroup(key, groupName, consumer1, count: 1);
-
-                // Read the remaining messages into the second consumer.
-                db.StreamReadGroup(key, groupName, consumer2);
-
-                // Get the pending info about the messages themselves.
-                var pendingMessageInfoList = db.StreamPendingMessages(key,
-                    groupName,
-                    10,
-                    consumer2);
-
-                Assert.NotNull(pendingMessageInfoList);
-                Assert.Equal(3, pendingMessageInfoList.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamDeleteConsumer()
-        {
-            var key = GetUniqueKey("delete_consumer");
-            const string groupName = "test_group";
-            const string consumer = "test_consumer";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Add a message to create the stream.
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-
-                // Create a consumer group and read the message.
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-                db.StreamReadGroup(key, groupName, consumer, StreamPosition.NewMessages);
-
-                var preDeleteConsumers = db.StreamConsumerInfo(key, groupName);
-
-                // Delete the consumer.
-                var deleteResult = db.StreamDeleteConsumer(key, groupName, consumer);
-
-                // Should get 2 messages in the deleteResult.
-                var postDeleteConsumers = db.StreamConsumerInfo(key, groupName);
-
-                Assert.Equal(2, deleteResult);
-                Assert.Single(preDeleteConsumers);
-                Assert.Empty(postDeleteConsumers);
-            }
-        }
-
-        [Fact]
-        public void StreamDeleteConsumerGroup()
-        {
-            var key = GetUniqueKey("delete_consumer_group");
-            const string groupName = "test_group";
-            const string consumer = "test_consumer";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Add a message to create the stream.
-                db.StreamAdd(key, "field1", "value1");
-
-                // Create a consumer group and read the messages.
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.Beginning);
-                db.StreamReadGroup(key, groupName, consumer, StreamPosition.Beginning);
-
-                var preDeleteInfo = db.StreamInfo(key);
-
-                // Now delete the group.
-                var deleteResult = db.StreamDeleteConsumerGroup(key, groupName);
-
-                var postDeleteInfo = db.StreamInfo(key);
-
-                Assert.True(deleteResult);
-                Assert.Equal(1, preDeleteInfo.ConsumerGroupCount);
-                Assert.Equal(0, postDeleteInfo.ConsumerGroupCount);
-            }
-        }
-
-        [Fact]
-        public void StreamDeleteMessage()
-        {
-            var key = GetUniqueKey("delete_msg");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                var deletedCount = db.StreamDelete(key, new [] { id3 });
-                var messages = db.StreamRange(key);
-
-                Assert.Equal(1, deletedCount);
-                Assert.Equal(3, messages.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamDeleteMessages()
-        {
-            var key = GetUniqueKey("delete_msgs");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                var deletedCount = db.StreamDelete(key, new [] { id2, id3 }, CommandFlags.None);
-                var messages = db.StreamRange(key);
-
-                Assert.Equal(2, deletedCount);
-                Assert.Equal(2, messages.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamGroupInfoGet()
-        {
-            var key = GetUniqueKey("group_info");
-            const string group1 = "test_group_1";
-            const string group2 = "test_group_2";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                db.KeyDelete(key);
-
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, group1, StreamPosition.Beginning);
-                db.StreamCreateConsumerGroup(key, group2, StreamPosition.Beginning);
-
-                // Read a single message into the first consumer.
-                db.StreamReadGroup(key, group1, consumer1, count: 1);
-
-                // Read the remaining messages into the second consumer.
-                db.StreamReadGroup(key, group2, consumer2);
-
-                var groupInfoList = db.StreamGroupInfo(key);
-
-                Assert.NotNull(groupInfoList);
-                Assert.Equal(2, groupInfoList.Length);
-
-                Assert.Equal(group1, groupInfoList[0].Name);
-                Assert.Equal(1, groupInfoList[0].PendingMessageCount);
-                Assert.True(IsMessageId(groupInfoList[0].LastDeliveredId)); // can't test actual - will vary
-
-                Assert.Equal(group2, groupInfoList[1].Name);
-                Assert.Equal(4, groupInfoList[1].PendingMessageCount);
-                Assert.True(IsMessageId(groupInfoList[1].LastDeliveredId)); // can't test actual - will vary
-            }
-
-            static bool IsMessageId(string? value)
-            {
-                if (value.IsNullOrWhiteSpace()) return false;
-                return value.Length >= 3 && value.Contains('-');
-            }
-        }
-
-        [Fact]
-        public void StreamGroupConsumerInfoGet()
-        {
-            var key = GetUniqueKey("group_consumer_info");
-            const string group = "test_group";
-            const string consumer1 = "test_consumer_1";
-            const string consumer2 = "test_consumer_2";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key, group, StreamPosition.Beginning);
-                db.StreamReadGroup(key, group, consumer1, count: 1);
-                db.StreamReadGroup(key, group, consumer2);
-
-                var consumerInfoList = db.StreamConsumerInfo(key, group);
-
-                Assert.NotNull(consumerInfoList);
-                Assert.Equal(2, consumerInfoList.Length);
-
-                Assert.Equal(consumer1, consumerInfoList[0].Name);
-                Assert.Equal(consumer2, consumerInfoList[1].Name);
-
-                Assert.Equal(1, consumerInfoList[0].PendingMessageCount);
-                Assert.Equal(3, consumerInfoList[1].PendingMessageCount);
-            }
-        }
-
-        [Fact]
-        public void StreamInfoGet()
-        {
-            var key = GetUniqueKey("stream_info");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                var id4 = db.StreamAdd(key, "field4", "value4");
-
-                var streamInfo = db.StreamInfo(key);
-
-                Assert.Equal(4, streamInfo.Length);
-                Assert.True(streamInfo.RadixTreeKeys > 0);
-                Assert.True(streamInfo.RadixTreeNodes > 0);
-                Assert.Equal(id1, streamInfo.FirstEntry.Id);
-                Assert.Equal(id4, streamInfo.LastEntry.Id);
-            }
-        }
-
-        [Fact]
-        public void StreamInfoGetWithEmptyStream()
-        {
-            var key = GetUniqueKey("stream_info_empty");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Add an entry and then delete it so the stream is empty, then run streaminfo
-                // to ensure it functions properly on an empty stream. Namely, the first-entry
-                // and last-entry messages should be null.
-
-                var id = db.StreamAdd(key, "field1", "value1");
-                db.StreamDelete(key, new [] { id });
-
-                Assert.Equal(0, db.StreamLength(key));
-
-                var streamInfo = db.StreamInfo(key);
-
-                Assert.True(streamInfo.FirstEntry.IsNull);
-                Assert.True(streamInfo.LastEntry.IsNull);
-            }
-        }
-
-        [Fact]
-        public void StreamNoConsumerGroups()
-        {
-            var key = GetUniqueKey("stream_with_no_consumers");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-
-                var groups = db.StreamGroupInfo(key);
-
-                Assert.NotNull(groups);
-                Assert.Empty(groups);
-            }
-        }
-
-        [Fact]
-        public void StreamPendingNoMessagesOrConsumers()
-        {
-            var key = GetUniqueKey("stream_pending_empty");
-            const string groupName = "test_group";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id = db.StreamAdd(key, "field1", "value1");
-                db.StreamDelete(key, new [] { id });
-
-                db.StreamCreateConsumerGroup(key, groupName, "0-0");
-
-                var pendingInfo = db.StreamPending(key, "test_group");
-
-                Assert.Equal(0, pendingInfo.PendingMessageCount);
-                Assert.Equal(RedisValue.Null, pendingInfo.LowestPendingMessageId);
-                Assert.Equal(RedisValue.Null, pendingInfo.HighestPendingMessageId);
-                Assert.NotNull(pendingInfo.Consumers);
-                Assert.Empty(pendingInfo.Consumers);
-            }
-        }
-
-        [Fact]
-        public void StreamPositionDefaultValueIsBeginning()
-        {
-            RedisValue position = StreamPosition.Beginning;
-            Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XREAD));
-            Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XREADGROUP));
-            Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XGROUP));
-        }
-
-        [Fact]
-        public void StreamPositionValidateBeginning()
-        {
-            var position = StreamPosition.Beginning;
-
-            Assert.Equal(StreamConstants.AllMessages, StreamPosition.Resolve(position, RedisCommand.XREAD));
-        }
-
-        [Fact]
-        public void StreamPositionValidateExplicit()
-        {
-            const string explicitValue = "1-0";
-            const string position = explicitValue;
-
-            Assert.Equal(explicitValue, StreamPosition.Resolve(position, RedisCommand.XREAD));
-        }
-
-        [Fact]
-        public void StreamPositionValidateNew()
-        {
-            var position = StreamPosition.NewMessages;
-
-            Assert.Equal(StreamConstants.NewMessages, StreamPosition.Resolve(position, RedisCommand.XGROUP));
-            Assert.Equal(StreamConstants.UndeliveredMessages, StreamPosition.Resolve(position, RedisCommand.XREADGROUP));
-            Assert.ThrowsAny<InvalidOperationException>(() => StreamPosition.Resolve(position, RedisCommand.XREAD));
-        }
-
-        [Fact]
-        public void StreamRead()
-        {
-            var key = GetUniqueKey("read");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-
-                // Read the entire stream from the beginning.
-                var entries = db.StreamRead(key, "0-0");
-
-                Assert.Equal(3, entries.Length);
-                Assert.Equal(id1, entries[0].Id);
-                Assert.Equal(id2, entries[1].Id);
-                Assert.Equal(id3, entries[2].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadEmptyStream()
-        {
-            var key = GetUniqueKey("read_empty_stream");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Write to a stream to create the key.
-                var id1 = db.StreamAdd(key, "field1", "value1");
-
-                // Delete the key to empty the stream.
-                db.StreamDelete(key, new [] { id1 });
-                var len = db.StreamLength(key);
-
-                // Read the entire stream from the beginning.
-                var entries = db.StreamRead(key, "0-0");
-
-                Assert.Empty(entries);
-                Assert.Equal(0, len);
-            }
-        }
-
-        [Fact]
-        public void StreamReadEmptyStreams()
-        {
-            var key1 = GetUniqueKey("read_empty_stream_1");
-            var key2 = GetUniqueKey("read_empty_stream_2");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Write to a stream to create the key.
-                var id1 = db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key2, "field2", "value2");
-
-                // Delete the key to empty the stream.
-                db.StreamDelete(key1, new [] { id1 });
-                db.StreamDelete(key2, new [] { id2 });
-
-                var len1 = db.StreamLength(key1);
-                var len2 = db.StreamLength(key2);
-
-                // Read the entire stream from the beginning.
-                var entries1 = db.StreamRead(key1, "0-0");
-                var entries2 = db.StreamRead(key2, "0-0");
-
-                Assert.Empty(entries1);
-                Assert.Empty(entries2);
-
-                Assert.Equal(0, len1);
-                Assert.Equal(0, len2);
-            }
-        }
-
-        [Fact]
-        public void StreamReadExpectedExceptionInvalidCountMultipleStream()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var streamPositions = new []
-                {
-                    new StreamPosition("key1", "0-0"),
-                    new StreamPosition("key2", "0-0")
-                };
-
-                var db = conn.GetDatabase();
-                Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(streamPositions, 0));
-            }
-        }
-
-        [Fact]
-        public void StreamReadExpectedExceptionInvalidCountSingleStream()
-        {
-            var key = GetUniqueKey("read_exception_invalid_count_single");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(key, "0-0", 0));
-            }
-        }
-
-        [Fact]
-        public void StreamReadExpectedExceptionNullStreamList()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                Assert.Throws<ArgumentNullException>(() => db.StreamRead(null!));
-            }
-        }
-
-        [Fact]
-        public void StreamReadExpectedExceptionEmptyStreamList()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var emptyList = Array.Empty<StreamPosition>();
-
-                Assert.Throws<ArgumentOutOfRangeException>(() => db.StreamRead(emptyList));
-            }
-        }
-
-        [Fact]
-        public void StreamReadMultipleStreams()
-        {
-            var key1 = GetUniqueKey("read_multi_1a");
-            var key2 = GetUniqueKey("read_multi_2a");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key1, "field2", "value2");
-                var id3 = db.StreamAdd(key2, "field3", "value3");
-                var id4 = db.StreamAdd(key2, "field4", "value4");
-
-                // Read from both streams at the same time.
-                var streamList = new []
-                {
-                    new StreamPosition(key1, "0-0"),
-                    new StreamPosition(key2, "0-0")
-                };
-
-                var streams = db.StreamRead(streamList);
-
-                Assert.True(streams.Length == 2);
-
-                Assert.Equal(key1, streams[0].Key);
-                Assert.Equal(2, streams[0].Entries.Length);
-                Assert.Equal(id1, streams[0].Entries[0].Id);
-                Assert.Equal(id2, streams[0].Entries[1].Id);
-
-                Assert.Equal(key2, streams[1].Key);
-                Assert.Equal(2, streams[1].Entries.Length);
-                Assert.Equal(id3, streams[1].Entries[0].Id);
-                Assert.Equal(id4, streams[1].Entries[1].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadMultipleStreamsWithCount()
-        {
-            var key1 = GetUniqueKey("read_multi_count_1");
-            var key2 = GetUniqueKey("read_multi_count_2");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key1, "field1", "value1");
-                db.StreamAdd(key1, "field2", "value2");
-                var id3 = db.StreamAdd(key2, "field3", "value3");
-                db.StreamAdd(key2, "field4", "value4");
-
-                var streamList = new []
-                {
-                    new StreamPosition(key1, "0-0"),
-                    new StreamPosition(key2, "0-0")
-                };
-
-                var streams = db.StreamRead(streamList, countPerStream: 1);
-
-                // We should get both streams back.
-                Assert.Equal(2, streams.Length);
-
-                // Ensure we only got one message per stream.
-                Assert.Single(streams[0].Entries);
-                Assert.Single(streams[1].Entries);
-
-                // Check the message IDs as well.
-                Assert.Equal(id1, streams[0].Entries[0].Id);
-                Assert.Equal(id3, streams[1].Entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadMultipleStreamsWithReadPastSecondStream()
-        {
-            var key1 = GetUniqueKey("read_multi_1b");
-            var key2 = GetUniqueKey("read_multi_2b");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key1, "field1", "value1");
-                db.StreamAdd(key1, "field2", "value2");
-                db.StreamAdd(key2, "field3", "value3");
-                var id4 = db.StreamAdd(key2, "field4", "value4");
-
-                var streamList = new []
-                {
-                    new StreamPosition(key1, "0-0"),
-
-                    // read past the end of stream # 2
-                    new StreamPosition(key2, id4)
-                };
-
-                var streams = db.StreamRead(streamList);
-
-                // We should only get the first stream back.
-                Assert.Single(streams);
-
-                Assert.Equal(key1, streams[0].Key);
-                Assert.Equal(2, streams[0].Entries.Length);
-            }
-        }
-
-        [Fact]
-        public void StreamReadMultipleStreamsWithEmptyResponse()
-        {
-            var key1 = GetUniqueKey("read_multi_1c");
-            var key2 = GetUniqueKey("read_multi_2c");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key1, "field1", "value1");
-                var id2 = db.StreamAdd(key1, "field2", "value2");
-                db.StreamAdd(key2, "field3", "value3");
-                var id4 = db.StreamAdd(key2, "field4", "value4");
-
-                var streamList = new []
-                {
-                    // Read past the end of both streams.
-                    new StreamPosition(key1, id2),
-                    new StreamPosition(key2, id4)
-                };
-
-                var streams = db.StreamRead(streamList);
-
-                // We expect an empty response.
-                Assert.Empty(streams);
-            }
-        }
-
-        [Fact]
-        public void StreamReadPastEndOfStream()
-        {
-            var key = GetUniqueKey("read_empty");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-
-                // Read after the final ID in the stream, we expect an empty array as a response.
-
-                var entries = db.StreamRead(key, id2);
-
-                Assert.Empty(entries);
-            }
-        }
-
-        [Fact]
-        public void StreamReadRange()
-        {
-            var key = GetUniqueKey("range");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-
-                var entries = db.StreamRange(key);
-
-                Assert.Equal(2, entries.Length);
-                Assert.Equal(id1, entries[0].Id);
-                Assert.Equal(id2, entries[1].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadRangeOfEmptyStream()
-        {
-            var key = GetUniqueKey("range_empty");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-
-                var deleted = db.StreamDelete(key, new [] { id1, id2 });
-
-                var entries = db.StreamRange(key);
-
-                Assert.Equal(2, deleted);
-                Assert.NotNull(entries);
-                Assert.Empty(entries);
-            }
-        }
-
-        [Fact]
-        public void StreamReadRangeWithCount()
-        {
-            var key = GetUniqueKey("range_count");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-
-                var entries = db.StreamRange(key, count: 1);
-
-                Assert.Single(entries);
-                Assert.Equal(id1, entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadRangeReverse()
-        {
-            var key = GetUniqueKey("rangerev");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-
-                var entries = db.StreamRange(key, messageOrder: Order.Descending);
-
-                Assert.Equal(2, entries.Length);
-                Assert.Equal(id2, entries[0].Id);
-                Assert.Equal(id1, entries[1].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadRangeReverseWithCount()
-        {
-            var key = GetUniqueKey("rangerev_count");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-
-                var entries = db.StreamRange(key, id1, id2, 1, Order.Descending);
-
-                Assert.Single(entries);
-                Assert.Equal(id2, entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadWithAfterIdAndCount_1()
-        {
-            var key = GetUniqueKey("read1");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-
-                // Only read a single item from the stream.
-                var entries = db.StreamRead(key, id1, 1);
-
-                Assert.Single(entries);
-                Assert.Equal(id2, entries[0].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamReadWithAfterIdAndCount_2()
-        {
-            var key = GetUniqueKey("read2");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                var id1 = db.StreamAdd(key, "field1", "value1");
-                var id2 = db.StreamAdd(key, "field2", "value2");
-                var id3 = db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                // Read multiple items from the stream.
-                var entries = db.StreamRead(key, id1, 2);
-
-                Assert.Equal(2, entries.Length);
-                Assert.Equal(id2, entries[0].Id);
-                Assert.Equal(id3, entries[1].Id);
-            }
-        }
-
-        [Fact]
-        public void StreamTrimLength()
-        {
-            var key = GetUniqueKey("trimlen");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Add a couple items and check length.
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-                db.StreamAdd(key, "field3", "value3");
-                db.StreamAdd(key, "field4", "value4");
-
-                var numRemoved = db.StreamTrim(key, 1);
-                var len = db.StreamLength(key);
-
-                Assert.Equal(3, numRemoved);
-                Assert.Equal(1, len);
-            }
-        }
-
-        [Fact]
-        public void StreamVerifyLength()
-        {
-            var key = GetUniqueKey("len");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                // Add a couple items and check length.
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-
-                var len = db.StreamLength(key);
-
-                Assert.Equal(2, len);
-            }
-        }
-
-        [Fact]
-        public async Task AddWithApproxCountAsync()
-        {
-            var key = GetUniqueKey("approx-async");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                await db.StreamAddAsync(key, "field", "value", maxLength: 10, useApproximateMaxLength: true, flags: CommandFlags.None).ConfigureAwait(false);
-            }
-        }
-
-        [Fact]
-        public void AddWithApproxCount()
-        {
-            var key = GetUniqueKey("approx");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-                db.StreamAdd(key, "field", "value", maxLength: 10, useApproximateMaxLength: true, flags: CommandFlags.None);
-            }
-        }
-
-        [Fact]
-        public void StreamReadGroupWithNoAckShowsNoPendingMessages()
-        {
-            var key = GetUniqueKey("read_group_noack");
-            const string groupName = "test_group";
-            const string consumer = "consumer";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key, "field1", "value1");
-                db.StreamAdd(key, "field2", "value2");
-
-                db.StreamCreateConsumerGroup(key, groupName, StreamPosition.NewMessages);
-
-                db.StreamReadGroup(key,
-                    groupName,
-                    consumer,
-                    StreamPosition.NewMessages,
-                    noAck: true);
-
-                var pendingInfo = db.StreamPending(key, groupName);
-
-                Assert.Equal(0, pendingInfo.PendingMessageCount);
-            }
-        }
-
-        [Fact]
-        public void StreamReadGroupMultiStreamWithNoAckShowsNoPendingMessages()
-        {
-            var key1 = GetUniqueKey("read_group_noack1");
-            var key2 = GetUniqueKey("read_group_noack2");
-            const string groupName = "test_group";
-            const string consumer = "consumer";
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                db.StreamAdd(key1, "field1", "value1");
-                db.StreamAdd(key1, "field2", "value2");
-
-                db.StreamAdd(key2, "field3", "value3");
-                db.StreamAdd(key2, "field4", "value4");
-
-                db.StreamCreateConsumerGroup(key1, groupName, StreamPosition.NewMessages);
-                db.StreamCreateConsumerGroup(key2, groupName, StreamPosition.NewMessages);
-
-                db.StreamReadGroup(
-                    new []
-                    {
-                        new StreamPosition(key1, StreamPosition.NewMessages),
-                        new StreamPosition(key2, StreamPosition.NewMessages)
-                    },
-                    groupName,
-                    consumer,
-                    noAck: true);
-
-                var pending1 = db.StreamPending(key1, groupName);
-                var pending2 = db.StreamPending(key2, groupName);
-
-                Assert.Equal(0, pending1.PendingMessageCount);
-                Assert.Equal(0, pending2.PendingMessageCount);
-            }
-        }
-
-        private static RedisKey GetUniqueKey(string type) => $"{type}_stream_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
-
-        [Fact]
-        public async Task StreamReadIndexerUsage()
-        {
-            var streamName = GetUniqueKey("read-group-indexer");
-
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v5_0_0);
-
-                var db = conn.GetDatabase();
-
-                await db.StreamAddAsync(streamName, new[] {
-                    new NameValueEntry("x", "blah"),
-                    new NameValueEntry("msg", /*lang=json,strict*/ @"{""name"":""test"",""id"":123}"),
-                    new NameValueEntry("y", "more blah"),
-                });
-
-                var streamResult = await db.StreamRangeAsync(streamName, count: 1000);
-                var evntJson = streamResult
-                    .Select(x => (dynamic?)JsonConvert.DeserializeObject(x["msg"]!))
-                    .ToList();
-                var obj = Assert.Single(evntJson);
-                Assert.Equal(123, (int)obj!.id);
-                Assert.Equal("test", (string)obj.name);
-            }
-        }
+                new StreamPosition(key1, StreamPosition.NewMessages),
+                new StreamPosition(key2, StreamPosition.NewMessages)
+            },
+            groupName,
+            consumer,
+            noAck: true);
+
+        var pending1 = db.StreamPending(key1, groupName);
+        var pending2 = db.StreamPending(key2, groupName);
+
+        Assert.Equal(0, pending1.PendingMessageCount);
+        Assert.Equal(0, pending2.PendingMessageCount);
+    }
+
+    private static RedisKey GetUniqueKey(string type) => $"{type}_stream_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+
+    [Fact]
+    public async Task StreamReadIndexerUsage()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var streamName = GetUniqueKey("read-group-indexer");
+
+        await db.StreamAddAsync(streamName, new[] {
+                new NameValueEntry("x", "blah"),
+                new NameValueEntry("msg", /*lang=json,strict*/ @"{""name"":""test"",""id"":123}"),
+                new NameValueEntry("y", "more blah"),
+            });
+
+        var streamResult = await db.StreamRangeAsync(streamName, count: 1000);
+        var evntJson = streamResult
+            .Select(x => (dynamic?)JsonConvert.DeserializeObject(x["msg"]!))
+            .ToList();
+        var obj = Assert.Single(evntJson);
+        Assert.Equal(123, (int)obj!.id);
+        Assert.Equal("test", (string)obj.name);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Strings.cs
+++ b/tests/StackExchange.Redis.Tests/Strings.cs
@@ -444,9 +444,9 @@ public class Strings : TestBase // https://redis.io/commands#string
     [Fact]
     public async Task IncrDecrFloat()
     {
-        using var muxer = Create(require: RedisFeatures.v2_6_0);
+        using var conn = Create(require: RedisFeatures.v2_6_0);
 
-        var db = muxer.GetDatabase();
+        var db = conn.GetDatabase();
         var key = Me();
         db.KeyDelete(key, CommandFlags.FireAndForget);
 

--- a/tests/StackExchange.Redis.Tests/Strings.cs
+++ b/tests/StackExchange.Redis.Tests/Strings.cs
@@ -6,622 +6,578 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Strings : TestBase // https://redis.io/commands#string
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Strings : TestBase // https://redis.io/commands#string
+    public Strings(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public async Task Append()
     {
-        public Strings(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public async Task Append()
+        var db = conn.GetDatabase();
+        var server = GetServer(conn);
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        var l0 = server.Features.StringLength ? db.StringLengthAsync(key) : null;
+
+        var s0 = db.StringGetAsync(key);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        var s1 = db.StringGetAsync(key);
+        var l1 = server.Features.StringLength ? db.StringLengthAsync(key) : null;
+
+        var result = db.StringAppendAsync(key, Encode("defgh"));
+        var s3 = db.StringGetAsync(key);
+        var l2 = server.Features.StringLength ? db.StringLengthAsync(key) : null;
+
+        Assert.Null((string?)await s0);
+        Assert.Equal("abc", await s1);
+        Assert.Equal(8, await result);
+        Assert.Equal("abcdefgh", await s3);
+
+        if (server.Features.StringLength)
         {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var server = GetServer(muxer);
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-                var l0 = server.Features.StringLength ? conn.StringLengthAsync(key) : null;
-
-                var s0 = conn.StringGetAsync(key);
-
-                conn.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                var s1 = conn.StringGetAsync(key);
-                var l1 = server.Features.StringLength ? conn.StringLengthAsync(key) : null;
-
-                var result = conn.StringAppendAsync(key, Encode("defgh"));
-                var s3 = conn.StringGetAsync(key);
-                var l2 = server.Features.StringLength ? conn.StringLengthAsync(key) : null;
-
-                Assert.Null((string?)await s0);
-                Assert.Equal("abc", await s1);
-                Assert.Equal(8, await result);
-                Assert.Equal("abcdefgh", await s3);
-
-                if (server.Features.StringLength)
-                {
-                    Assert.Equal(0, await l0!);
-                    Assert.Equal(3, await l1!);
-                    Assert.Equal(8, await l2!);
-                }
-            }
+            Assert.Equal(0, await l0!);
+            Assert.Equal(3, await l1!);
+            Assert.Equal(8, await l2!);
         }
-
-        [Fact]
-        public async Task Set()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                var v1 = conn.StringGetAsync(key);
-
-                conn.StringSet(key, Encode("def"), flags: CommandFlags.FireAndForget);
-                var v2 = conn.StringGetAsync(key);
-
-                Assert.Equal("abc", await v1);
-                Assert.Equal("def", Decode(await v2));
-            }
-        }
-
-        [Fact]
-        public async Task StringGetSetExpiryNoValue()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var conn = muxer.GetDatabase();
-            var key = Me();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-            var emptyVal = await conn.StringGetSetExpiryAsync(key, TimeSpan.FromHours(1));
-
-            Assert.Equal(RedisValue.Null, emptyVal);
-        }
-
-        [Fact]
-        public async Task StringGetSetExpiryRelative()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var conn = muxer.GetDatabase();
-            var key = Me();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-            conn.StringSet(key, "abc", TimeSpan.FromHours(1));
-            var relativeSec = conn.StringGetSetExpiryAsync(key, TimeSpan.FromMinutes(30));
-            var relativeSecTtl = conn.KeyTimeToLiveAsync(key);
-
-            Assert.Equal("abc", await relativeSec);
-            var time = await relativeSecTtl;
-            Assert.NotNull(time);
-            Assert.InRange(time.Value, TimeSpan.FromMinutes(29.8), TimeSpan.FromMinutes(30.2));
-        }
-
-        [Fact]
-        public async Task StringGetSetExpiryAbsolute()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var conn = muxer.GetDatabase();
-            var key = Me();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-            conn.StringSet(key, "abc", TimeSpan.FromHours(1));
-            var newDate = DateTime.UtcNow.AddMinutes(30);
-            var val = conn.StringGetSetExpiryAsync(key, newDate);
-            var valTtl = conn.KeyTimeToLiveAsync(key);
-
-            Assert.Equal("abc", await val);
-            var time = await valTtl;
-            Assert.NotNull(time);
-            Assert.InRange(time.Value, TimeSpan.FromMinutes(29.8), TimeSpan.FromMinutes(30.2));
-
-            // And ensure our type checking works
-            var ex = await Assert.ThrowsAsync<ArgumentException>(() => conn.StringGetSetExpiryAsync(key, new DateTime(100, DateTimeKind.Unspecified)));
-            Assert.NotNull(ex);
-        }
-
-        [Fact]
-        public async Task StringGetSetExpiryPersist()
-        {
-            using var muxer = Create();
-            Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-            var conn = muxer.GetDatabase();
-            var key = Me();
-            conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-            conn.StringSet(key, "abc", TimeSpan.FromHours(1));
-            var val = conn.StringGetSetExpiryAsync(key, null);
-            var valTtl = conn.KeyTimeToLiveAsync(key);
-
-            Assert.Equal("abc", await val);
-            Assert.Null(await valTtl);
-        }
-
-        [Fact]
-        public async Task GetLease()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                using (var v1 = await conn.StringGetLeaseAsync(key).ConfigureAwait(false))
-                {
-                    string? s = v1?.DecodeString();
-                    Assert.Equal("abc", s);
-                }
-            }
-        }
-
-        [Fact]
-        public async Task GetLeaseAsStream()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
-                var lease = await conn.StringGetLeaseAsync(key).ConfigureAwait(false);
-                Assert.NotNull(lease);
-                using (var v1 = lease.AsStream())
-                {
-                    using (var sr = new StreamReader(v1))
-                    {
-                        string s = sr.ReadToEnd();
-                        Assert.Equal("abc", s);
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void GetDelete()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                conn.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
-
-                Assert.True(conn.KeyExists(prefix + "1"));
-                Assert.False(conn.KeyExists(prefix + "2"));
-
-                var s0 = conn.StringGetDelete(prefix + "1");
-                var s2 = conn.StringGetDelete(prefix + "2");
-
-                Assert.False(conn.KeyExists(prefix + "1"));
-                Assert.Equal("abc", s0);
-                Assert.Equal(RedisValue.Null, s2);
-            }
-        }
-
-        [Fact]
-        public async Task GetDeleteAsync()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                conn.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
-
-                Assert.True(conn.KeyExists(prefix + "1"));
-                Assert.False(conn.KeyExists(prefix + "2"));
-
-                var s0 = conn.StringGetDeleteAsync(prefix + "1");
-                var s2 = conn.StringGetDeleteAsync(prefix + "2");
-
-                Assert.False(conn.KeyExists(prefix + "1"));
-                Assert.Equal("abc", await s0);
-                Assert.Equal(RedisValue.Null, await s2);
-            }
-        }
-
-        [Fact]
-        public async Task SetNotExists()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                conn.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "4", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "5", CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
-
-                var x0 = conn.StringSetAsync(prefix + "1", "def", when: When.NotExists);
-                var x1 = conn.StringSetAsync(prefix + "1", Encode("def"), when: When.NotExists);
-                var x2 = conn.StringSetAsync(prefix + "2", "def", when: When.NotExists);
-                var x3 = conn.StringSetAsync(prefix + "3", Encode("def"), when: When.NotExists);
-                var x4 = conn.StringSetAsync(prefix + "4", "def", expiry: TimeSpan.FromSeconds(4), when: When.NotExists);
-                var x5 = conn.StringSetAsync(prefix + "5", "def", expiry: TimeSpan.FromMilliseconds(4001), when: When.NotExists);
-
-                var s0 = conn.StringGetAsync(prefix + "1");
-                var s2 = conn.StringGetAsync(prefix + "2");
-                var s3 = conn.StringGetAsync(prefix + "3");
-
-                Assert.False(await x0);
-                Assert.False(await x1);
-                Assert.True(await x2);
-                Assert.True(await x3);
-                Assert.True(await x4);
-                Assert.True(await x5);
-                Assert.Equal("abc", await s0);
-                Assert.Equal("def", await s2);
-                Assert.Equal("def", await s3);
-            }
-        }
-
-        [Fact]
-        public async Task SetKeepTtl()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v6_0_0);
-
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                conn.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "2", "abc", expiry: TimeSpan.FromMinutes(5), flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "3", "abc", expiry: TimeSpan.FromMinutes(10), flags: CommandFlags.FireAndForget);
-
-                var x0 = conn.KeyTimeToLiveAsync(prefix + "1");
-                var x1 = conn.KeyTimeToLiveAsync(prefix + "2");
-                var x2 = conn.KeyTimeToLiveAsync(prefix + "3");
-
-                Assert.Null(await x0);
-                Assert.True(await x1 > TimeSpan.FromMinutes(4), "Over 4");
-                Assert.True(await x1 <= TimeSpan.FromMinutes(5), "Under 5");
-                Assert.True(await x2 > TimeSpan.FromMinutes(9), "Over 9");
-                Assert.True(await x2 <= TimeSpan.FromMinutes(10), "Under 10");
-
-                conn.StringSet(prefix + "1", "def", keepTtl: true, flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "2", "def", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "3", "def", keepTtl: true, flags: CommandFlags.FireAndForget);
-
-                var y0 = conn.KeyTimeToLiveAsync(prefix + "1");
-                var y1 = conn.KeyTimeToLiveAsync(prefix + "2");
-                var y2 = conn.KeyTimeToLiveAsync(prefix + "3");
-
-                Assert.Null(await y0);
-                Assert.Null(await y1);
-                Assert.True(await y2 > TimeSpan.FromMinutes(9), "Over 9");
-                Assert.True(await y2 <= TimeSpan.FromMinutes(10), "Under 10");
-            }
-        }
-
-        [Fact]
-        public async Task SetAndGet()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v6_2_0);
-
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                conn.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "4", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "5", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "6", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "7", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "8", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "9", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "10", CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "2", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "4", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "6", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "7", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "8", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "9", "abc", flags: CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "10", "abc", expiry: TimeSpan.FromMinutes(10), flags: CommandFlags.FireAndForget);
-
-                var x0 = conn.StringSetAndGetAsync(prefix + "1", RedisValue.Null);
-                var x1 = conn.StringSetAndGetAsync(prefix + "2", "def");
-                var x2 = conn.StringSetAndGetAsync(prefix + "3", "def");
-                var x3 = conn.StringSetAndGetAsync(prefix + "4", "def", when: When.Exists);
-                var x4 = conn.StringSetAndGetAsync(prefix + "5", "def", when: When.Exists);
-                var x5 = conn.StringSetAndGetAsync(prefix + "6", "def", expiry: TimeSpan.FromSeconds(4));
-                var x6 = conn.StringSetAndGetAsync(prefix + "7", "def", expiry: TimeSpan.FromMilliseconds(4001));
-                var x7 = conn.StringSetAndGetAsync(prefix + "8", "def", expiry: TimeSpan.FromSeconds(4), when: When.Exists);
-                var x8 = conn.StringSetAndGetAsync(prefix + "9", "def", expiry: TimeSpan.FromMilliseconds(4001), when: When.Exists);
-
-                var y0 = conn.StringSetAndGetAsync(prefix + "10", "def", keepTtl: true);
-                var y1 = conn.KeyTimeToLiveAsync(prefix + "10");
-                var y2 = conn.StringGetAsync(prefix + "10");
-
-                var s0 = conn.StringGetAsync(prefix + "1");
-                var s1 = conn.StringGetAsync(prefix + "2");
-                var s2 = conn.StringGetAsync(prefix + "3");
-                var s3 = conn.StringGetAsync(prefix + "4");
-                var s4 = conn.StringGetAsync(prefix + "5");
-
-                Assert.Equal("abc", await x0);
-                Assert.Equal("abc", await x1);
-                Assert.Equal(RedisValue.Null, await x2);
-                Assert.Equal("abc", await x3);
-                Assert.Equal(RedisValue.Null, await x4);
-                Assert.Equal("abc", await x5);
-                Assert.Equal("abc", await x6);
-                Assert.Equal("abc", await x7);
-                Assert.Equal("abc", await x8);
-
-                Assert.Equal("abc", await y0);
-                Assert.True(await y1 <= TimeSpan.FromMinutes(10), "Under 10 min");
-                Assert.True(await y1 >= TimeSpan.FromMinutes(8), "Over 8 min");
-                Assert.Equal("def", await y2);
-
-                Assert.Equal(RedisValue.Null, await s0);
-                Assert.Equal("def", await s1);
-                Assert.Equal("def", await s2);
-                Assert.Equal("def", await s3);
-                Assert.Equal(RedisValue.Null, await s4);
-            }
-        }
-
-        [Fact]
-        public async Task SetNotExistsAndGet()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v7_0_0_rc1);
-
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                conn.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
-                conn.KeyDelete(prefix + "4", CommandFlags.FireAndForget);
-                conn.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
-
-                var x0 = conn.StringSetAndGetAsync(prefix + "1", "def", when: When.NotExists);
-                var x1 = conn.StringSetAndGetAsync(prefix + "2", "def", when: When.NotExists);
-                var x2 = conn.StringSetAndGetAsync(prefix + "3", "def", expiry: TimeSpan.FromSeconds(4), when: When.NotExists);
-                var x3 = conn.StringSetAndGetAsync(prefix + "4", "def", expiry: TimeSpan.FromMilliseconds(4001), when: When.NotExists);
-
-                var s0 = conn.StringGetAsync(prefix + "1");
-                var s1 = conn.StringGetAsync(prefix + "2");
-
-                Assert.Equal("abc", await x0);
-                Assert.Equal(RedisValue.Null, await x1);
-                Assert.Equal(RedisValue.Null, await x2);
-                Assert.Equal(RedisValue.Null, await x3);
-
-                Assert.Equal("abc", await s0);
-                Assert.Equal("def", await s1);
-            }
-        }
-
-        [Fact]
-        public async Task Ranges()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_1_8);
-                var conn = muxer.GetDatabase();
-                var key = Me();
-
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "abcdefghi", flags: CommandFlags.FireAndForget);
-                conn.StringSetRange(key, 2, "xy", CommandFlags.FireAndForget);
-                conn.StringSetRange(key, 4, Encode("z"), CommandFlags.FireAndForget);
-
-                var val = conn.StringGetAsync(key);
-
-                Assert.Equal("abxyzfghi", await val);
-            }
-        }
-
-        [Fact]
-        public async Task IncrDecr()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "2", flags: CommandFlags.FireAndForget);
-                var v1 = conn.StringIncrementAsync(key);
-                var v2 = conn.StringIncrementAsync(key, 5);
-                var v3 = conn.StringIncrementAsync(key, -2);
-                var v4 = conn.StringDecrementAsync(key);
-                var v5 = conn.StringDecrementAsync(key, 5);
-                var v6 = conn.StringDecrementAsync(key, -2);
-                var s = conn.StringGetAsync(key);
-
-                Assert.Equal(3, await v1);
-                Assert.Equal(8, await v2);
-                Assert.Equal(6, await v3);
-                Assert.Equal(5, await v4);
-                Assert.Equal(0, await v5);
-                Assert.Equal(2, await v6);
-                Assert.Equal("2", await s);
-            }
-        }
-
-        [Fact]
-        public async Task IncrDecrFloat()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "2", flags: CommandFlags.FireAndForget);
-                var v1 = conn.StringIncrementAsync(key, 1.1);
-                var v2 = conn.StringIncrementAsync(key, 5.0);
-                var v3 = conn.StringIncrementAsync(key, -2.0);
-                var v4 = conn.StringIncrementAsync(key, -1.0);
-                var v5 = conn.StringIncrementAsync(key, -5.0);
-                var v6 = conn.StringIncrementAsync(key, 2.0);
-
-                var s = conn.StringGetAsync(key);
-
-                Assert.Equal(3.1, await v1, 5);
-                Assert.Equal(8.1, await v2, 5);
-                Assert.Equal(6.1, await v3, 5);
-                Assert.Equal(5.1, await v4, 5);
-                Assert.Equal(0.1, await v5, 5);
-                Assert.Equal(2.1, await v6, 5);
-                Assert.Equal(2.1, (double)await s, 5);
-            }
-        }
-
-        [Fact]
-        public async Task GetRange()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.KeyDelete(key, CommandFlags.FireAndForget);
-
-                conn.StringSet(key, "abcdefghi", flags: CommandFlags.FireAndForget);
-                var s = conn.StringGetRangeAsync(key, 2, 4);
-                var b = conn.StringGetRangeAsync(key, 2, 4);
-
-                Assert.Equal("cde", await s);
-                Assert.Equal("cde", Decode(await b));
-            }
-        }
-
-        [Fact]
-        public async Task BitCount()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
-
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.StringSet(key, "foobar", flags: CommandFlags.FireAndForget);
-                var r1 = conn.StringBitCountAsync(key);
-                var r2 = conn.StringBitCountAsync(key, 0, 0);
-                var r3 = conn.StringBitCountAsync(key, 1, 1);
-
-                Assert.Equal(26, await r1);
-                Assert.Equal(4, await r2);
-                Assert.Equal(6, await r3);
-            }
-        }
-
-        [Fact]
-        public async Task BitOp()
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v2_6_0);
-
-                var conn = muxer.GetDatabase();
-                var prefix = Me();
-                var key1 = prefix + "1";
-                var key2 = prefix + "2";
-                var key3 = prefix + "3";
-                conn.StringSet(key1, new byte[] { 3 }, flags: CommandFlags.FireAndForget);
-                conn.StringSet(key2, new byte[] { 6 }, flags: CommandFlags.FireAndForget);
-                conn.StringSet(key3, new byte[] { 12 }, flags: CommandFlags.FireAndForget);
-
-                var len_and = conn.StringBitOperationAsync(Bitwise.And, "and", new RedisKey[] { key1, key2, key3 });
-                var len_or = conn.StringBitOperationAsync(Bitwise.Or, "or", new RedisKey[] { key1, key2, key3 });
-                var len_xor = conn.StringBitOperationAsync(Bitwise.Xor, "xor", new RedisKey[] { key1, key2, key3 });
-                var len_not = conn.StringBitOperationAsync(Bitwise.Not, "not", key1);
-
-                Assert.Equal(1, await len_and);
-                Assert.Equal(1, await len_or);
-                Assert.Equal(1, await len_xor);
-                Assert.Equal(1, await len_not);
-
-                var r_and = ((byte[]?)(await conn.StringGetAsync("and").ForAwait()))?.Single();
-                var r_or = ((byte[]?)(await conn.StringGetAsync("or").ForAwait()))?.Single();
-                var r_xor = ((byte[]?)(await conn.StringGetAsync("xor").ForAwait()))?.Single();
-                var r_not = ((byte[]?)(await conn.StringGetAsync("not").ForAwait()))?.Single();
-
-                Assert.Equal((byte)(3 & 6 & 12), r_and);
-                Assert.Equal((byte)(3 | 6 | 12), r_or);
-                Assert.Equal((byte)(3 ^ 6 ^ 12), r_xor);
-                Assert.Equal(unchecked((byte)(~3)), r_not);
-            }
-        }
-
-        [Fact]
-        public async Task RangeString()
-        {
-            using (var muxer = Create())
-            {
-                var conn = muxer.GetDatabase();
-                var key = Me();
-                conn.StringSet(key, "hello world", flags: CommandFlags.FireAndForget);
-                var result = conn.StringGetRangeAsync(key, 2, 6);
-                Assert.Equal("llo w", await result);
-            }
-        }
-
-        [Fact]
-        public async Task HashStringLengthAsync()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-
-                var database = conn.GetDatabase();
-                var key = Me();
-                const string value = "hello world";
-                database.HashSet(key, "field", value);
-                var resAsync = database.HashStringLengthAsync(key, "field");
-                var resNonExistingAsync = database.HashStringLengthAsync(key, "non-existing-field");
-                Assert.Equal(value.Length, await resAsync);
-                Assert.Equal(0, await resNonExistingAsync);
-            }
-        }
-
-        [Fact]
-        public void HashStringLength()
-        {
-            using (var conn = Create())
-            {
-                Skip.IfBelow(conn, RedisFeatures.v3_2_0);
-
-                var database = conn.GetDatabase();
-                var key = Me();
-                const string value = "hello world";
-                database.HashSet(key, "field", value);
-                Assert.Equal(value.Length, database.HashStringLength(key, "field"));
-                Assert.Equal(0, database.HashStringLength(key, "non-existing-field"));
-            }
-        }
-
-        private static byte[] Encode(string value) => Encoding.UTF8.GetBytes(value);
-        private static string? Decode(byte[]? value) => value is null ? null : Encoding.UTF8.GetString(value);
     }
+
+    [Fact]
+    public async Task Set()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        var v1 = db.StringGetAsync(key);
+
+        db.StringSet(key, Encode("def"), flags: CommandFlags.FireAndForget);
+        var v2 = db.StringGetAsync(key);
+
+        Assert.Equal("abc", await v1);
+        Assert.Equal("def", Decode(await v2));
+    }
+
+    [Fact]
+    public async Task StringGetSetExpiryNoValue()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        var emptyVal = await db.StringGetSetExpiryAsync(key, TimeSpan.FromHours(1));
+
+        Assert.Equal(RedisValue.Null, emptyVal);
+    }
+
+    [Fact]
+    public async Task StringGetSetExpiryRelative()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", TimeSpan.FromHours(1));
+        var relativeSec = db.StringGetSetExpiryAsync(key, TimeSpan.FromMinutes(30));
+        var relativeSecTtl = db.KeyTimeToLiveAsync(key);
+
+        Assert.Equal("abc", await relativeSec);
+        var time = await relativeSecTtl;
+        Assert.NotNull(time);
+        Assert.InRange(time.Value, TimeSpan.FromMinutes(29.8), TimeSpan.FromMinutes(30.2));
+    }
+
+    [Fact]
+    public async Task StringGetSetExpiryAbsolute()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", TimeSpan.FromHours(1));
+        var newDate = DateTime.UtcNow.AddMinutes(30);
+        var val = db.StringGetSetExpiryAsync(key, newDate);
+        var valTtl = db.KeyTimeToLiveAsync(key);
+
+        Assert.Equal("abc", await val);
+        var time = await valTtl;
+        Assert.NotNull(time);
+        Assert.InRange(time.Value, TimeSpan.FromMinutes(29.8), TimeSpan.FromMinutes(30.2));
+
+        // And ensure our type checking works
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() => db.StringGetSetExpiryAsync(key, new DateTime(100, DateTimeKind.Unspecified)));
+        Assert.NotNull(ex);
+    }
+
+    [Fact]
+    public async Task StringGetSetExpiryPersist()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", TimeSpan.FromHours(1));
+        var val = db.StringGetSetExpiryAsync(key, null);
+        var valTtl = db.KeyTimeToLiveAsync(key);
+
+        Assert.Equal("abc", await val);
+        Assert.Null(await valTtl);
+    }
+
+    [Fact]
+    public async Task GetLease()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        using (var v1 = await db.StringGetLeaseAsync(key).ConfigureAwait(false))
+        {
+            string? s = v1?.DecodeString();
+            Assert.Equal("abc", s);
+        }
+    }
+
+    [Fact]
+    public async Task GetLeaseAsStream()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abc", flags: CommandFlags.FireAndForget);
+        var lease = await db.StringGetLeaseAsync(key).ConfigureAwait(false);
+        Assert.NotNull(lease);
+        using (var v1 = lease.AsStream())
+        {
+            using (var sr = new StreamReader(v1))
+            {
+                string s = sr.ReadToEnd();
+                Assert.Equal("abc", s);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetDelete()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        db.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
+        db.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
+
+        Assert.True(db.KeyExists(prefix + "1"));
+        Assert.False(db.KeyExists(prefix + "2"));
+
+        var s0 = db.StringGetDelete(prefix + "1");
+        var s2 = db.StringGetDelete(prefix + "2");
+
+        Assert.False(db.KeyExists(prefix + "1"));
+        Assert.Equal("abc", s0);
+        Assert.Equal(RedisValue.Null, s2);
+    }
+
+    [Fact]
+    public async Task GetDeleteAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        db.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
+        db.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
+
+        Assert.True(db.KeyExists(prefix + "1"));
+        Assert.False(db.KeyExists(prefix + "2"));
+
+        var s0 = db.StringGetDeleteAsync(prefix + "1");
+        var s2 = db.StringGetDeleteAsync(prefix + "2");
+
+        Assert.False(db.KeyExists(prefix + "1"));
+        Assert.Equal("abc", await s0);
+        Assert.Equal(RedisValue.Null, await s2);
+    }
+
+    [Fact]
+    public async Task SetNotExists()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        db.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "4", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "5", CommandFlags.FireAndForget);
+        db.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
+
+        var x0 = db.StringSetAsync(prefix + "1", "def", when: When.NotExists);
+        var x1 = db.StringSetAsync(prefix + "1", Encode("def"), when: When.NotExists);
+        var x2 = db.StringSetAsync(prefix + "2", "def", when: When.NotExists);
+        var x3 = db.StringSetAsync(prefix + "3", Encode("def"), when: When.NotExists);
+        var x4 = db.StringSetAsync(prefix + "4", "def", expiry: TimeSpan.FromSeconds(4), when: When.NotExists);
+        var x5 = db.StringSetAsync(prefix + "5", "def", expiry: TimeSpan.FromMilliseconds(4001), when: When.NotExists);
+
+        var s0 = db.StringGetAsync(prefix + "1");
+        var s2 = db.StringGetAsync(prefix + "2");
+        var s3 = db.StringGetAsync(prefix + "3");
+
+        Assert.False(await x0);
+        Assert.False(await x1);
+        Assert.True(await x2);
+        Assert.True(await x3);
+        Assert.True(await x4);
+        Assert.True(await x5);
+        Assert.Equal("abc", await s0);
+        Assert.Equal("def", await s2);
+        Assert.Equal("def", await s3);
+    }
+
+    [Fact]
+    public async Task SetKeepTtl()
+    {
+        using var conn = Create(require: RedisFeatures.v6_0_0);
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        db.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
+        db.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "2", "abc", expiry: TimeSpan.FromMinutes(5), flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "3", "abc", expiry: TimeSpan.FromMinutes(10), flags: CommandFlags.FireAndForget);
+
+        var x0 = db.KeyTimeToLiveAsync(prefix + "1");
+        var x1 = db.KeyTimeToLiveAsync(prefix + "2");
+        var x2 = db.KeyTimeToLiveAsync(prefix + "3");
+
+        Assert.Null(await x0);
+        Assert.True(await x1 > TimeSpan.FromMinutes(4), "Over 4");
+        Assert.True(await x1 <= TimeSpan.FromMinutes(5), "Under 5");
+        Assert.True(await x2 > TimeSpan.FromMinutes(9), "Over 9");
+        Assert.True(await x2 <= TimeSpan.FromMinutes(10), "Under 10");
+
+        db.StringSet(prefix + "1", "def", keepTtl: true, flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "2", "def", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "3", "def", keepTtl: true, flags: CommandFlags.FireAndForget);
+
+        var y0 = db.KeyTimeToLiveAsync(prefix + "1");
+        var y1 = db.KeyTimeToLiveAsync(prefix + "2");
+        var y2 = db.KeyTimeToLiveAsync(prefix + "3");
+
+        Assert.Null(await y0);
+        Assert.Null(await y1);
+        Assert.True(await y2 > TimeSpan.FromMinutes(9), "Over 9");
+        Assert.True(await y2 <= TimeSpan.FromMinutes(10), "Under 10");
+    }
+
+    [Fact]
+    public async Task SetAndGet()
+    {
+        using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        db.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "4", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "5", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "6", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "7", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "8", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "9", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "10", CommandFlags.FireAndForget);
+        db.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "2", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "4", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "6", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "7", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "8", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "9", "abc", flags: CommandFlags.FireAndForget);
+        db.StringSet(prefix + "10", "abc", expiry: TimeSpan.FromMinutes(10), flags: CommandFlags.FireAndForget);
+
+        var x0 = db.StringSetAndGetAsync(prefix + "1", RedisValue.Null);
+        var x1 = db.StringSetAndGetAsync(prefix + "2", "def");
+        var x2 = db.StringSetAndGetAsync(prefix + "3", "def");
+        var x3 = db.StringSetAndGetAsync(prefix + "4", "def", when: When.Exists);
+        var x4 = db.StringSetAndGetAsync(prefix + "5", "def", when: When.Exists);
+        var x5 = db.StringSetAndGetAsync(prefix + "6", "def", expiry: TimeSpan.FromSeconds(4));
+        var x6 = db.StringSetAndGetAsync(prefix + "7", "def", expiry: TimeSpan.FromMilliseconds(4001));
+        var x7 = db.StringSetAndGetAsync(prefix + "8", "def", expiry: TimeSpan.FromSeconds(4), when: When.Exists);
+        var x8 = db.StringSetAndGetAsync(prefix + "9", "def", expiry: TimeSpan.FromMilliseconds(4001), when: When.Exists);
+
+        var y0 = db.StringSetAndGetAsync(prefix + "10", "def", keepTtl: true);
+        var y1 = db.KeyTimeToLiveAsync(prefix + "10");
+        var y2 = db.StringGetAsync(prefix + "10");
+
+        var s0 = db.StringGetAsync(prefix + "1");
+        var s1 = db.StringGetAsync(prefix + "2");
+        var s2 = db.StringGetAsync(prefix + "3");
+        var s3 = db.StringGetAsync(prefix + "4");
+        var s4 = db.StringGetAsync(prefix + "5");
+
+        Assert.Equal("abc", await x0);
+        Assert.Equal("abc", await x1);
+        Assert.Equal(RedisValue.Null, await x2);
+        Assert.Equal("abc", await x3);
+        Assert.Equal(RedisValue.Null, await x4);
+        Assert.Equal("abc", await x5);
+        Assert.Equal("abc", await x6);
+        Assert.Equal("abc", await x7);
+        Assert.Equal("abc", await x8);
+
+        Assert.Equal("abc", await y0);
+        Assert.True(await y1 <= TimeSpan.FromMinutes(10), "Under 10 min");
+        Assert.True(await y1 >= TimeSpan.FromMinutes(8), "Over 8 min");
+        Assert.Equal("def", await y2);
+
+        Assert.Equal(RedisValue.Null, await s0);
+        Assert.Equal("def", await s1);
+        Assert.Equal("def", await s2);
+        Assert.Equal("def", await s3);
+        Assert.Equal(RedisValue.Null, await s4);
+    }
+
+    [Fact]
+    public async Task SetNotExistsAndGet()
+    {
+        using var conn = Create(require: RedisFeatures.v7_0_0_rc1);
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        db.KeyDelete(prefix + "1", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "2", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "3", CommandFlags.FireAndForget);
+        db.KeyDelete(prefix + "4", CommandFlags.FireAndForget);
+        db.StringSet(prefix + "1", "abc", flags: CommandFlags.FireAndForget);
+
+        var x0 = db.StringSetAndGetAsync(prefix + "1", "def", when: When.NotExists);
+        var x1 = db.StringSetAndGetAsync(prefix + "2", "def", when: When.NotExists);
+        var x2 = db.StringSetAndGetAsync(prefix + "3", "def", expiry: TimeSpan.FromSeconds(4), when: When.NotExists);
+        var x3 = db.StringSetAndGetAsync(prefix + "4", "def", expiry: TimeSpan.FromMilliseconds(4001), when: When.NotExists);
+
+        var s0 = db.StringGetAsync(prefix + "1");
+        var s1 = db.StringGetAsync(prefix + "2");
+
+        Assert.Equal("abc", await x0);
+        Assert.Equal(RedisValue.Null, await x1);
+        Assert.Equal(RedisValue.Null, await x2);
+        Assert.Equal(RedisValue.Null, await x3);
+
+        Assert.Equal("abc", await s0);
+        Assert.Equal("def", await s1);
+    }
+
+    [Fact]
+    public async Task Ranges()
+    {
+        using var conn = Create(require: RedisFeatures.v2_1_8);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abcdefghi", flags: CommandFlags.FireAndForget);
+        db.StringSetRange(key, 2, "xy", CommandFlags.FireAndForget);
+        db.StringSetRange(key, 4, Encode("z"), CommandFlags.FireAndForget);
+
+        var val = db.StringGetAsync(key);
+
+        Assert.Equal("abxyzfghi", await val);
+    }
+
+    [Fact]
+    public async Task IncrDecr()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "2", flags: CommandFlags.FireAndForget);
+        var v1 = db.StringIncrementAsync(key);
+        var v2 = db.StringIncrementAsync(key, 5);
+        var v3 = db.StringIncrementAsync(key, -2);
+        var v4 = db.StringDecrementAsync(key);
+        var v5 = db.StringDecrementAsync(key, 5);
+        var v6 = db.StringDecrementAsync(key, -2);
+        var s = db.StringGetAsync(key);
+
+        Assert.Equal(3, await v1);
+        Assert.Equal(8, await v2);
+        Assert.Equal(6, await v3);
+        Assert.Equal(5, await v4);
+        Assert.Equal(0, await v5);
+        Assert.Equal(2, await v6);
+        Assert.Equal("2", await s);
+    }
+
+    [Fact]
+    public async Task IncrDecrFloat()
+    {
+        using var muxer = Create(require: RedisFeatures.v2_6_0);
+
+        var db = muxer.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "2", flags: CommandFlags.FireAndForget);
+        var v1 = db.StringIncrementAsync(key, 1.1);
+        var v2 = db.StringIncrementAsync(key, 5.0);
+        var v3 = db.StringIncrementAsync(key, -2.0);
+        var v4 = db.StringIncrementAsync(key, -1.0);
+        var v5 = db.StringIncrementAsync(key, -5.0);
+        var v6 = db.StringIncrementAsync(key, 2.0);
+
+        var s = db.StringGetAsync(key);
+
+        Assert.Equal(3.1, await v1, 5);
+        Assert.Equal(8.1, await v2, 5);
+        Assert.Equal(6.1, await v3, 5);
+        Assert.Equal(5.1, await v4, 5);
+        Assert.Equal(0.1, await v5, 5);
+        Assert.Equal(2.1, await v6, 5);
+        Assert.Equal(2.1, (double)await s, 5);
+    }
+
+    [Fact]
+    public async Task GetRange()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, "abcdefghi", flags: CommandFlags.FireAndForget);
+        var s = db.StringGetRangeAsync(key, 2, 4);
+        var b = db.StringGetRangeAsync(key, 2, 4);
+
+        Assert.Equal("cde", await s);
+        Assert.Equal("cde", Decode(await b));
+    }
+
+    [Fact]
+    public async Task BitCount()
+    {
+        using var conn = Create(require: RedisFeatures.v2_6_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.StringSet(key, "foobar", flags: CommandFlags.FireAndForget);
+        var r1 = db.StringBitCountAsync(key);
+        var r2 = db.StringBitCountAsync(key, 0, 0);
+        var r3 = db.StringBitCountAsync(key, 1, 1);
+
+        Assert.Equal(26, await r1);
+        Assert.Equal(4, await r2);
+        Assert.Equal(6, await r3);
+    }
+
+    [Fact]
+    public async Task BitOp()
+    {
+        using var conn = Create(require: RedisFeatures.v2_6_0);
+
+        var db = conn.GetDatabase();
+        var prefix = Me();
+        var key1 = prefix + "1";
+        var key2 = prefix + "2";
+        var key3 = prefix + "3";
+        db.StringSet(key1, new byte[] { 3 }, flags: CommandFlags.FireAndForget);
+        db.StringSet(key2, new byte[] { 6 }, flags: CommandFlags.FireAndForget);
+        db.StringSet(key3, new byte[] { 12 }, flags: CommandFlags.FireAndForget);
+
+        var len_and = db.StringBitOperationAsync(Bitwise.And, "and", new RedisKey[] { key1, key2, key3 });
+        var len_or = db.StringBitOperationAsync(Bitwise.Or, "or", new RedisKey[] { key1, key2, key3 });
+        var len_xor = db.StringBitOperationAsync(Bitwise.Xor, "xor", new RedisKey[] { key1, key2, key3 });
+        var len_not = db.StringBitOperationAsync(Bitwise.Not, "not", key1);
+
+        Assert.Equal(1, await len_and);
+        Assert.Equal(1, await len_or);
+        Assert.Equal(1, await len_xor);
+        Assert.Equal(1, await len_not);
+
+        var r_and = ((byte[]?)(await db.StringGetAsync("and").ForAwait()))?.Single();
+        var r_or = ((byte[]?)(await db.StringGetAsync("or").ForAwait()))?.Single();
+        var r_xor = ((byte[]?)(await db.StringGetAsync("xor").ForAwait()))?.Single();
+        var r_not = ((byte[]?)(await db.StringGetAsync("not").ForAwait()))?.Single();
+
+        Assert.Equal((byte)(3 & 6 & 12), r_and);
+        Assert.Equal((byte)(3 | 6 | 12), r_or);
+        Assert.Equal((byte)(3 ^ 6 ^ 12), r_xor);
+        Assert.Equal(unchecked((byte)(~3)), r_not);
+    }
+
+    [Fact]
+    public async Task RangeString()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.StringSet(key, "hello world", flags: CommandFlags.FireAndForget);
+        var result = db.StringGetRangeAsync(key, 2, 6);
+        Assert.Equal("llo w", await result);
+    }
+
+    [Fact]
+    public async Task HashStringLengthAsync()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var database = conn.GetDatabase();
+        var key = Me();
+        const string value = "hello world";
+        database.HashSet(key, "field", value);
+        var resAsync = database.HashStringLengthAsync(key, "field");
+        var resNonExistingAsync = database.HashStringLengthAsync(key, "non-existing-field");
+        Assert.Equal(value.Length, await resAsync);
+        Assert.Equal(0, await resNonExistingAsync);
+    }
+
+    [Fact]
+    public void HashStringLength()
+    {
+        using var conn = Create(require: RedisFeatures.v3_2_0);
+
+        var database = conn.GetDatabase();
+        var key = Me();
+        const string value = "hello world";
+        database.HashSet(key, "field", value);
+        Assert.Equal(value.Length, database.HashStringLength(key, "field"));
+        Assert.Equal(0, database.HashStringLength(key, "non-existing-field"));
+    }
+
+    private static byte[] Encode(string value) => Encoding.UTF8.GetBytes(value);
+    private static string? Decode(byte[]? value) => value is null ? null : Encoding.UTF8.GetString(value);
 }

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -13,498 +13,497 @@ using StackExchange.Redis.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public abstract class TestBase : IDisposable
 {
-    public abstract class TestBase : IDisposable
+    private ITestOutputHelper Output { get; }
+    protected TextWriterOutputHelper Writer { get; }
+    protected static bool RunningInCI { get; } = Environment.GetEnvironmentVariable("APPVEYOR") != null;
+    protected virtual string GetConfiguration() => GetDefaultConfiguration();
+    internal static string GetDefaultConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+
+    private readonly SharedConnectionFixture? _fixture;
+
+    protected bool SharedFixtureAvailable => _fixture != null && _fixture.IsEnabled;
+
+    protected TestBase(ITestOutputHelper output, SharedConnectionFixture? fixture = null)
     {
-        private ITestOutputHelper Output { get; }
-        protected TextWriterOutputHelper Writer { get; }
-        protected static bool RunningInCI { get; } = Environment.GetEnvironmentVariable("APPVEYOR") != null;
-        protected virtual string GetConfiguration() => GetDefaultConfiguration();
-        internal static string GetDefaultConfiguration() => TestConfig.Current.PrimaryServerAndPort;
+        Output = output;
+        Output.WriteFrameworkVersion();
+        Writer = new TextWriterOutputHelper(output, TestConfig.Current.LogToConsole);
+        _fixture = fixture;
+        ClearAmbientFailures();
+    }
 
-        private readonly SharedConnectionFixture? _fixture;
+    /// <summary>
+    /// Useful to temporarily get extra worker threads for an otherwise synchronous test case which will 'block' the thread,
+    /// on a synchronous API like <see cref="Task.Wait"/> or <see cref="Task.Result"/>.
+    /// </summary>
+    /// <note>
+    /// Must NOT be used for test cases which *goes async*, as then the inferred return type will become 'async void',
+    /// and we will fail to observe the result of  the async part.
+    /// </note>
+    /// <remarks>See 'ConnectFailTimeout' class for example usage.</remarks>
+    protected static Task RunBlockingSynchronousWithExtraThreadAsync(Action testScenario) => Task.Factory.StartNew(testScenario, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
-        protected bool SharedFixtureAvailable => _fixture != null && _fixture.IsEnabled;
-
-        protected TestBase(ITestOutputHelper output, SharedConnectionFixture? fixture = null)
+    protected void LogNoTime(string message) => LogNoTime(Writer, message);
+    internal static void LogNoTime(TextWriter output, string? message)
+    {
+        lock (output)
         {
-            Output = output;
-            Output.WriteFrameworkVersion();
-            Writer = new TextWriterOutputHelper(output, TestConfig.Current.LogToConsole);
-            _fixture = fixture;
-            ClearAmbientFailures();
+            output.WriteLine(message);
         }
+        if (TestConfig.Current.LogToConsole)
+        {
+            Console.WriteLine(message);
+        }
+    }
+    protected void Log(string? message) => LogNoTime(Writer, message);
+    public static void Log(TextWriter output, string message)
+    {
+        lock (output)
+        {
+            output?.WriteLine(Time() + ": " + message);
+        }
+        if (TestConfig.Current.LogToConsole)
+        {
+            Console.WriteLine(message);
+        }
+    }
+    protected void Log(string message, params object?[] args)
+    {
+        lock (Output)
+        {
+            Output.WriteLine(Time() + ": " + message, args);
+        }
+        if (TestConfig.Current.LogToConsole)
+        {
+            Console.WriteLine(message, args);
+        }
+    }
 
-        /// <summary>
-        /// Useful to temporarily get extra worker threads for an otherwise synchronous test case which will 'block' the thread,
-        /// on a synchronous API like <see cref="Task.Wait"/> or <see cref="Task.Result"/>.
-        /// </summary>
-        /// <note>
-        /// Must NOT be used for test cases which *goes async*, as then the inferred return type will become 'async void',
-        /// and we will fail to observe the result of  the async part.
-        /// </note>
-        /// <remarks>See 'ConnectFailTimeout' class for example usage.</remarks>
-        protected static Task RunBlockingSynchronousWithExtraThreadAsync(Action testScenario) => Task.Factory.StartNew(testScenario, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+    protected ProfiledCommandEnumerable Log(ProfilingSession session)
+    {
+        var profile = session.FinishProfiling();
+        foreach (var command in profile)
+        {
+            Writer.WriteLineNoTime(command.ToString());
+        }
+        return profile;
+    }
 
-        protected void LogNoTime(string message) => LogNoTime(Writer, message);
-        internal static void LogNoTime(TextWriter output, string? message)
-        {
-            lock (output)
-            {
-                output.WriteLine(message);
-            }
-            if (TestConfig.Current.LogToConsole)
-            {
-                Console.WriteLine(message);
-            }
-        }
-        protected void Log(string? message) => LogNoTime(Writer, message);
-        public static void Log(TextWriter output, string message)
-        {
-            lock (output)
-            {
-                output?.WriteLine(Time() + ": " + message);
-            }
-            if (TestConfig.Current.LogToConsole)
-            {
-                Console.WriteLine(message);
-            }
-        }
-        protected void Log(string message, params object?[] args)
-        {
-            lock (Output)
-            {
-                Output.WriteLine(Time() + ": " + message, args);
-            }
-            if (TestConfig.Current.LogToConsole)
-            {
-                Console.WriteLine(message, args);
-            }
-        }
+    protected static void CollectGarbage()
+    {
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+    }
 
-        protected ProfiledCommandEnumerable Log(ProfilingSession session)
-        {
-            var profile = session.FinishProfiling();
-            foreach (var command in profile)
-            {
-                Writer.WriteLineNoTime(command.ToString());
-            }
-            return profile;
-        }
-
-        protected static void CollectGarbage()
-        {
-            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
-            GC.WaitForPendingFinalizers();
-            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
-        }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly")]
-        public void Dispose()
-        {
-            _fixture?.Teardown(Writer);
-            Teardown();
-            Writer.Dispose();
-            GC.SuppressFinalize(this);
-        }
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly")]
+    public void Dispose()
+    {
+        _fixture?.Teardown(Writer);
+        Teardown();
+        Writer.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
 #if VERBOSE
-        protected const int AsyncOpsQty = 100, SyncOpsQty = 10;
+    protected const int AsyncOpsQty = 100, SyncOpsQty = 10;
 #else
-        protected const int AsyncOpsQty = 2000, SyncOpsQty = 2000;
+    protected const int AsyncOpsQty = 2000, SyncOpsQty = 2000;
 #endif
 
-        static TestBase()
+    static TestBase()
+    {
+        TaskScheduler.UnobservedTaskException += (sender, args) =>
         {
-            TaskScheduler.UnobservedTaskException += (sender, args) =>
-            {
-                Console.WriteLine("Unobserved: " + args.Exception);
-                args.SetObserved();
-                lock (sharedFailCount)
-                {
-                    if (sharedFailCount != null)
-                    {
-                        sharedFailCount.Value++;
-                    }
-                }
-                lock (backgroundExceptions)
-                {
-                    backgroundExceptions.Add(args.Exception.ToString());
-                }
-            };
-            Console.WriteLine("Setup information:");
-            Console.WriteLine("  GC IsServer: " + GCSettings.IsServerGC);
-            Console.WriteLine("  GC LOH Mode: " + GCSettings.LargeObjectHeapCompactionMode);
-            Console.WriteLine("  GC Latency Mode: " + GCSettings.LatencyMode);
-        }
-
-        internal static string Time() => DateTime.UtcNow.ToString("HH:mm:ss.ffff");
-        protected void OnConnectionFailed(object? sender, ConnectionFailedEventArgs e)
-        {
-            Interlocked.Increment(ref privateFailCount);
-            lock (privateExceptions)
-            {
-                privateExceptions.Add($"{Time()}: Connection failed ({e.FailureType}): {EndPointCollection.ToString(e.EndPoint)}/{e.ConnectionType}: {e.Exception}");
-            }
-            Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
-        }
-
-        protected void OnInternalError(object? sender, InternalErrorEventArgs e)
-        {
-            Interlocked.Increment(ref privateFailCount);
-            lock (privateExceptions)
-            {
-                privateExceptions.Add(Time() + ": Internal error: " + e.Origin + ", " + EndPointCollection.ToString(e.EndPoint) + "/" + e.ConnectionType);
-            }
-        }
-
-        private int privateFailCount;
-        private static readonly AsyncLocal<int> sharedFailCount = new AsyncLocal<int>();
-        private volatile int expectedFailCount;
-
-        private readonly List<string> privateExceptions = new List<string>();
-        private static readonly List<string> backgroundExceptions = new List<string>();
-
-        public void ClearAmbientFailures()
-        {
-            Interlocked.Exchange(ref privateFailCount, 0);
+            Console.WriteLine("Unobserved: " + args.Exception);
+            args.SetObserved();
             lock (sharedFailCount)
             {
-                sharedFailCount.Value = 0;
-            }
-            expectedFailCount = 0;
-            lock (privateExceptions)
-            {
-                privateExceptions.Clear();
+                if (sharedFailCount != null)
+                {
+                    sharedFailCount.Value++;
+                }
             }
             lock (backgroundExceptions)
             {
-                backgroundExceptions.Clear();
+                backgroundExceptions.Add(args.Exception.ToString());
             }
-        }
+        };
+        Console.WriteLine("Setup information:");
+        Console.WriteLine("  GC IsServer: " + GCSettings.IsServerGC);
+        Console.WriteLine("  GC LOH Mode: " + GCSettings.LargeObjectHeapCompactionMode);
+        Console.WriteLine("  GC Latency Mode: " + GCSettings.LatencyMode);
+    }
 
-        public void SetExpectedAmbientFailureCount(int count)
+    internal static string Time() => DateTime.UtcNow.ToString("HH:mm:ss.ffff");
+    protected void OnConnectionFailed(object? sender, ConnectionFailedEventArgs e)
+    {
+        Interlocked.Increment(ref privateFailCount);
+        lock (privateExceptions)
         {
-            expectedFailCount = count;
+            privateExceptions.Add($"{Time()}: Connection failed ({e.FailureType}): {EndPointCollection.ToString(e.EndPoint)}/{e.ConnectionType}: {e.Exception}");
         }
+        Log($"Connection Failed ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+    }
 
-        public void Teardown()
+    protected void OnInternalError(object? sender, InternalErrorEventArgs e)
+    {
+        Interlocked.Increment(ref privateFailCount);
+        lock (privateExceptions)
         {
-            int sharedFails;
-            lock (sharedFailCount)
+            privateExceptions.Add(Time() + ": Internal error: " + e.Origin + ", " + EndPointCollection.ToString(e.EndPoint) + "/" + e.ConnectionType);
+        }
+    }
+
+    private int privateFailCount;
+    private static readonly AsyncLocal<int> sharedFailCount = new AsyncLocal<int>();
+    private volatile int expectedFailCount;
+
+    private readonly List<string> privateExceptions = new List<string>();
+    private static readonly List<string> backgroundExceptions = new List<string>();
+
+    public void ClearAmbientFailures()
+    {
+        Interlocked.Exchange(ref privateFailCount, 0);
+        lock (sharedFailCount)
+        {
+            sharedFailCount.Value = 0;
+        }
+        expectedFailCount = 0;
+        lock (privateExceptions)
+        {
+            privateExceptions.Clear();
+        }
+        lock (backgroundExceptions)
+        {
+            backgroundExceptions.Clear();
+        }
+    }
+
+    public void SetExpectedAmbientFailureCount(int count)
+    {
+        expectedFailCount = count;
+    }
+
+    public void Teardown()
+    {
+        int sharedFails;
+        lock (sharedFailCount)
+        {
+            sharedFails = sharedFailCount.Value;
+            sharedFailCount.Value = 0;
+        }
+        if (expectedFailCount >= 0 && (sharedFails + privateFailCount) != expectedFailCount)
+        {
+            lock (privateExceptions)
             {
-                sharedFails = sharedFailCount.Value;
-                sharedFailCount.Value = 0;
-            }
-            if (expectedFailCount >= 0 && (sharedFails + privateFailCount) != expectedFailCount)
-            {
-                lock (privateExceptions)
+                foreach (var item in privateExceptions.Take(5))
                 {
-                    foreach (var item in privateExceptions.Take(5))
-                    {
-                        LogNoTime(item);
-                    }
-                }
-                lock (backgroundExceptions)
-                {
-                    foreach (var item in backgroundExceptions.Take(5))
-                    {
-                        LogNoTime(item);
-                    }
-                }
-                Skip.Inconclusive($"There were {privateFailCount} private and {sharedFailCount.Value} ambient exceptions; expected {expectedFailCount}.");
-            }
-            var pool = SocketManager.Shared?.SchedulerPool;
-            Log($"Service Counts: (Scheduler) Queue: {pool?.TotalServicedByQueue.ToString()}, Pool: {pool?.TotalServicedByPool.ToString()}, Workers: {pool?.WorkerCount.ToString()}, Available: {pool?.AvailableCount.ToString()}");
-        }
-
-        protected static IServer GetServer(IConnectionMultiplexer muxer)
-        {
-            EndPoint[] endpoints = muxer.GetEndPoints();
-            IServer? result = null;
-            foreach (var endpoint in endpoints)
-            {
-                var server = muxer.GetServer(endpoint);
-                if (server.IsReplica || !server.IsConnected) continue;
-                if (result != null) throw new InvalidOperationException("Requires exactly one primary endpoint (found " + server.EndPoint + " and " + result.EndPoint + ")");
-                result = server;
-            }
-            if (result == null) throw new InvalidOperationException("Requires exactly one primary endpoint (found none)");
-            return result;
-        }
-
-        protected static IServer GetAnyPrimary(IConnectionMultiplexer muxer)
-        {
-            foreach (var endpoint in muxer.GetEndPoints())
-            {
-                var server = muxer.GetServer(endpoint);
-                if (!server.IsReplica) return server;
-            }
-            throw new InvalidOperationException("Requires a primary endpoint (found none)");
-        }
-
-        internal virtual IInternalConnectionMultiplexer Create(
-            string? clientName = null,
-            int? syncTimeout = null,
-            bool? allowAdmin = null,
-            int? keepAlive = null,
-            int? connectTimeout = null,
-            string? password = null,
-            string? tieBreaker = null,
-            TextWriter? log = null,
-            bool fail = true,
-            string[]? disabledCommands = null,
-            string[]? enabledCommands = null,
-            bool checkConnect = true,
-            string? failMessage = null,
-            string? channelPrefix = null,
-            Proxy? proxy = null,
-            string? configuration = null,
-            bool logTransactionData = true,
-            bool shared = true,
-            int? defaultDatabase = null,
-            BacklogPolicy? backlogPolicy = null,
-            Version? require = null,
-            [CallerMemberName] string? caller = null)
-        {
-            if (Output == null)
-            {
-                Assert.True(false, "Failure: Be sure to call the TestBase constuctor like this: BasicOpsTests(ITestOutputHelper output) : base(output) { }");
-            }
-
-            // Share a connection if instructed to and we can - many specifics mean no sharing
-            if (shared
-                && _fixture != null && _fixture.IsEnabled
-                && enabledCommands == null
-                && disabledCommands == null
-                && fail
-                && channelPrefix == null
-                && proxy == null
-                && configuration == null
-                && password == null
-                && tieBreaker == null
-                && defaultDatabase == null
-                && (allowAdmin == null || allowAdmin == true)
-                && expectedFailCount == 0
-                && backlogPolicy == null)
-            {
-                configuration = GetConfiguration();
-                if (configuration == _fixture.Configuration)
-                {
-                    // Only return if we match
-                    if (require != null)
-                    {
-                        Skip.IfBelow(_fixture.Connection, require);
-                    }
-                    return _fixture.Connection;
+                    LogNoTime(item);
                 }
             }
-
-            var muxer = CreateDefault(
-                Writer,
-                configuration ?? GetConfiguration(),
-                clientName, syncTimeout, allowAdmin, keepAlive,
-                connectTimeout, password, tieBreaker, log,
-                fail, disabledCommands, enabledCommands,
-                checkConnect, failMessage,
-                channelPrefix, proxy,
-                logTransactionData, defaultDatabase,
-                backlogPolicy,
-                caller);
-
-            if (require != null)
+            lock (backgroundExceptions)
             {
-                Skip.IfBelow(muxer, require);
+                foreach (var item in backgroundExceptions.Take(5))
+                {
+                    LogNoTime(item);
+                }
+            }
+            Skip.Inconclusive($"There were {privateFailCount} private and {sharedFailCount.Value} ambient exceptions; expected {expectedFailCount}.");
+        }
+        var pool = SocketManager.Shared?.SchedulerPool;
+        Log($"Service Counts: (Scheduler) Queue: {pool?.TotalServicedByQueue.ToString()}, Pool: {pool?.TotalServicedByPool.ToString()}, Workers: {pool?.WorkerCount.ToString()}, Available: {pool?.AvailableCount.ToString()}");
+    }
+
+    protected static IServer GetServer(IConnectionMultiplexer muxer)
+    {
+        EndPoint[] endpoints = muxer.GetEndPoints();
+        IServer? result = null;
+        foreach (var endpoint in endpoints)
+        {
+            var server = muxer.GetServer(endpoint);
+            if (server.IsReplica || !server.IsConnected) continue;
+            if (result != null) throw new InvalidOperationException("Requires exactly one primary endpoint (found " + server.EndPoint + " and " + result.EndPoint + ")");
+            result = server;
+        }
+        if (result == null) throw new InvalidOperationException("Requires exactly one primary endpoint (found none)");
+        return result;
+    }
+
+    protected static IServer GetAnyPrimary(IConnectionMultiplexer muxer)
+    {
+        foreach (var endpoint in muxer.GetEndPoints())
+        {
+            var server = muxer.GetServer(endpoint);
+            if (!server.IsReplica) return server;
+        }
+        throw new InvalidOperationException("Requires a primary endpoint (found none)");
+    }
+
+    internal virtual IInternalConnectionMultiplexer Create(
+        string? clientName = null,
+        int? syncTimeout = null,
+        bool? allowAdmin = null,
+        int? keepAlive = null,
+        int? connectTimeout = null,
+        string? password = null,
+        string? tieBreaker = null,
+        TextWriter? log = null,
+        bool fail = true,
+        string[]? disabledCommands = null,
+        string[]? enabledCommands = null,
+        bool checkConnect = true,
+        string? failMessage = null,
+        string? channelPrefix = null,
+        Proxy? proxy = null,
+        string? configuration = null,
+        bool logTransactionData = true,
+        bool shared = true,
+        int? defaultDatabase = null,
+        BacklogPolicy? backlogPolicy = null,
+        Version? require = null,
+        [CallerMemberName] string? caller = null)
+    {
+        if (Output == null)
+        {
+            Assert.True(false, "Failure: Be sure to call the TestBase constuctor like this: BasicOpsTests(ITestOutputHelper output) : base(output) { }");
+        }
+
+        // Share a connection if instructed to and we can - many specifics mean no sharing
+        if (shared
+            && _fixture != null && _fixture.IsEnabled
+            && enabledCommands == null
+            && disabledCommands == null
+            && fail
+            && channelPrefix == null
+            && proxy == null
+            && configuration == null
+            && password == null
+            && tieBreaker == null
+            && defaultDatabase == null
+            && (allowAdmin == null || allowAdmin == true)
+            && expectedFailCount == 0
+            && backlogPolicy == null)
+        {
+            configuration = GetConfiguration();
+            if (configuration == _fixture.Configuration)
+            {
+                // Only return if we match
+                if (require != null)
+                {
+                    Skip.IfBelow(_fixture.Connection, require);
+                }
+                return _fixture.Connection;
+            }
+        }
+
+        var muxer = CreateDefault(
+            Writer,
+            configuration ?? GetConfiguration(),
+            clientName, syncTimeout, allowAdmin, keepAlive,
+            connectTimeout, password, tieBreaker, log,
+            fail, disabledCommands, enabledCommands,
+            checkConnect, failMessage,
+            channelPrefix, proxy,
+            logTransactionData, defaultDatabase,
+            backlogPolicy,
+            caller);
+
+        if (require != null)
+        {
+            Skip.IfBelow(muxer, require);
+        }
+
+        muxer.InternalError += OnInternalError;
+        muxer.ConnectionFailed += OnConnectionFailed;
+        muxer.ConnectionRestored += (s, e) => Log($"Connection Restored ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+        return muxer;
+    }
+
+    public static ConnectionMultiplexer CreateDefault(
+        TextWriter? output,
+        string configuration,
+        string? clientName = null,
+        int? syncTimeout = null,
+        bool? allowAdmin = null,
+        int? keepAlive = null,
+        int? connectTimeout = null,
+        string? password = null,
+        string? tieBreaker = null,
+        TextWriter? log = null,
+        bool fail = true,
+        string[]? disabledCommands = null,
+        string[]? enabledCommands = null,
+        bool checkConnect = true,
+        string? failMessage = null,
+        string? channelPrefix = null,
+        Proxy? proxy = null,
+        bool logTransactionData = true,
+        int? defaultDatabase = null,
+        BacklogPolicy? backlogPolicy = null,
+        [CallerMemberName] string? caller = null)
+    {
+        StringWriter? localLog = null;
+        if (log == null)
+        {
+            log = localLog = new StringWriter();
+        }
+        try
+        {
+            var config = ConfigurationOptions.Parse(configuration);
+            if (disabledCommands != null && disabledCommands.Length != 0)
+            {
+                config.CommandMap = CommandMap.Create(new HashSet<string>(disabledCommands), false);
+            }
+            else if (enabledCommands != null && enabledCommands.Length != 0)
+            {
+                config.CommandMap = CommandMap.Create(new HashSet<string>(enabledCommands), true);
             }
 
-            muxer.InternalError += OnInternalError;
-            muxer.ConnectionFailed += OnConnectionFailed;
-            muxer.ConnectionRestored += (s, e) => Log($"Connection Restored ({e.ConnectionType},{e.FailureType}): {e.Exception}");
+            if (Debugger.IsAttached)
+            {
+                syncTimeout = int.MaxValue;
+            }
+
+            if (channelPrefix != null) config.ChannelPrefix = channelPrefix;
+            if (tieBreaker != null) config.TieBreaker = tieBreaker;
+            if (password != null) config.Password = string.IsNullOrEmpty(password) ? null : password;
+            if (clientName != null) config.ClientName = clientName;
+            else if (caller != null) config.ClientName = caller;
+            if (syncTimeout != null) config.SyncTimeout = syncTimeout.Value;
+            if (allowAdmin != null) config.AllowAdmin = allowAdmin.Value;
+            if (keepAlive != null) config.KeepAlive = keepAlive.Value;
+            if (connectTimeout != null) config.ConnectTimeout = connectTimeout.Value;
+            if (proxy != null) config.Proxy = proxy.Value;
+            if (defaultDatabase != null) config.DefaultDatabase = defaultDatabase.Value;
+            if (backlogPolicy != null) config.BacklogPolicy = backlogPolicy;
+            var watch = Stopwatch.StartNew();
+            var task = ConnectionMultiplexer.ConnectAsync(config, log);
+            if (!task.Wait(config.ConnectTimeout >= (int.MaxValue / 2) ? int.MaxValue : config.ConnectTimeout * 2))
+            {
+                task.ContinueWith(x =>
+                {
+                    try
+                    {
+                        GC.KeepAlive(x.Exception);
+                    }
+                    catch { /* No boom */ }
+                }, TaskContinuationOptions.OnlyOnFaulted);
+                throw new TimeoutException("Connect timeout");
+            }
+            watch.Stop();
+            if (output != null)
+            {
+                Log(output, "Connect took: " + watch.ElapsedMilliseconds + "ms");
+            }
+            var muxer = task.Result;
+            if (checkConnect && !muxer.IsConnected)
+            {
+                // If fail is true, we throw.
+                Assert.False(fail, failMessage + "Server is not available");
+                Skip.Inconclusive(failMessage + "Server is not available");
+            }
+            if (output != null)
+            {
+                muxer.MessageFaulted += (msg, ex, origin) =>
+                {
+                    output?.WriteLine($"Faulted from '{origin}': '{msg}' - '{(ex == null ? "(null)" : ex.Message)}'");
+                    if (ex != null && ex.Data.Contains("got"))
+                    {
+                        output?.WriteLine($"Got: '{ex.Data["got"]}'");
+                    }
+                };
+                muxer.Connecting += (e, t) => output?.WriteLine($"Connecting to {Format.ToString(e)} as {t}");
+                if (logTransactionData)
+                {
+                    muxer.TransactionLog += msg => output?.WriteLine("tran: " + msg);
+                }
+                muxer.InfoMessage += msg => output?.WriteLine(msg);
+                muxer.Resurrecting += (e, t) => output?.WriteLine($"Resurrecting {Format.ToString(e)} as {t}");
+                muxer.Closing += complete => output?.WriteLine(complete ? "Closed" : "Closing...");
+            }
             return muxer;
         }
-
-        public static ConnectionMultiplexer CreateDefault(
-            TextWriter? output,
-            string configuration,
-            string? clientName = null,
-            int? syncTimeout = null,
-            bool? allowAdmin = null,
-            int? keepAlive = null,
-            int? connectTimeout = null,
-            string? password = null,
-            string? tieBreaker = null,
-            TextWriter? log = null,
-            bool fail = true,
-            string[]? disabledCommands = null,
-            string[]? enabledCommands = null,
-            bool checkConnect = true,
-            string? failMessage = null,
-            string? channelPrefix = null,
-            Proxy? proxy = null,
-            bool logTransactionData = true,
-            int? defaultDatabase = null,
-            BacklogPolicy? backlogPolicy = null,
-            [CallerMemberName] string? caller = null)
+        catch
         {
-            StringWriter? localLog = null;
-            if (log == null)
-            {
-                log = localLog = new StringWriter();
-            }
-            try
-            {
-                var config = ConfigurationOptions.Parse(configuration);
-                if (disabledCommands != null && disabledCommands.Length != 0)
-                {
-                    config.CommandMap = CommandMap.Create(new HashSet<string>(disabledCommands), false);
-                }
-                else if (enabledCommands != null && enabledCommands.Length != 0)
-                {
-                    config.CommandMap = CommandMap.Create(new HashSet<string>(enabledCommands), true);
-                }
+            if (localLog != null) output?.WriteLine(localLog.ToString());
+            throw;
+        }
+    }
 
-                if (Debugger.IsAttached)
-                {
-                    syncTimeout = int.MaxValue;
-                }
+    public static string Me([CallerFilePath] string? filePath = null, [CallerMemberName] string? caller = null) =>
+        Environment.Version.ToString() + Path.GetFileNameWithoutExtension(filePath) + "-" + caller;
 
-                if (channelPrefix != null) config.ChannelPrefix = channelPrefix;
-                if (tieBreaker != null) config.TieBreaker = tieBreaker;
-                if (password != null) config.Password = string.IsNullOrEmpty(password) ? null : password;
-                if (clientName != null) config.ClientName = clientName;
-                else if (caller != null) config.ClientName = caller;
-                if (syncTimeout != null) config.SyncTimeout = syncTimeout.Value;
-                if (allowAdmin != null) config.AllowAdmin = allowAdmin.Value;
-                if (keepAlive != null) config.KeepAlive = keepAlive.Value;
-                if (connectTimeout != null) config.ConnectTimeout = connectTimeout.Value;
-                if (proxy != null) config.Proxy = proxy.Value;
-                if (defaultDatabase != null) config.DefaultDatabase = defaultDatabase.Value;
-                if (backlogPolicy != null) config.BacklogPolicy = backlogPolicy;
-                var watch = Stopwatch.StartNew();
-                var task = ConnectionMultiplexer.ConnectAsync(config, log);
-                if (!task.Wait(config.ConnectTimeout >= (int.MaxValue / 2) ? int.MaxValue : config.ConnectTimeout * 2))
-                {
-                    task.ContinueWith(x =>
-                    {
-                        try
-                        {
-                            GC.KeepAlive(x.Exception);
-                        }
-                        catch { /* No boom */ }
-                    }, TaskContinuationOptions.OnlyOnFaulted);
-                    throw new TimeoutException("Connect timeout");
-                }
-                watch.Stop();
-                if (output != null)
-                {
-                    Log(output, "Connect took: " + watch.ElapsedMilliseconds + "ms");
-                }
-                var muxer = task.Result;
-                if (checkConnect && !muxer.IsConnected)
-                {
-                    // If fail is true, we throw.
-                    Assert.False(fail, failMessage + "Server is not available");
-                    Skip.Inconclusive(failMessage + "Server is not available");
-                }
-                if (output != null)
-                {
-                    muxer.MessageFaulted += (msg, ex, origin) =>
-                    {
-                        output?.WriteLine($"Faulted from '{origin}': '{msg}' - '{(ex == null ? "(null)" : ex.Message)}'");
-                        if (ex != null && ex.Data.Contains("got"))
-                        {
-                            output?.WriteLine($"Got: '{ex.Data["got"]}'");
-                        }
-                    };
-                    muxer.Connecting += (e, t) => output?.WriteLine($"Connecting to {Format.ToString(e)} as {t}");
-                    if (logTransactionData)
-                    {
-                        muxer.TransactionLog += msg => output?.WriteLine("tran: " + msg);
-                    }
-                    muxer.InfoMessage += msg => output?.WriteLine(msg);
-                    muxer.Resurrecting += (e, t) => output?.WriteLine($"Resurrecting {Format.ToString(e)} as {t}");
-                    muxer.Closing += complete => output?.WriteLine(complete ? "Closed" : "Closing...");
-                }
-                return muxer;
-            }
-            catch
+    protected static TimeSpan RunConcurrent(Action work, int threads, int timeout = 10000, [CallerMemberName] string? caller = null)
+    {
+        if (work == null) throw new ArgumentNullException(nameof(work));
+        if (threads < 1) throw new ArgumentOutOfRangeException(nameof(threads));
+        if (string.IsNullOrWhiteSpace(caller)) caller = Me();
+        Stopwatch? watch = null;
+        ManualResetEvent allDone = new ManualResetEvent(false);
+        object token = new object();
+        int active = 0;
+        void callback()
+        {
+            lock (token)
             {
-                if (localLog != null) output?.WriteLine(localLog.ToString());
-                throw;
+                int nowActive = Interlocked.Increment(ref active);
+                if (nowActive == threads)
+                {
+                    watch = Stopwatch.StartNew();
+                    Monitor.PulseAll(token);
+                }
+                else
+                {
+                    Monitor.Wait(token);
+                }
+            }
+            work();
+            if (Interlocked.Decrement(ref active) == 0)
+            {
+                watch?.Stop();
+                allDone.Set();
             }
         }
 
-        public static string Me([CallerFilePath] string? filePath = null, [CallerMemberName] string? caller = null) =>
-            Environment.Version.ToString() + Path.GetFileNameWithoutExtension(filePath) + "-" + caller;
-
-        protected static TimeSpan RunConcurrent(Action work, int threads, int timeout = 10000, [CallerMemberName] string? caller = null)
+        var threadArr = new Thread[threads];
+        for (int i = 0; i < threads; i++)
         {
-            if (work == null) throw new ArgumentNullException(nameof(work));
-            if (threads < 1) throw new ArgumentOutOfRangeException(nameof(threads));
-            if (string.IsNullOrWhiteSpace(caller)) caller = Me();
-            Stopwatch? watch = null;
-            ManualResetEvent allDone = new ManualResetEvent(false);
-            object token = new object();
-            int active = 0;
-            void callback()
+            var thd = new Thread(callback)
             {
-                lock (token)
-                {
-                    int nowActive = Interlocked.Increment(ref active);
-                    if (nowActive == threads)
-                    {
-                        watch = Stopwatch.StartNew();
-                        Monitor.PulseAll(token);
-                    }
-                    else
-                    {
-                        Monitor.Wait(token);
-                    }
-                }
-                work();
-                if (Interlocked.Decrement(ref active) == 0)
-                {
-                    watch?.Stop();
-                    allDone.Set();
-                }
-            }
-
-            var threadArr = new Thread[threads];
+                Name = caller
+            };
+            threadArr[i] = thd;
+            thd.Start();
+        }
+        if (!allDone.WaitOne(timeout))
+        {
             for (int i = 0; i < threads; i++)
             {
-                var thd = new Thread(callback)
-                {
-                    Name = caller
-                };
-                threadArr[i] = thd;
-                thd.Start();
-            }
-            if (!allDone.WaitOne(timeout))
-            {
-                for (int i = 0; i < threads; i++)
-                {
-                    var thd = threadArr[i];
+                var thd = threadArr[i];
 #if !NET6_0_OR_GREATER
-                    if (thd.IsAlive) thd.Abort();
+                if (thd.IsAlive) thd.Abort();
 #endif
-                }
-                throw new TimeoutException();
             }
-
-            return watch?.Elapsed ?? TimeSpan.Zero;
+            throw new TimeoutException();
         }
 
-        private static readonly TimeSpan DefaultWaitPerLoop = TimeSpan.FromMilliseconds(50);
-        protected static async Task UntilConditionAsync(TimeSpan maxWaitTime, Func<bool> predicate, TimeSpan? waitPerLoop = null)
+        return watch?.Elapsed ?? TimeSpan.Zero;
+    }
+
+    private static readonly TimeSpan DefaultWaitPerLoop = TimeSpan.FromMilliseconds(50);
+    protected static async Task UntilConditionAsync(TimeSpan maxWaitTime, Func<bool> predicate, TimeSpan? waitPerLoop = null)
+    {
+        TimeSpan spent = TimeSpan.Zero;
+        while (spent < maxWaitTime && !predicate())
         {
-            TimeSpan spent = TimeSpan.Zero;
-            while (spent < maxWaitTime && !predicate())
-            {
-                var wait = waitPerLoop ?? DefaultWaitPerLoop;
-                await Task.Delay(wait).ForAwait();
-                spent += wait;
-            }
+            var wait = waitPerLoop ?? DefaultWaitPerLoop;
+            await Task.Delay(wait).ForAwait();
+            spent += wait;
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/TestExtensions.cs
+++ b/tests/StackExchange.Redis.Tests/TestExtensions.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using StackExchange.Redis.Profiling;
+﻿using StackExchange.Redis.Profiling;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public static class TestExtensions
 {
-    public static class TestExtensions
+    public static ProfilingSession AddProfiler(this IConnectionMultiplexer mutex)
     {
-        public static ProfilingSession AddProfiler(this IConnectionMultiplexer mutex)
-        {
-            var session = new ProfilingSession();
-            mutex.RegisterProfiler(() => session);
-            return session;
-        }
+        var session = new ProfilingSession();
+        mutex.RegisterProfiler(() => session);
+        return session;
     }
 }

--- a/tests/StackExchange.Redis.Tests/TestInfoReplicationChecks.cs
+++ b/tests/StackExchange.Redis.Tests/TestInfoReplicationChecks.cs
@@ -2,28 +2,26 @@
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class TestInfoReplicationChecks : TestBase
 {
-    public class TestInfoReplicationChecks : TestBase
+    protected override string GetConfiguration() => base.GetConfiguration() + ",configCheckSeconds=2";
+    public TestInfoReplicationChecks(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public async Task Exec()
     {
-        protected override string GetConfiguration() => base.GetConfiguration() + ",configCheckSeconds=2";
-        public TestInfoReplicationChecks(ITestOutputHelper output) : base (output) { }
+        Skip.Inconclusive("need to think about CompletedSynchronously");
 
-        [Fact]
-        public async Task Exec()
-        {
-            Skip.Inconclusive("need to think about CompletedSynchronously");
+        using var conn = Create();
 
-            using(var conn = Create())
-            {
-                var parsed = ConfigurationOptions.Parse(conn.Configuration);
-                Assert.Equal(2, parsed.ConfigCheckSeconds);
-                var before = conn.GetCounters();
-                await Task.Delay(7000).ForAwait();
-                var after = conn.GetCounters();
-                int done = (int)(after.Interactive.CompletedSynchronously - before.Interactive.CompletedSynchronously);
-                Assert.True(done >= 2, $"expected >=2, got {done}");
-            }
-        }
+        var parsed = ConfigurationOptions.Parse(conn.Configuration);
+        Assert.Equal(2, parsed.ConfigCheckSeconds);
+        var before = conn.GetCounters();
+        await Task.Delay(7000).ForAwait();
+        var after = conn.GetCounters();
+        int done = (int)(after.Interactive.CompletedSynchronously - before.Interactive.CompletedSynchronously);
+        Assert.True(done >= 2, $"expected >=2, got {done}");
     }
 }

--- a/tests/StackExchange.Redis.Tests/TransactionWrapperTests.cs
+++ b/tests/StackExchange.Redis.Tests/TransactionWrapperTests.cs
@@ -4,130 +4,129 @@ using Moq;
 using StackExchange.Redis.KeyspaceIsolation;
 using Xunit;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(nameof(MoqDependentCollection))]
+public sealed class TransactionWrapperTests
 {
-    [Collection(nameof(MoqDependentCollection))]
-    public sealed class TransactionWrapperTests
+    private readonly Mock<ITransaction> mock;
+    private readonly TransactionWrapper wrapper;
+
+    public TransactionWrapperTests()
     {
-        private readonly Mock<ITransaction> mock;
-        private readonly TransactionWrapper wrapper;
+        mock = new Mock<ITransaction>();
+        wrapper = new TransactionWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+    }
 
-        public TransactionWrapperTests()
-        {
-            mock = new Mock<ITransaction>();
-            wrapper = new TransactionWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
-        }
+    [Fact]
+    public void AddCondition_HashEqual()
+    {
+        wrapper.AddCondition(Condition.HashEqual("key", "field", "value"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field == value" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_HashEqual()
-        {
-            wrapper.AddCondition(Condition.HashEqual("key", "field", "value"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field == value" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_HashNotEqual()
+    {
+        wrapper.AddCondition(Condition.HashNotEqual("key", "field", "value"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field != value" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_HashNotEqual()
-        {
-            wrapper.AddCondition(Condition.HashNotEqual("key", "field", "value"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field != value" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_HashExists()
+    {
+        wrapper.AddCondition(Condition.HashExists("key", "field"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field exists" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_HashExists()
-        {
-            wrapper.AddCondition(Condition.HashExists("key", "field"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field exists" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_HashNotExists()
+    {
+        wrapper.AddCondition(Condition.HashNotExists("key", "field"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field does not exists" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_HashNotExists()
-        {
-            wrapper.AddCondition(Condition.HashNotExists("key", "field"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field does not exists" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_KeyExists()
+    {
+        wrapper.AddCondition(Condition.KeyExists("key"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key exists" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_KeyExists()
-        {
-            wrapper.AddCondition(Condition.KeyExists("key"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key exists" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_KeyNotExists()
+    {
+        wrapper.AddCondition(Condition.KeyNotExists("key"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key does not exists" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_KeyNotExists()
-        {
-            wrapper.AddCondition(Condition.KeyNotExists("key"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key does not exists" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_StringEqual()
+    {
+        wrapper.AddCondition(Condition.StringEqual("key", "value"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key == value" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_StringEqual()
-        {
-            wrapper.AddCondition(Condition.StringEqual("key", "value"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key == value" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_StringNotEqual()
+    {
+        wrapper.AddCondition(Condition.StringNotEqual("key", "value"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key != value" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_StringNotEqual()
-        {
-            wrapper.AddCondition(Condition.StringNotEqual("key", "value"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key != value" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_SortedSetEqual()
+    {
+        wrapper.AddCondition(Condition.SortedSetEqual("key", "member", "score"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key SortedSet > member == score" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_SortedSetEqual()
-        {
-            wrapper.AddCondition(Condition.SortedSetEqual("key", "member", "score"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key SortedSet > member == score" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_SortedSetNotEqual()
+    {
+        wrapper.AddCondition(Condition.SortedSetNotEqual("key", "member", "score"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key SortedSet > member != score" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_SortedSetNotEqual()
-        {
-            wrapper.AddCondition(Condition.SortedSetNotEqual("key", "member", "score"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key SortedSet > member != score" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_SortedSetScoreExists()
+    {
+        wrapper.AddCondition(Condition.SortedSetScoreExists("key", "score"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key not contains 0 members with score: score" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_SortedSetScoreExists()
-        {
-            wrapper.AddCondition(Condition.SortedSetScoreExists("key", "score"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key not contains 0 members with score: score" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_SortedSetScoreNotExists()
+    {
+        wrapper.AddCondition(Condition.SortedSetScoreNotExists("key", "score"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key contains 0 members with score: score" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_SortedSetScoreNotExists()
-        {
-            wrapper.AddCondition(Condition.SortedSetScoreNotExists("key", "score"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key contains 0 members with score: score" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_SortedSetScoreCountExists()
+    {
+        wrapper.AddCondition(Condition.SortedSetScoreExists("key", "score", "count"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key contains count members with score: score" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_SortedSetScoreCountExists()
-        {
-            wrapper.AddCondition(Condition.SortedSetScoreExists("key", "score", "count"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key contains count members with score: score" == value.ToString())));
-        }
+    [Fact]
+    public void AddCondition_SortedSetScoreCountNotExists()
+    {
+        wrapper.AddCondition(Condition.SortedSetScoreNotExists("key", "score", "count"));
+        mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key not contains count members with score: score" == value.ToString())));
+    }
 
-        [Fact]
-        public void AddCondition_SortedSetScoreCountNotExists()
-        {
-            wrapper.AddCondition(Condition.SortedSetScoreNotExists("key", "score", "count"));
-            mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key not contains count members with score: score" == value.ToString())));
-        }
+    [Fact]
+    public async Task ExecuteAsync()
+    {
+        await wrapper.ExecuteAsync(CommandFlags.None);
+        mock.Verify(_ => _.ExecuteAsync(CommandFlags.None), Times.Once());
+    }
 
-        [Fact]
-        public async Task ExecuteAsync()
-        {
-            await wrapper.ExecuteAsync(CommandFlags.None);
-            mock.Verify(_ => _.ExecuteAsync(CommandFlags.None), Times.Once());
-        }
-
-        [Fact]
-        public void Execute()
-        {
-            wrapper.Execute(CommandFlags.None);
-            mock.Verify(_ => _.Execute(CommandFlags.None), Times.Once());
-        }
+    [Fact]
+    public void Execute()
+    {
+        wrapper.Execute(CommandFlags.None);
+        mock.Verify(_ => _.Execute(CommandFlags.None), Times.Once());
     }
 }

--- a/tests/StackExchange.Redis.Tests/Transactions.cs
+++ b/tests/StackExchange.Redis.Tests/Transactions.cs
@@ -3,1330 +3,1303 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class Transactions : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class Transactions : TestBase
+    public Transactions(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void BasicEmptyTran()
     {
-        public Transactions(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void BasicEmptyTran()
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+
+        var tran = db.CreateTransaction();
+
+        var result = tran.Execute();
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void NestedTransactionThrows()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var tran = db.CreateTransaction();
+        var redisTransaction = Assert.IsType<RedisTransaction>(tran);
+        Assert.Throws<NotSupportedException>(() => redisTransaction.CreateTransaction(null));
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public async Task BasicTranWithExistsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+    {
+        using var conn = Create(disabledCommands: new[] { "info", "config" });
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        if (keyExists) db.StringSet(key2, "any value", flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(keyExists, db.KeyExists(key2));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(demandKeyExists ? Condition.KeyExists(key2) : Condition.KeyNotExists(key2));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (demandKeyExists == keyExists)
         {
-            using (var muxer = Create())
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData("same", "same", true, true)]
+    [InlineData("x", "y", true, false)]
+    [InlineData("x", null, true, false)]
+    [InlineData(null, "y", true, false)]
+    [InlineData(null, null, true, true)]
+
+    [InlineData("same", "same", false, false)]
+    [InlineData("x", "y", false, true)]
+    [InlineData("x", null, false, true)]
+    [InlineData(null, "y", false, true)]
+    [InlineData(null, null, false, false)]
+    public async Task BasicTranWithEqualsCondition(string expected, string value, bool expectEqual, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        if (value != null) db.StringSet(key2, value, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(value, db.StringGet(key2));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(expectEqual ? Condition.StringEqual(key2, expected) : Condition.StringNotEqual(key2, expected));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (expectEqual == (value == expected))
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public async Task BasicTranWithHashExistsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+    {
+        using var conn = Create(disabledCommands: new[] { "info", "config" });
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        RedisValue hashField = "field";
+        if (keyExists) db.HashSet(key2, hashField, "any value", flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(keyExists, db.HashExists(key2, hashField));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(demandKeyExists ? Condition.HashExists(key2, hashField) : Condition.HashNotExists(key2, hashField));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (demandKeyExists == keyExists)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData("same", "same", true, true)]
+    [InlineData("x", "y", true, false)]
+    [InlineData("x", null, true, false)]
+    [InlineData(null, "y", true, false)]
+    [InlineData(null, null, true, true)]
+
+    [InlineData("same", "same", false, false)]
+    [InlineData("x", "y", false, true)]
+    [InlineData("x", null, false, true)]
+    [InlineData(null, "y", false, true)]
+    [InlineData(null, null, false, false)]
+    public async Task BasicTranWithHashEqualsCondition(string expected, string value, bool expectEqual, bool expectedTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        RedisValue hashField = "field";
+        if (value != null) db.HashSet(key2, hashField, value, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(value, db.HashGet(key2, hashField));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(expectEqual ? Condition.HashEqual(key2, hashField, expected) : Condition.HashNotEqual(key2, hashField, expected));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectedTranResult, await exec);
+        if (expectEqual == (value == expected))
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    private static TaskStatus SafeStatus(Task task)
+    {
+        if (task.Status == TaskStatus.WaitingForActivation)
+        {
+            try
             {
-                RedisKey key = Me();
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-
-                var tran = db.CreateTransaction();
-
-                var result = tran.Execute();
-                Assert.True(result);
+                if (!task.Wait(1000)) throw new TimeoutException("timeout waiting for task to complete");
+            }
+            catch (AggregateException ex)
+            when (ex.InnerException is TaskCanceledException
+                || (ex.InnerExceptions.Count == 1 && ex.InnerException is TaskCanceledException))
+            {
+                return TaskStatus.Canceled;
+            }
+            catch (TaskCanceledException)
+            {
+                return TaskStatus.Canceled;
             }
         }
+        return task.Status;
+    }
 
-        [Fact]
-        public void NestedTransactionThrows()
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public async Task BasicTranWithListExistsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+    {
+        using var conn = Create(disabledCommands: new[] { "info", "config" });
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        if (keyExists) db.ListRightPush(key2, "any value", flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(keyExists, db.KeyExists(key2));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(demandKeyExists ? Condition.ListIndexExists(key2, 0) : Condition.ListIndexNotExists(key2, 0));
+        var push = tran.ListRightPushAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.ListGetByIndex(key, 0);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (demandKeyExists == keyExists)
         {
-            using (var muxer = Create())
-            {
-                var db = muxer.GetDatabase();
-                var tran = db.CreateTransaction();
-                var redisTransaction = Assert.IsType<RedisTransaction>(tran);
-                Assert.Throws<NotSupportedException>(() => redisTransaction.CreateTransaction(null));
-            }
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await push); // eq: push
+            Assert.Equal("any value", get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Null((string?)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData("same", "same", true, true)]
+    [InlineData("x", "y", true, false)]
+    [InlineData("x", null, true, false)]
+    [InlineData(null, "y", true, false)]
+    [InlineData(null, null, true, true)]
+
+    [InlineData("same", "same", false, false)]
+    [InlineData("x", "y", false, true)]
+    [InlineData("x", null, false, true)]
+    [InlineData(null, "y", false, true)]
+    [InlineData(null, null, false, false)]
+    public async Task BasicTranWithListEqualsCondition(string expected, string value, bool expectEqual, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        if (value != null) db.ListRightPush(key2, value, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(value, db.ListGetByIndex(key2, 0));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(expectEqual ? Condition.ListIndexEqual(key2, 0, expected) : Condition.ListIndexNotEqual(key2, 0, expected));
+        var push = tran.ListRightPushAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.ListGetByIndex(key, 0);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (expectEqual == (value == expected))
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await push); // eq: push
+            Assert.Equal("any value", get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Null((string?)get); // neq: get
+        }
+    }
+
+    public enum ComparisonType
+    {
+        Equal,
+        LessThan,
+        GreaterThan
+    }
+
+    [Theory]
+    [InlineData("five", ComparisonType.Equal, 5L, false)]
+    [InlineData("four", ComparisonType.Equal, 4L, true)]
+    [InlineData("three", ComparisonType.Equal, 3L, false)]
+    [InlineData("", ComparisonType.Equal, 2L, false)]
+    [InlineData("", ComparisonType.Equal, 0L, true)]
+    [InlineData(null, ComparisonType.Equal, 1L, false)]
+    [InlineData(null, ComparisonType.Equal, 0L, true)]
+
+    [InlineData("five", ComparisonType.LessThan, 5L, true)]
+    [InlineData("four", ComparisonType.LessThan, 4L, false)]
+    [InlineData("three", ComparisonType.LessThan, 3L, false)]
+    [InlineData("", ComparisonType.LessThan, 2L, true)]
+    [InlineData("", ComparisonType.LessThan, 0L, false)]
+    [InlineData(null, ComparisonType.LessThan, 1L, true)]
+    [InlineData(null, ComparisonType.LessThan, 0L, false)]
+
+    [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
+    [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
+    [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
+    [InlineData("", ComparisonType.GreaterThan, 2L, false)]
+    [InlineData("", ComparisonType.GreaterThan, 0L, false)]
+    [InlineData(null, ComparisonType.GreaterThan, 1L, false)]
+    [InlineData(null, ComparisonType.GreaterThan, 0L, false)]
+    public async Task BasicTranWithStringLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = value?.Length ?? 0;
+        switch (type)
+        {
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.StringLengthEqual(key2, length);
+                Assert.Contains("String length == " + length, condition.ToString());
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.StringLengthGreaterThan(key2, length);
+                Assert.Contains("String length > " + length, condition.ToString());
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.StringLengthLessThan(key2, length);
+                Assert.Contains("String length < " + length, condition.ToString());
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        [Theory]
-        [InlineData(false, false, true)]
-        [InlineData(false, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(true, true, true)]
-        public async Task BasicTranWithExistsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+        if (value != null) db.StringSet(key2, value, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(value, db.StringGet(key2));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
+
+        Assert.Equal(expectTranResult, await exec);
+
+        if (expectSuccess)
         {
-            using (var muxer = Create(disabledCommands: new[] { "info", "config" }))
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-                if (keyExists) db.StringSet(key2, "any value", flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(keyExists, db.KeyExists(key2));
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
+        }
+    }
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(demandKeyExists ? Condition.KeyExists(key2) : Condition.KeyNotExists(key2));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
+    [Theory]
+    [InlineData("five", ComparisonType.Equal, 5L, false)]
+    [InlineData("four", ComparisonType.Equal, 4L, true)]
+    [InlineData("three", ComparisonType.Equal, 3L, false)]
+    [InlineData("", ComparisonType.Equal, 2L, false)]
+    [InlineData("", ComparisonType.Equal, 0L, true)]
 
-                Assert.Equal(expectTranResult, await exec);
-                if (demandKeyExists == keyExists)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+    [InlineData("five", ComparisonType.LessThan, 5L, true)]
+    [InlineData("four", ComparisonType.LessThan, 4L, false)]
+    [InlineData("three", ComparisonType.LessThan, 3L, false)]
+    [InlineData("", ComparisonType.LessThan, 2L, true)]
+    [InlineData("", ComparisonType.LessThan, 0L, false)]
+
+    [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
+    [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
+    [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
+    [InlineData("", ComparisonType.GreaterThan, 2L, false)]
+    [InlineData("", ComparisonType.GreaterThan, 0L, false)]
+    public async Task BasicTranWithHashLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = value?.Length ?? 0;
+        switch (type)
+        {
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.HashLengthEqual(key2, length);
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.HashLengthGreaterThan(key2, length);
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.HashLengthLessThan(key2, length);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        [Theory]
-        [InlineData("same", "same", true, true)]
-        [InlineData("x", "y", true, false)]
-        [InlineData("x", null, true, false)]
-        [InlineData(null, "y", true, false)]
-        [InlineData(null, null, true, true)]
-
-        [InlineData("same", "same", false, false)]
-        [InlineData("x", "y", false, true)]
-        [InlineData("x", null, false, true)]
-        [InlineData(null, "y", false, true)]
-        [InlineData(null, null, false, false)]
-        public async Task BasicTranWithEqualsCondition(string expected, string value, bool expectEqual, bool expectTranResult)
+        for (var i = 0; i < valueLength; i++)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
+            db.HashSet(key2, i, value![i].ToString(), flags: CommandFlags.FireAndForget);
+        }
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(valueLength, db.HashLength(key2));
 
-                if (value != null) db.StringSet(key2, value, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(value, db.StringGet(key2));
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(expectEqual ? Condition.StringEqual(key2, expected) : Condition.StringNotEqual(key2, expected));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
+        Assert.Equal(expectTranResult, await exec);
 
-                Assert.Equal(expectTranResult, await exec);
-                if (expectEqual == (value == expected))
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+        if (expectSuccess)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData("five", ComparisonType.Equal, 5L, false)]
+    [InlineData("four", ComparisonType.Equal, 4L, true)]
+    [InlineData("three", ComparisonType.Equal, 3L, false)]
+    [InlineData("", ComparisonType.Equal, 2L, false)]
+    [InlineData("", ComparisonType.Equal, 0L, true)]
+
+    [InlineData("five", ComparisonType.LessThan, 5L, true)]
+    [InlineData("four", ComparisonType.LessThan, 4L, false)]
+    [InlineData("three", ComparisonType.LessThan, 3L, false)]
+    [InlineData("", ComparisonType.LessThan, 2L, true)]
+    [InlineData("", ComparisonType.LessThan, 0L, false)]
+
+    [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
+    [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
+    [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
+    [InlineData("", ComparisonType.GreaterThan, 2L, false)]
+    [InlineData("", ComparisonType.GreaterThan, 0L, false)]
+    public async Task BasicTranWithSetCardinalityCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = value?.Length ?? 0;
+        switch (type)
+        {
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.SetLengthEqual(key2, length);
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.SetLengthGreaterThan(key2, length);
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.SetLengthLessThan(key2, length);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        [Theory]
-        [InlineData(false, false, true)]
-        [InlineData(false, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(true, true, true)]
-        public async Task BasicTranWithHashExistsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+        for (var i = 0; i < valueLength; i++)
         {
-            using (var muxer = Create(disabledCommands: new[] { "info", "config" }))
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-                RedisValue hashField = "field";
-                if (keyExists) db.HashSet(key2, hashField, "any value", flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(keyExists, db.HashExists(key2, hashField));
+            db.SetAdd(key2, i, flags: CommandFlags.FireAndForget);
+        }
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(valueLength, db.SetLength(key2));
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(demandKeyExists ? Condition.HashExists(key2, hashField) : Condition.HashNotExists(key2, hashField));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
 
-                Assert.Equal(expectTranResult, await exec);
-                if (demandKeyExists == keyExists)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+        Assert.Equal(expectTranResult, await exec);
+
+        if (expectSuccess)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public async Task BasicTranWithSetContainsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+    {
+        using var conn = Create(disabledCommands: new[] { "info", "config" });
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        RedisValue member = "value";
+        if (keyExists) db.SetAdd(key2, member, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(keyExists, db.SetContains(key2, member));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(demandKeyExists ? Condition.SetContains(key2, member) : Condition.SetNotContains(key2, member));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (demandKeyExists == keyExists)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData("five", ComparisonType.Equal, 5L, false)]
+    [InlineData("four", ComparisonType.Equal, 4L, true)]
+    [InlineData("three", ComparisonType.Equal, 3L, false)]
+    [InlineData("", ComparisonType.Equal, 2L, false)]
+    [InlineData("", ComparisonType.Equal, 0L, true)]
+
+    [InlineData("five", ComparisonType.LessThan, 5L, true)]
+    [InlineData("four", ComparisonType.LessThan, 4L, false)]
+    [InlineData("three", ComparisonType.LessThan, 3L, false)]
+    [InlineData("", ComparisonType.LessThan, 2L, true)]
+    [InlineData("", ComparisonType.LessThan, 0L, false)]
+
+    [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
+    [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
+    [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
+    [InlineData("", ComparisonType.GreaterThan, 2L, false)]
+    [InlineData("", ComparisonType.GreaterThan, 0L, false)]
+    public async Task BasicTranWithSortedSetCardinalityCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = value?.Length ?? 0;
+        switch (type)
+        {
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.SortedSetLengthEqual(key2, length);
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.SortedSetLengthGreaterThan(key2, length);
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.SortedSetLengthLessThan(key2, length);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        [Theory]
-        [InlineData("same", "same", true, true)]
-        [InlineData("x", "y", true, false)]
-        [InlineData("x", null, true, false)]
-        [InlineData(null, "y", true, false)]
-        [InlineData(null, null, true, true)]
-
-        [InlineData("same", "same", false, false)]
-        [InlineData("x", "y", false, true)]
-        [InlineData("x", null, false, true)]
-        [InlineData(null, "y", false, true)]
-        [InlineData(null, null, false, false)]
-        public async Task BasicTranWithHashEqualsCondition(string expected, string value, bool expectEqual, bool expectedTranResult)
+        for (var i = 0; i < valueLength; i++)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
+            db.SortedSetAdd(key2, i, i, flags: CommandFlags.FireAndForget);
+        }
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(valueLength, db.SortedSetLength(key2));
 
-                RedisValue hashField = "field";
-                if (value != null) db.HashSet(key2, hashField, value, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(value, db.HashGet(key2, hashField));
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(expectEqual ? Condition.HashEqual(key2, hashField, expected) : Condition.HashNotEqual(key2, hashField, expected));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
+        Assert.Equal(expectTranResult, await exec);
 
-                Assert.Equal(expectedTranResult, await exec);
-                if (expectEqual == (value == expected))
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+        if (expectSuccess)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData(1, 4, ComparisonType.Equal, 5L, false)]
+    [InlineData(1, 4, ComparisonType.Equal, 4L, true)]
+    [InlineData(1, 2, ComparisonType.Equal, 3L, false)]
+    [InlineData(1, 1, ComparisonType.Equal, 2L, false)]
+    [InlineData(0, 0, ComparisonType.Equal, 0L, false)]
+
+    [InlineData(1, 4, ComparisonType.LessThan, 5L, true)]
+    [InlineData(1, 4, ComparisonType.LessThan, 4L, false)]
+    [InlineData(1, 3, ComparisonType.LessThan, 3L, false)]
+    [InlineData(1, 1, ComparisonType.LessThan, 2L, true)]
+    [InlineData(0, 0, ComparisonType.LessThan, 0L, false)]
+
+    [InlineData(1, 5, ComparisonType.GreaterThan, 5L, false)]
+    [InlineData(1, 4, ComparisonType.GreaterThan, 4L, false)]
+    [InlineData(1, 4, ComparisonType.GreaterThan, 3L, true)]
+    [InlineData(1, 2, ComparisonType.GreaterThan, 2L, false)]
+    [InlineData(0, 0, ComparisonType.GreaterThan, 0L, true)]
+    public async Task BasicTranWithSortedSetRangeCountCondition(double min, double max, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = (int)(max - min) + 1;
+        switch (type)
+        {
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.SortedSetLengthEqual(key2, length, min, max);
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.SortedSetLengthGreaterThan(key2, length, min, max);
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.SortedSetLengthLessThan(key2, length, min, max);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        private static TaskStatus SafeStatus(Task task)
+        for (var i = 0; i < 5; i++)
         {
-            if (task.Status == TaskStatus.WaitingForActivation)
-            {
-                try
-                {
-                    if (!task.Wait(1000)) throw new TimeoutException("timeout waiting for task to complete");
-                }
-                catch (AggregateException ex)
-                when (ex.InnerException is TaskCanceledException
-                    || (ex.InnerExceptions.Count == 1 && ex.InnerException is TaskCanceledException))
-                {
-                    return TaskStatus.Canceled;
-                }
-                catch (TaskCanceledException)
-                {
-                    return TaskStatus.Canceled;
-                }
-            }
-            return task.Status;
+            db.SortedSetAdd(key2, i, i, flags: CommandFlags.FireAndForget);
+        }
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(5, db.SortedSetLength(key2));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
+
+        Assert.Equal(expectTranResult, await exec);
+
+        if (expectSuccess)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public async Task BasicTranWithSortedSetContainsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+    {
+        using var conn = Create(disabledCommands: new[] { "info", "config" });
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+        RedisValue member = "value";
+        if (keyExists) db.SortedSetAdd(key2, member, 0.0, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(keyExists, db.SortedSetScore(key2, member).HasValue);
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(demandKeyExists ? Condition.SortedSetContains(key2, member) : Condition.SortedSetNotContains(key2, member));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectTranResult, await exec);
+        if (demandKeyExists == keyExists)
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData(4D, 4D, true, true)]
+    [InlineData(4D, 5D, true, false)]
+    [InlineData(4D, null, true, false)]
+    [InlineData(null, 5D, true, false)]
+    [InlineData(null, null, true, true)]
+
+    [InlineData(4D, 4D, false, false)]
+    [InlineData(4D, 5D, false, true)]
+    [InlineData(4D, null, false, true)]
+    [InlineData(null, 5D, false, true)]
+    [InlineData(null, null, false, false)]
+    public async Task BasicTranWithSortedSetEqualCondition(double? expected, double? value, bool expectEqual, bool expectedTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        RedisValue member = "member";
+        if (value != null) db.SortedSetAdd(key2, member, value.Value, flags: CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(value, db.SortedSetScore(key2, member));
+
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(expectEqual ? Condition.SortedSetEqual(key2, member, expected) : Condition.SortedSetNotEqual(key2, member, expected));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectedTranResult, await exec);
+        if (expectEqual == (value == expected))
+        {
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(true, false, true, true)]
+    [InlineData(false, true, true, true)]
+    [InlineData(true, true, false, false)]
+    [InlineData(true, false, false, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, false, true, false)]
+    [InlineData(false, false, false, true)]
+    public async Task BasicTranWithSortedSetScoreExistsCondition(bool member1HasScore, bool member2HasScore, bool demandScoreExists, bool expectedTranResult)
+    {
+        using var conn = Create();
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        const double Score = 4D;
+        RedisValue member1 = "member1";
+        RedisValue member2 = "member2";
+        if (member1HasScore)
+        {
+            db.SortedSetAdd(key2, member1, Score, flags: CommandFlags.FireAndForget);
         }
 
-        [Theory]
-        [InlineData(false, false, true)]
-        [InlineData(false, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(true, true, true)]
-        public async Task BasicTranWithListExistsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+        if (member2HasScore)
         {
-            using (var muxer = Create(disabledCommands: new[] { "info", "config" }))
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-                if (keyExists) db.ListRightPush(key2, "any value", flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(keyExists, db.KeyExists(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(demandKeyExists ? Condition.ListIndexExists(key2, 0) : Condition.ListIndexNotExists(key2, 0));
-                var push = tran.ListRightPushAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.ListGetByIndex(key, 0);
-
-                Assert.Equal(expectTranResult, await exec);
-                if (demandKeyExists == keyExists)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await push); // eq: push
-                    Assert.Equal("any value", get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Null((string?)get); // neq: get
-                }
-            }
+            db.SortedSetAdd(key2, member2, Score, flags: CommandFlags.FireAndForget);
         }
 
-        [Theory]
-        [InlineData("same", "same", true, true)]
-        [InlineData("x", "y", true, false)]
-        [InlineData("x", null, true, false)]
-        [InlineData(null, "y", true, false)]
-        [InlineData(null, null, true, true)]
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(member1HasScore ? (double?)Score : null, db.SortedSetScore(key2, member1));
+        Assert.Equal(member2HasScore ? (double?)Score : null, db.SortedSetScore(key2, member2));
 
-        [InlineData("same", "same", false, false)]
-        [InlineData("x", "y", false, true)]
-        [InlineData("x", null, false, true)]
-        [InlineData(null, "y", false, true)]
-        [InlineData(null, null, false, false)]
-        public async Task BasicTranWithListEqualsCondition(string expected, string value, bool expectEqual, bool expectTranResult)
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(demandScoreExists ? Condition.SortedSetScoreExists(key2, Score) : Condition.SortedSetScoreNotExists(key2, Score));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
+
+        Assert.Equal(expectedTranResult, await exec);
+        if ((member1HasScore || member2HasScore) == demandScoreExists)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
 
-                if (value != null) db.ListRightPush(key2, value, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(value, db.ListGetByIndex(key2, 0));
+    [Theory]
+    [InlineData(true, true, 2L, true, true)]
+    [InlineData(true, true, 2L, false, false)]
+    [InlineData(true, true, 1L, true, false)]
+    [InlineData(true, true, 1L, false, true)]
+    [InlineData(true, false, 2L, true, false)]
+    [InlineData(true, false, 2L, false, true)]
+    [InlineData(true, false, 1L, true, true)]
+    [InlineData(true, false, 1L, false, false)]
+    [InlineData(false, true, 2L, true, false)]
+    [InlineData(false, true, 2L, false, true)]
+    [InlineData(false, true, 1L, true, true)]
+    [InlineData(false, true, 1L, false, false)]
+    [InlineData(false, false, 2L, true, false)]
+    [InlineData(false, false, 2L, false, true)]
+    [InlineData(false, false, 1L, true, false)]
+    [InlineData(false, false, 1L, false, true)]
+    public async Task BasicTranWithSortedSetScoreCountExistsCondition(bool member1HasScore, bool member2HasScore, long expectedLength, bool expectEqual, bool expectedTranResult)
+    {
+        using var conn = Create();
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(expectEqual ? Condition.ListIndexEqual(key2, 0, expected) : Condition.ListIndexNotEqual(key2, 0, expected));
-                var push = tran.ListRightPushAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.ListGetByIndex(key, 0);
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
 
-                Assert.Equal(expectTranResult, await exec);
-                if (expectEqual == (value == expected))
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await push); // eq: push
-                    Assert.Equal("any value", get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Null((string?)get); // neq: get
-                }
-            }
+        const double Score = 4D;
+        var length = 0L;
+        RedisValue member1 = "member1";
+        RedisValue member2 = "member2";
+        if (member1HasScore)
+        {
+            db.SortedSetAdd(key2, member1, Score, flags: CommandFlags.FireAndForget);
+            length++;
         }
 
-        public enum ComparisonType
+        if (member2HasScore)
         {
-            Equal,
-            LessThan,
-            GreaterThan
+            db.SortedSetAdd(key2, member2, Score, flags: CommandFlags.FireAndForget);
+            length++;
         }
 
-        [Theory]
-        [InlineData("five", ComparisonType.Equal, 5L, false)]
-        [InlineData("four", ComparisonType.Equal, 4L, true)]
-        [InlineData("three", ComparisonType.Equal, 3L, false)]
-        [InlineData("", ComparisonType.Equal, 2L, false)]
-        [InlineData("", ComparisonType.Equal, 0L, true)]
-        [InlineData(null, ComparisonType.Equal, 1L, false)]
-        [InlineData(null, ComparisonType.Equal, 0L, true)]
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(length, db.SortedSetLength(key2, Score, Score));
 
-        [InlineData("five", ComparisonType.LessThan, 5L, true)]
-        [InlineData("four", ComparisonType.LessThan, 4L, false)]
-        [InlineData("three", ComparisonType.LessThan, 3L, false)]
-        [InlineData("", ComparisonType.LessThan, 2L, true)]
-        [InlineData("", ComparisonType.LessThan, 0L, false)]
-        [InlineData(null, ComparisonType.LessThan, 1L, true)]
-        [InlineData(null, ComparisonType.LessThan, 0L, false)]
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(expectEqual ? Condition.SortedSetScoreExists(key2, Score, expectedLength) : Condition.SortedSetScoreNotExists(key2, Score, expectedLength));
+        var incr = tran.StringIncrementAsync(key);
+        var exec = tran.ExecuteAsync();
+        var get = db.StringGet(key);
 
-        [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
-        [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
-        [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
-        [InlineData("", ComparisonType.GreaterThan, 2L, false)]
-        [InlineData("", ComparisonType.GreaterThan, 0L, false)]
-        [InlineData(null, ComparisonType.GreaterThan, 1L, false)]
-        [InlineData(null, ComparisonType.GreaterThan, 0L, false)]
-        public async Task BasicTranWithStringLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
+        Assert.Equal(expectedTranResult, await exec);
+        if (expectEqual == (length == expectedLength))
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.Equal(1, await incr); // eq: incr
+            Assert.Equal(1, (long)get); // eq: get
+        }
+        else
+        {
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
+            Assert.Equal(0, (long)get); // neq: get
+        }
+    }
 
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = value?.Length ?? 0;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.StringLengthEqual(key2, length);
-                        Assert.Contains("String length == " + length, condition.ToString());
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.StringLengthGreaterThan(key2, length);
-                        Assert.Contains("String length > " + length, condition.ToString());
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.StringLengthLessThan(key2, length);
-                        Assert.Contains("String length < " + length, condition.ToString());
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
+    [Theory]
+    [InlineData("five", ComparisonType.Equal, 5L, false)]
+    [InlineData("four", ComparisonType.Equal, 4L, true)]
+    [InlineData("three", ComparisonType.Equal, 3L, false)]
+    [InlineData("", ComparisonType.Equal, 2L, false)]
+    [InlineData("", ComparisonType.Equal, 0L, true)]
 
-                if (value != null) db.StringSet(key2, value, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(value, db.StringGet(key2));
+    [InlineData("five", ComparisonType.LessThan, 5L, true)]
+    [InlineData("four", ComparisonType.LessThan, 4L, false)]
+    [InlineData("three", ComparisonType.LessThan, 3L, false)]
+    [InlineData("", ComparisonType.LessThan, 2L, true)]
+    [InlineData("", ComparisonType.LessThan, 0L, false)]
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
+    [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
+    [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
+    [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
+    [InlineData("", ComparisonType.GreaterThan, 2L, false)]
+    [InlineData("", ComparisonType.GreaterThan, 0L, false)]
+    public async Task BasicTranWithListLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create();
 
-                Assert.Equal(expectTranResult, await exec);
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
 
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = value?.Length ?? 0;
+        switch (type)
+        {
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.ListLengthEqual(key2, length);
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.ListLengthGreaterThan(key2, length);
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.ListLengthLessThan(key2, length);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        [Theory]
-        [InlineData("five", ComparisonType.Equal, 5L, false)]
-        [InlineData("four", ComparisonType.Equal, 4L, true)]
-        [InlineData("three", ComparisonType.Equal, 3L, false)]
-        [InlineData("", ComparisonType.Equal, 2L, false)]
-        [InlineData("", ComparisonType.Equal, 0L, true)]
-
-        [InlineData("five", ComparisonType.LessThan, 5L, true)]
-        [InlineData("four", ComparisonType.LessThan, 4L, false)]
-        [InlineData("three", ComparisonType.LessThan, 3L, false)]
-        [InlineData("", ComparisonType.LessThan, 2L, true)]
-        [InlineData("", ComparisonType.LessThan, 0L, false)]
-
-        [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
-        [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
-        [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
-        [InlineData("", ComparisonType.GreaterThan, 2L, false)]
-        [InlineData("", ComparisonType.GreaterThan, 0L, false)]
-        public async Task BasicTranWithHashLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
+        for (var i = 0; i < valueLength; i++)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = value?.Length ?? 0;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.HashLengthEqual(key2, length);
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.HashLengthGreaterThan(key2, length);
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.HashLengthLessThan(key2, length);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-
-                for (var i = 0; i < valueLength; i++)
-                {
-                    db.HashSet(key2, i, value![i].ToString(), flags: CommandFlags.FireAndForget);
-                }
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(valueLength, db.HashLength(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
-
-                Assert.Equal(expectTranResult, await exec);
-
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
+            db.ListRightPush(key2, i, flags: CommandFlags.FireAndForget);
         }
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(valueLength, db.ListLength(key2));
 
-        [Theory]
-        [InlineData("five", ComparisonType.Equal, 5L, false)]
-        [InlineData("four", ComparisonType.Equal, 4L, true)]
-        [InlineData("three", ComparisonType.Equal, 3L, false)]
-        [InlineData("", ComparisonType.Equal, 2L, false)]
-        [InlineData("", ComparisonType.Equal, 0L, true)]
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
 
-        [InlineData("five", ComparisonType.LessThan, 5L, true)]
-        [InlineData("four", ComparisonType.LessThan, 4L, false)]
-        [InlineData("three", ComparisonType.LessThan, 3L, false)]
-        [InlineData("", ComparisonType.LessThan, 2L, true)]
-        [InlineData("", ComparisonType.LessThan, 0L, false)]
+        Assert.Equal(expectTranResult, await exec);
 
-        [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
-        [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
-        [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
-        [InlineData("", ComparisonType.GreaterThan, 2L, false)]
-        [InlineData("", ComparisonType.GreaterThan, 0L, false)]
-        public async Task BasicTranWithSetCardinalityCondition(string value, ComparisonType type, long length, bool expectTranResult)
+        if (expectSuccess)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = value?.Length ?? 0;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.SetLengthEqual(key2, length);
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.SetLengthGreaterThan(key2, length);
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.SetLengthLessThan(key2, length);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-
-                for (var i = 0; i < valueLength; i++)
-                {
-                    db.SetAdd(key2, i, flags: CommandFlags.FireAndForget);
-                }
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(valueLength, db.SetLength(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
-
-                Assert.Equal(expectTranResult, await exec);
-
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
         }
-
-        [Theory]
-        [InlineData(false, false, true)]
-        [InlineData(false, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(true, true, true)]
-        public async Task BasicTranWithSetContainsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+        else
         {
-            using (var muxer = Create(disabledCommands: new[] { "info", "config" }))
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-                RedisValue member = "value";
-                if (keyExists) db.SetAdd(key2, member, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(keyExists, db.SetContains(key2, member));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(demandKeyExists ? Condition.SetContains(key2, member) : Condition.SetNotContains(key2, member));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
-
-                Assert.Equal(expectTranResult, await exec);
-                if (demandKeyExists == keyExists)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
         }
+    }
 
-        [Theory]
-        [InlineData("five", ComparisonType.Equal, 5L, false)]
-        [InlineData("four", ComparisonType.Equal, 4L, true)]
-        [InlineData("three", ComparisonType.Equal, 3L, false)]
-        [InlineData("", ComparisonType.Equal, 2L, false)]
-        [InlineData("", ComparisonType.Equal, 0L, true)]
+    [Theory]
+    [InlineData("five", ComparisonType.Equal, 5L, false)]
+    [InlineData("four", ComparisonType.Equal, 4L, true)]
+    [InlineData("three", ComparisonType.Equal, 3L, false)]
+    [InlineData("", ComparisonType.Equal, 2L, false)]
+    [InlineData("", ComparisonType.Equal, 0L, true)]
 
-        [InlineData("five", ComparisonType.LessThan, 5L, true)]
-        [InlineData("four", ComparisonType.LessThan, 4L, false)]
-        [InlineData("three", ComparisonType.LessThan, 3L, false)]
-        [InlineData("", ComparisonType.LessThan, 2L, true)]
-        [InlineData("", ComparisonType.LessThan, 0L, false)]
+    [InlineData("five", ComparisonType.LessThan, 5L, true)]
+    [InlineData("four", ComparisonType.LessThan, 4L, false)]
+    [InlineData("three", ComparisonType.LessThan, 3L, false)]
+    [InlineData("", ComparisonType.LessThan, 2L, true)]
+    [InlineData("", ComparisonType.LessThan, 0L, false)]
 
-        [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
-        [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
-        [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
-        [InlineData("", ComparisonType.GreaterThan, 2L, false)]
-        [InlineData("", ComparisonType.GreaterThan, 0L, false)]
-        public async Task BasicTranWithSortedSetCardinalityCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
+    [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
+    [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
+    [InlineData("", ComparisonType.GreaterThan, 2L, false)]
+    [InlineData("", ComparisonType.GreaterThan, 0L, false)]
+    public async Task BasicTranWithStreamLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        RedisKey key = Me(), key2 = Me() + "2";
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.KeyDelete(key2, CommandFlags.FireAndForget);
+
+        var expectSuccess = false;
+        Condition? condition = null;
+        var valueLength = value?.Length ?? 0;
+        switch (type)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = value?.Length ?? 0;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.SortedSetLengthEqual(key2, length);
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.SortedSetLengthGreaterThan(key2, length);
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.SortedSetLengthLessThan(key2, length);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-
-                for (var i = 0; i < valueLength; i++)
-                {
-                    db.SortedSetAdd(key2, i, i, flags: CommandFlags.FireAndForget);
-                }
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(valueLength, db.SortedSetLength(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
-
-                Assert.Equal(expectTranResult, await exec);
-
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
+            case ComparisonType.Equal:
+                expectSuccess = valueLength == length;
+                condition = Condition.StreamLengthEqual(key2, length);
+                break;
+            case ComparisonType.GreaterThan:
+                expectSuccess = valueLength > length;
+                condition = Condition.StreamLengthGreaterThan(key2, length);
+                break;
+            case ComparisonType.LessThan:
+                expectSuccess = valueLength < length;
+                condition = Condition.StreamLengthLessThan(key2, length);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type));
         }
-
-        [Theory]
-        [InlineData(1, 4, ComparisonType.Equal, 5L, false)]
-        [InlineData(1, 4, ComparisonType.Equal, 4L, true)]
-        [InlineData(1, 2, ComparisonType.Equal, 3L, false)]
-        [InlineData(1, 1, ComparisonType.Equal, 2L, false)]
-        [InlineData(0, 0, ComparisonType.Equal, 0L, false)]
-
-        [InlineData(1, 4, ComparisonType.LessThan, 5L, true)]
-        [InlineData(1, 4, ComparisonType.LessThan, 4L, false)]
-        [InlineData(1, 3, ComparisonType.LessThan, 3L, false)]
-        [InlineData(1, 1, ComparisonType.LessThan, 2L, true)]
-        [InlineData(0, 0, ComparisonType.LessThan, 0L, false)]
-
-        [InlineData(1, 5, ComparisonType.GreaterThan, 5L, false)]
-        [InlineData(1, 4, ComparisonType.GreaterThan, 4L, false)]
-        [InlineData(1, 4, ComparisonType.GreaterThan, 3L, true)]
-        [InlineData(1, 2, ComparisonType.GreaterThan, 2L, false)]
-        [InlineData(0, 0, ComparisonType.GreaterThan, 0L, true)]
-        public async Task BasicTranWithSortedSetRangeCountCondition(double min, double max, ComparisonType type, long length, bool expectTranResult)
+        RedisValue fieldName = "Test";
+        for (var i = 0; i < valueLength; i++)
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = (int)(max - min) + 1;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.SortedSetLengthEqual(key2, length, min, max);
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.SortedSetLengthGreaterThan(key2, length, min, max);
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.SortedSetLengthLessThan(key2, length, min, max);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-
-                for (var i = 0; i < 5; i++)
-                {
-                    db.SortedSetAdd(key2, i, i, flags: CommandFlags.FireAndForget);
-                }
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(5, db.SortedSetLength(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
-
-                Assert.Equal(expectTranResult, await exec);
-
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
+            db.StreamAdd(key2, fieldName, i, flags: CommandFlags.FireAndForget);
         }
+        Assert.False(db.KeyExists(key));
+        Assert.Equal(valueLength, db.StreamLength(key2));
 
-        [Theory]
-        [InlineData(false, false, true)]
-        [InlineData(false, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(true, true, true)]
-        public async Task BasicTranWithSortedSetContainsCondition(bool demandKeyExists, bool keyExists, bool expectTranResult)
+        var tran = db.CreateTransaction();
+        var cond = tran.AddCondition(condition);
+        var push = tran.StringSetAsync(key, "any value");
+        var exec = tran.ExecuteAsync();
+        var get = db.StringLength(key);
+
+        Assert.Equal(expectTranResult, await exec);
+
+        if (expectSuccess)
         {
-            using (var muxer = Create(disabledCommands: new[] { "info", "config" }))
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-                RedisValue member = "value";
-                if (keyExists) db.SortedSetAdd(key2, member, 0.0, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(keyExists, db.SortedSetScore(key2, member).HasValue);
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(demandKeyExists ? Condition.SortedSetContains(key2, member) : Condition.SortedSetNotContains(key2, member));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
-
-                Assert.Equal(expectTranResult, await exec);
-                if (demandKeyExists == keyExists)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+            Assert.True(await exec, "eq: exec");
+            Assert.True(cond.WasSatisfied, "eq: was satisfied");
+            Assert.True(await push); // eq: push
+            Assert.Equal("any value".Length, get); // eq: get
         }
-
-        [Theory]
-        [InlineData(4D, 4D, true, true)]
-        [InlineData(4D, 5D, true, false)]
-        [InlineData(4D, null, true, false)]
-        [InlineData(null, 5D, true, false)]
-        [InlineData(null, null, true, true)]
-
-        [InlineData(4D, 4D, false, false)]
-        [InlineData(4D, 5D, false, true)]
-        [InlineData(4D, null, false, true)]
-        [InlineData(null, 5D, false, true)]
-        [InlineData(null, null, false, false)]
-        public async Task BasicTranWithSortedSetEqualCondition(double? expected, double? value, bool expectEqual, bool expectedTranResult)
+        else
         {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                RedisValue member = "member";
-                if (value != null) db.SortedSetAdd(key2, member, value.Value, flags: CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(value, db.SortedSetScore(key2, member));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(expectEqual ? Condition.SortedSetEqual(key2, member, expected) : Condition.SortedSetNotEqual(key2, member, expected));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
-
-                Assert.Equal(expectedTranResult, await exec);
-                if (expectEqual == (value == expected))
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
+            Assert.False(await exec, "neq: exec");
+            Assert.False(cond.WasSatisfied, "neq: was satisfied");
+            Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
+            Assert.Equal(0, get); // neq: get
         }
+    }
 
-        [Theory]
-        [InlineData(true, true, true, true)]
-        [InlineData(true, false, true, true)]
-        [InlineData(false, true, true, true)]
-        [InlineData(true, true, false, false)]
-        [InlineData(true, false, false, false)]
-        [InlineData(false, true, false, false)]
-        [InlineData(false, false, true, false)]
-        [InlineData(false, false, false, true)]
-        public async Task BasicTranWithSortedSetScoreExistsCondition(bool member1HasScore, bool member2HasScore, bool demandScoreExists, bool expectedTranResult)
-        {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
+    [Fact]
+    public async Task BasicTran()
+    {
+        using var conn = Create();
 
-                const double Score = 4D;
-                RedisValue member1 = "member1";
-                RedisValue member2 = "member2";
-                if (member1HasScore)
-                {
-                    db.SortedSetAdd(key2, member1, Score, flags: CommandFlags.FireAndForget);
-                }
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
 
-                if (member2HasScore)
-                {
-                    db.SortedSetAdd(key2, member2, Score, flags: CommandFlags.FireAndForget);
-                }
+        var tran = db.CreateTransaction();
+        var a = tran.StringIncrementAsync(key, 10);
+        var b = tran.StringIncrementAsync(key, 5);
+        var c = tran.StringGetAsync(key);
+        var d = tran.KeyExistsAsync(key);
+        var e = tran.KeyDeleteAsync(key);
+        var f = tran.KeyExistsAsync(key);
+        Assert.False(a.IsCompleted);
+        Assert.False(b.IsCompleted);
+        Assert.False(c.IsCompleted);
+        Assert.False(d.IsCompleted);
+        Assert.False(e.IsCompleted);
+        Assert.False(f.IsCompleted);
+        var result = await tran.ExecuteAsync().ForAwait();
+        Assert.True(result, "result");
+        await Task.WhenAll(a, b, c, d, e, f).ForAwait();
+        Assert.True(a.IsCompleted, "a");
+        Assert.True(b.IsCompleted, "b");
+        Assert.True(c.IsCompleted, "c");
+        Assert.True(d.IsCompleted, "d");
+        Assert.True(e.IsCompleted, "e");
+        Assert.True(f.IsCompleted, "f");
 
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(member1HasScore ? (double?)Score : null, db.SortedSetScore(key2, member1));
-                Assert.Equal(member2HasScore ? (double?)Score : null, db.SortedSetScore(key2, member2));
+        var g = db.KeyExists(key);
 
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(demandScoreExists ? Condition.SortedSetScoreExists(key2, Score) : Condition.SortedSetScoreNotExists(key2, Score));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
+        Assert.Equal(10, await a.ForAwait());
+        Assert.Equal(15, await b.ForAwait());
+        Assert.Equal(15, (long)await c.ForAwait());
+        Assert.True(await d.ForAwait());
+        Assert.True(await e.ForAwait());
+        Assert.False(await f.ForAwait());
+        Assert.False(g);
+    }
 
-                Assert.Equal(expectedTranResult, await exec);
-                if ((member1HasScore || member2HasScore) == demandScoreExists)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
-        }
+    [Fact]
+    public async Task CombineFireAndForgetAndRegularAsyncInTransaction()
+    {
+        using var conn = Create();
 
-        [Theory]
-        [InlineData(true, true, 2L, true, true)]
-        [InlineData(true, true, 2L, false, false)]
-        [InlineData(true, true, 1L, true, false)]
-        [InlineData(true, true, 1L, false, true)]
-        [InlineData(true, false, 2L, true, false)]
-        [InlineData(true, false, 2L, false, true)]
-        [InlineData(true, false, 1L, true, true)]
-        [InlineData(true, false, 1L, false, false)]
-        [InlineData(false, true, 2L, true, false)]
-        [InlineData(false, true, 2L, false, true)]
-        [InlineData(false, true, 1L, true, true)]
-        [InlineData(false, true, 1L, false, false)]
-        [InlineData(false, false, 2L, true, false)]
-        [InlineData(false, false, 2L, false, true)]
-        [InlineData(false, false, 1L, true, false)]
-        [InlineData(false, false, 1L, false, true)]
-        public async Task BasicTranWithSortedSetScoreCountExistsCondition(bool member1HasScore, bool member2HasScore, long expectedLength, bool expectEqual, bool expectedTranResult)
-        {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
 
-                const double Score = 4D;
-                var length = 0L;
-                RedisValue member1 = "member1";
-                RedisValue member2 = "member2";
-                if (member1HasScore)
-                {
-                    db.SortedSetAdd(key2, member1, Score, flags: CommandFlags.FireAndForget);
-                    length++;
-                }
+        var tran = db.CreateTransaction("state");
+        var a = tran.StringIncrementAsync(key, 5);
+        var b = tran.StringIncrementAsync(key, 10, CommandFlags.FireAndForget);
+        var c = tran.StringIncrementAsync(key, 15);
+        Assert.True(tran.Execute());
+        var count = (long)db.StringGet(key);
 
-                if (member2HasScore)
-                {
-                    db.SortedSetAdd(key2, member2, Score, flags: CommandFlags.FireAndForget);
-                    length++;
-                }
-
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(length, db.SortedSetLength(key2, Score, Score));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(expectEqual ? Condition.SortedSetScoreExists(key2, Score, expectedLength) : Condition.SortedSetScoreNotExists(key2, Score, expectedLength));
-                var incr = tran.StringIncrementAsync(key);
-                var exec = tran.ExecuteAsync();
-                var get = db.StringGet(key);
-
-                Assert.Equal(expectedTranResult, await exec);
-                if (expectEqual == (length == expectedLength))
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.Equal(1, await incr); // eq: incr
-                    Assert.Equal(1, (long)get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(incr)); // neq: incr
-                    Assert.Equal(0, (long)get); // neq: get
-                }
-            }
-        }
-
-        [Theory]
-        [InlineData("five", ComparisonType.Equal, 5L, false)]
-        [InlineData("four", ComparisonType.Equal, 4L, true)]
-        [InlineData("three", ComparisonType.Equal, 3L, false)]
-        [InlineData("", ComparisonType.Equal, 2L, false)]
-        [InlineData("", ComparisonType.Equal, 0L, true)]
-
-        [InlineData("five", ComparisonType.LessThan, 5L, true)]
-        [InlineData("four", ComparisonType.LessThan, 4L, false)]
-        [InlineData("three", ComparisonType.LessThan, 3L, false)]
-        [InlineData("", ComparisonType.LessThan, 2L, true)]
-        [InlineData("", ComparisonType.LessThan, 0L, false)]
-
-        [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
-        [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
-        [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
-        [InlineData("", ComparisonType.GreaterThan, 2L, false)]
-        [InlineData("", ComparisonType.GreaterThan, 0L, false)]
-        public async Task BasicTranWithListLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
-        {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = value?.Length ?? 0;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.ListLengthEqual(key2, length);
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.ListLengthGreaterThan(key2, length);
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.ListLengthLessThan(key2, length);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-
-                for (var i = 0; i < valueLength; i++)
-                {
-                    db.ListRightPush(key2, i, flags: CommandFlags.FireAndForget);
-                }
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(valueLength, db.ListLength(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
-
-                Assert.Equal(expectTranResult, await exec);
-
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
-        }
-
-        [Theory]
-        [InlineData("five", ComparisonType.Equal, 5L, false)]
-        [InlineData("four", ComparisonType.Equal, 4L, true)]
-        [InlineData("three", ComparisonType.Equal, 3L, false)]
-        [InlineData("", ComparisonType.Equal, 2L, false)]
-        [InlineData("", ComparisonType.Equal, 0L, true)]
-
-        [InlineData("five", ComparisonType.LessThan, 5L, true)]
-        [InlineData("four", ComparisonType.LessThan, 4L, false)]
-        [InlineData("three", ComparisonType.LessThan, 3L, false)]
-        [InlineData("", ComparisonType.LessThan, 2L, true)]
-        [InlineData("", ComparisonType.LessThan, 0L, false)]
-
-        [InlineData("five", ComparisonType.GreaterThan, 5L, false)]
-        [InlineData("four", ComparisonType.GreaterThan, 4L, false)]
-        [InlineData("three", ComparisonType.GreaterThan, 3L, true)]
-        [InlineData("", ComparisonType.GreaterThan, 2L, false)]
-        [InlineData("", ComparisonType.GreaterThan, 0L, false)]
-        public async Task BasicTranWithStreamLengthCondition(string value, ComparisonType type, long length, bool expectTranResult)
-        {
-            using (var muxer = Create())
-            {
-                Skip.IfBelow(muxer, RedisFeatures.v5_0_0);
-
-                RedisKey key = Me(), key2 = Me() + "2";
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                db.KeyDelete(key2, CommandFlags.FireAndForget);
-
-                var expectSuccess = false;
-                Condition? condition = null;
-                var valueLength = value?.Length ?? 0;
-                switch (type)
-                {
-                    case ComparisonType.Equal:
-                        expectSuccess = valueLength == length;
-                        condition = Condition.StreamLengthEqual(key2, length);
-                        break;
-                    case ComparisonType.GreaterThan:
-                        expectSuccess = valueLength > length;
-                        condition = Condition.StreamLengthGreaterThan(key2, length);
-                        break;
-                    case ComparisonType.LessThan:
-                        expectSuccess = valueLength < length;
-                        condition = Condition.StreamLengthLessThan(key2, length);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(type));
-                }
-                RedisValue fieldName = "Test";
-                for (var i = 0; i < valueLength; i++)
-                {
-                    db.StreamAdd(key2, fieldName, i, flags: CommandFlags.FireAndForget);
-                }
-                Assert.False(db.KeyExists(key));
-                Assert.Equal(valueLength, db.StreamLength(key2));
-
-                var tran = db.CreateTransaction();
-                var cond = tran.AddCondition(condition);
-                var push = tran.StringSetAsync(key, "any value");
-                var exec = tran.ExecuteAsync();
-                var get = db.StringLength(key);
-
-                Assert.Equal(expectTranResult, await exec);
-
-                if (expectSuccess)
-                {
-                    Assert.True(await exec, "eq: exec");
-                    Assert.True(cond.WasSatisfied, "eq: was satisfied");
-                    Assert.True(await push); // eq: push
-                    Assert.Equal("any value".Length, get); // eq: get
-                }
-                else
-                {
-                    Assert.False(await exec, "neq: exec");
-                    Assert.False(cond.WasSatisfied, "neq: was satisfied");
-                    Assert.Equal(TaskStatus.Canceled, SafeStatus(push)); // neq: push
-                    Assert.Equal(0, get); // neq: get
-                }
-            }
-        }
-
-        [Fact]
-        public async Task BasicTran()
-        {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me();
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-
-                var tran = db.CreateTransaction();
-                var a = tran.StringIncrementAsync(key, 10);
-                var b = tran.StringIncrementAsync(key, 5);
-                var c = tran.StringGetAsync(key);
-                var d = tran.KeyExistsAsync(key);
-                var e = tran.KeyDeleteAsync(key);
-                var f = tran.KeyExistsAsync(key);
-                Assert.False(a.IsCompleted);
-                Assert.False(b.IsCompleted);
-                Assert.False(c.IsCompleted);
-                Assert.False(d.IsCompleted);
-                Assert.False(e.IsCompleted);
-                Assert.False(f.IsCompleted);
-                var result = await tran.ExecuteAsync().ForAwait();
-                Assert.True(result, "result");
-                await Task.WhenAll(a, b, c, d, e, f).ForAwait();
-                Assert.True(a.IsCompleted, "a");
-                Assert.True(b.IsCompleted, "b");
-                Assert.True(c.IsCompleted, "c");
-                Assert.True(d.IsCompleted, "d");
-                Assert.True(e.IsCompleted, "e");
-                Assert.True(f.IsCompleted, "f");
-
-                var g = db.KeyExists(key);
-
-                Assert.Equal(10, await a.ForAwait());
-                Assert.Equal(15, await b.ForAwait());
-                Assert.Equal(15, (long)await c.ForAwait());
-                Assert.True(await d.ForAwait());
-                Assert.True(await e.ForAwait());
-                Assert.False(await f.ForAwait());
-                Assert.False(g);
-            }
-        }
-
-        [Fact]
-        public async Task CombineFireAndForgetAndRegularAsyncInTransaction()
-        {
-            using (var muxer = Create())
-            {
-                RedisKey key = Me();
-                var db = muxer.GetDatabase();
-                db.KeyDelete(key, CommandFlags.FireAndForget);
-                Assert.False(db.KeyExists(key));
-
-                var tran = db.CreateTransaction("state");
-                var a = tran.StringIncrementAsync(key, 5);
-                var b = tran.StringIncrementAsync(key, 10, CommandFlags.FireAndForget);
-                var c = tran.StringIncrementAsync(key, 15);
-                Assert.True(tran.Execute());
-                var count = (long)db.StringGet(key);
-
-                Assert.Equal(5, await a);
-                Assert.Equal("state", a.AsyncState);
-                Assert.Equal(0, await b);
-                Assert.Null(b.AsyncState);
-                Assert.Equal(30, await c);
-                Assert.Equal("state", a.AsyncState);
-                Assert.Equal(30, count);
-            }
-        }
+        Assert.Equal(5, await a);
+        Assert.Equal("state", a.AsyncState);
+        Assert.Equal(0, await b);
+        Assert.Null(b.AsyncState);
+        Assert.Equal(30, await c);
+        Assert.Equal("state", a.AsyncState);
+        Assert.Equal(30, count);
+    }
 
 #if VERBOSE
-        [Fact]
-        public async Task WatchAbort_StringEqual()
+    [Fact]
+    public async Task WatchAbort_StringEqual()
+    {
+        using var vicConn = Create();
+        using var perpConn = Create();
+
+        var key = Me();
+        var db = vicConn.GetDatabase();
+
+        // expect foo, change to bar at the last minute
+        vicConn.PreTransactionExec += cmd =>
         {
-            using (var vic = Create())
-            using (var perp = Create())
-            {
-                var key = Me();
-                var db = vic.GetDatabase();
+            Writer.WriteLine($"'{cmd}' detected; changing it...");
+            perpConn.GetDatabase().StringSet(key, "bar");
+        };
+        db.KeyDelete(key);
+        db.StringSet(key, "foo");
+        var tran = db.CreateTransaction();
+        tran.AddCondition(Condition.StringEqual(key, "foo"));
+        var pong = tran.PingAsync();
+        Assert.False(await tran.ExecuteAsync(), "expected abort");
+        await Assert.ThrowsAsync<TaskCanceledException>(() => pong);
+    }
 
-                // expect foo, change to bar at the last minute
-                vic.PreTransactionExec += cmd =>
-                {
-                    Writer.WriteLine($"'{cmd}' detected; changing it...");
-                    perp.GetDatabase().StringSet(key, "bar");
-                };
-                db.KeyDelete(key);
-                db.StringSet(key, "foo");
-                var tran = db.CreateTransaction();
-                tran.AddCondition(Condition.StringEqual(key, "foo"));
-                var pong = tran.PingAsync();
-                Assert.False(await tran.ExecuteAsync(), "expected abort");
-                await Assert.ThrowsAsync<TaskCanceledException>(() => pong);
-            }
-        }
+    [Fact]
+    public async Task WatchAbort_HashLengthEqual()
+    {
+        using var vicConn = Create();
+        using var perpConn = Create();
 
-        [Fact]
-        public async Task WatchAbort_HashLengthEqual()
+        var key = Me();
+        var db = vicConn.GetDatabase();
+
+        // expect foo, change to bar at the last minute
+        vicConn.PreTransactionExec += cmd =>
         {
-            using (var vic = Create())
-            using (var perp = Create())
-            {
-                var key = Me();
-                var db = vic.GetDatabase();
-
-                // expect foo, change to bar at the last minute
-                vic.PreTransactionExec += cmd =>
-                {
-                    Writer.WriteLine($"'{cmd}' detected; changing it...");
-                    perp.GetDatabase().HashSet(key, "bar", "def");
-                };
-                db.KeyDelete(key);
-                db.HashSet(key, "foo", "abc");
-                var tran = db.CreateTransaction();
-                tran.AddCondition(Condition.HashLengthEqual(key, 1));
-                var pong = tran.PingAsync();
-                Assert.False(await tran.ExecuteAsync());
-                await Assert.ThrowsAsync<TaskCanceledException>(() => pong);
-            }
-        }
+            Writer.WriteLine($"'{cmd}' detected; changing it...");
+            perpConn.GetDatabase().HashSet(key, "bar", "def");
+        };
+        db.KeyDelete(key);
+        db.HashSet(key, "foo", "abc");
+        var tran = db.CreateTransaction();
+        tran.AddCondition(Condition.HashLengthEqual(key, 1));
+        var pong = tran.PingAsync();
+        Assert.False(await tran.ExecuteAsync());
+        await Assert.ThrowsAsync<TaskCanceledException>(() => pong);
+    }
 #endif
 
-        [FactLongRunning]
-        public async Task ExecCompletes_Issue943()
+    [FactLongRunning]
+    public async Task ExecCompletes_Issue943()
+    {
+        int hashHit = 0, hashMiss = 0, expireHit = 0, expireMiss = 0;
+        using (var conn = Create())
         {
-            int hashHit = 0, hashMiss = 0, expireHit = 0, expireMiss = 0;
-            using (var conn = Create())
+            var db = conn.GetDatabase();
+            for (int i = 0; i < 40000; i++)
             {
-                var db = conn.GetDatabase();
-                for (int i = 0; i < 40000; i++)
+                RedisKey key = Me();
+                await db.KeyDeleteAsync(key);
+                HashEntry[] hashEntries = new []
                 {
-                    RedisKey key = Me();
-                    await db.KeyDeleteAsync(key);
-                    HashEntry[] hashEntries = new []
-                    {
-                        new HashEntry("blah", DateTime.UtcNow.ToString("R"))
-                    };
-                    ITransaction transaction = db.CreateTransaction();
-                    transaction.AddCondition(Condition.KeyNotExists(key));
-                    Task hashSetTask = transaction.HashSetAsync(key, hashEntries);
-                    Task<bool> expireTask = transaction.KeyExpireAsync(key, TimeSpan.FromSeconds(30));
-                    bool committed = await transaction.ExecuteAsync();
-                    if (committed)
-                    {
-                        if (hashSetTask.IsCompleted) hashHit++; else hashMiss++;
-                        if (expireTask.IsCompleted) expireHit++; else expireMiss++;
-                        await hashSetTask;
-                        await expireTask;
-                    }
+                    new HashEntry("blah", DateTime.UtcNow.ToString("R"))
+                };
+                ITransaction transaction = db.CreateTransaction();
+                transaction.AddCondition(Condition.KeyNotExists(key));
+                Task hashSetTask = transaction.HashSetAsync(key, hashEntries);
+                Task<bool> expireTask = transaction.KeyExpireAsync(key, TimeSpan.FromSeconds(30));
+                bool committed = await transaction.ExecuteAsync();
+                if (committed)
+                {
+                    if (hashSetTask.IsCompleted) hashHit++; else hashMiss++;
+                    if (expireTask.IsCompleted) expireHit++; else expireMiss++;
+                    await hashSetTask;
+                    await expireTask;
                 }
             }
-
-            Writer.WriteLine($"hash hit: {hashHit}, miss: {hashMiss}; expire hit: {expireHit}, miss: {expireMiss}");
-            Assert.Equal(0, hashMiss);
-            Assert.Equal(0, expireMiss);
         }
+
+        Writer.WriteLine($"hash hit: {hashHit}, miss: {hashMiss}; expire hit: {expireHit}, miss: {expireMiss}");
+        Assert.Equal(0, hashMiss);
+        Assert.Equal(0, expireMiss);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Values.cs
+++ b/tests/StackExchange.Redis.Tests/Values.cs
@@ -4,49 +4,48 @@ using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+public class Values : TestBase
 {
-    public class Values : TestBase
+    public Values(ITestOutputHelper output) : base (output) { }
+
+    [Fact]
+    public void NullValueChecks()
     {
-        public Values(ITestOutputHelper output) : base (output) { }
+        RedisValue four = 4;
+        Assert.False(four.IsNull);
+        Assert.True(four.IsInteger);
+        Assert.True(four.HasValue);
+        Assert.False(four.IsNullOrEmpty);
 
-        [Fact]
-        public void NullValueChecks()
-        {
-            RedisValue four = 4;
-            Assert.False(four.IsNull);
-            Assert.True(four.IsInteger);
-            Assert.True(four.HasValue);
-            Assert.False(four.IsNullOrEmpty);
+        RedisValue n = default;
+        Assert.True(n.IsNull);
+        Assert.False(n.IsInteger);
+        Assert.False(n.HasValue);
+        Assert.True(n.IsNullOrEmpty);
 
-            RedisValue n = default;
-            Assert.True(n.IsNull);
-            Assert.False(n.IsInteger);
-            Assert.False(n.HasValue);
-            Assert.True(n.IsNullOrEmpty);
+        RedisValue emptyArr = Array.Empty<byte>();
+        Assert.False(emptyArr.IsNull);
+        Assert.False(emptyArr.IsInteger);
+        Assert.False(emptyArr.HasValue);
+        Assert.True(emptyArr.IsNullOrEmpty);
+    }
 
-            RedisValue emptyArr = Array.Empty<byte>();
-            Assert.False(emptyArr.IsNull);
-            Assert.False(emptyArr.IsInteger);
-            Assert.False(emptyArr.HasValue);
-            Assert.True(emptyArr.IsNullOrEmpty);
-        }
+    [Fact]
+    public void FromStream()
+    {
+        var arr = Encoding.UTF8.GetBytes("hello world");
+        var ms = new MemoryStream(arr);
+        var val = RedisValue.CreateFrom(ms);
+        Assert.Equal("hello world", val);
 
-        [Fact]
-        public void FromStream()
-        {
-            var arr = Encoding.UTF8.GetBytes("hello world");
-            var ms = new MemoryStream(arr);
-            var val = RedisValue.CreateFrom(ms);
-            Assert.Equal("hello world", val);
+        ms = new MemoryStream(arr, 1, 6, false, false);
+        val = RedisValue.CreateFrom(ms);
+        Assert.Equal("ello w", val);
 
-            ms = new MemoryStream(arr, 1, 6, false, false);
-            val = RedisValue.CreateFrom(ms);
-            Assert.Equal("ello w", val);
-
-            ms = new MemoryStream(arr, 2, 6, false, true);
-            val = RedisValue.CreateFrom(ms);
-            Assert.Equal("llo wo", val);
-        }
+        ms = new MemoryStream(arr, 2, 6, false, true);
+        val = RedisValue.CreateFrom(ms);
+        Assert.Equal("llo wo", val);
     }
 }

--- a/tests/StackExchange.Redis.Tests/WithKeyPrefixTests.cs
+++ b/tests/StackExchange.Redis.Tests/WithKeyPrefixTests.cs
@@ -3,137 +3,134 @@ using StackExchange.Redis.KeyspaceIsolation;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace StackExchange.Redis.Tests
+namespace StackExchange.Redis.Tests;
+
+[Collection(SharedConnectionFixture.Key)]
+public class WithKeyPrefixTests : TestBase
 {
-    [Collection(SharedConnectionFixture.Key)]
-    public class WithKeyPrefixTests : TestBase
+    public WithKeyPrefixTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    [Fact]
+    public void BlankPrefixYieldsSame_Bytes()
     {
-        public WithKeyPrefixTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+        using var conn = Create();
 
-        [Fact]
-        public void BlankPrefixYieldsSame_Bytes()
+        var raw = conn.GetDatabase();
+        var prefixed = raw.WithKeyPrefix(Array.Empty<byte>());
+        Assert.Same(raw, prefixed);
+    }
+
+    [Fact]
+    public void BlankPrefixYieldsSame_String()
+    {
+        using var conn = Create();
+
+        var raw = conn.GetDatabase();
+        var prefixed = raw.WithKeyPrefix("");
+        Assert.Same(raw, prefixed);
+    }
+
+    [Fact]
+    public void NullPrefixIsError_Bytes()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
         {
-            using (var conn = Create())
-            {
-                var raw = conn.GetDatabase();
-                var prefixed = raw.WithKeyPrefix(Array.Empty<byte>());
-                Assert.Same(raw, prefixed);
-            }
-        }
+            using var conn = Create();
 
-        [Fact]
-        public void BlankPrefixYieldsSame_String()
+            var raw = conn.GetDatabase();
+            raw.WithKeyPrefix((byte[]?)null);
+        });
+    }
+
+    [Fact]
+    public void NullPrefixIsError_String()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
         {
-            using (var conn = Create())
-            {
-                var raw = conn.GetDatabase();
-                var prefixed = raw.WithKeyPrefix("");
-                Assert.Same(raw, prefixed);
-            }
-        }
+            using var conn = Create();
 
-        [Fact]
-        public void NullPrefixIsError_Bytes()
+            var raw = conn.GetDatabase();
+            raw.WithKeyPrefix((string?)null);
+        });
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void NullDatabaseIsError(string prefix)
+    {
+        Assert.Throws<ArgumentNullException>(() =>
         {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                using var conn = Create();
-                var raw = conn.GetDatabase();
-                raw.WithKeyPrefix((byte[]?)null);
-            });
-        }
+            IDatabase? raw = null;
+            raw!.WithKeyPrefix(prefix);
+        });
+    }
 
-        [Fact]
-        public void NullPrefixIsError_String()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                using var conn = Create();
-                var raw = conn.GetDatabase();
-                raw.WithKeyPrefix((string?)null);
-            });
-        }
+    [Fact]
+    public void BasicSmokeTest()
+    {
+        using var conn = Create();
 
-        [Theory]
-        [InlineData("abc")]
-        [InlineData("")]
-        [InlineData(null)]
-        public void NullDatabaseIsError(string prefix)
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                IDatabase? raw = null;
-                raw!.WithKeyPrefix(prefix);
-            });
-        }
+        var raw = conn.GetDatabase();
 
-        [Fact]
-        public void BasicSmokeTest()
-        {
-            using (var conn = Create())
-            {
-                var raw = conn.GetDatabase();
+        var prefix = Me();
+        var foo = raw.WithKeyPrefix(prefix);
+        var foobar = foo.WithKeyPrefix("bar");
 
-                var prefix = Me();
-                var foo = raw.WithKeyPrefix(prefix);
-                var foobar = foo.WithKeyPrefix("bar");
+        string key = Me();
 
-                string key = Me();
+        string s = Guid.NewGuid().ToString(), t = Guid.NewGuid().ToString();
 
-                string s = Guid.NewGuid().ToString(), t = Guid.NewGuid().ToString();
+        foo.StringSet(key, s, flags: CommandFlags.FireAndForget);
+        var val = (string?)foo.StringGet(key);
+        Assert.Equal(s, val); // fooBasicSmokeTest
 
-                foo.StringSet(key, s, flags: CommandFlags.FireAndForget);
-                var val = (string?)foo.StringGet(key);
-                Assert.Equal(s, val); // fooBasicSmokeTest
+        foobar.StringSet(key, t, flags: CommandFlags.FireAndForget);
+        val = foobar.StringGet(key);
+        Assert.Equal(t, val); // foobarBasicSmokeTest
 
-                foobar.StringSet(key, t, flags: CommandFlags.FireAndForget);
-                val = foobar.StringGet(key);
-                Assert.Equal(t, val); // foobarBasicSmokeTest
+        val = foo.StringGet("bar" + key);
+        Assert.Equal(t, val); // foobarBasicSmokeTest
 
-                val = foo.StringGet("bar" + key);
-                Assert.Equal(t, val); // foobarBasicSmokeTest
+        val = raw.StringGet(prefix + key);
+        Assert.Equal(s, val); // fooBasicSmokeTest
 
-                val = raw.StringGet(prefix + key);
-                Assert.Equal(s, val); // fooBasicSmokeTest
+        val = raw.StringGet(prefix + "bar" + key);
+        Assert.Equal(t, val); // foobarBasicSmokeTest
+    }
 
-                val = raw.StringGet(prefix + "bar" + key);
-                Assert.Equal(t, val); // foobarBasicSmokeTest
-            }
-        }
+    [Fact]
+    public void ConditionTest()
+    {
+        using var conn = Create();
 
-        [Fact]
-        public void ConditionTest()
-        {
-            using (var conn = Create())
-            {
-                var raw = conn.GetDatabase();
+        var raw = conn.GetDatabase();
 
-                var prefix = Me() + ":";
-                var foo = raw.WithKeyPrefix(prefix);
+        var prefix = Me() + ":";
+        var foo = raw.WithKeyPrefix(prefix);
 
-                raw.KeyDelete(prefix + "abc", CommandFlags.FireAndForget);
-                raw.KeyDelete(prefix + "i", CommandFlags.FireAndForget);
+        raw.KeyDelete(prefix + "abc", CommandFlags.FireAndForget);
+        raw.KeyDelete(prefix + "i", CommandFlags.FireAndForget);
 
-                // execute while key exists
-                raw.StringSet(prefix + "abc", "def", flags: CommandFlags.FireAndForget);
-                var tran = foo.CreateTransaction();
-                tran.AddCondition(Condition.KeyExists("abc"));
-                tran.StringIncrementAsync("i");
-                tran.Execute();
+        // execute while key exists
+        raw.StringSet(prefix + "abc", "def", flags: CommandFlags.FireAndForget);
+        var tran = foo.CreateTransaction();
+        tran.AddCondition(Condition.KeyExists("abc"));
+        tran.StringIncrementAsync("i");
+        tran.Execute();
 
-                int i = (int)raw.StringGet(prefix + "i");
-                Assert.Equal(1, i);
+        int i = (int)raw.StringGet(prefix + "i");
+        Assert.Equal(1, i);
 
-                // repeat without key
-                raw.KeyDelete(prefix + "abc", CommandFlags.FireAndForget);
-                tran = foo.CreateTransaction();
-                tran.AddCondition(Condition.KeyExists("abc"));
-                tran.StringIncrementAsync("i");
-                tran.Execute();
+        // repeat without key
+        raw.KeyDelete(prefix + "abc", CommandFlags.FireAndForget);
+        tran = foo.CreateTransaction();
+        tran.AddCondition(Condition.KeyExists("abc"));
+        tran.StringIncrementAsync("i");
+        tran.Execute();
 
-                i = (int)raw.StringGet(prefix + "i");
-                Assert.Equal(1, i);
-            }
-        }
+        i = (int)raw.StringGet(prefix + "i");
+        Assert.Equal(1, i);
     }
 }

--- a/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/WrapperBaseTests.cs
@@ -1258,6 +1258,5 @@ namespace StackExchange.Redis.Tests
             wrapper.KeyTouchAsync(keys, CommandFlags.None);
             mock.Verify(_ => _.KeyTouchAsync(It.Is(valid), CommandFlags.None));
         }
-#pragma warning restore RCS1047 // Non-asynchronous method name should not end with 'Async'.
     }
 }


### PR DESCRIPTION
In recent PRs, through no fault of their own, I can see a lot of inconsistency because they're based on inconsistency in the existing test suite. This is one major overhaul to unify how things are laid out, connection naming, etc.

Once this builds, I'll merge in then tidy up PRs in progress to be on the common scheme and have less confusion for contributors going forward.