### PR TITLE
Link to fuget.org on docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 StackExchange.Redis
 ===================
 
-[Release Notes](ReleaseNotes)
+- [Release Notes](ReleaseNotes)
+- [API Browser (via furget.org)](https://www.fuget.org/packages/StackExchange.Redis/)
 
 ## Overview
 


### PR DESCRIPTION
Adds a link to fuget.org for people who want to quickly go search/browse the latest package's API.