### PR TITLE
Docs: Love! Linking, <remarks> fixes, code formatting, etc.

### DIFF
--- a/src/StackExchange.Redis/APITypes/LatencyHistoryEntry.cs
+++ b/src/StackExchange.Redis/APITypes/LatencyHistoryEntry.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// A latency entry as reported by the built-in LATENCY HISTORY command
+/// </summary>
+public readonly struct LatencyHistoryEntry
+{
+    internal static readonly ResultProcessor<LatencyHistoryEntry[]> ToArray = new Processor();
+
+    private sealed class Processor : ArrayResultProcessor<LatencyHistoryEntry>
+    {
+        protected override bool TryParse(in RawResult raw, out LatencyHistoryEntry parsed)
+        {
+            if (raw.Type == ResultType.MultiBulk)
+            {
+                var items = raw.GetItems();
+                if (items.Length >= 2
+                    && items[0].TryGetInt64(out var timestamp)
+                    && items[1].TryGetInt64(out var duration))
+                {
+                    parsed = new LatencyHistoryEntry(timestamp, duration);
+                    return true;
+                }
+            }
+            parsed = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The time at which this entry was recorded
+    /// </summary>
+    public DateTime Timestamp { get; }
+
+    /// <summary>
+    /// The latency recorded for this event
+    /// </summary>
+    public int DurationMilliseconds { get; }
+
+    internal LatencyHistoryEntry(long timestamp, long duration)
+    {
+        Timestamp = RedisBase.UnixEpoch.AddSeconds(timestamp);
+        DurationMilliseconds = checked((int)duration);
+    }
+}

--- a/src/StackExchange.Redis/APITypes/LatencyLatestEntry.cs
+++ b/src/StackExchange.Redis/APITypes/LatencyLatestEntry.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// A latency entry as reported by the built-in LATENCY LATEST command
+/// </summary>
+public readonly struct LatencyLatestEntry
+{
+    internal static readonly ResultProcessor<LatencyLatestEntry[]> ToArray = new Processor();
+
+    private sealed class Processor : ArrayResultProcessor<LatencyLatestEntry>
+    {
+        protected override bool TryParse(in RawResult raw, out LatencyLatestEntry parsed)
+        {
+            if (raw.Type == ResultType.MultiBulk)
+            {
+                var items = raw.GetItems();
+                if (items.Length >= 4
+                    && items[1].TryGetInt64(out var timestamp)
+                    && items[2].TryGetInt64(out var duration)
+                    && items[3].TryGetInt64(out var maxDuration))
+                {
+                    parsed = new LatencyLatestEntry(items[0].GetString()!, timestamp, duration, maxDuration);
+                    return true;
+                }
+            }
+            parsed = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The name of this event
+    /// </summary>
+    public string EventName { get; }
+
+    /// <summary>
+    /// The time at which this entry was recorded
+    /// </summary>
+    public DateTime Timestamp { get; }
+
+    /// <summary>
+    /// The latency recorded for this event
+    /// </summary>
+    public int DurationMilliseconds { get; }
+
+    /// <summary>
+    /// The max latency recorded for all events
+    /// </summary>
+    public int MaxDurationMilliseconds { get; }
+
+    internal LatencyLatestEntry(string eventName, long timestamp, long duration, long maxDuration)
+    {
+        EventName = eventName;
+        Timestamp = RedisBase.UnixEpoch.AddSeconds(timestamp);
+        DurationMilliseconds = checked((int)duration);
+        MaxDurationMilliseconds = checked((int)maxDuration);
+    }
+}

--- a/src/StackExchange.Redis/ClientInfo.cs
+++ b/src/StackExchange.Redis/ClientInfo.cs
@@ -105,7 +105,7 @@ namespace StackExchange.Redis
         ///     </item>
         /// </list>
         /// </summary>
-        /// <remarks>https://redis.io/commands/client-list</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/client-list"/></remarks>
         public string? FlagsRaw { get; private set; }
 
         /// <summary>

--- a/src/StackExchange.Redis/ClusterConfiguration.cs
+++ b/src/StackExchange.Redis/ClusterConfiguration.cs
@@ -264,6 +264,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// Represents the configuration of a single node in a cluster configuration.
     /// </summary>
+    /// <remarks><seealso href="https://redis.io/commands/cluster-nodes"/></remarks>
     public sealed class ClusterNode :  IEquatable<ClusterNode>, IComparable<ClusterNode>, IComparable
     {
         private readonly ClusterConfiguration configuration;
@@ -273,7 +274,6 @@ namespace StackExchange.Redis
 
         internal ClusterNode(ClusterConfiguration configuration, string raw, EndPoint origin)
         {
-            // https://redis.io/commands/cluster-nodes
             this.configuration = configuration;
             Raw = raw;
             var parts = raw.Split(StringSplits.Space);

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -24,7 +24,6 @@ namespace StackExchange.Redis
         /// <remarks><seealso href="https://github.com/twitter/twemproxy/blob/master/notes/redis.md"/></remarks>
         public static CommandMap Twemproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
         {
-            // see https://github.com/twitter/twemproxy/blob/master/notes/redis.md
             RedisCommand.KEYS, RedisCommand.MIGRATE, RedisCommand.MOVE, RedisCommand.OBJECT, RedisCommand.RANDOMKEY,
             RedisCommand.RENAME, RedisCommand.RENAMENX, RedisCommand.SCAN,
 
@@ -48,9 +47,9 @@ namespace StackExchange.Redis
         /// <summary>
         /// The commands available to <a href="https://github.com/envoyproxy/envoy">envoyproxy</a>.
         /// </summary>
+        /// <remarks><seealso href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_protocols/redis.html?highlight=redis"/></remarks>
         public static CommandMap Envoyproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
         {
-            // see https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_protocols/redis.html?highlight=redis
             RedisCommand.KEYS, RedisCommand.MIGRATE, RedisCommand.MOVE, RedisCommand.OBJECT, RedisCommand.RANDOMKEY,
             RedisCommand.RENAME, RedisCommand.RENAMENX, RedisCommand.SORT, RedisCommand.SCAN,
 
@@ -94,7 +93,6 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {
-            // see https://redis.io/topics/sentinel
             "auth", "ping", "info", "role", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);
 
         /// <summary>

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -21,7 +21,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The commands available to <a href="https://github.com/twitter/twemproxy">twemproxy</a>.
         /// </summary>
-        /// <remarks>https://github.com/twitter/twemproxy/blob/master/notes/redis.md</remarks>
+        /// <remarks><seealso href="https://github.com/twitter/twemproxy/blob/master/notes/redis.md"/></remarks>
         public static CommandMap Twemproxy { get; } = CreateImpl(null, exclusions: new HashSet<RedisCommand>
         {
             // see https://github.com/twitter/twemproxy/blob/master/notes/redis.md
@@ -80,7 +80,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The commands available to <a href="https://ssdb.io/">SSDB</a>.
         /// </summary>
-        /// <remarks>https://ssdb.io/docs/redis-to-ssdb.html</remarks>
+        /// <remarks><seealso href="https://ssdb.io/docs/redis-to-ssdb.html"/></remarks>
         public static CommandMap SSDB { get; } = Create(new HashSet<string> {
             "ping",
             "get", "set", "del", "incr", "incrby", "mget", "mset", "keys", "getset", "setnx",
@@ -92,7 +92,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// The commands available to <a href="https://redis.io/topics/sentinel">Sentinel</a>.
         /// </summary>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {
             // see https://redis.io/topics/sentinel
             "auth", "ping", "info", "role", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -19,7 +19,7 @@ namespace StackExchange.Redis
     /// Represents an inter-related group of connections to redis servers.
     /// A reference to this should be held and re-used.
     /// </summary>
-    /// <remarks>https://stackexchange.github.io/StackExchange.Redis/PipelinesMultiplexers</remarks>
+    /// <remarks><seealso href="https://stackexchange.github.io/StackExchange.Redis/PipelinesMultiplexers"/></remarks>
     public sealed partial class ConnectionMultiplexer : IInternalConnectionMultiplexer // implies : IConnectionMultiplexer and : IDisposable
     {
         internal const int MillisecondsPerHeartbeat = 1000;

--- a/src/StackExchange.Redis/Enums/ClientFlags.cs
+++ b/src/StackExchange.Redis/Enums/ClientFlags.cs
@@ -76,7 +76,7 @@ namespace StackExchange.Redis
     ///     </item>
     /// </list>
     /// </summary>
-    /// <remarks>https://redis.io/commands/client-list</remarks>
+    /// <remarks><seealso href="https://redis.io/commands/client-list"/></remarks>
     [Flags]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1069:Enums values should not be duplicated", Justification = "Compatibility")]
     public enum ClientFlags : long

--- a/src/StackExchange.Redis/Enums/RedisType.cs
+++ b/src/StackExchange.Redis/Enums/RedisType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// The intrinsic data-types supported by redis.
     /// </summary>
-    /// <remarks>https://redis.io/topics/data-types</remarks>
+    /// <remarks><seealso href="https://redis.io/topics/data-types"/></remarks>
     public enum RedisType
     {
         /// <summary>
@@ -15,14 +15,14 @@
         /// a Redis string can contain any kind of data, for instance a JPEG image or a serialized Ruby object.
         /// A String value can be at max 512 Megabytes in length.
         /// </summary>
-        /// <remarks>https://redis.io/commands#string</remarks>
+        /// <remarks><seealso href="https://redis.io/commands#string"/></remarks>
         String,
         /// <summary>
         /// Redis Lists are simply lists of strings, sorted by insertion order.
         /// It is possible to add elements to a Redis List pushing new elements on the head (on the left) or
         /// on the tail (on the right) of the list.
         /// </summary>
-        /// <remarks>https://redis.io/commands#list</remarks>
+        /// <remarks><seealso href="https://redis.io/commands#list"/></remarks>
         List,
         /// <summary>
         /// Redis Sets are an unordered collection of Strings. It is possible to add, remove, and test for
@@ -31,7 +31,7 @@
         /// Adding the same element multiple times will result in a set having a single copy of this element.
         /// Practically speaking this means that adding a member does not require a check if exists then add operation.
         /// </summary>
-        /// <remarks>https://redis.io/commands#set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands#set"/></remarks>
         Set,
         /// <summary>
         /// Redis Sorted Sets are, similarly to Redis Sets, non repeating collections of Strings.
@@ -39,20 +39,20 @@
         /// in order to take the sorted set ordered, from the smallest to the greatest score.
         /// While members are unique, scores may be repeated.
         /// </summary>
-        /// <remarks>https://redis.io/commands#sorted_set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands#sorted_set"/></remarks>
         SortedSet,
         /// <summary>
         /// Redis Hashes are maps between string fields and string values, so they are the perfect data type
         /// to represent objects (e.g. A User with a number of fields like name, surname, age, and so forth).
         /// </summary>
-        /// <remarks>https://redis.io/commands#hash</remarks>
+        /// <remarks><seealso href="https://redis.io/commands#hash"/></remarks>
         Hash,
         /// <summary>
         /// A Redis Stream is a data structure which models the behavior of an append only log but it has more
         /// advanced features for manipulating the data contained within the stream. Each entry in a
         /// stream contains a unique message ID and a list of name/value pairs containing the entry's data.
         /// </summary>
-        /// <remarks>https://redis.io/commands#stream</remarks>
+        /// <remarks><seealso href="https://redis.io/commands#stream"/></remarks>
         Stream,
         /// <summary>
         /// The data-type was not recognised by the client library.

--- a/src/StackExchange.Redis/Enums/SaveType.cs
+++ b/src/StackExchange.Redis/Enums/SaveType.cs
@@ -11,21 +11,21 @@ namespace StackExchange.Redis
         /// Instruct Redis to start an Append Only File rewrite process.
         /// The rewrite will create a small optimized version of the current Append Only File.
         /// </summary>
-        /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bgrewriteaof"/></remarks>
         BackgroundRewriteAppendOnlyFile,
         /// <summary>
         /// Save the DB in background. The OK code is immediately returned.
         /// Redis forks, the parent continues to serve the clients, the child saves the DB on disk then exits.
         /// A client my be able to check if the operation succeeded using the LASTSAVE command.
         /// </summary>
-        /// <remarks>https://redis.io/commands/bgsave</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bgsave"/></remarks>
         BackgroundSave,
         /// <summary>
         /// Save the DB in foreground.
         /// This is almost never a good thing to do, and could cause significant blocking.
         /// Only do this if you know you need to save.
         /// </summary>
-        /// <remarks>https://redis.io/commands/save</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/save"/></remarks>
         [Obsolete("Saving on the foreground can cause significant blocking; use with extreme caution")]
         ForegroundSave,
     }

--- a/src/StackExchange.Redis/Format.cs
+++ b/src/StackExchange.Redis/Format.cs
@@ -234,12 +234,19 @@ namespace StackExchange.Redis
             return true;
         }
 
+        /// <summary>
+        /// <para>
+        /// Adapted from IPEndPointParser in Microsoft.AspNetCore
+        /// Link: <see href="https://github.com/aspnet/BasicMiddleware/blob/f320511b63da35571e890d53f3906c7761cd00a1/src/Microsoft.AspNetCore.HttpOverrides/Internal/IPEndPointParser.cs#L8"/>
+        /// </para>
+        /// <para>
+        /// Copyright (c) .NET Foundation. All rights reserved.
+        /// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+        /// </para>
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">If Unix sockets are attempted but not supported.</exception>
         internal static bool TryParseEndPoint(string? addressWithPort, [NotNullWhen(true)] out EndPoint? endpoint)
         {
-            // Adapted from IPEndPointParser in Microsoft.AspNetCore
-            // Link: https://github.com/aspnet/BasicMiddleware/blob/f320511b63da35571e890d53f3906c7761cd00a1/src/Microsoft.AspNetCore.HttpOverrides/Internal/IPEndPointParser.cs#L8
-            // Copyright (c) .NET Foundation. All rights reserved.
-            // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
             string addressPart;
             string? portPart = null;
             if (addressWithPort.IsNullOrEmpty())

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -41,7 +41,7 @@ namespace StackExchange.Redis
         /// <param name="timeoutMilliseconds">The timeout to use for the transfer.</param>
         /// <param name="migrateOptions">The options to use for this migration.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/MIGRATE</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/migrate"/></remarks>
         void KeyMigrate(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to debug.</param>
         /// <param name="flags">The flags to use for this migration.</param>
         /// <returns>The raw output from DEBUG OBJECT.</returns>
-        /// <remarks>https://redis.io/commands/debug-object</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/debug-object"/></remarks>
         RedisValue DebugObject(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace StackExchange.Redis
         /// <param name="member">The value to set at this entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/geoadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geoadd"/></remarks>
         bool GeoAdd(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace StackExchange.Redis
         /// <param name="value">The geo value to store.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/geoadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geoadd"/></remarks>
         bool GeoAdd(RedisKey key, GeoEntry value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace StackExchange.Redis
         /// <param name="values">The geo values add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements that were added to the set, not including all the elements already present into the set.</returns>
-        /// <remarks>https://redis.io/commands/geoadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geoadd"/></remarks>
         long GeoAdd(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace StackExchange.Redis
         /// <param name="member">The geo value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the member existed in the sorted set and was removed, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/zrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrem"/></remarks>
         bool GeoRemove(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace StackExchange.Redis
         /// <param name="unit">The unit of distance to return (defaults to meters).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or <see langword="null"/> if one or both the elements are missing.</returns>
-        /// <remarks>https://redis.io/commands/geodist</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geodist"/></remarks>
         double? GeoDistance(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace StackExchange.Redis
         /// <param name="members">The members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.</returns>
-        /// <remarks>https://redis.io/commands/geohash</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geohash"/></remarks>
         string?[] GeoHash(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace StackExchange.Redis
         /// <param name="member">The member to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.</returns>
-        /// <remarks>https://redis.io/commands/geohash</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geohash"/></remarks>
         string? GeoHash(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace StackExchange.Redis
         /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
         /// Non existing elements are reported as NULL elements of the array.
         /// </returns>
-        /// <remarks>https://redis.io/commands/geopos</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geopos"/></remarks>
         GeoPosition?[] GeoPosition(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace StackExchange.Redis
         /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
         /// Non existing elements are reported as NULL elements of the array.
         /// </returns>
-        /// <remarks>https://redis.io/commands/geopos</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geopos"/></remarks>
         GeoPosition? GeoPosition(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace StackExchange.Redis
         /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The results found within the radius, if any.</returns>
-        /// <remarks>https://redis.io/commands/georadius</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/georadius"/></remarks>
         GeoRadiusResult[] GeoRadius(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace StackExchange.Redis
         /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The results found within the radius, if any.</returns>
-        /// <remarks>https://redis.io/commands/georadius</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/georadius"/></remarks>
         GeoRadiusResult[] GeoRadius(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -204,10 +204,10 @@ namespace StackExchange.Redis
         /// <param name="count">The maximum number of results to pull back.</param>
         /// <param name="demandClosest">Whether or not to terminate the search after finding <paramref name="count"/> results. Must be true of count is -1.</param>
         /// <param name="order">The order to sort by (defaults to unordered).</param>
-        /// <param name="options">The search options to use</param>
+        /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The results found within the shape, if any.</returns>
-        /// <remarks>https://redis.io/commands/geosearch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearch"/></remarks>
         GeoRadiusResult[] GeoSearch(RedisKey key, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -221,10 +221,10 @@ namespace StackExchange.Redis
         /// <param name="count">The maximum number of results to pull back.</param>
         /// <param name="demandClosest">Whether or not to terminate the search after finding <paramref name="count"/> results. Must be true of count is -1.</param>
         /// <param name="order">The order to sort by (defaults to unordered).</param>
-        /// <param name="options">The search options to use</param>
+        /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The results found within the shape, if any.</returns>
-        /// /// <remarks>https://redis.io/commands/geosearch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearch"/></remarks>
         GeoRadiusResult[] GeoSearch(RedisKey key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace StackExchange.Redis
         /// <param name="storeDistances">If set to true, the resulting set will be a regular sorted-set containing only distances, rather than a geo-encoded sorted-set.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The size of the set stored at <paramref name="destinationKey"/>.</returns>
-        /// <remarks>https://redis.io/commands/geosearchstore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearchstore"/></remarks>
         long GeoSearchAndStore(RedisKey sourceKey, RedisKey destinationKey, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace StackExchange.Redis
         /// <param name="storeDistances">If set to true, the resulting set will be a regular sorted-set containing only distances, rather than a geo-encoded sorted-set.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The size of the set stored at <paramref name="destinationKey"/>.</returns>
-        /// <remarks>https://redis.io/commands/geosearchstore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearchstore"/></remarks>
         long GeoSearchAndStore(RedisKey sourceKey, RedisKey destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -272,8 +272,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the decrement operation.</returns>
-        /// <remarks>The range of values supported by HINCRBY is limited to 64 bit signed integers.</remarks>
-        /// <remarks>https://redis.io/commands/hincrby</remarks>
+        /// <remarks>
+        /// <para>The range of values supported by HINCRBY is limited to 64 bit signed integers.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrby"/></para>
+        /// </remarks>
         long HashDecrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -285,8 +287,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the decrement operation.</returns>
-        /// <remarks>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</remarks>
-        /// <remarks>https://redis.io/commands/hincrbyfloat</remarks>
+        /// <remarks>
+        /// <para>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrbyfloat"/></para>
+        /// </remarks>
         double HashDecrement(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -297,7 +301,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of fields that were removed.</returns>
-        /// <remarks>https://redis.io/commands/hdel</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hdel"/></remarks>
         bool HashDelete(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -308,7 +312,7 @@ namespace StackExchange.Redis
         /// <param name="hashFields">The fields in the hash to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of fields that were removed.</returns>
-        /// <remarks>https://redis.io/commands/hdel</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hdel"/></remarks>
         long HashDelete(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -318,7 +322,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the hash contains field, <see langword="false"/> if the hash does not contain field, or key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hexists</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hexists"/></remarks>
         bool HashExists(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -328,7 +332,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hget"/></remarks>
         RedisValue HashGet(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -338,7 +342,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hget"/></remarks>
         Lease<byte>? HashGetLease(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -349,7 +353,7 @@ namespace StackExchange.Redis
         /// <param name="hashFields">The fields in the hash to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of values associated with the given fields, in the same order as they are requested.</returns>
-        /// <remarks>https://redis.io/commands/hmget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hmget"/></remarks>
         RedisValue[] HashGet(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -358,7 +362,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash to get all entries from.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hgetall</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hgetall"/></remarks>
         HashEntry[] HashGetAll(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -371,8 +375,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the increment operation.</returns>
-        /// <remarks>The range of values supported by HINCRBY is limited to 64 bit signed integers.</remarks>
-        /// <remarks>https://redis.io/commands/hincrby</remarks>
+        /// <remarks>
+        /// <para>The range of values supported by <c>HINCRBY</c> is limited to 64 bit signed integers.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrby"/></para>
+        /// </remarks>
         long HashIncrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -384,8 +390,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the increment operation.</returns>
-        /// <remarks>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</remarks>
-        /// <remarks>https://redis.io/commands/hincrbyfloat</remarks>
+        /// <remarks>
+        /// <para>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrbyfloat"/></para>
+        /// </remarks>
         double HashIncrement(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -394,7 +402,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of fields in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hkeys</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hkeys"/></remarks>
         RedisValue[] HashKeys(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -403,7 +411,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of fields in the hash, or 0 when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hlen"/></remarks>
         long HashLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -412,7 +420,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A random hash field name or <see cref="RedisValue.Null"/> if the hash does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hrandfield</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hrandfield"/></remarks>
         RedisValue HashRandomField(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -422,7 +430,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of fields to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of hash field names of size of at most <paramref name="count"/>, or <see cref="Array.Empty{RedisValue}"/> if the hash does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hrandfield</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hrandfield"/></remarks>
         RedisValue[] HashRandomFields(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -432,7 +440,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of fields to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of hash entries of size of at most <paramref name="count"/>, or <see cref="Array.Empty{HashEntry}"/> if the hash does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hrandfield</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hrandfield"/></remarks>
         HashEntry[] HashRandomFieldsWithValues(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -443,7 +451,7 @@ namespace StackExchange.Redis
         /// <param name="pageSize">The page size to iterate by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all elements of the hash matching the pattern.</returns>
-        /// <remarks>https://redis.io/commands/hscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hscan"/></remarks>
         IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
@@ -457,7 +465,7 @@ namespace StackExchange.Redis
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all elements of the hash matching the pattern.</returns>
-        /// <remarks>https://redis.io/commands/hscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hscan"/></remarks>
         IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern = default, int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -468,7 +476,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The entries to set in the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/hmset</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hmset"/></remarks>
         void HashSet(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -482,8 +490,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions under which to set the field value (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if field is a new field in the hash and value was set, <see langword="false"/> if field already exists in the hash and the value was updated.</returns>
-        /// <remarks>https://redis.io/commands/hset</remarks>
-        /// <remarks>https://redis.io/commands/hsetnx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/hset"/>,
+        /// <seealso href="https://redis.io/commands/hsetnx"/>
+        /// </remarks>
         bool HashSet(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -493,7 +503,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field containing the string</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string at field, or 0 when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hstrlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hstrlen"/></remarks>
         long HashStringLength(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -502,7 +512,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of values in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hvals</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hvals"/></remarks>
         RedisValue[] HashValues(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -512,7 +522,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/pfadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfadd"/></remarks>
         bool HyperLogLogAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -522,7 +532,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/pfadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfadd"/></remarks>
         bool HyperLogLogAdd(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -531,7 +541,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hyperloglog.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The approximated number of unique elements observed via HyperLogLogAdd.</returns>
-        /// <remarks>https://redis.io/commands/pfcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfcount"/></remarks>
         long HyperLogLogLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -540,7 +550,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the hyperloglogs.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The approximated number of unique elements observed via HyperLogLogAdd.</returns>
-        /// <remarks>https://redis.io/commands/pfcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfcount"/></remarks>
         long HyperLogLogLength(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -550,7 +560,7 @@ namespace StackExchange.Redis
         /// <param name="first">The key of the first hyperloglog to merge.</param>
         /// <param name="second">The key of the first hyperloglog to merge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/pfmerge</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfmerge"/></remarks>
         void HyperLogLogMerge(RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -559,7 +569,7 @@ namespace StackExchange.Redis
         /// <param name="destination">The key of the merged hyperloglog.</param>
         /// <param name="sourceKeys">The keys of the hyperloglogs to merge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/pfmerge</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfmerge"/></remarks>
         void HyperLogLogMerge(RedisKey destination, RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -579,7 +589,7 @@ namespace StackExchange.Redis
         /// <param name="replace">Whether to overwrite an existing values at <paramref name="destinationKey"/>. If <see langword="false"/> and the key exists, the copy will not succeed.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if key was copied. <see langword="false"/> if key was not copied.</returns>
-        /// <remarks>https://redis.io/commands/copy</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/copy"/></remarks>
         bool KeyCopy(RedisKey sourceKey, RedisKey destinationKey, int destinationDatabase = -1, bool replace = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -589,8 +599,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key was removed.</returns>
-        /// <remarks>https://redis.io/commands/del</remarks>
-        /// <remarks>https://redis.io/commands/unlink</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/del"/>,
+        /// <seealso href="https://redis.io/commands/unlink"/>
+        /// </remarks>
         bool KeyDelete(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -600,8 +612,10 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of keys that were removed.</returns>
-        /// <remarks>https://redis.io/commands/del</remarks>
-        /// <remarks>https://redis.io/commands/unlink</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/del"/>,
+        /// <seealso href="https://redis.io/commands/unlink"/>
+        /// </remarks>
         long KeyDelete(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -611,7 +625,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to dump.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The serialized value.</returns>
-        /// <remarks>https://redis.io/commands/dump</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/dump"/></remarks>
         byte[]? KeyDump(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -620,7 +634,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to dump.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The Redis encoding for the value or <see langword="null"/> is the key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/object-encoding</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/object-encoding"/></remarks>
         string? KeyEncoding(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -629,7 +643,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key exists. <see langword="false"/> if the key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/exists</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/exists"/></remarks>
         bool KeyExists(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -638,7 +652,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of keys that existed.</returns>
-        /// <remarks>https://redis.io/commands/exists</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/exists"/></remarks>
         long KeyExists(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -658,12 +672,15 @@ namespace StackExchange.Redis
         /// </para>
         /// <para>
         /// Since Redis 2.1.3, you can update the timeout of a key.
-        /// It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.
+        /// It is also possible to remove the timeout using the PERSIST command.
+        /// See the page on key expiry for more information.
+        /// </para>
+        /// <para>
+        /// <seealso href="https://redis.io/commands/expire"/>,
+        /// <seealso href="https://redis.io/commands/pexpire"/>,
+        /// <seealso href="https://redis.io/commands/persist"/>
         /// </para>
         /// </remarks>
-        /// <remarks>https://redis.io/commands/expire</remarks>
-        /// <remarks>https://redis.io/commands/pexpire</remarks>
-        /// <remarks>https://redis.io/commands/persist</remarks>
         bool KeyExpire(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -676,8 +693,10 @@ namespace StackExchange.Redis
         /// <param name="when">Since Redis 7.0.0, you can choose under which condition the expiration will be set using <see cref="ExpireWhen"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>https://redis.io/commands/expire</remarks>
-        /// <remarks>https://redis.io/commands/pexpire</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/expire"/>,
+        /// <seealso href="https://redis.io/commands/pexpire"/>
+        /// </remarks>
         bool KeyExpire(RedisKey key, TimeSpan? expiry, ExpireWhen when, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -697,12 +716,15 @@ namespace StackExchange.Redis
         /// </para>
         /// <para>
         /// Since Redis 2.1.3, you can update the timeout of a key.
-        /// It is also possible to remove the timeout using the PERSIST command. See the page on key expiry for more information.
+        /// It is also possible to remove the timeout using the PERSIST command.
+        /// See the page on key expiry for more information.
+        /// </para>
+        /// <para>
+        /// <seealso href="https://redis.io/commands/expireat"/>,
+        /// <seealso href="https://redis.io/commands/pexpireat"/>,
+        /// <seealso href="https://redis.io/commands/persist"/>
         /// </para>
         /// </remarks>
-        /// <remarks>https://redis.io/commands/expireat</remarks>
-        /// <remarks>https://redis.io/commands/pexpireat</remarks>
-        /// <remarks>https://redis.io/commands/persist</remarks>
         bool KeyExpire(RedisKey key, DateTime? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -715,8 +737,10 @@ namespace StackExchange.Redis
         /// <param name="when">Since Redis 7.0.0, you can choose under which condition the expiration will be set using <see cref="ExpireWhen"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>https://redis.io/commands/expire</remarks>
-        /// <remarks>https://redis.io/commands/pexpire</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/expire"/>,
+        /// <seealso href="https://redis.io/commands/pexpire"/>
+        /// </remarks>
         bool KeyExpire(RedisKey key, DateTime? expiry, ExpireWhen when, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -725,8 +749,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get the expiration for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The time at which the given key will expire, or <see langword="null"/> if the key does not exist or has no associated expiration time.</returns>
-        /// <remarks>https://redis.io/commands/expiretime</remarks>
-        /// <remarks>https://redis.io/commands/pexpiretime</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/expiretime"/>,
+        /// <seealso href="https://redis.io/commands/pexpiretime"/>
+        /// </remarks>
         DateTime? KeyExpireTime(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -735,7 +761,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get the time of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The time since the object stored at the specified key is idle.</returns>
-        /// <remarks>https://redis.io/commands/object</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/object"/></remarks>
         TimeSpan? KeyIdleTime(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -747,7 +773,7 @@ namespace StackExchange.Redis
         /// <param name="database">The database to move the key to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if key was moved. <see langword="false"/> if key was not moved.</returns>
-        /// <remarks>https://redis.io/commands/move</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/move"/></remarks>
         bool KeyMove(RedisKey key, int database, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -756,7 +782,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to persist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the timeout was removed. <see langword="false"/> if key does not exist or does not have an associated timeout.</returns>
-        /// <remarks>https://redis.io/commands/persist</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/persist"/></remarks>
         bool KeyPersist(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -764,7 +790,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The random key, or nil when the database is empty.</returns>
-        /// <remarks>https://redis.io/commands/randomkey</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/randomkey"/></remarks>
         RedisKey KeyRandom(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -773,7 +799,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get a reference count for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of references (<see langword="Null"/> if the key does not exist).</returns>
-        /// <remarks>https://redis.io/commands/object-refcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/object-refcount"/></remarks>
         long? KeyRefCount(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -785,8 +811,10 @@ namespace StackExchange.Redis
         /// <param name="when">What conditions to rename under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key was renamed, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/rename</remarks>
-        /// <remarks>https://redis.io/commands/renamenx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/rename"/>,
+        /// <seealso href="https://redis.io/commands/renamenx"/>
+        /// </remarks>
         bool KeyRename(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -797,7 +825,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value of the key.</param>
         /// <param name="expiry">The expiry to set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/restore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/restore"/></remarks>
         void KeyRestore(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -807,7 +835,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>TTL, or nil when key does not exist or does not have a timeout.</returns>
-        /// <remarks>https://redis.io/commands/ttl</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/ttl"/></remarks>
         TimeSpan? KeyTimeToLive(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -816,7 +844,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key was touched, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/touch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/touch"/></remarks>
         bool KeyTouch(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -825,7 +853,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of keys that were touched.</returns>
-        /// <remarks>https://redis.io/commands/touch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/touch"/></remarks>
         long KeyTouch(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -835,7 +863,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get the type of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Type of key, or none when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/type</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/type"/></remarks>
         RedisType KeyType(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -848,7 +876,7 @@ namespace StackExchange.Redis
         /// <param name="index">The index position to get the value at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The requested element, or nil when index is out of range.</returns>
-        /// <remarks>https://redis.io/commands/lindex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lindex"/></remarks>
         RedisValue ListGetByIndex(RedisKey key, long index, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -860,7 +888,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to insert.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the insert operation, or -1 when the value pivot was not found.</returns>
-        /// <remarks>https://redis.io/commands/linsert</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/linsert"/></remarks>
         long ListInsertAfter(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -872,7 +900,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to insert.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the insert operation, or -1 when the value pivot was not found.</returns>
-        /// <remarks>https://redis.io/commands/linsert</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/linsert"/></remarks>
         long ListInsertBefore(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -881,7 +909,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of the first element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/lpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lpop"/></remarks>
         RedisValue ListLeftPop(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -892,7 +920,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of elements to remove</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
-        /// <remarks>https://redis.io/commands/lpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lpop"/></remarks>
         RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -905,6 +933,7 @@ namespace StackExchange.Redis
         /// <param name="maxLength">The maximum number of elements to scan through before stopping, defaults to 0 (a full scan of the list.)</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The 0-based index of the first matching element, or -1 if not found.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/lpos"/></remarks>
         long ListPosition(RedisKey key, RedisValue element, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -918,6 +947,7 @@ namespace StackExchange.Redis
         /// <param name="maxLength">The maximum number of elements to scan through before stopping, defaults to 0 (a full scan of the list.)</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of at most <paramref name="count"/> of indexes of matching elements. If none are found, and empty array is returned.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/lpos"/></remarks>
         long[] ListPositions(RedisKey key, RedisValue element, long count, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -929,8 +959,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
-        /// <remarks>https://redis.io/commands/lpush</remarks>
-        /// <remarks>https://redis.io/commands/lpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/lpush"/>,
+        /// <seealso href="https://redis.io/commands/lpushx"/>
+        /// </remarks>
         long ListLeftPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -942,21 +974,23 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
-        /// <remarks>https://redis.io/commands/lpush</remarks>
-        /// <remarks>https://redis.io/commands/lpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/lpush"/>,
+        /// <seealso href="https://redis.io/commands/lpushx"/>
+        /// </remarks>
         long ListLeftPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Insert all the specified values at the head of the list stored at key.
         /// If key does not exist, it is created as empty list before performing the push operations.
         /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element.
-        /// So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
+        /// So for instance the command <c>LPUSH mylist a b c</c> will result into a list containing c as first element, b as second element and a as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the head of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
-        /// <remarks>https://redis.io/commands/lpush</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lpush"/></remarks>
         long ListLeftPush(RedisKey key, RedisValue[] values, CommandFlags flags);
 
         /// <summary>
@@ -965,7 +999,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list at key.</returns>
-        /// <remarks>https://redis.io/commands/llen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/llen"/></remarks>
         long ListLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -978,7 +1012,7 @@ namespace StackExchange.Redis
         /// <param name="destinationSide">What side of the <paramref name="destinationKey"/> list to move to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The element being popped and pushed or <see cref="RedisValue.Null"/> if there is no element to move.</returns>
-        /// <remarks>https://redis.io/commands/lmove</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lmove"/></remarks>
         RedisValue ListMove(RedisKey sourceKey, RedisKey destinationKey, ListSide sourceSide, ListSide destinationSide, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -992,7 +1026,7 @@ namespace StackExchange.Redis
         /// <param name="stop">The stop index of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified range.</returns>
-        /// <remarks>https://redis.io/commands/lrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lrange"/></remarks>
         RedisValue[] ListRange(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1009,7 +1043,7 @@ namespace StackExchange.Redis
         /// <param name="count">The count behavior (see method summary).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of removed elements.</returns>
-        /// <remarks>https://redis.io/commands/lrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lrem"/></remarks>
         long ListRemove(RedisKey key, RedisValue value, long count = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1018,7 +1052,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The element being popped.</returns>
-        /// <remarks>https://redis.io/commands/rpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpop"/></remarks>
         RedisValue ListRightPop(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1029,7 +1063,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of elements to pop</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
-        /// <remarks>https://redis.io/commands/rpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpop"/></remarks>
         RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1039,7 +1073,7 @@ namespace StackExchange.Redis
         /// <param name="destination">The key of the destination list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The element being popped and pushed.</returns>
-        /// <remarks>https://redis.io/commands/rpoplpush</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpoplpush"/></remarks>
         RedisValue ListRightPopLeftPush(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1051,8 +1085,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operation.</returns>
-        /// <remarks>https://redis.io/commands/rpush</remarks>
-        /// <remarks>https://redis.io/commands/rpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/rpush"/>,
+        /// <seealso href="https://redis.io/commands/rpushx"/>
+        /// </remarks>
         long ListRightPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1064,21 +1100,23 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operation.</returns>
-        /// <remarks>https://redis.io/commands/rpush</remarks>
-        /// <remarks>https://redis.io/commands/rpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/rpush"/>,
+        /// <seealso href="https://redis.io/commands/rpushx"/>
+        /// </remarks>
         long ListRightPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Insert all the specified values at the tail of the list stored at key.
         /// If key does not exist, it is created as empty list before performing the push operation.
         /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
-        /// So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
+        /// So for instance the command <c>RPUSH mylist a b c</c> will result into a list containing a as first element, b as second element and c as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the tail of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operation.</returns>
-        /// <remarks>https://redis.io/commands/rpush</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpush"/></remarks>
         long ListRightPush(RedisKey key, RedisValue[] values, CommandFlags flags);
 
         /// <summary>
@@ -1090,20 +1128,20 @@ namespace StackExchange.Redis
         /// <param name="index">The index to set the value at.</param>
         /// <param name="value">The values to add to the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/lset</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lset"/></remarks>
         void ListSetByIndex(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Trim an existing list so that it will contain only the specified range of elements specified.
         /// Both start and stop are zero-based indexes, where 0 is the first element of the list (the head), 1 the next element and so on.
-        /// For example: LTRIM foobar 0 2 will modify the list stored at foobar so that only the first three elements of the list will remain.
+        /// For example: <c>LTRIM foobar 0 2</c> will modify the list stored at foobar so that only the first three elements of the list will remain.
         /// start and end can also be negative numbers indicating offsets from the end of the list, where -1 is the last element of the list, -2 the penultimate element and so on.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="start">The start index of the list to trim to.</param>
         /// <param name="stop">The end index of the list to trim to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/ltrim</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/ltrim"/></remarks>
         void ListTrim(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1153,7 +1191,7 @@ namespace StackExchange.Redis
         /// The number of clients that received the message *on the destination server*,
         /// note that this doesn't mean much in a cluster as clients can get the message through other nodes.
         /// </returns>
-        /// <remarks>https://redis.io/commands/publish</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/publish"/></remarks>
         long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1162,8 +1200,8 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         /// <returns>A dynamic representation of the command's result.</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         RedisResult Execute(string command, params object[] args);
 
         /// <summary>
@@ -1173,8 +1211,8 @@ namespace StackExchange.Redis
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         /// <returns>A dynamic representation of the command's result.</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         RedisResult Execute(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1185,8 +1223,10 @@ namespace StackExchange.Redis
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/eval</remarks>
-        /// <remarks>https://redis.io/commands/evalsha</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/eval"/>,
+        /// <seealso href="https://redis.io/commands/evalsha"/>
+        /// </remarks>
         RedisResult ScriptEvaluate(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1197,7 +1237,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/evalsha</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/evalsha"/></remarks>
         RedisResult ScriptEvaluate(byte[] hash, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1208,7 +1248,7 @@ namespace StackExchange.Redis
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/eval</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/eval"/></remarks>
         RedisResult ScriptEvaluate(LuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1220,7 +1260,7 @@ namespace StackExchange.Redis
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/eval</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/eval"/></remarks>
         RedisResult ScriptEvaluate(LoadedLuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1232,7 +1272,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/sadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sadd"/></remarks>
         bool SetAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1244,7 +1284,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements that were added to the set, not including all the elements already present into the set.</returns>
-        /// <remarks>https://redis.io/commands/sadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sadd"/></remarks>
         long SetAdd(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1255,9 +1295,11 @@ namespace StackExchange.Redis
         /// <param name="second">The key of the second set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List with members of the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunion</remarks>
-        /// <remarks>https://redis.io/commands/sinter</remarks>
-        /// <remarks>https://redis.io/commands/sdiff</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunion"/>,
+        /// <seealso href="https://redis.io/commands/sinter"/>,
+        /// <seealso href="https://redis.io/commands/sdiff"/>
+        /// </remarks>
         RedisValue[] SetCombine(SetOperation operation, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1267,9 +1309,11 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the sets to operate on.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List with members of the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunion</remarks>
-        /// <remarks>https://redis.io/commands/sinter</remarks>
-        /// <remarks>https://redis.io/commands/sdiff</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunion"/>,
+        /// <seealso href="https://redis.io/commands/sinter"/>,
+        /// <seealso href="https://redis.io/commands/sdiff"/>
+        /// </remarks>
         RedisValue[] SetCombine(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1282,9 +1326,11 @@ namespace StackExchange.Redis
         /// <param name="second">The key of the second set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunionstore</remarks>
-        /// <remarks>https://redis.io/commands/sinterstore</remarks>
-        /// <remarks>https://redis.io/commands/sdiffstore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunionstore"/>,
+        /// <seealso href="https://redis.io/commands/sinterstore"/>,
+        /// <seealso href="https://redis.io/commands/sdiffstore"/>
+        /// </remarks>
         long SetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1296,9 +1342,11 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the sets to operate on.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunionstore</remarks>
-        /// <remarks>https://redis.io/commands/sinterstore</remarks>
-        /// <remarks>https://redis.io/commands/sdiffstore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunionstore"/>,
+        /// <seealso href="https://redis.io/commands/sinterstore"/>,
+        /// <seealso href="https://redis.io/commands/sdiffstore"/>
+        /// </remarks>
         long SetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1311,7 +1359,7 @@ namespace StackExchange.Redis
         /// <see langword="true"/> if the element is a member of the set.
         /// <see langword="false"/> if the element is not a member of the set, or if key does not exist.
         /// </returns>
-        /// <remarks>https://redis.io/commands/sismember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sismember"/></remarks>
         bool SetContains(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1321,11 +1369,10 @@ namespace StackExchange.Redis
         /// <param name="values">The members to check for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>
-        /// An array of booleans corresponding to <paramref name="values"/>, for each:
         /// <see langword="true"/> if the element is a member of the set.
         /// <see langword="false"/> if the element is not a member of the set, or if key does not exist.
         /// </returns>
-        /// <remarks>https://redis.io/commands/smismember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/smismember"/></remarks>
         bool[] SetContains(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1341,7 +1388,7 @@ namespace StackExchange.Redis
         /// <param name="limit">The number of elements to check (defaults to 0 and means unlimited).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The cardinality (number of elements) of the set, or 0 if key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/scard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/scard"/></remarks>
         long SetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1350,7 +1397,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The cardinality (number of elements) of the set, or 0 if key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/scard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/scard"/></remarks>
         long SetLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1359,7 +1406,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>All elements of the set.</returns>
-        /// <remarks>https://redis.io/commands/smembers</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/smembers"/></remarks>
         RedisValue[] SetMembers(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1375,7 +1422,7 @@ namespace StackExchange.Redis
         /// <see langword="true"/> if the element is moved.
         /// <see langword="false"/> if the element is not a member of source and no operation was performed.
         /// </returns>
-        /// <remarks>https://redis.io/commands/smove</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/smove"/></remarks>
         bool SetMove(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1384,7 +1431,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The removed element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/spop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/spop"/></remarks>
         RedisValue SetPop(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1394,7 +1441,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of elements to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of elements, or an empty array when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/spop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/spop"/></remarks>
         RedisValue[] SetPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1403,7 +1450,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected element, or <see cref="RedisValue.Null"/> when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/srandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/srandmember"/></remarks>
         RedisValue SetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1415,7 +1462,7 @@ namespace StackExchange.Redis
         /// <param name="count">The count of members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of elements, or an empty array when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/srandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/srandmember"/></remarks>
         RedisValue[] SetRandomMembers(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1426,7 +1473,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was already present in the set, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/srem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/srem"/></remarks>
         bool SetRemove(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1437,7 +1484,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of members that were removed from the set, not including non existing members.</returns>
-        /// <remarks>https://redis.io/commands/srem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/srem"/></remarks>
         long SetRemove(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1448,7 +1495,7 @@ namespace StackExchange.Redis
         /// <param name="pageSize">The page size to iterate by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the set.</returns>
-        /// <remarks>https://redis.io/commands/sscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sscan"/></remarks>
         IEnumerable<RedisValue> SetScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
@@ -1462,7 +1509,7 @@ namespace StackExchange.Redis
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the set.</returns>
-        /// <remarks>https://redis.io/commands/sscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sscan"/></remarks>
         IEnumerable<RedisValue> SetScan(RedisKey key, RedisValue pattern = default, int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1482,7 +1529,7 @@ namespace StackExchange.Redis
         /// <param name="get">The key pattern to sort by, if any e.g. ExternalKey_* would return the value of ExternalKey_{listvalue} for each entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The sorted elements, or the external values if <c>get</c> is specified.</returns>
-        /// <remarks>https://redis.io/commands/sort</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
         RedisValue[] Sort(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1490,7 +1537,7 @@ namespace StackExchange.Redis
         /// By default, the elements themselves are compared, but the values can also be used to perform external key-lookups using the <c>by</c> parameter.
         /// By default, the elements themselves are returned, but external key-lookups (one or many) can be performed instead by specifying
         /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation</a> for examples is recommended.
         /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
         /// <param name="destination">The destination key to store results in.</param>
@@ -1503,7 +1550,7 @@ namespace StackExchange.Redis
         /// <param name="get">The key pattern to sort by, if any e.g. ExternalKey_* would return the value of ExternalKey_{listvalue} for each entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements stored in the new list.</returns>
-        /// <remarks>https://redis.io/commands/sort</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
         long SortAndStore(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1515,7 +1562,7 @@ namespace StackExchange.Redis
         /// <param name="score">The score for the member to add to the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         bool SortedSetAdd(RedisKey key, RedisValue member, double score, CommandFlags flags);
 
         /// <summary>
@@ -1528,7 +1575,7 @@ namespace StackExchange.Redis
         /// <param name="when">What conditions to add the element under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         bool SortedSetAdd(RedisKey key, RedisValue member, double score, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1539,7 +1586,7 @@ namespace StackExchange.Redis
         /// <param name="values">The members and values to add to the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements added to the sorted sets, not including elements already existing for which the score was updated.</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         long SortedSetAdd(RedisKey key, SortedSetEntry[] values, CommandFlags flags);
 
         /// <summary>
@@ -1551,7 +1598,7 @@ namespace StackExchange.Redis
         /// <param name="when">What conditions to add the element under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements added to the sorted sets, not including elements already existing for which the score was updated.</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         long SortedSetAdd(RedisKey key, SortedSetEntry[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1564,10 +1611,12 @@ namespace StackExchange.Redis
         /// <param name="weights">The optional weights per set that correspond to <paramref name="keys"/>.</param>
         /// <param name="aggregate">The aggregation method (defaults to <see cref="Aggregate.Sum"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunion</remarks>
-        /// <remarks>https://redis.io/commands/zinter</remarks>
-        /// <remarks>https://redis.io/commands/zdiff</remarks>
         /// <returns>The resulting sorted set.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunion"/>,
+        /// <seealso href="https://redis.io/commands/zinter"/>,
+        /// <seealso href="https://redis.io/commands/zdiff"/>
+        /// </remarks>
         RedisValue[] SortedSetCombine(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1580,10 +1629,12 @@ namespace StackExchange.Redis
         /// <param name="weights">The optional weights per set that correspond to <paramref name="keys"/>.</param>
         /// <param name="aggregate">The aggregation method (defaults to <see cref="Aggregate.Sum"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunion</remarks>
-        /// <remarks>https://redis.io/commands/zinter</remarks>
-        /// <remarks>https://redis.io/commands/zdiff</remarks>
         /// <returns>The resulting sorted set with scores.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunion"/>,
+        /// <seealso href="https://redis.io/commands/zinter"/>,
+        /// <seealso href="https://redis.io/commands/zdiff"/>
+        /// </remarks>
         SortedSetEntry[] SortedSetCombineWithScores(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1597,10 +1648,12 @@ namespace StackExchange.Redis
         /// <param name="second">The key of the second sorted set.</param>
         /// <param name="aggregate">The aggregation method (defaults to sum).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunionstore</remarks>
-        /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <remarks>https://redis.io/commands/zdiffstore</remarks>
         /// <returns>The number of elements in the resulting sorted set at destination.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunionstore"/>,
+        /// <seealso href="https://redis.io/commands/zinterstore"/>,
+        /// <seealso href="https://redis.io/commands/zdiffstore"/>
+        /// </remarks>
         long SortedSetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1614,10 +1667,12 @@ namespace StackExchange.Redis
         /// <param name="weights">The optional weights per set that correspond to <paramref name="keys"/>.</param>
         /// <param name="aggregate">The aggregation method (defaults to sum).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunionstore</remarks>
-        /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <remarks>https://redis.io/commands/zdiffstore</remarks>
         /// <returns>The number of elements in the resulting sorted set at destination.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunionstore"/>,
+        /// <seealso href="https://redis.io/commands/zinterstore"/>,
+        /// <seealso href="https://redis.io/commands/zdiffstore"/>
+        /// </remarks>
         long SortedSetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1629,7 +1684,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The new score of member.</returns>
-        /// <remarks>https://redis.io/commands/zincrby</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zincrby"/></remarks>
         double SortedSetDecrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1640,7 +1695,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The new score of member.</returns>
-        /// <remarks>https://redis.io/commands/zincrby</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zincrby"/></remarks>
         double SortedSetIncrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1650,7 +1705,7 @@ namespace StackExchange.Redis
         /// <param name="limit">If the intersection cardinality reaches <paramref name="limit"/> partway through the computation, the algorithm will exit and yield <paramref name="limit"/> as the cardinality (defaults to 0 meaning unlimited).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the resulting intersection.</returns>
-        /// <remarks>https://redis.io/commands/zintercard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zintercard"/></remarks>
         long SortedSetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1662,7 +1717,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Whether to exclude <paramref name="min"/> and <paramref name="max"/> from the range check (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The cardinality (number of elements) of the sorted set, or 0 if key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zcard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zcard"/></remarks>
         long SortedSetLength(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1675,7 +1730,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Whether to exclude <paramref name="min"/> and <paramref name="max"/> from the range check (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the specified score range.</returns>
-        /// <remarks>https://redis.io/commands/zlexcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zlexcount"/></remarks>
         long SortedSetLengthByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1684,7 +1739,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected element, or <see cref="RedisValue.Null"/> when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zrandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrandmember"/></remarks>
         RedisValue SortedSetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1703,7 +1758,7 @@ namespace StackExchange.Redis
         /// </param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected elements, or an empty array when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zrandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrandmember"/></remarks>
         RedisValue[] SortedSetRandomMembers(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1722,7 +1777,7 @@ namespace StackExchange.Redis
         /// </param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected elements with scores, or an empty array when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zrandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrandmember"/></remarks>
         SortedSetEntry[] SortedSetRandomMembersWithScores(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1738,8 +1793,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified range.</returns>
-        /// <remarks>https://redis.io/commands/zrange</remarks>
-        /// <remarks>https://redis.io/commands/zrevrange</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrange"/>,
+        /// <seealso href="https://redis.io/commands/zrevrange"/>
+        /// </remarks>
         RedisValue[] SortedSetRangeByRank(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1760,8 +1817,8 @@ namespace StackExchange.Redis
         /// <param name="skip">The number of elements into the sorted set to skip. Note: this iterates after sorting so incurs O(n) cost for large values.</param>
         /// <param name="take">The maximum number of elements to pull into the new (<paramref name="destinationKey"/>) set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zrangestore</remarks>
         /// <returns>The cardinality of (number of elements in) the newly created sorted set.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/zrangestore"/></remarks>
         long SortedSetRangeAndStore(
             RedisKey sourceKey,
             RedisKey destinationKey,
@@ -1787,8 +1844,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified range.</returns>
-        /// <remarks>https://redis.io/commands/zrange</remarks>
-        /// <remarks>https://redis.io/commands/zrevrange</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrange"/>,
+        /// <seealso href="https://redis.io/commands/zrevrange"/>
+        /// </remarks>
         SortedSetEntry[] SortedSetRangeByRankWithScores(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1807,8 +1866,10 @@ namespace StackExchange.Redis
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified score range.</returns>
-        /// <remarks>https://redis.io/commands/zrangebyscore</remarks>
-        /// <remarks>https://redis.io/commands/zrevrangebyscore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrangebyscore"/>,
+        /// <seealso href="https://redis.io/commands/zrevrangebyscore"/>
+        /// </remarks>
         RedisValue[] SortedSetRangeByScore(RedisKey key,
             double start = double.NegativeInfinity,
             double stop = double.PositiveInfinity,
@@ -1834,8 +1895,10 @@ namespace StackExchange.Redis
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified score range.</returns>
-        /// <remarks>https://redis.io/commands/zrangebyscore</remarks>
-        /// <remarks>https://redis.io/commands/zrevrangebyscore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrangebyscore"/>,
+        /// <seealso href="https://redis.io/commands/zrevrangebyscore"/>
+        /// </remarks>
         SortedSetEntry[] SortedSetRangeByScoreWithScores(RedisKey key,
             double start = double.NegativeInfinity,
             double stop = double.PositiveInfinity,
@@ -1856,8 +1919,8 @@ namespace StackExchange.Redis
         /// <param name="skip">How many items to skip.</param>
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zrangebylex</remarks>
         /// <returns>List of elements in the specified score range.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/zrangebylex"/></remarks>
         RedisValue[] SortedSetRangeByValue(RedisKey key,
             RedisValue min,
             RedisValue max,
@@ -1878,9 +1941,11 @@ namespace StackExchange.Redis
         /// <param name="skip">How many items to skip.</param>
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zrangebylex</remarks>
-        /// <remarks>https://redis.io/commands/zrevrangebylex</remarks>
         /// <returns>List of elements in the specified score range.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrangebylex"/>,
+        /// <seealso href="https://redis.io/commands/zrevrangebylex"/>
+        /// </remarks>
         RedisValue[] SortedSetRangeByValue(RedisKey key,
             RedisValue min = default,
             RedisValue max = default,
@@ -1899,8 +1964,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>If member exists in the sorted set, the rank of member. If member does not exist in the sorted set or key does not exist, <see langword="null"/>.</returns>
-        /// <remarks>https://redis.io/commands/zrank</remarks>
-        /// <remarks>https://redis.io/commands/zrevrank</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrank"/>,
+        /// <seealso href="https://redis.io/commands/zrevrank"/>
+        /// </remarks>
         long? SortedSetRank(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1910,7 +1977,7 @@ namespace StackExchange.Redis
         /// <param name="member">The member to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the member existed in the sorted set and was removed. <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/zrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrem"/></remarks>
         bool SortedSetRemove(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1920,7 +1987,7 @@ namespace StackExchange.Redis
         /// <param name="members">The members to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of members removed from the sorted set, not including non existing members.</returns>
-        /// <remarks>https://redis.io/commands/zrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrem"/></remarks>
         long SortedSetRemove(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1934,7 +2001,7 @@ namespace StackExchange.Redis
         /// <param name="stop">The maximum rank to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements removed.</returns>
-        /// <remarks>https://redis.io/commands/zremrangebyrank</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zremrangebyrank"/></remarks>
         long SortedSetRemoveRangeByRank(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1946,7 +2013,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Which of <paramref name="start"/> and <paramref name="stop"/> to exclude (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements removed.</returns>
-        /// <remarks>https://redis.io/commands/zremrangebyscore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zremrangebyscore"/></remarks>
         long SortedSetRemoveRangeByScore(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1959,7 +2026,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Which of <paramref name="min"/> and <paramref name="max"/> to exclude (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements removed.</returns>
-        /// <remarks>https://redis.io/commands/zremrangebylex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zremrangebylex"/></remarks>
         long SortedSetRemoveRangeByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1970,7 +2037,7 @@ namespace StackExchange.Redis
         /// <param name="pageSize">The page size to iterate by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the sorted set.</returns>
-        /// <remarks>https://redis.io/commands/zscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zscan"/></remarks>
         IEnumerable<SortedSetEntry> SortedSetScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
@@ -1984,7 +2051,7 @@ namespace StackExchange.Redis
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the sorted set.</returns>
-        /// <remarks>https://redis.io/commands/zscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zscan"/></remarks>
         IEnumerable<SortedSetEntry> SortedSetScan(RedisKey key,
             RedisValue pattern = default,
             int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize,
@@ -2000,7 +2067,7 @@ namespace StackExchange.Redis
         /// <param name="member">The member to get a score for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The score of the member.</returns>
-        /// <remarks>https://redis.io/commands/zscore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zscore"/></remarks>
         double? SortedSetScore(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2014,7 +2081,7 @@ namespace StackExchange.Redis
         /// The scores of the members in the same order as the <paramref name="members"/> array.
         /// If a member does not exist in the set, <see langword="null"/> is returned.
         /// </returns>
-        /// <remarks>https://redis.io/commands/zmscore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zmscore"/></remarks>
         double?[] SortedSetScores(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2024,8 +2091,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The removed element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zpopmin</remarks>
-        /// <remarks>https://redis.io/commands/zpopmax</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zpopmin"/>,
+        /// <seealso href="https://redis.io/commands/zpopmax"/>
+        /// </remarks>
         SortedSetEntry? SortedSetPop(RedisKey key, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2036,8 +2105,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of elements, or an empty array when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zpopmin</remarks>
-        /// <remarks>https://redis.io/commands/zpopmax</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zpopmin"/>,
+        /// <seealso href="https://redis.io/commands/zpopmax"/>
+        /// </remarks>
         SortedSetEntry[] SortedSetPop(RedisKey key, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2048,7 +2119,7 @@ namespace StackExchange.Redis
         /// <param name="messageId">The ID of the message to acknowledge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages acknowledged.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         long StreamAcknowledge(RedisKey key, RedisValue groupName, RedisValue messageId, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2059,7 +2130,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to acknowledge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages acknowledged.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         long StreamAcknowledge(RedisKey key, RedisValue groupName, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2075,7 +2146,7 @@ namespace StackExchange.Redis
         /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed max length by a small number. This improves performance when removing messages.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The ID of the newly created message.</returns>
-        /// <remarks>https://redis.io/commands/xadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xadd"/></remarks>
         RedisValue StreamAdd(RedisKey key, RedisValue streamField, RedisValue streamValue, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2090,7 +2161,7 @@ namespace StackExchange.Redis
         /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed max length by a small number. This improves performance when removing messages.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The ID of the newly created message.</returns>
-        /// <remarks>https://redis.io/commands/xadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xadd"/></remarks>
         RedisValue StreamAdd(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2104,7 +2175,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to claim for the given consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The messages successfully claimed by the given consumer.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         StreamEntry[] StreamClaim(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2118,7 +2189,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to claim for the given consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The message IDs for the messages successfully claimed by the given consumer.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         RedisValue[] StreamClaimIdsOnly(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2129,6 +2200,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position from which to read for the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if successful, <see langword="false"/> otherwise.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         bool StreamConsumerGroupSetPosition(RedisKey key, RedisValue groupName, RedisValue position, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2139,7 +2211,7 @@ namespace StackExchange.Redis
         /// <param name="groupName">The consumer group name.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An instance of <see cref="StreamConsumerInfo"/> for each of the consumer group's consumers.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         StreamConsumerInfo[] StreamConsumerInfo(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2150,7 +2222,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position to begin reading the stream. Defaults to <see cref="StreamPosition.NewMessages"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         bool StreamCreateConsumerGroup(RedisKey key, RedisValue groupName, RedisValue? position, CommandFlags flags);
 
         /// <summary>
@@ -2162,7 +2234,7 @@ namespace StackExchange.Redis
         /// <param name="createStream">Create the stream if it does not already exist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         bool StreamCreateConsumerGroup(RedisKey key, RedisValue groupName, RedisValue? position = null, bool createStream = true, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2172,7 +2244,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns the number of messages successfully deleted from the stream.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         long StreamDelete(RedisKey key, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2183,6 +2255,7 @@ namespace StackExchange.Redis
         /// <param name="consumerName">The name of the consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages that were pending for the deleted consumer.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         long StreamDeleteConsumer(RedisKey key, RedisValue groupName, RedisValue consumerName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2192,6 +2265,7 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if deleted, <see langword="false"/> otherwise.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         bool StreamDeleteConsumerGroup(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2200,7 +2274,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An instance of <see cref="StreamGroupInfo"/> for each of the stream's groups.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         StreamGroupInfo[] StreamGroupInfo(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2209,7 +2283,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A <see cref="StreamInfo"/> instance with information about the stream.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         StreamInfo StreamInfo(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2218,7 +2292,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of entries inside the given stream.</returns>
-        /// <remarks>https://redis.io/commands/xlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xlen"/></remarks>
         long StreamLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2234,7 +2308,7 @@ namespace StackExchange.Redis
         /// The highest and lowest ID of the pending messages, and the consumers with their pending message count.
         /// </returns>
         /// <remarks>The equivalent of calling XPENDING key group.</remarks>
-        /// <remarks>https://redis.io/commands/xpending</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xpending"/></remarks>
         StreamPendingInfo StreamPending(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2249,7 +2323,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An instance of <see cref="StreamPendingMessageInfo"/> for each pending message.</returns>
         /// <remarks>Equivalent of calling XPENDING key group start-id end-id count consumer-name.</remarks>
-        /// <remarks>https://redis.io/commands/xpending</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xpending"/></remarks>
         StreamPendingMessageInfo[] StreamPendingMessages(RedisKey key, RedisValue groupName, int count, RedisValue consumerName, RedisValue? minId = null, RedisValue? maxId = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2262,7 +2336,7 @@ namespace StackExchange.Redis
         /// <param name="messageOrder">The order of the messages. <see cref="Order.Ascending"/> will execute XRANGE and <see cref="Order.Descending"/> will execute XREVRANGE.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>https://redis.io/commands/xrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xrange"/></remarks>
         StreamEntry[] StreamRange(RedisKey key, RedisValue? minId = null, RedisValue? maxId = null, int? count = null, Order messageOrder = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2273,8 +2347,10 @@ namespace StackExchange.Redis
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key id.</remarks>
-        /// <remarks>https://redis.io/commands/xread</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREAD COUNT num STREAMS key id</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xread"/></para>
+        /// </remarks>
         StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2284,8 +2360,10 @@ namespace StackExchange.Redis
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
-        /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key1 key2 id1 id2.</remarks>
-        /// <remarks>https://redis.io/commands/xread</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREAD COUNT num STREAMS key1 key2 id1 id2</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xread"/></para>
+        /// </remarks>
         RedisStream[] StreamRead(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2298,7 +2376,7 @@ namespace StackExchange.Redis
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xreadgroup"/></remarks>
         StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position, int? count, CommandFlags flags);
 
         /// <summary>
@@ -2312,7 +2390,7 @@ namespace StackExchange.Redis
         /// <param name="noAck">When true, the message will not be added to the pending message list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xreadgroup"/></remarks>
         StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2325,8 +2403,10 @@ namespace StackExchange.Redis
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
-        /// <remarks>Equivalent of calling XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</remarks>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xreadgroup"/></para>
+        /// </remarks>
         RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream, CommandFlags flags);
 
         /// <summary>
@@ -2340,8 +2420,10 @@ namespace StackExchange.Redis
         /// <param name="noAck">When true, the message will not be added to the pending message list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
-        /// <remarks>Equivalent of calling XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</remarks>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xreadgroup"/></para>
+        /// </remarks>
         RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, bool noAck = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2352,7 +2434,7 @@ namespace StackExchange.Redis
         /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed max length by a small number. This improves performance when removing messages.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages removed from the stream.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2363,7 +2445,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to append to the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string after the append operation.</returns>
-        /// <remarks>https://redis.io/commands/append</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/append"/></remarks>
         long StringAppend(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2377,7 +2459,7 @@ namespace StackExchange.Redis
         /// <param name="end">The end byte to count at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of bits set to 1.</returns>
-        /// <remarks>https://redis.io/commands/bitcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bitcount"/></remarks>
         long StringBitCount(RedisKey key, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2392,7 +2474,7 @@ namespace StackExchange.Redis
         /// <param name="second">The second key to get the bit value from.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The size of the string stored in the destination key, that is equal to the size of the longest input string.</returns>
-        /// <remarks>https://redis.io/commands/bitop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bitop"/></remarks>
         long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second = default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2405,7 +2487,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to get the bit values from.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The size of the string stored in the destination key, that is equal to the size of the longest input string.</returns>
-        /// <remarks>https://redis.io/commands/bitop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bitop"/></remarks>
         long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2419,9 +2501,11 @@ namespace StackExchange.Redis
         /// <param name="start">The position to start looking (defaults to 0).</param>
         /// <param name="end">The position to stop looking (defaults to -1, unlimited).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns the position of the first bit set to 1 or 0 according to the request.
-        /// If we look for set bits(the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.</returns>
-        /// <remarks>https://redis.io/commands/bitpos</remarks>
+        /// <returns>
+        /// The command returns the position of the first bit set to 1 or 0 according to the request.
+        /// If we look for set bits(the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.
+        /// </returns>
+        /// <remarks><seealso href="https://redis.io/commands/bitpos"/></remarks>
         long StringBitPosition(RedisKey key, bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2434,8 +2518,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the decrement.</returns>
-        /// <remarks>https://redis.io/commands/decrby</remarks>
-        /// <remarks>https://redis.io/commands/decr</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/decrby"/>,
+        /// <seealso href="https://redis.io/commands/decr"/>
+        /// </remarks>
         long StringDecrement(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2447,7 +2533,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the decrement.</returns>
-        /// <remarks>https://redis.io/commands/incrbyfloat</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/incrbyfloat"/></remarks>
         double StringDecrement(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2457,7 +2543,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/get"/></remarks>
         RedisValue StringGet(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2467,7 +2553,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the strings.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The values of the strings with nil for keys do not exist.</returns>
-        /// <remarks>https://redis.io/commands/mget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/mget"/></remarks>
         RedisValue[] StringGet(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2477,7 +2563,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/get"/></remarks>
         Lease<byte>? StringGetLease(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2488,7 +2574,7 @@ namespace StackExchange.Redis
         /// <param name="offset">The offset in the string to get a bit at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The bit value stored at offset.</returns>
-        /// <remarks>https://redis.io/commands/getbit</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getbit"/></remarks>
         bool StringGetBit(RedisKey key, long offset, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2501,7 +2587,7 @@ namespace StackExchange.Redis
         /// <param name="end">The end index of the substring to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The substring of the string value stored at key.</returns>
-        /// <remarks>https://redis.io/commands/getrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getrange"/></remarks>
         RedisValue StringGetRange(RedisKey key, long start, long end, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2511,7 +2597,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to replace the existing value with.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The old value stored at key, or nil when key did not exist.</returns>
-        /// <remarks>https://redis.io/commands/getset</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getset"/></remarks>
         RedisValue StringGetSet(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2522,7 +2608,7 @@ namespace StackExchange.Redis
         /// <param name="expiry">The expiry to set. <see langword="null"/> will remove expiry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/getex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getex"/></remarks>
         RedisValue StringGetSetExpiry(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2533,7 +2619,7 @@ namespace StackExchange.Redis
         /// <param name="expiry">The exact date and time to expire at. <see cref="DateTime.MaxValue"/> will remove expiry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/getex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getex"/></remarks>
         RedisValue StringGetSetExpiry(RedisKey key, DateTime expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2544,7 +2630,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/getdelete</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getdelete"/></remarks>
         RedisValue StringGetDelete(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2555,7 +2641,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key and its expiry, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/get"/></remarks>
         RedisValueWithExpiry StringGetWithExpiry(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2568,8 +2654,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the increment.</returns>
-        /// <remarks>https://redis.io/commands/incrby</remarks>
-        /// <remarks>https://redis.io/commands/incr</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/incrby"/>,
+        /// <seealso href="https://redis.io/commands/incr"/>
+        /// </remarks>
         long StringIncrement(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2581,7 +2669,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the increment.</returns>
-        /// <remarks>https://redis.io/commands/incrbyfloat</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/incrbyfloat"/></remarks>
         double StringIncrement(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2590,7 +2678,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string at key, or 0 when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/strlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/strlen"/></remarks>
         long StringLength(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <inheritdoc cref="StringSet(RedisKey, RedisValue, TimeSpan?, bool, When, CommandFlags)" />
@@ -2611,7 +2699,7 @@ namespace StackExchange.Redis
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the string was set, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/set"/></remarks>
         bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2622,8 +2710,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the keys were set, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/mset</remarks>
-        /// <remarks>https://redis.io/commands/msetnx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/mset"/>,
+        /// <seealso href="https://redis.io/commands/msetnx"/>
+        /// </remarks>
         bool StringSet(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2635,8 +2725,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which condition to set the value under (defaults to <see cref="When.Always"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The previous value stored at <paramref name="key"/>, or nil when key did not exist.</returns>
-        /// <remarks>This method uses the SET command with the GET option introduced in Redis 6.2.0 instead of the deprecated GETSET command.</remarks>
-        /// <remarks>https://redis.io/commands/set</remarks>
+        /// <remarks>
+        /// <para>This method uses the <c>SET</c> command with the <c>GET</c> option introduced in Redis 6.2.0 instead of the deprecated <c>GETSET</c> command.</para>
+        /// <para><seealso href="https://redis.io/commands/set"/></para>
+        /// </remarks>
         RedisValue StringSetAndGet(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags);
 
         /// <summary>
@@ -2650,7 +2742,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The previous value stored at <paramref name="key"/>, or nil when key did not exist.</returns>
         /// <remarks>This method uses the SET command with the GET option introduced in Redis 6.2.0 instead of the deprecated GETSET command.</remarks>
-        /// <remarks>https://redis.io/commands/set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/set"/></remarks>
         RedisValue StringSetAndGet(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2663,7 +2755,7 @@ namespace StackExchange.Redis
         /// <param name="bit">The bit value to set, true for 1, false for 0.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The original bit value stored at offset.</returns>
-        /// <remarks>https://redis.io/commands/setbit</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/setbit"/></remarks>
         bool StringSetBit(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2676,7 +2768,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to overwrite with.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string after it was modified by the command.</returns>
-        /// <remarks>https://redis.io/commands/setrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/setrange"/></remarks>
         RedisValue StringSetRange(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None);
     }
 }

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -178,7 +178,7 @@ namespace StackExchange.Redis
         GeoRadiusResult[] GeoRadius(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return the members of a sorted set populated with geospatial information using GEOADD, which are
+        /// Return the members of a sorted set populated with geospatial information using <c>GEOADD</c>, which are
         /// within the borders of the area specified with the center location and the maximum distance from the center (the radius).
         /// </summary>
         /// <param name="key">The key of the set.</param>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -28,7 +28,7 @@ namespace StackExchange.Redis
         /// <param name="timeoutMilliseconds">The timeout to use for the transfer.</param>
         /// <param name="migrateOptions">The options to use for this migration.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/MIGRATE</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/migrate"/></remarks>
         Task KeyMigrateAsync(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to debug.</param>
         /// <param name="flags">The flags to use for this migration.</param>
         /// <returns>The raw output from DEBUG OBJECT.</returns>
-        /// <remarks>https://redis.io/commands/debug-object</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/debug-object"/></remarks>
         Task<RedisValue> DebugObjectAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace StackExchange.Redis
         /// <param name="member">The value to set at this entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/geoadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geoadd"/></remarks>
         Task<bool> GeoAddAsync(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -64,8 +64,8 @@ namespace StackExchange.Redis
         /// <param name="value">The geo value to store.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/geoadd</remarks>
-        Task<bool> GeoAddAsync(RedisKey key, StackExchange.Redis.GeoEntry value, CommandFlags flags = CommandFlags.None);
+        /// <remarks><seealso href="https://redis.io/commands/geoadd"/></remarks>
+        Task<bool> GeoAddAsync(RedisKey key, GeoEntry value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Add the specified members to the set stored at key.
@@ -76,7 +76,7 @@ namespace StackExchange.Redis
         /// <param name="values">The geo values add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements that were added to the set, not including all the elements already present into the set.</returns>
-        /// <remarks>https://redis.io/commands/geoadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geoadd"/></remarks>
         Task<long> GeoAddAsync(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace StackExchange.Redis
         /// <param name="member">The geo value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the member existed in the sorted set and was removed, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/zrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrem"/></remarks>
         Task<bool> GeoRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace StackExchange.Redis
         /// <param name="unit">The unit of distance to return (defaults to meters).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The command returns the distance as a double (represented as a string) in the specified unit, or <see langword="null"/> if one or both the elements are missing.</returns>
-        /// <remarks>https://redis.io/commands/geodist</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geodist"/></remarks>
         Task<double?> GeoDistanceAsync(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace StackExchange.Redis
         /// <param name="members">The members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.</returns>
-        /// <remarks>https://redis.io/commands/geohash</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geohash"/></remarks>
         Task<string?[]> GeoHashAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace StackExchange.Redis
         /// <param name="member">The member to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.</returns>
-        /// <remarks>https://redis.io/commands/geohash</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geohash"/></remarks>
         Task<string?> GeoHashAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace StackExchange.Redis
         /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
         /// Non existing elements are reported as NULL elements of the array.
         /// </returns>
-        /// <remarks>https://redis.io/commands/geopos</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geopos"/></remarks>
         Task<GeoPosition?[]> GeoPositionAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace StackExchange.Redis
         /// The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
         /// Non existing elements are reported as NULL elements of the array.
         /// </returns>
-        /// <remarks>https://redis.io/commands/geopos</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geopos"/></remarks>
         Task<GeoPosition?> GeoPositionAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace StackExchange.Redis
         /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The results found within the radius, if any.</returns>
-        /// <remarks>https://redis.io/commands/georadius</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/georadius"/></remarks>
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace StackExchange.Redis
         /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The results found within the radius, if any.</returns>
-        /// <remarks>https://redis.io/commands/georadius</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/georadius"/></remarks>
         Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace StackExchange.Redis
         /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The results found within the shape, if any.</returns>
-        /// <remarks>https://redis.io/commands/geosearch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearch"/></remarks>
         Task<GeoRadiusResult[]> GeoSearchAsync(RedisKey key, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace StackExchange.Redis
         /// <param name="options">The search options to use.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The results found within the shape, if any.</returns>
-        /// /// <remarks>https://redis.io/commands/geosearch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearch"/></remarks>
         Task<GeoRadiusResult[]> GeoSearchAsync(RedisKey key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -228,7 +228,7 @@ namespace StackExchange.Redis
         /// <param name="storeDistances">If set to true, the resulting set will be a regular sorted-set containing only distances, rather than a geo-encoded sorted-set.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The size of the set stored at <paramref name="destinationKey"/>.</returns>
-        /// <remarks>https://redis.io/commands/geosearchstore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearchstore"/></remarks>
         Task<long> GeoSearchAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace StackExchange.Redis
         /// <param name="storeDistances">If set to true, the resulting set will be a regular sorted-set containing only distances, rather than a geo-encoded sorted-set.</param>
         /// <param name="flags">The flags for this operation.</param>
         /// <returns>The size of the set stored at <paramref name="destinationKey"/>.</returns>
-        /// <remarks>https://redis.io/commands/geosearchstore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/geosearchstore"/></remarks>
         Task<long> GeoSearchAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -259,8 +259,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the decrement operation.</returns>
-        /// <remarks>The range of values supported by HINCRBY is limited to 64 bit signed integers.</remarks>
-        /// <remarks>https://redis.io/commands/hincrby</remarks>
+        /// <remarks>
+        /// <para>The range of values supported by HINCRBY is limited to 64 bit signed integers.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrby"/></para>
+        /// </remarks>
         Task<long> HashDecrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -272,8 +274,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the decrement operation.</returns>
-        /// <remarks>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</remarks>
-        /// <remarks>https://redis.io/commands/hincrbyfloat</remarks>
+        /// <remarks>
+        /// <para>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrbyfloat"/></para>
+        /// </remarks>
         Task<double> HashDecrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -284,7 +288,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of fields that were removed.</returns>
-        /// <remarks>https://redis.io/commands/hdel</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hdel"/></remarks>
         Task<bool> HashDeleteAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -295,7 +299,7 @@ namespace StackExchange.Redis
         /// <param name="hashFields">The fields in the hash to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of fields that were removed.</returns>
-        /// <remarks>https://redis.io/commands/hdel</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hdel"/></remarks>
         Task<long> HashDeleteAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -305,7 +309,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the hash contains field, <see langword="false"/> if the hash does not contain field, or key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hexists</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hexists"/></remarks>
         Task<bool> HashExistsAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -315,7 +319,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hget"/></remarks>
         Task<RedisValue> HashGetAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -325,7 +329,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field in the hash to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value associated with field, or nil when field is not present in the hash or key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hget"/></remarks>
         Task<Lease<byte>?> HashGetLeaseAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -336,7 +340,7 @@ namespace StackExchange.Redis
         /// <param name="hashFields">The fields in the hash to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of values associated with the given fields, in the same order as they are requested.</returns>
-        /// <remarks>https://redis.io/commands/hmget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hmget"/></remarks>
         Task<RedisValue[]> HashGetAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -345,7 +349,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash to get all entries from.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of fields and their values stored in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hgetall</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hgetall"/></remarks>
         Task<HashEntry[]> HashGetAllAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -358,8 +362,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the increment operation.</returns>
-        /// <remarks>The range of values supported by HINCRBY is limited to 64 bit signed integers.</remarks>
-        /// <remarks>https://redis.io/commands/hincrby</remarks>
+        /// <remarks>
+        /// <para>The range of values supported by <c>HINCRBY</c> is limited to 64 bit signed integers.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrby"/></para>
+        /// </remarks>
         Task<long> HashIncrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -371,8 +377,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value at field after the increment operation.</returns>
-        /// <remarks>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</remarks>
-        /// <remarks>https://redis.io/commands/hincrbyfloat</remarks>
+        /// <remarks>
+        /// <para>The precision of the output is fixed at 17 digits after the decimal point regardless of the actual internal precision of the computation.</para>
+        /// <para><seealso href="https://redis.io/commands/hincrbyfloat"/></para>
+        /// </remarks>
         Task<double> HashIncrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -381,7 +389,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of fields in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hkeys</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hkeys"/></remarks>
         Task<RedisValue[]> HashKeysAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -390,7 +398,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of fields in the hash, or 0 when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hlen"/></remarks>
         Task<long> HashLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -399,7 +407,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A random hash field name or <see cref="RedisValue.Null"/> if the hash does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hrandfield</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hrandfield"/></remarks>
         Task<RedisValue> HashRandomFieldAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -409,7 +417,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of fields to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of hash field names of size of at most <paramref name="count"/>, or <see cref="Array.Empty{RedisValue}"/> if the hash does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hrandfield</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hrandfield"/></remarks>
         Task<RedisValue[]> HashRandomFieldsAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -419,7 +427,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of fields to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of hash entries of size of at most <paramref name="count"/>, or <see cref="Array.Empty{HashEntry}"/> if the hash does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hrandfield</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hrandfield"/></remarks>
         Task<HashEntry[]> HashRandomFieldsWithValuesAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -433,7 +441,7 @@ namespace StackExchange.Redis
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all elements of the hash matching the pattern.</returns>
-        /// <remarks>https://redis.io/commands/hscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hscan"/></remarks>
         IAsyncEnumerable<HashEntry> HashScanAsync(RedisKey key, RedisValue pattern = default, int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -444,7 +452,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="hashFields">The entries to set in the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/hmset</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hmset"/></remarks>
         Task HashSetAsync(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -458,8 +466,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions under which to set the field value (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if field is a new field in the hash and value was set, <see langword="false"/> if field already exists in the hash and the value was updated.</returns>
-        /// <remarks>https://redis.io/commands/hset</remarks>
-        /// <remarks>https://redis.io/commands/hsetnx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/hset"/>,
+        /// <seealso href="https://redis.io/commands/hsetnx"/>
+        /// </remarks>
         Task<bool> HashSetAsync(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -469,7 +479,7 @@ namespace StackExchange.Redis
         /// <param name="hashField">The field containing the string</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string at field, or 0 when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hstrlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hstrlen"/></remarks>
         Task<long> HashStringLengthAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -478,7 +488,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hash.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of values in the hash, or an empty list when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/hvals</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/hvals"/></remarks>
         Task<RedisValue[]> HashValuesAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -488,7 +498,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/pfadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfadd"/></remarks>
         Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -498,7 +508,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to add.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if at least 1 HyperLogLog internal register was altered, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/pfadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfadd"/></remarks>
         Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -507,7 +517,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the hyperloglog.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The approximated number of unique elements observed via HyperLogLogAdd.</returns>
-        /// <remarks>https://redis.io/commands/pfcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfcount"/></remarks>
         Task<long> HyperLogLogLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -516,7 +526,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the hyperloglogs.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The approximated number of unique elements observed via HyperLogLogAdd.</returns>
-        /// <remarks>https://redis.io/commands/pfcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfcount"/></remarks>
         Task<long> HyperLogLogLengthAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -526,7 +536,7 @@ namespace StackExchange.Redis
         /// <param name="first">The key of the first hyperloglog to merge.</param>
         /// <param name="second">The key of the first hyperloglog to merge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/pfmerge</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfmerge"/></remarks>
         Task HyperLogLogMergeAsync(RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -535,7 +545,7 @@ namespace StackExchange.Redis
         /// <param name="destination">The key of the merged hyperloglog.</param>
         /// <param name="sourceKeys">The keys of the hyperloglogs to merge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/pfmerge</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pfmerge"/></remarks>
         Task HyperLogLogMergeAsync(RedisKey destination, RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -555,7 +565,7 @@ namespace StackExchange.Redis
         /// <param name="replace">Whether to overwrite an existing values at <paramref name="destinationKey"/>. If <see langword="false"/> and the key exists, the copy will not succeed.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if key was copied. <see langword="false"/> if key was not copied.</returns>
-        /// <remarks>https://redis.io/commands/copy</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/copy"/></remarks>
         Task<bool> KeyCopyAsync(RedisKey sourceKey, RedisKey destinationKey, int destinationDatabase = -1, bool replace = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -565,8 +575,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key was removed.</returns>
-        /// <remarks>https://redis.io/commands/del</remarks>
-        /// <remarks>https://redis.io/commands/unlink</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/del"/>,
+        /// <seealso href="https://redis.io/commands/unlink"/>
+        /// </remarks>
         Task<bool> KeyDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -576,8 +588,10 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of keys that were removed.</returns>
-        /// <remarks>https://redis.io/commands/del</remarks>
-        /// <remarks>https://redis.io/commands/unlink</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/del"/>,
+        /// <seealso href="https://redis.io/commands/unlink"/>
+        /// </remarks>
         Task<long> KeyDeleteAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -587,7 +601,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to dump.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The serialized value.</returns>
-        /// <remarks>https://redis.io/commands/dump</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/dump"/></remarks>
         Task<byte[]?> KeyDumpAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -596,7 +610,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to dump.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The Redis encoding for the value or <see langword="null"/> is the key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/object-encoding</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/object-encoding"/></remarks>
         Task<string?> KeyEncodingAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -605,7 +619,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key exists. <see langword="false"/> if the key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/exists</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/exists"/></remarks>
         Task<bool> KeyExistsAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -614,7 +628,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of keys that existed.</returns>
-        /// <remarks>https://redis.io/commands/exists</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/exists"/></remarks>
         Task<long> KeyExistsAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -637,10 +651,12 @@ namespace StackExchange.Redis
         /// It is also possible to remove the timeout using the PERSIST command.
         /// See the page on key expiry for more information.
         /// </para>
+        /// <para>
+        /// <seealso href="https://redis.io/commands/expire"/>,
+        /// <seealso href="https://redis.io/commands/pexpire"/>,
+        /// <seealso href="https://redis.io/commands/persist"/>
+        /// </para>
         /// </remarks>
-        /// <remarks>https://redis.io/commands/expire</remarks>
-        /// <remarks>https://redis.io/commands/pexpire</remarks>
-        /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -653,8 +669,10 @@ namespace StackExchange.Redis
         /// <param name="when">Since Redis 7.0.0, you can choose under which condition the expiration will be set using <see cref="ExpireWhen"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>https://redis.io/commands/expire</remarks>
-        /// <remarks>https://redis.io/commands/pexpire</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/expire"/>,
+        /// <seealso href="https://redis.io/commands/pexpire"/>
+        /// </remarks>
         Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, ExpireWhen when, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -677,10 +695,12 @@ namespace StackExchange.Redis
         /// It is also possible to remove the timeout using the PERSIST command.
         /// See the page on key expiry for more information.
         /// </para>
+        /// <para>
+        /// <seealso href="https://redis.io/commands/expireat"/>,
+        /// <seealso href="https://redis.io/commands/pexpireat"/>,
+        /// <seealso href="https://redis.io/commands/persist"/>
+        /// </para>
         /// </remarks>
-        /// <remarks>https://redis.io/commands/expireat</remarks>
-        /// <remarks>https://redis.io/commands/pexpireat</remarks>
-        /// <remarks>https://redis.io/commands/persist</remarks>
         Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -693,8 +713,10 @@ namespace StackExchange.Redis
         /// <param name="when">Since Redis 7.0.0, you can choose under which condition the expiration will be set using <see cref="ExpireWhen"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the timeout was set. <see langword="false"/> if key does not exist or the timeout could not be set.</returns>
-        /// <remarks>https://redis.io/commands/expire</remarks>
-        /// <remarks>https://redis.io/commands/pexpire</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/expire"/>,
+        /// <seealso href="https://redis.io/commands/pexpire"/>
+        /// </remarks>
         Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, ExpireWhen when, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -703,8 +725,10 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get the expiration for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The time at which the given key will expire, or <see langword="null"/> if the key does not exist or has no associated expiration time.</returns>
-        /// <remarks>https://redis.io/commands/expiretime</remarks>
-        /// <remarks>https://redis.io/commands/pexpiretime</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/expiretime"/>,
+        /// <seealso href="https://redis.io/commands/pexpiretime"/>
+        /// </remarks>
         Task<DateTime?> KeyExpireTimeAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -713,7 +737,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get the time of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The time since the object stored at the specified key is idle.</returns>
-        /// <remarks>https://redis.io/commands/object</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/object"/></remarks>
         Task<TimeSpan?> KeyIdleTimeAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -725,7 +749,7 @@ namespace StackExchange.Redis
         /// <param name="database">The database to move the key to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if key was moved. <see langword="false"/> if key was not moved.</returns>
-        /// <remarks>https://redis.io/commands/move</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/move"/></remarks>
         Task<bool> KeyMoveAsync(RedisKey key, int database, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -734,7 +758,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to persist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the timeout was removed. <see langword="false"/> if key does not exist or does not have an associated timeout.</returns>
-        /// <remarks>https://redis.io/commands/persist</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/persist"/></remarks>
         Task<bool> KeyPersistAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -742,7 +766,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The random key, or nil when the database is empty.</returns>
-        /// <remarks>https://redis.io/commands/randomkey</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/randomkey"/></remarks>
         Task<RedisKey> KeyRandomAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -751,7 +775,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get a reference count for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of references (<see langword="Null"/> if the key does not exist).</returns>
-        /// <remarks>https://redis.io/commands/object-refcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/object-refcount"/></remarks>
         Task<long?> KeyRefCountAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -763,8 +787,10 @@ namespace StackExchange.Redis
         /// <param name="when">What conditions to rename under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key was renamed, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/rename</remarks>
-        /// <remarks>https://redis.io/commands/renamenx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/rename"/>,
+        /// <seealso href="https://redis.io/commands/renamenx"/>
+        /// </remarks>
         Task<bool> KeyRenameAsync(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -775,7 +801,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value of the key.</param>
         /// <param name="expiry">The expiry to set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/restore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/restore"/></remarks>
         Task KeyRestoreAsync(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -785,7 +811,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to check.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>TTL, or nil when key does not exist or does not have a timeout.</returns>
-        /// <remarks>https://redis.io/commands/ttl</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/ttl"/></remarks>
         Task<TimeSpan?> KeyTimeToLiveAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -794,7 +820,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the key was touched, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/touch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/touch"/></remarks>
         Task<bool> KeyTouchAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -803,7 +829,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to touch.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of keys that were touched.</returns>
-        /// <remarks>https://redis.io/commands/touch</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/touch"/></remarks>
         Task<long> KeyTouchAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -813,7 +839,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key to get the type of.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Type of key, or none when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/type</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/type"/></remarks>
         Task<RedisType> KeyTypeAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -826,7 +852,7 @@ namespace StackExchange.Redis
         /// <param name="index">The index position to get the value at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The requested element, or nil when index is out of range.</returns>
-        /// <remarks>https://redis.io/commands/lindex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lindex"/></remarks>
         Task<RedisValue> ListGetByIndexAsync(RedisKey key, long index, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -838,7 +864,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to insert.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the insert operation, or -1 when the value pivot was not found.</returns>
-        /// <remarks>https://redis.io/commands/linsert</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/linsert"/></remarks>
         Task<long> ListInsertAfterAsync(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -850,7 +876,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to insert.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the insert operation, or -1 when the value pivot was not found.</returns>
-        /// <remarks>https://redis.io/commands/linsert</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/linsert"/></remarks>
         Task<long> ListInsertBeforeAsync(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -859,7 +885,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of the first element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/lpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lpop"/></remarks>
         Task<RedisValue> ListLeftPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -870,7 +896,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of elements to remove</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
-        /// <remarks>https://redis.io/commands/lpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lpop"/></remarks>
         Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -883,6 +909,7 @@ namespace StackExchange.Redis
         /// <param name="maxLength">The maximum number of elements to scan through before stopping, defaults to 0 (a full scan of the list.)</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The 0-based index of the first matching element, or -1 if not found.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/lpos"/></remarks>
         Task<long> ListPositionAsync(RedisKey key, RedisValue element, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -896,6 +923,7 @@ namespace StackExchange.Redis
         /// <param name="maxLength">The maximum number of elements to scan through before stopping, defaults to 0 (a full scan of the list.)</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of at most <paramref name="count"/> of indexes of matching elements. If none are found, and empty array is returned.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/lpos"/></remarks>
         Task<long[]> ListPositionsAsync(RedisKey key, RedisValue element, long count, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -907,8 +935,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
-        /// <remarks>https://redis.io/commands/lpush</remarks>
-        /// <remarks>https://redis.io/commands/lpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/lpush"/>,
+        /// <seealso href="https://redis.io/commands/lpushx"/>
+        /// </remarks>
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -920,21 +950,23 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
-        /// <remarks>https://redis.io/commands/lpush</remarks>
-        /// <remarks>https://redis.io/commands/lpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/lpush"/>,
+        /// <seealso href="https://redis.io/commands/lpushx"/>
+        /// </remarks>
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Insert all the specified values at the head of the list stored at key.
         /// If key does not exist, it is created as empty list before performing the push operations.
         /// Elements are inserted one after the other to the head of the list, from the leftmost element to the rightmost element.
-        /// So for instance the command LPUSH mylist a b c will result into a list containing c as first element, b as second element and a as third element.
+        /// So for instance the command <c>LPUSH mylist a b c</c> will result into a list containing c as first element, b as second element and a as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the head of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operations.</returns>
-        /// <remarks>https://redis.io/commands/lpush</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lpush"/></remarks>
         Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags);
 
         /// <summary>
@@ -943,7 +975,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list at key.</returns>
-        /// <remarks>https://redis.io/commands/llen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/llen"/></remarks>
         Task<long> ListLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -956,7 +988,7 @@ namespace StackExchange.Redis
         /// <param name="destinationSide">What side of the <paramref name="destinationKey"/> list to move to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The element being popped and pushed or <see cref="RedisValue.Null"/> if there is no element to move.</returns>
-        /// <remarks>https://redis.io/commands/lmove</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lmove"/></remarks>
         Task<RedisValue> ListMoveAsync(RedisKey sourceKey, RedisKey destinationKey, ListSide sourceSide, ListSide destinationSide, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -970,7 +1002,7 @@ namespace StackExchange.Redis
         /// <param name="stop">The stop index of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified range.</returns>
-        /// <remarks>https://redis.io/commands/lrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lrange"/></remarks>
         Task<RedisValue[]> ListRangeAsync(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -987,7 +1019,7 @@ namespace StackExchange.Redis
         /// <param name="count">The count behavior (see method summary).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of removed elements.</returns>
-        /// <remarks>https://redis.io/commands/lrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lrem"/></remarks>
         Task<long> ListRemoveAsync(RedisKey key, RedisValue value, long count = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -996,7 +1028,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The element being popped.</returns>
-        /// <remarks>https://redis.io/commands/rpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpop"/></remarks>
         Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1007,7 +1039,7 @@ namespace StackExchange.Redis
         /// <param name="count">The number of elements to pop</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Array of values that were popped, or nil if the key doesn't exist.</returns>
-        /// <remarks>https://redis.io/commands/rpop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpop"/></remarks>
         Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1017,7 +1049,7 @@ namespace StackExchange.Redis
         /// <param name="destination">The key of the destination list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The element being popped and pushed.</returns>
-        /// <remarks>https://redis.io/commands/rpoplpush</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpoplpush"/></remarks>
         Task<RedisValue> ListRightPopLeftPushAsync(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1029,8 +1061,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operation.</returns>
-        /// <remarks>https://redis.io/commands/rpush</remarks>
-        /// <remarks>https://redis.io/commands/rpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/rpush"/>,
+        /// <seealso href="https://redis.io/commands/rpushx"/>
+        /// </remarks>
         Task<long> ListRightPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1042,21 +1076,23 @@ namespace StackExchange.Redis
         /// <param name="when">Which conditions to add to the list under.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operation.</returns>
-        /// <remarks>https://redis.io/commands/rpush</remarks>
-        /// <remarks>https://redis.io/commands/rpushx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/rpush"/>,
+        /// <seealso href="https://redis.io/commands/rpushx"/>
+        /// </remarks>
         Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Insert all the specified values at the tail of the list stored at key.
         /// If key does not exist, it is created as empty list before performing the push operation.
         /// Elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
-        /// So for instance the command RPUSH mylist a b c will result into a list containing a as first element, b as second element and c as third element.
+        /// So for instance the command <c>RPUSH mylist a b c</c> will result into a list containing a as first element, b as second element and c as third element.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="values">The values to add to the tail of the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the list after the push operation.</returns>
-        /// <remarks>https://redis.io/commands/rpush</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/rpush"/></remarks>
         Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags);
 
         /// <summary>
@@ -1068,20 +1104,20 @@ namespace StackExchange.Redis
         /// <param name="index">The index to set the value at.</param>
         /// <param name="value">The values to add to the list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/lset</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/lset"/></remarks>
         Task ListSetByIndexAsync(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Trim an existing list so that it will contain only the specified range of elements specified.
         /// Both start and stop are zero-based indexes, where 0 is the first element of the list (the head), 1 the next element and so on.
-        /// For example: LTRIM foobar 0 2 will modify the list stored at foobar so that only the first three elements of the list will remain.
+        /// For example: <c>LTRIM foobar 0 2</c> will modify the list stored at foobar so that only the first three elements of the list will remain.
         /// start and end can also be negative numbers indicating offsets from the end of the list, where -1 is the last element of the list, -2 the penultimate element and so on.
         /// </summary>
         /// <param name="key">The key of the list.</param>
         /// <param name="start">The start index of the list to trim to.</param>
         /// <param name="stop">The end index of the list to trim to.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/ltrim</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/ltrim"/></remarks>
         Task ListTrimAsync(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1131,7 +1167,7 @@ namespace StackExchange.Redis
         /// The number of clients that received the message *on the destination server*,
         /// note that this doesn't mean much in a cluster as clients can get the message through other nodes.
         /// </returns>
-        /// <remarks>https://redis.io/commands/publish</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/publish"/></remarks>
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1140,8 +1176,8 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         /// <returns>A dynamic representation of the command's result.</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         Task<RedisResult> ExecuteAsync(string command, params object[] args);
 
         /// <summary>
@@ -1151,8 +1187,8 @@ namespace StackExchange.Redis
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         /// <returns>A dynamic representation of the command's result.</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         Task<RedisResult> ExecuteAsync(string command, ICollection<object>? args, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1163,8 +1199,10 @@ namespace StackExchange.Redis
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/eval</remarks>
-        /// <remarks>https://redis.io/commands/evalsha</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/eval"/>,
+        /// <seealso href="https://redis.io/commands/evalsha"/>
+        /// </remarks>
         Task<RedisResult> ScriptEvaluateAsync(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1175,7 +1213,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to execute against.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/evalsha</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/evalsha"/></remarks>
         Task<RedisResult> ScriptEvaluateAsync(byte[] hash, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1186,7 +1224,7 @@ namespace StackExchange.Redis
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/eval</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/eval"/></remarks>
         Task<RedisResult> ScriptEvaluateAsync(LuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1198,7 +1236,7 @@ namespace StackExchange.Redis
         /// <param name="parameters">The parameters to pass to the script.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A dynamic representation of the script's result.</returns>
-        /// <remarks>https://redis.io/commands/eval</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/eval"/></remarks>
         Task<RedisResult> ScriptEvaluateAsync(LoadedLuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1210,7 +1248,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was not already present in the set, else <see langword="false"/>.</returns>
-        /// <remarks>https://redis.io/commands/sadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sadd"/></remarks>
         Task<bool> SetAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1222,7 +1260,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to add to the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements that were added to the set, not including all the elements already present into the set.</returns>
-        /// <remarks>https://redis.io/commands/sadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sadd"/></remarks>
         Task<long> SetAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1233,9 +1271,11 @@ namespace StackExchange.Redis
         /// <param name="second">The key of the second set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List with members of the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunion</remarks>
-        /// <remarks>https://redis.io/commands/sinter</remarks>
-        /// <remarks>https://redis.io/commands/sdiff</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunion"/>,
+        /// <seealso href="https://redis.io/commands/sinter"/>,
+        /// <seealso href="https://redis.io/commands/sdiff"/>
+        /// </remarks>
         Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1245,9 +1285,11 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the sets to operate on.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List with members of the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunion</remarks>
-        /// <remarks>https://redis.io/commands/sinter</remarks>
-        /// <remarks>https://redis.io/commands/sdiff</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunion"/>,
+        /// <seealso href="https://redis.io/commands/sinter"/>,
+        /// <seealso href="https://redis.io/commands/sdiff"/>
+        /// </remarks>
         Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1260,9 +1302,11 @@ namespace StackExchange.Redis
         /// <param name="second">The key of the second set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunionstore</remarks>
-        /// <remarks>https://redis.io/commands/sinterstore</remarks>
-        /// <remarks>https://redis.io/commands/sdiffstore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunionstore"/>,
+        /// <seealso href="https://redis.io/commands/sinterstore"/>,
+        /// <seealso href="https://redis.io/commands/sdiffstore"/>
+        /// </remarks>
         Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1274,9 +1318,11 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the sets to operate on.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the resulting set.</returns>
-        /// <remarks>https://redis.io/commands/sunionstore</remarks>
-        /// <remarks>https://redis.io/commands/sinterstore</remarks>
-        /// <remarks>https://redis.io/commands/sdiffstore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sunionstore"/>,
+        /// <seealso href="https://redis.io/commands/sinterstore"/>,
+        /// <seealso href="https://redis.io/commands/sdiffstore"/>
+        /// </remarks>
         Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1289,7 +1335,7 @@ namespace StackExchange.Redis
         /// <see langword="true"/> if the element is a member of the set.
         /// <see langword="false"/> if the element is not a member of the set, or if key does not exist.
         /// </returns>
-        /// <remarks>https://redis.io/commands/sismember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sismember"/></remarks>
         Task<bool> SetContainsAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1302,7 +1348,7 @@ namespace StackExchange.Redis
         /// <see langword="true"/> if the element is a member of the set.
         /// <see langword="false"/> if the element is not a member of the set, or if key does not exist.
         /// </returns>
-        /// <remarks>https://redis.io/commands/smismember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/smismember"/></remarks>
         Task<bool[]> SetContainsAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1318,7 +1364,7 @@ namespace StackExchange.Redis
         /// <param name="limit">The number of elements to check (defaults to 0 and means unlimited).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The cardinality (number of elements) of the set, or 0 if key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/scard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/scard"/></remarks>
         Task<long> SetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1327,7 +1373,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The cardinality (number of elements) of the set, or 0 if key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/scard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/scard"/></remarks>
         Task<long> SetLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1336,7 +1382,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>All elements of the set.</returns>
-        /// <remarks>https://redis.io/commands/smembers</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/smembers"/></remarks>
         Task<RedisValue[]> SetMembersAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1352,7 +1398,7 @@ namespace StackExchange.Redis
         /// <see langword="true"/> if the element is moved.
         /// <see langword="false"/> if the element is not a member of source and no operation was performed.
         /// </returns>
-        /// <remarks>https://redis.io/commands/smove</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/smove"/></remarks>
         Task<bool> SetMoveAsync(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1361,7 +1407,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The removed element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/spop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/spop"/></remarks>
         Task<RedisValue> SetPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1371,16 +1417,16 @@ namespace StackExchange.Redis
         /// <param name="count">The number of elements to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of elements, or an empty array when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/spop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/spop"/></remarks>
         Task<RedisValue[]> SetPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Return a random element from the set value stored at key.
+        /// Return a random element from the set value stored at <paramref name="key"/>.
         /// </summary>
         /// <param name="key">The key of the set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The randomly selected element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/srandmember</remarks>
+        /// <returns>The randomly selected element, or <see cref="RedisValue.Null"/> when <paramref name="key"/> does not exist.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/srandmember"/></remarks>
         Task<RedisValue> SetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1391,8 +1437,8 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the set.</param>
         /// <param name="count">The count of members to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>An array of elements, or an empty array when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/srandmember</remarks>
+        /// <returns>An array of elements, or an empty array when <paramref name="key"/> does not exist.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/srandmember"/></remarks>
         Task<RedisValue[]> SetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1403,7 +1449,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the specified member was already present in the set, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/srem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/srem"/></remarks>
         Task<bool> SetRemoveAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1414,7 +1460,7 @@ namespace StackExchange.Redis
         /// <param name="values">The values to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of members that were removed from the set, not including non existing members.</returns>
-        /// <remarks>https://redis.io/commands/srem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/srem"/></remarks>
         Task<long> SetRemoveAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1428,7 +1474,7 @@ namespace StackExchange.Redis
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the set.</returns>
-        /// <remarks>https://redis.io/commands/sscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sscan"/></remarks>
         IAsyncEnumerable<RedisValue> SetScanAsync(RedisKey key, RedisValue pattern = default, int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1448,7 +1494,7 @@ namespace StackExchange.Redis
         /// <param name="get">The key pattern to sort by, if any e.g. ExternalKey_* would return the value of ExternalKey_{listvalue} for each entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The sorted elements, or the external values if <c>get</c> is specified.</returns>
-        /// <remarks>https://redis.io/commands/sort</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
         Task<RedisValue[]> SortAsync(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1456,7 +1502,7 @@ namespace StackExchange.Redis
         /// By default, the elements themselves are compared, but the values can also be used to perform external key-lookups using the <c>by</c> parameter.
         /// By default, the elements themselves are returned, but external key-lookups (one or many) can be performed instead by specifying
         /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
-        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
+        /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation</a> for examples is recommended.
         /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
         /// </summary>
         /// <param name="destination">The destination key to store results in.</param>
@@ -1469,7 +1515,7 @@ namespace StackExchange.Redis
         /// <param name="get">The key pattern to sort by, if any e.g. ExternalKey_* would return the value of ExternalKey_{listvalue} for each entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements stored in the new list.</returns>
-        /// <remarks>https://redis.io/commands/sort</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
         Task<long> SortAndStoreAsync(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1481,7 +1527,7 @@ namespace StackExchange.Redis
         /// <param name="score">The score for the member to add to the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, CommandFlags flags);
 
         /// <summary>
@@ -1494,7 +1540,7 @@ namespace StackExchange.Redis
         /// <param name="when">What conditions to add the element under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the value was added. <see langword="false"/> if it already existed (the score is still updated).</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1505,7 +1551,7 @@ namespace StackExchange.Redis
         /// <param name="values">The members and values to add to the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements added to the sorted sets, not including elements already existing for which the score was updated.</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, CommandFlags flags);
 
         /// <summary>
@@ -1517,7 +1563,7 @@ namespace StackExchange.Redis
         /// <param name="when">What conditions to add the element under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements added to the sorted sets, not including elements already existing for which the score was updated.</returns>
-        /// <remarks>https://redis.io/commands/zadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zadd"/></remarks>
         Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1530,10 +1576,12 @@ namespace StackExchange.Redis
         /// <param name="weights">The optional weights per set that correspond to <paramref name="keys"/>.</param>
         /// <param name="aggregate">The aggregation method (defaults to <see cref="Aggregate.Sum"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunion</remarks>
-        /// <remarks>https://redis.io/commands/zinter</remarks>
-        /// <remarks>https://redis.io/commands/zdiff</remarks>
         /// <returns>The resulting sorted set.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunion"/>,
+        /// <seealso href="https://redis.io/commands/zinter"/>,
+        /// <seealso href="https://redis.io/commands/zdiff"/>
+        /// </remarks>
         Task<RedisValue[]> SortedSetCombineAsync(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1546,10 +1594,12 @@ namespace StackExchange.Redis
         /// <param name="weights">The optional weights per set that correspond to <paramref name="keys"/>.</param>
         /// <param name="aggregate">The aggregation method (defaults to <see cref="Aggregate.Sum"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunion</remarks>
-        /// <remarks>https://redis.io/commands/zinter</remarks>
-        /// <remarks>https://redis.io/commands/zdiff</remarks>
         /// <returns>The resulting sorted set with scores.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunion"/>,
+        /// <seealso href="https://redis.io/commands/zinter"/>,
+        /// <seealso href="https://redis.io/commands/zdiff"/>
+        /// </remarks>
         Task<SortedSetEntry[]> SortedSetCombineWithScoresAsync(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1563,10 +1613,12 @@ namespace StackExchange.Redis
         /// <param name="second">The key of the second sorted set.</param>
         /// <param name="aggregate">The aggregation method (defaults to sum).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunionstore</remarks>
-        /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <remarks>https://redis.io/commands/zdiffstore</remarks>
         /// <returns>The number of elements in the resulting sorted set at destination.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunionstore"/>,
+        /// <seealso href="https://redis.io/commands/zinterstore"/>,
+        /// <seealso href="https://redis.io/commands/zdiffstore"/>
+        /// </remarks>
         Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1580,10 +1632,12 @@ namespace StackExchange.Redis
         /// <param name="weights">The optional weights per set that correspond to <paramref name="keys"/>.</param>
         /// <param name="aggregate">The aggregation method (defaults to sum).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zunionstore</remarks>
-        /// <remarks>https://redis.io/commands/zinterstore</remarks>
-        /// <remarks>https://redis.io/commands/zdiffstore</remarks>
         /// <returns>The number of elements in the resulting sorted set at destination.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zunionstore"/>,
+        /// <seealso href="https://redis.io/commands/zinterstore"/>,
+        /// <seealso href="https://redis.io/commands/zdiffstore"/>
+        /// </remarks>
         Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1595,7 +1649,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The new score of member.</returns>
-        /// <remarks>https://redis.io/commands/zincrby</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zincrby"/></remarks>
         Task<double> SortedSetDecrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1606,7 +1660,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The new score of member.</returns>
-        /// <remarks>https://redis.io/commands/zincrby</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zincrby"/></remarks>
         Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1616,7 +1670,7 @@ namespace StackExchange.Redis
         /// <param name="limit">If the intersection cardinality reaches <paramref name="limit"/> partway through the computation, the algorithm will exit and yield <paramref name="limit"/> as the cardinality (defaults to 0 meaning unlimited).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the resulting intersection.</returns>
-        /// <remarks>https://redis.io/commands/zintercard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zintercard"/></remarks>
         Task<long> SortedSetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1628,7 +1682,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Whether to exclude <paramref name="min"/> and <paramref name="max"/> from the range check (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The cardinality (number of elements) of the sorted set, or 0 if key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zcard</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zcard"/></remarks>
         Task<long> SortedSetLengthAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1641,7 +1695,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Whether to exclude <paramref name="min"/> and <paramref name="max"/> from the range check (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements in the specified score range.</returns>
-        /// <remarks>https://redis.io/commands/zlexcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zlexcount"/></remarks>
         Task<long> SortedSetLengthByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1650,7 +1704,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the sorted set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected element, or <see cref="RedisValue.Null"/> when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zrandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrandmember"/></remarks>
         Task<RedisValue> SortedSetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1669,7 +1723,7 @@ namespace StackExchange.Redis
         /// </param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected elements, or an empty array when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zrandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrandmember"/></remarks>
         Task<RedisValue[]> SortedSetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1688,7 +1742,7 @@ namespace StackExchange.Redis
         /// </param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The randomly selected elements with scores, or an empty array when <paramref name="key"/> does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zrandmember</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrandmember"/></remarks>
         Task<SortedSetEntry[]> SortedSetRandomMembersWithScoresAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1704,8 +1758,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified range.</returns>
-        /// <remarks>https://redis.io/commands/zrange</remarks>
-        /// <remarks>https://redis.io/commands/zrevrange</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrange"/>,
+        /// <seealso href="https://redis.io/commands/zrevrange"/>
+        /// </remarks>
         Task<RedisValue[]> SortedSetRangeByRankAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1726,8 +1782,8 @@ namespace StackExchange.Redis
         /// <param name="skip">The number of elements into the sorted set to skip. Note: this iterates after sorting so incurs O(n) cost for large values.</param>
         /// <param name="take">The maximum number of elements to pull into the new (<paramref name="destinationKey"/>) set.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zrangestore</remarks>
         /// <returns>The cardinality of (number of elements in) the newly created sorted set.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/zrangestore"/></remarks>
         Task<long> SortedSetRangeAndStoreAsync(
             RedisKey sourceKey,
             RedisKey destinationKey,
@@ -1753,8 +1809,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified range.</returns>
-        /// <remarks>https://redis.io/commands/zrange</remarks>
-        /// <remarks>https://redis.io/commands/zrevrange</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrange"/>,
+        /// <seealso href="https://redis.io/commands/zrevrange"/>
+        /// </remarks>
         Task<SortedSetEntry[]> SortedSetRangeByRankWithScoresAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1773,8 +1831,10 @@ namespace StackExchange.Redis
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified score range.</returns>
-        /// <remarks>https://redis.io/commands/zrangebyscore</remarks>
-        /// <remarks>https://redis.io/commands/zrevrangebyscore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrangebyscore"/>,
+        /// <seealso href="https://redis.io/commands/zrevrangebyscore"/>
+        /// </remarks>
         Task<RedisValue[]> SortedSetRangeByScoreAsync(RedisKey key,
             double start = double.NegativeInfinity,
             double stop = double.PositiveInfinity,
@@ -1800,8 +1860,10 @@ namespace StackExchange.Redis
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>List of elements in the specified score range.</returns>
-        /// <remarks>https://redis.io/commands/zrangebyscore</remarks>
-        /// <remarks>https://redis.io/commands/zrevrangebyscore</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrangebyscore"/>,
+        /// <seealso href="https://redis.io/commands/zrevrangebyscore"/>
+        /// </remarks>
         Task<SortedSetEntry[]> SortedSetRangeByScoreWithScoresAsync(RedisKey key,
             double start = double.NegativeInfinity,
             double stop = double.PositiveInfinity,
@@ -1822,8 +1884,8 @@ namespace StackExchange.Redis
         /// <param name="skip">How many items to skip.</param>
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zrangebylex</remarks>
         /// <returns>List of elements in the specified score range.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/zrangebylex"/></remarks>
         Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key,
             RedisValue min,
             RedisValue max,
@@ -1844,9 +1906,11 @@ namespace StackExchange.Redis
         /// <param name="skip">How many items to skip.</param>
         /// <param name="take">How many items to take.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>https://redis.io/commands/zrangebylex</remarks>
-        /// <remarks>https://redis.io/commands/zrevrangebylex</remarks>
         /// <returns>List of elements in the specified score range.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrangebylex"/>,
+        /// <seealso href="https://redis.io/commands/zrevrangebylex"/>
+        /// </remarks>
         Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key,
             RedisValue min = default,
             RedisValue max = default,
@@ -1865,8 +1929,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>If member exists in the sorted set, the rank of member. If member does not exist in the sorted set or key does not exist, <see langword="null"/>.</returns>
-        /// <remarks>https://redis.io/commands/zrank</remarks>
-        /// <remarks>https://redis.io/commands/zrevrank</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zrank"/>,
+        /// <seealso href="https://redis.io/commands/zrevrank"/>
+        /// </remarks>
         Task<long?> SortedSetRankAsync(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1876,7 +1942,7 @@ namespace StackExchange.Redis
         /// <param name="member">The member to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the member existed in the sorted set and was removed. <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/zrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrem"/></remarks>
         Task<bool> SortedSetRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1886,7 +1952,7 @@ namespace StackExchange.Redis
         /// <param name="members">The members to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of members removed from the sorted set, not including non existing members.</returns>
-        /// <remarks>https://redis.io/commands/zrem</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zrem"/></remarks>
         Task<long> SortedSetRemoveAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1900,7 +1966,7 @@ namespace StackExchange.Redis
         /// <param name="stop">The maximum rank to remove.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements removed.</returns>
-        /// <remarks>https://redis.io/commands/zremrangebyrank</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zremrangebyrank"/></remarks>
         Task<long> SortedSetRemoveRangeByRankAsync(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1912,7 +1978,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Which of <paramref name="start"/> and <paramref name="stop"/> to exclude (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements removed.</returns>
-        /// <remarks>https://redis.io/commands/zremrangebyscore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zremrangebyscore"/></remarks>
         Task<long> SortedSetRemoveRangeByScoreAsync(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1925,7 +1991,7 @@ namespace StackExchange.Redis
         /// <param name="exclude">Which of <paramref name="min"/> and <paramref name="max"/> to exclude (defaults to both inclusive).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of elements removed.</returns>
-        /// <remarks>https://redis.io/commands/zremrangebylex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zremrangebylex"/></remarks>
         Task<long> SortedSetRemoveRangeByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1938,7 +2004,7 @@ namespace StackExchange.Redis
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Yields all matching elements of the sorted set.</returns>
-        /// <remarks>https://redis.io/commands/zscan</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zscan"/></remarks>
         IAsyncEnumerable<SortedSetEntry> SortedSetScanAsync(RedisKey key,
             RedisValue pattern = default,
             int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize,
@@ -1954,7 +2020,7 @@ namespace StackExchange.Redis
         /// <param name="member">The member to get a score for.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The score of the member.</returns>
-        /// <remarks>https://redis.io/commands/zscore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zscore"/></remarks>
         Task<double?> SortedSetScoreAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1968,7 +2034,7 @@ namespace StackExchange.Redis
         /// The scores of the members in the same order as the <paramref name="members"/> array.
         /// If a member does not exist in the set, <see langword="null"/> is returned.
         /// </returns>
-        /// <remarks>https://redis.io/commands/zmscore</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/zmscore"/></remarks>
         Task<double?[]> SortedSetScoresAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1978,8 +2044,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The removed element, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zpopmin</remarks>
-        /// <remarks>https://redis.io/commands/zpopmax</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zpopmin"/>,
+        /// <seealso href="https://redis.io/commands/zpopmax"/>
+        /// </remarks>
         Task<SortedSetEntry?> SortedSetPopAsync(RedisKey key, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -1990,8 +2058,10 @@ namespace StackExchange.Redis
         /// <param name="order">The order to sort by (defaults to ascending).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An array of elements, or an empty array when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/zpopmin</remarks>
-        /// <remarks>https://redis.io/commands/zpopmax</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/zpopmin"/>,
+        /// <seealso href="https://redis.io/commands/zpopmax"/>
+        /// </remarks>
         Task<SortedSetEntry[]> SortedSetPopAsync(RedisKey key, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2002,7 +2072,7 @@ namespace StackExchange.Redis
         /// <param name="messageId">The ID of the message to acknowledge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages acknowledged.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<long> StreamAcknowledgeAsync(RedisKey key, RedisValue groupName, RedisValue messageId, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2013,7 +2083,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to acknowledge.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages acknowledged.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<long> StreamAcknowledgeAsync(RedisKey key, RedisValue groupName, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2029,7 +2099,7 @@ namespace StackExchange.Redis
         /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed max length by a small number. This improves performance when removing messages.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The ID of the newly created message.</returns>
-        /// <remarks>https://redis.io/commands/xadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xadd"/></remarks>
         Task<RedisValue> StreamAddAsync(RedisKey key, RedisValue streamField, RedisValue streamValue, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2044,7 +2114,7 @@ namespace StackExchange.Redis
         /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed max length by a small number. This improves performance when removing messages.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The ID of the newly created message.</returns>
-        /// <remarks>https://redis.io/commands/xadd</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xadd"/></remarks>
         Task<RedisValue> StreamAddAsync(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2058,7 +2128,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to claim for the given consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The messages successfully claimed by the given consumer.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<StreamEntry[]> StreamClaimAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2072,7 +2142,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to claim for the given consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The message IDs for the messages successfully claimed by the given consumer.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<RedisValue[]> StreamClaimIdsOnlyAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2083,6 +2153,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position from which to read for the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if successful, <see langword="false"/> otherwise.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<bool> StreamConsumerGroupSetPositionAsync(RedisKey key, RedisValue groupName, RedisValue position, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2093,7 +2164,7 @@ namespace StackExchange.Redis
         /// <param name="groupName">The consumer group name.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An instance of <see cref="StreamConsumerInfo"/> for each of the consumer group's consumers.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<StreamConsumerInfo[]> StreamConsumerInfoAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2104,7 +2175,7 @@ namespace StackExchange.Redis
         /// <param name="position">The position to begin reading the stream. Defaults to <see cref="StreamPosition.NewMessages"/>.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<bool> StreamCreateConsumerGroupAsync(RedisKey key, RedisValue groupName, RedisValue? position, CommandFlags flags);
 
         /// <summary>
@@ -2116,7 +2187,7 @@ namespace StackExchange.Redis
         /// <param name="createStream">Create the stream if it does not already exist.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the group was created, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<bool> StreamCreateConsumerGroupAsync(RedisKey key, RedisValue groupName, RedisValue? position = null, bool createStream = true, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2126,7 +2197,7 @@ namespace StackExchange.Redis
         /// <param name="messageIds">The IDs of the messages to delete.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns the number of messages successfully deleted from the stream.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<long> StreamDeleteAsync(RedisKey key, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2137,6 +2208,7 @@ namespace StackExchange.Redis
         /// <param name="consumerName">The name of the consumer.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages that were pending for the deleted consumer.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<long> StreamDeleteConsumerAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2146,6 +2218,7 @@ namespace StackExchange.Redis
         /// <param name="groupName">The name of the consumer group.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if deleted, <see langword="false"/> otherwise.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<bool> StreamDeleteConsumerGroupAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2154,7 +2227,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An instance of <see cref="StreamGroupInfo"/> for each of the stream's groups.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<StreamGroupInfo[]> StreamGroupInfoAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2163,7 +2236,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A <see cref="StreamInfo"/> instance with information about the stream.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<StreamInfo> StreamInfoAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2172,7 +2245,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of entries inside the given stream.</returns>
-        /// <remarks>https://redis.io/commands/xlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xlen"/></remarks>
         Task<long> StreamLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2188,7 +2261,7 @@ namespace StackExchange.Redis
         /// The highest and lowest ID of the pending messages, and the consumers with their pending message count.
         /// </returns>
         /// <remarks>The equivalent of calling XPENDING key group.</remarks>
-        /// <remarks>https://redis.io/commands/xpending</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xpending"/></remarks>
         Task<StreamPendingInfo> StreamPendingAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2203,7 +2276,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>An instance of <see cref="StreamPendingMessageInfo"/> for each pending message.</returns>
         /// <remarks>Equivalent of calling XPENDING key group start-id end-id count consumer-name.</remarks>
-        /// <remarks>https://redis.io/commands/xpending</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xpending"/></remarks>
         Task<StreamPendingMessageInfo[]> StreamPendingMessagesAsync(RedisKey key, RedisValue groupName, int count, RedisValue consumerName, RedisValue? minId = null, RedisValue? maxId = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2216,7 +2289,7 @@ namespace StackExchange.Redis
         /// <param name="messageOrder">The order of the messages. <see cref="Order.Ascending"/> will execute XRANGE and <see cref="Order.Descending"/> will execute XREVRANGE.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>https://redis.io/commands/xrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xrange"/></remarks>
         Task<StreamEntry[]> StreamRangeAsync(RedisKey key, RedisValue? minId = null, RedisValue? maxId = null, int? count = null, Order messageOrder = Order.Ascending, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2227,8 +2300,10 @@ namespace StackExchange.Redis
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns an instance of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key id.</remarks>
-        /// <remarks>https://redis.io/commands/xread</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREAD COUNT num STREAMS key id</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xread"/></para>
+        /// </remarks>
         Task<StreamEntry[]> StreamReadAsync(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2238,8 +2313,10 @@ namespace StackExchange.Redis
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
-        /// <remarks>Equivalent of calling XREAD COUNT num STREAMS key1 key2 id1 id2.</remarks>
-        /// <remarks>https://redis.io/commands/xread</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREAD COUNT num STREAMS key1 key2 id1 id2</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xread"/></para>
+        /// </remarks>
         Task<RedisStream[]> StreamReadAsync(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2252,7 +2329,7 @@ namespace StackExchange.Redis
         /// <param name="count">The maximum number of messages to return.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xreadgroup"/></remarks>
         Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position, int? count, CommandFlags flags);
 
         /// <summary>
@@ -2266,7 +2343,7 @@ namespace StackExchange.Redis
         /// <param name="noAck">When true, the message will not be added to the pending message list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>Returns a value of <see cref="StreamEntry"/> for each message returned.</returns>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/xreadgroup"/></remarks>
         Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2279,8 +2356,10 @@ namespace StackExchange.Redis
         /// <param name="countPerStream">The maximum number of messages to return from each stream.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
-        /// <remarks>Equivalent of calling XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</remarks>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xreadgroup"/></para>
+        /// </remarks>
         Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream, CommandFlags flags);
 
         /// <summary>
@@ -2294,8 +2373,10 @@ namespace StackExchange.Redis
         /// <param name="noAck">When true, the message will not be added to the pending message list.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>A value of <see cref="RedisStream"/> for each stream.</returns>
-        /// <remarks>Equivalent of calling XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</remarks>
-        /// <remarks>https://redis.io/commands/xreadgroup</remarks>
+        /// <remarks>
+        /// <para>Equivalent of calling <c>XREADGROUP GROUP groupName consumerName COUNT countPerStream STREAMS stream1 stream2 id1 id2</c>.</para>
+        /// <para><seealso href="https://redis.io/commands/xreadgroup"/></para>
+        /// </remarks>
         Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, bool noAck = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2306,7 +2387,7 @@ namespace StackExchange.Redis
         /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed max length by a small number. This improves performance when removing messages.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages removed from the stream.</returns>
-        /// <remarks>https://redis.io/topics/streams-intro</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2317,7 +2398,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to append to the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string after the append operation.</returns>
-        /// <remarks>https://redis.io/commands/append</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/append"/></remarks>
         Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2331,7 +2412,7 @@ namespace StackExchange.Redis
         /// <param name="end">The end byte to count at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of bits set to 1.</returns>
-        /// <remarks>https://redis.io/commands/bitcount</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bitcount"/></remarks>
         Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2346,7 +2427,7 @@ namespace StackExchange.Redis
         /// <param name="second">The second key to get the bit value from.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The size of the string stored in the destination key, that is equal to the size of the longest input string.</returns>
-        /// <remarks>https://redis.io/commands/bitop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bitop"/></remarks>
         Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second = default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2359,7 +2440,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys to get the bit values from.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The size of the string stored in the destination key, that is equal to the size of the longest input string.</returns>
-        /// <remarks>https://redis.io/commands/bitop</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/bitop"/></remarks>
         Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2373,9 +2454,11 @@ namespace StackExchange.Redis
         /// <param name="start">The position to start looking (defaults to 0).</param>
         /// <param name="end">The position to stop looking (defaults to -1, unlimited).</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <returns>The command returns the position of the first bit set to 1 or 0 according to the request.
-        /// If we look for set bits(the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.</returns>
-        /// <remarks>https://redis.io/commands/bitpos</remarks>
+        /// <returns>
+        /// The command returns the position of the first bit set to 1 or 0 according to the request.
+        /// If we look for set bits(the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.
+        /// </returns>
+        /// <remarks><seealso href="https://redis.io/commands/bitpos"/></remarks>
         Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2388,8 +2471,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the decrement.</returns>
-        /// <remarks>https://redis.io/commands/decrby</remarks>
-        /// <remarks>https://redis.io/commands/decr</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/decrby"/>,
+        /// <seealso href="https://redis.io/commands/decr"/>
+        /// </remarks>
         Task<long> StringDecrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2401,7 +2486,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to decrement by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the decrement.</returns>
-        /// <remarks>https://redis.io/commands/incrbyfloat</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/incrbyfloat"/></remarks>
         Task<double> StringDecrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2411,7 +2496,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/get"/></remarks>
         Task<RedisValue> StringGetAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2421,7 +2506,7 @@ namespace StackExchange.Redis
         /// <param name="keys">The keys of the strings.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The values of the strings with nil for keys do not exist.</returns>
-        /// <remarks>https://redis.io/commands/mget</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/mget"/></remarks>
         Task<RedisValue[]> StringGetAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2431,7 +2516,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/get"/></remarks>
         Task<Lease<byte>?> StringGetLeaseAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2442,7 +2527,7 @@ namespace StackExchange.Redis
         /// <param name="offset">The offset in the string to get a bit at.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The bit value stored at offset.</returns>
-        /// <remarks>https://redis.io/commands/getbit</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getbit"/></remarks>
         Task<bool> StringGetBitAsync(RedisKey key, long offset, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2455,7 +2540,7 @@ namespace StackExchange.Redis
         /// <param name="end">The end index of the substring to get.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The substring of the string value stored at key.</returns>
-        /// <remarks>https://redis.io/commands/getrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getrange"/></remarks>
         Task<RedisValue> StringGetRangeAsync(RedisKey key, long start, long end, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2465,7 +2550,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to replace the existing value with.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The old value stored at key, or nil when key did not exist.</returns>
-        /// <remarks>https://redis.io/commands/getset</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getset"/></remarks>
         Task<RedisValue> StringGetSetAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2476,7 +2561,7 @@ namespace StackExchange.Redis
         /// <param name="expiry">The expiry to set. <see langword="null"/> will remove expiry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/getex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getex"/></remarks>
         Task<RedisValue> StringGetSetExpiryAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2487,7 +2572,7 @@ namespace StackExchange.Redis
         /// <param name="expiry">The exact date and time to expire at. <see cref="DateTime.MaxValue"/> will remove expiry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/getex</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getex"/></remarks>
         Task<RedisValue> StringGetSetExpiryAsync(RedisKey key, DateTime expiry, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2498,7 +2583,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/getdelete</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/getdelete"/></remarks>
         Task<RedisValue> StringGetDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2509,7 +2594,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key and its expiry, or nil when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/get"/></remarks>
         Task<RedisValueWithExpiry> StringGetWithExpiryAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2522,8 +2607,10 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the increment.</returns>
-        /// <remarks>https://redis.io/commands/incrby</remarks>
-        /// <remarks>https://redis.io/commands/incr</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/incrby"/>,
+        /// <seealso href="https://redis.io/commands/incr"/>
+        /// </remarks>
         Task<long> StringIncrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2535,7 +2622,7 @@ namespace StackExchange.Redis
         /// <param name="value">The amount to increment by (defaults to 1).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The value of key after the increment.</returns>
-        /// <remarks>https://redis.io/commands/incrbyfloat</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/incrbyfloat"/></remarks>
         Task<double> StringIncrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2544,7 +2631,7 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string at key, or 0 when key does not exist.</returns>
-        /// <remarks>https://redis.io/commands/strlen</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/strlen"/></remarks>
         Task<long> StringLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None);
 
         /// <inheritdoc cref="StringSetAsync(RedisKey, RedisValue, TimeSpan?, bool, When, CommandFlags)" />
@@ -2565,7 +2652,7 @@ namespace StackExchange.Redis
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the string was set, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/set"/></remarks>
         Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2576,8 +2663,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which condition to set the value under (defaults to always).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns><see langword="true"/> if the keys were set, <see langword="false"/> otherwise.</returns>
-        /// <remarks>https://redis.io/commands/mset</remarks>
-        /// <remarks>https://redis.io/commands/msetnx</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/mset"/>,
+        /// <seealso href="https://redis.io/commands/msetnx"/>
+        /// </remarks>
         Task<bool> StringSetAsync(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2589,8 +2678,10 @@ namespace StackExchange.Redis
         /// <param name="when">Which condition to set the value under (defaults to <see cref="When.Always"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The previous value stored at <paramref name="key"/>, or nil when key did not exist.</returns>
-        /// <remarks>This method uses the SET command with the GET option introduced in Redis 6.2.0 instead of the deprecated GETSET command.</remarks>
-        /// <remarks>https://redis.io/commands/set</remarks>
+        /// <remarks>
+        /// <para>This method uses the <c>SET</c> command with the <c>GET</c> option introduced in Redis 6.2.0 instead of the deprecated <c>GETSET</c> command.</para>
+        /// <para><seealso href="https://redis.io/commands/set"/></para>
+        /// </remarks>
         Task<RedisValue> StringSetAndGetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags);
 
         /// <summary>
@@ -2604,7 +2695,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The previous value stored at <paramref name="key"/>, or nil when key did not exist.</returns>
         /// <remarks>This method uses the SET command with the GET option introduced in Redis 6.2.0 instead of the deprecated GETSET command.</remarks>
-        /// <remarks>https://redis.io/commands/set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/set"/></remarks>
         Task<RedisValue> StringSetAndGetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2617,7 +2708,7 @@ namespace StackExchange.Redis
         /// <param name="bit">The bit value to set, true for 1, false for 0.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The original bit value stored at offset.</returns>
-        /// <remarks>https://redis.io/commands/setbit</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/setbit"/></remarks>
         Task<bool> StringSetBitAsync(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -2630,7 +2721,7 @@ namespace StackExchange.Redis
         /// <param name="value">The value to overwrite with.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The length of the string after it was modified by the command.</returns>
-        /// <remarks>https://redis.io/commands/setrange</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/setrange"/></remarks>
         Task<RedisValue> StringSetRangeAsync(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None);
     }
 }

--- a/src/StackExchange.Redis/Interfaces/IRedis.cs
+++ b/src/StackExchange.Redis/Interfaces/IRedis.cs
@@ -12,7 +12,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The command flags to use when pinging.</param>
         /// <returns>The observed latency.</returns>
-        /// <remarks>https://redis.io/commands/ping</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/ping"/></remarks>
         TimeSpan Ping(CommandFlags flags = CommandFlags.None);
     }
 }

--- a/src/StackExchange.Redis/Interfaces/IRedisAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IRedisAsync.cs
@@ -18,7 +18,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>The observed latency.</returns>
-        /// <remarks>https://redis.io/commands/ping</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/ping"/></remarks>
         Task<TimeSpan> PingAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>

--- a/src/StackExchange.Redis/Interfaces/IServer.cs
+++ b/src/StackExchange.Redis/Interfaces/IServer.cs
@@ -73,27 +73,18 @@ namespace StackExchange.Redis
         int DatabaseCount { get; }
 
         /// <summary>
-        /// The CLIENT KILL command closes a given client connection identified by ip:port.
-        /// The ip:port should match a line returned by the CLIENT LIST command.
+        /// The <c>CLIENT KILL</c> command closes a given client connection identified by <c>ip:port</c>.
+        /// The <c>ip:port</c> should match a line returned by the <c>CLIENT LIST</c> command.
         /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection while it is executing a command.
         /// From the client point of view, the connection can never be closed in the middle of the execution of a command.
         /// However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
         /// </summary>
         /// <param name="endpoint">The endpoint of the client to kill.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/client-kill</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/client-kill"/></remarks>
         void ClientKill(EndPoint endpoint, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The CLIENT KILL command closes a given client connection identified by ip:port.
-        /// The ip:port should match a line returned by the CLIENT LIST command.
-        /// Due to the single-threaded nature of Redis, it is not possible to kill a client connection while it is executing a command.
-        /// From the client point of view, the connection can never be closed in the middle of the execution of a command.
-        /// However, the client will notice the connection has been closed only when the next command is sent (and results in network error).
-        /// </summary>
-        /// <param name="endpoint">The endpoint of the client to kill.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/client-kill</remarks>
+        /// <inheritdoc cref="ClientKill(EndPoint, CommandFlags)"/>
         Task ClientKillAsync(EndPoint endpoint, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -105,61 +96,40 @@ namespace StackExchange.Redis
         /// <param name="skipMe">Whether to skip the current connection.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>the number of clients killed.</returns>
-        /// <remarks>https://redis.io/commands/client-kill</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/client-kill"/></remarks>
         long ClientKill(long? id = null, ClientType? clientType = null, EndPoint? endpoint = null, bool skipMe = true, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The CLIENT KILL command closes multiple connections that match the specified filters.
-        /// </summary>
-        /// <param name="id">The ID of the client to kill.</param>
-        /// <param name="clientType">The type of client.</param>
-        /// <param name="endpoint">The endpoint to kill.</param>
-        /// <param name="skipMe">Whether to skip the current connection.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>the number of clients killed.</returns>
-        /// <remarks>https://redis.io/commands/client-kill</remarks>
+        /// <inheritdoc cref="ClientKill(long?, ClientType?, EndPoint?, bool, CommandFlags)"/>
         Task<long> ClientKillAsync(long? id = null, ClientType? clientType = null, EndPoint? endpoint = null, bool skipMe = true, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The CLIENT LIST command returns information and statistics about the client connections server in a mostly human readable format.
+        /// The <c>CLIENT LIST</c> command returns information and statistics about the client connections server in a mostly human readable format.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/client-list</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/client-list"/></remarks>
         ClientInfo[] ClientList(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The CLIENT LIST command returns information and statistics about the client connections server in a mostly human readable format.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/client-list</remarks>
+        /// <inheritdoc cref="ClientList(CommandFlags)"/>
         Task<ClientInfo[]> ClientListAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Obtains the current CLUSTER NODES output from a cluster server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/cluster-nodes/</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/cluster-nodes/"/></remarks>
         ClusterConfiguration? ClusterNodes(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Obtains the current CLUSTER NODES output from a cluster server.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/cluster-nodes/</remarks>
+        /// <inheritdoc cref="ClusterNodes(CommandFlags)"/>
         Task<ClusterConfiguration?> ClusterNodesAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Obtains the current raw CLUSTER NODES output from a cluster server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/cluster-nodes/</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/cluster-nodes/"/></remarks>
         string? ClusterNodesRaw(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Obtains the current raw CLUSTER NODES output from a cluster server.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/cluster-nodes/</remarks>
+        /// <inheritdoc cref="ClusterNodesRaw(CommandFlags)"/>
         Task<string?> ClusterNodesRawAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -168,30 +138,20 @@ namespace StackExchange.Redis
         /// <param name="pattern">The pattern of config values to get.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>All matching configuration parameters.</returns>
-        /// <remarks>https://redis.io/commands/config-get</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/config-get"/></remarks>
         KeyValuePair<string, string>[] ConfigGet(RedisValue pattern = default, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Get all configuration parameters matching the specified pattern.
-        /// </summary>
-        /// <param name="pattern">The pattern of config values to get.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>All matching configuration parameters.</returns>
-        /// <remarks>https://redis.io/commands/config-get</remarks>
+        /// <inheritdoc cref="ConfigGet(RedisValue, CommandFlags)"/>
         Task<KeyValuePair<string, string>[]> ConfigGetAsync(RedisValue pattern = default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Resets the statistics reported by Redis using the INFO command.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/config-resetstat</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/config-resetstat"/></remarks>
         void ConfigResetStatistics(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Resets the statistics reported by Redis using the INFO command.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/config-resetstat</remarks>
+        /// <inheritdoc cref="ConfigResetStatistics(CommandFlags)"/>
         Task ConfigResetStatisticsAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -200,16 +160,10 @@ namespace StackExchange.Redis
         /// used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/config-rewrite</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/config-rewrite"/></remarks>
         void ConfigRewrite(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The CONFIG REWRITE command rewrites the redis.conf file the server was started with,
-        /// applying the minimal changes needed to make it reflecting the configuration currently
-        /// used by the server, that may be different compared to the original one because of the use of the CONFIG SET command.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/config-rewrite</remarks>
+        /// <inheritdoc cref="ConfigRewrite(CommandFlags)"/>
         Task ConfigRewriteAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -219,17 +173,10 @@ namespace StackExchange.Redis
         /// <param name="setting">The setting name.</param>
         /// <param name="value">The new setting value.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/config-set</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/config-set"/></remarks>
         void ConfigSet(RedisValue setting, RedisValue value, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The CONFIG SET command is used in order to reconfigure the server at runtime without the need to restart Redis.
-        /// You can change both trivial parameters or switch from one to another persistence option using this command.
-        /// </summary>
-        /// <param name="setting">The setting name.</param>
-        /// <param name="value">The new setting value.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/config-set</remarks>
+        /// <inheritdoc cref="ConfigSet(RedisValue, RedisValue, CommandFlags)"/>
         Task ConfigSetAsync(RedisValue setting, RedisValue value, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -237,15 +184,10 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="database">The database ID.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/dbsize</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/dbsize"/></remarks>
         long DatabaseSize(int database = -1, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Return the number of keys in the database.
-        /// </summary>
-        /// <param name="database">The database ID.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/dbsize</remarks>
+        /// <inheritdoc cref="DatabaseSize(int, CommandFlags)"/>
         Task<long> DatabaseSizeAsync(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -253,15 +195,10 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="message">The message to echo.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/echo</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/echo"/></remarks>
         RedisValue Echo(RedisValue message, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Return the same message passed in.
-        /// </summary>
-        /// <param name="message">The message to echo.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/echo</remarks>
+        /// <inheritdoc cref="Echo(RedisValue, CommandFlags)"/>
         Task<RedisValue> EchoAsync(RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -271,31 +208,11 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <returns>A dynamic representation of the command's result.</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
         RedisResult Execute(string command, params object[] args);
 
-        /// <summary>
-        /// Execute an arbitrary command against the server; this is primarily intended for
-        /// executing modules, but may also be used to provide access to new features that lack
-        /// a direct API.
-        /// </summary>
-        /// <param name="command">The command to run.</param>
-        /// <param name="args">The arguments to pass for the command.</param>
-        /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
-        RedisResult Execute(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// Execute an arbitrary command against the server; this is primarily intended for
-        /// executing modules, but may also be used to provide access to new features that lack
-        /// a direct API.
-        /// </summary>
-        /// <param name="command">The command to run.</param>
-        /// <param name="args">The arguments to pass for the command.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <inheritdoc cref="Execute(string, object[])"/>
         Task<RedisResult> ExecuteAsync(string command, params object[] args);
 
         /// <summary>
@@ -306,22 +223,21 @@ namespace StackExchange.Redis
         /// <param name="command">The command to run.</param>
         /// <param name="args">The arguments to pass for the command.</param>
         /// <param name="flags">The flags to use for this operation.</param>
-        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful</remarks>
-        /// <returns>A dynamic representation of the command's result</returns>
+        /// <returns>A dynamic representation of the command's result.</returns>
+        /// <remarks>This API should be considered an advanced feature; inappropriate use can be harmful.</remarks>
+        RedisResult Execute(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="Execute(string, ICollection{object}, CommandFlags)"/>
         Task<RedisResult> ExecuteAsync(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Delete all the keys of all databases on the server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/flushall</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/flushall"/></remarks>
         void FlushAllDatabases(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Delete all the keys of all databases on the server.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/flushall</remarks>
+        /// <inheritdoc cref="FlushAllDatabases(CommandFlags)"/>
         Task FlushAllDatabasesAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -329,15 +245,10 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="database">The database ID.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/flushdb</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/flushdb"/></remarks>
         void FlushDatabase(int database = -1, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Delete all the keys of the database.
-        /// </summary>
-        /// <param name="database">The database ID.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/flushdb</remarks>
+        /// <inheritdoc cref="FlushDatabase(int, CommandFlags)"/>
         Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -350,15 +261,11 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="section">The info section to get, if getting a specific one.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/info</remarks>
+        /// <returns>A grouping of key/value pairs, grouped by their section header.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/info"/></remarks>
         IGrouping<string, KeyValuePair<string, string>>[] Info(RedisValue section = default, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
-        /// </summary>
-        /// <param name="section">The info section to get, if getting a specific one.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/info</remarks>
+        /// <inheritdoc cref="Info(RedisValue, CommandFlags)"/>
         Task<IGrouping<string, KeyValuePair<string, string>>[]> InfoAsync(RedisValue section = default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -366,33 +273,20 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="section">The info section to get, if getting a specific one.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/info</remarks>
+        /// <returns>The entire raw <c>INFO</c> string.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/info"/></remarks>
         string? InfoRaw(RedisValue section = default, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The INFO command returns information and statistics about the server in a format that is simple to parse by computers and easy to read by humans.
-        /// </summary>
-        /// <param name="section">The info section to get, if getting a specific one.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/info</remarks>
+        /// <inheritdoc cref="InfoRaw(RedisValue, CommandFlags)"/>
         Task<string?> InfoRawAsync(RedisValue section = default, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns all keys matching pattern; the KEYS or SCAN commands will be used based on the server capabilities.
-        /// </summary>
-        /// <param name="database">The database ID.</param>
-        /// <param name="pattern">The pattern to use.</param>
-        /// <param name="pageSize">The page size to iterate by.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
-        /// <remarks>https://redis.io/commands/keys</remarks>
-        /// <remarks>https://redis.io/commands/scan</remarks>
+        /// <inheritdoc cref="Keys(int, RedisValue, int, long, int, CommandFlags)"/>
         IEnumerable<RedisKey> Keys(int database, RedisValue pattern, int pageSize, CommandFlags flags);
 
         /// <summary>
-        /// Returns all keys matching pattern.
-        /// The KEYS or SCAN commands will be used based on the server capabilities.
-        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
+        /// Returns all keys matching <paramref name="pattern"/>.
+        /// The <c>KEYS</c> or <c>SCAN</c> commands will be used based on the server capabilities.
+        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <see cref="IScanningCursor"/>.
         /// </summary>
         /// <param name="database">The database ID.</param>
         /// <param name="pattern">The pattern to use.</param>
@@ -400,51 +294,33 @@ namespace StackExchange.Redis
         /// <param name="cursor">The cursor position to resume at.</param>
         /// <param name="pageOffset">The page offset to start at.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
-        /// <remarks>https://redis.io/commands/keys</remarks>
-        /// <remarks>https://redis.io/commands/scan</remarks>
+        /// <returns>An enumeration of matching redis keys.</returns>
+        /// <remarks>
+        /// <para>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</para>
+        /// <para>
+        /// <seealso href="https://redis.io/commands/keys"/>,
+        /// <seealso href="https://redis.io/commands/scan"/>
+        /// </para>
+        /// </remarks>
         IEnumerable<RedisKey> Keys(int database = -1, RedisValue pattern = default, int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns all keys matching pattern.
-        /// The KEYS or SCAN commands will be used based on the server capabilities.
-        /// Note: to resume an iteration via <i>cursor</i>, cast the original enumerable or enumerator to <i>IScanningCursor</i>.
-        /// </summary>
-        /// <param name="database">The database ID.</param>
-        /// <param name="pattern">The pattern to use.</param>
-        /// <param name="pageSize">The page size to iterate by.</param>
-        /// <param name="cursor">The cursor position to resume at.</param>
-        /// <param name="pageOffset">The page offset to start at.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>Warning: consider KEYS as a command that should only be used in production environments with extreme care.</remarks>
-        /// <remarks>https://redis.io/commands/keys</remarks>
-        /// <remarks>https://redis.io/commands/scan</remarks>
+        /// <inheritdoc cref="Keys(int, RedisValue, int, long, int, CommandFlags)"/>
         IAsyncEnumerable<RedisKey> KeysAsync(int database = -1, RedisValue pattern = default, int pageSize = RedisBase.CursorUtils.DefaultLibraryPageSize, long cursor = RedisBase.CursorUtils.Origin, int pageOffset = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Return the time of the last DB save executed with success.
-        /// A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command
-        /// and checking at regular intervals every N seconds if LASTSAVE changed.
+        /// A client may check if a <c>BGSAVE</c> command succeeded reading the <c>LASTSAVE</c> value, then issuing a BGSAVE command
+        /// and checking at regular intervals every N seconds if <c>LASTSAVE</c> changed.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/lastsave</remarks>
+        /// <returns>The last time a save was performed.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/lastsave"/></remarks>
         DateTime LastSave(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Return the time of the last DB save executed with success.
-        /// A client may check if a BGSAVE command succeeded reading the LASTSAVE value, then issuing a BGSAVE command
-        /// and checking at regular intervals every N seconds if LASTSAVE changed.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/lastsave</remarks>
+        /// <inheritdoc cref="LastSave(CommandFlags)"/>
         Task<DateTime> LastSaveAsync(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Promote the selected node to be primary.
-        /// </summary>
-        /// <param name="options">The options to use for this topology change.</param>
-        /// <param name="log">The log to write output to.</param>
-        /// <remarks>https://redis.io/commands/replicaof/</remarks>
+        /// <inheritdoc cref="MakePrimaryAsync(ReplicationChangeOptions, TextWriter?)"/>
         [Obsolete("Please use " + nameof(MakePrimaryAsync) + ", this will be removed in 3.0.")]
         void MakeMaster(ReplicationChangeOptions options, TextWriter? log = null);
 
@@ -453,19 +329,16 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="options">The options to use for this topology change.</param>
         /// <param name="log">The log to write output to.</param>
-        /// <remarks>https://redis.io/commands/replicaof/</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/replicaof/"/></remarks>
         Task MakePrimaryAsync(ReplicationChangeOptions options, TextWriter? log = null);
 
         /// <summary>
         /// Returns the role info for the current server.
         /// </summary>
-        /// <remarks>https://redis.io/commands/role</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/role"/></remarks>
         Role Role(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns the role info for the current server.
-        /// </summary>
-        /// <remarks>https://redis.io/commands/role</remarks>
+        /// <inheritdoc cref="Role(CommandFlags)"/>
         Task<Role> RoleAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -473,21 +346,15 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="type">The method of the save (e.g. background or foreground).</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
-        /// <remarks>https://redis.io/commands/bgsave</remarks>
-        /// <remarks>https://redis.io/commands/save</remarks>
-        /// <remarks>https://redis.io/topics/persistence</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/bgrewriteaof"/>,
+        /// <seealso href="https://redis.io/commands/bgsave"/>,
+        /// <seealso href="https://redis.io/commands/save"/>,
+        /// <seealso href="https://redis.io/topics/persistence"/>
+        /// </remarks>
         void Save(SaveType type, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Explicitly request the database to persist the current state to disk.
-        /// </summary>
-        /// <param name="type">The method of the save (e.g. background or foreground).</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/bgrewriteaof</remarks>
-        /// <remarks>https://redis.io/commands/bgsave</remarks>
-        /// <remarks>https://redis.io/commands/save</remarks>
-        /// <remarks>https://redis.io/topics/persistence</remarks>
+        /// <inheritdoc cref="Save(SaveType, CommandFlags)"/>
         Task SaveAsync(SaveType type, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -495,23 +362,10 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="script">The text of the script to check for on the server.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/script-exists/</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/script-exists/"/></remarks>
         bool ScriptExists(string script, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Indicates whether the specified script hash is defined on the server.
-        /// </summary>
-        /// <param name="sha1">The SHA1 of the script to check for on the server.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/script-exists/</remarks>
-        bool ScriptExists(byte[] sha1, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// Indicates whether the specified script is defined on the server.
-        /// </summary>
-        /// <param name="script">The text of the script to check for on the server.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/script-exists/</remarks>
+        /// <inheritdoc cref="ScriptExists(string, CommandFlags)"/>
         Task<bool> ScriptExistsAsync(string script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -519,21 +373,20 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="sha1">The SHA1 of the script to check for on the server.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/script-exists/</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/script-exists/"/></remarks>
+        bool ScriptExists(byte[] sha1, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="ScriptExists(byte[], CommandFlags)"/>
         Task<bool> ScriptExistsAsync(byte[] sha1, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Removes all cached scripts on this server.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/script-flush/</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/script-flush/"/></remarks>
         void ScriptFlush(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Removes all cached scripts on this server.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/script-flush/</remarks>
+        /// <inheritdoc cref="ScriptFlush(CommandFlags)"/>
         Task ScriptFlushAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -541,23 +394,11 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="script">The script to load.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remark>https://redis.io/commands/script-load/</remark>
+        /// <returns>The SHA1 of the loaded script.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/script-load/"/></remarks>
         byte[] ScriptLoad(string script, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Explicitly defines a script on the server.
-        /// </summary>
-        /// <param name="script">The script to load.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remark>https://redis.io/commands/script-load/</remark>
-        LoadedLuaScript ScriptLoad(LuaScript script, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// Explicitly defines a script on the server.
-        /// </summary>
-        /// <param name="script">The script to load.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remark>https://redis.io/commands/script-load/</remark>
+        /// <inheritdoc cref="ScriptLoad(string, CommandFlags)"/>
         Task<byte[]> ScriptLoadAsync(string script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -565,39 +406,32 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="script">The script to load.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remark>https://redis.io/commands/script-load/</remark>
+        /// <returns>The loaded script, ready for rapid reuse based on the SHA1.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/script-load/"/></remarks>
+        LoadedLuaScript ScriptLoad(LuaScript script, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="ScriptLoad(LuaScript, CommandFlags)"/>
         Task<LoadedLuaScript> ScriptLoadAsync(LuaScript script, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Asks the redis server to shutdown, killing all connections. Please FULLY read the notes on the SHUTDOWN command.
+        /// Asks the redis server to shutdown, killing all connections. Please FULLY read the notes on the <c>SHUTDOWN</c> command.
         /// </summary>
         /// <param name="shutdownMode">The mode of the shutdown.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/shutdown</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/shutdown"/></remarks>
         void Shutdown(ShutdownMode shutdownMode = ShutdownMode.Default, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly.
-        /// If a Redis server is already acting as replica, specifying a null primary will turn off the replication,
-        /// turning the Redis server into a PRIMARY. Specifying a non-null primary will make the server a replica of
-        /// another server listening at the specified hostname and port.
-        /// </summary>
-        /// <param name="master">Endpoint of the new primary to replicate from.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/replicaof</remarks>
+        /// <inheritdoc cref="ReplicaOfAsync(EndPoint, CommandFlags)"/>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         void SlaveOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly.
-        /// If a Redis server is already acting as replica, specifying a null primary will turn off the replication,
-        /// turning the Redis server into a PRIMARY. Specifying a non-null primary will make the server a replica of
-        /// another server listening at the specified hostname and port.
-        /// </summary>
-        /// <param name="master">Endpoint of the new primary to replicate from.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/replicaof</remarks>
+        /// <inheritdoc cref="ReplicaOfAsync(EndPoint, CommandFlags)"/>
+        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        Task SlaveOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="ReplicaOfAsync(EndPoint, CommandFlags)"/>
         [Obsolete("Please use " + nameof(ReplicaOfAsync) + ", this will be removed in 3.0.")]
         void ReplicaOf(EndPoint master, CommandFlags flags = CommandFlags.None);
 
@@ -609,20 +443,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="master">Endpoint of the new primary to replicate from.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/replicaof</remarks>
-        [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(ReplicaOfAsync) + " instead, this will be removed in 3.0.")]
-        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        Task SlaveOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// The REPLICAOF command can change the replication settings of a replica on the fly.
-        /// If a Redis server is already acting as replica, specifying a null primary will turn off the replication,
-        /// turning the Redis server into a PRIMARY. Specifying a non-null primary will make the server a replica of
-        /// another server listening at the specified hostname and port.
-        /// </summary>
-        /// <param name="master">Endpoint of the new primary to replicate from.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/replicaof</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/replicaof"/></remarks>
         Task ReplicaOfAsync(EndPoint master, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -631,30 +452,21 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="count">The count of items to get.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/slowlog</remarks>
+        /// <returns>The slow command traces as recorded by the Redis server.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/slowlog"/></remarks>
         CommandTrace[] SlowlogGet(int count = 0, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// To read the slow log the SLOWLOG GET command is used, that returns every entry in the slow log.
-        /// It is possible to return only the N most recent entries passing an additional argument to the command (for instance SLOWLOG GET 10).
-        /// </summary>
-        /// <param name="count">The count of items to get.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/slowlog</remarks>
+        /// <inheritdoc cref="SlowlogGet(int, CommandFlags)"/>
         Task<CommandTrace[]> SlowlogGetAsync(int count = 0, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// You can reset the slow log using the SLOWLOG RESET command. Once deleted the information is lost forever.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/slowlog</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/slowlog"/></remarks>
         void SlowlogReset(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// You can reset the slow log using the SLOWLOG RESET command. Once deleted the information is lost forever.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/slowlog</remarks>
+        /// <inheritdoc cref="SlowlogReset(CommandFlags)"/>
         Task SlowlogResetAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -664,17 +476,10 @@ namespace StackExchange.Redis
         /// <param name="pattern">The channel name pattern to get channels for.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns> a list of active channels, optionally matching the specified pattern.</returns>
-        /// <remarks>https://redis.io/commands/pubsub</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pubsub"/></remarks>
         RedisChannel[] SubscriptionChannels(RedisChannel pattern = default, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Lists the currently active channels.
-        /// An active channel is a Pub/Sub channel with one ore more subscribers (not including clients subscribed to patterns).
-        /// </summary>
-        /// <param name="pattern">The channel name pattern to get channels for.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns> a list of active channels, optionally matching the specified pattern.</returns>
-        /// <remarks>https://redis.io/commands/pubsub</remarks>
+        /// <inheritdoc cref="SubscriptionChannels(RedisChannel, CommandFlags)"/>
         Task<RedisChannel[]> SubscriptionChannelsAsync(RedisChannel pattern = default, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -683,16 +488,10 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>the number of patterns all the clients are subscribed to.</returns>
-        /// <remarks>https://redis.io/commands/pubsub</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/pubsub"/></remarks>
         long SubscriptionPatternCount(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command).
-        /// Note that this is not just the count of clients subscribed to patterns but the total number of patterns all the clients are subscribed to.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>the number of patterns all the clients are subscribed to.</returns>
-        /// <remarks>https://redis.io/commands/pubsub</remarks>
+        /// <inheritdoc cref="SubscriptionPatternCount(CommandFlags)"/>
         Task<long> SubscriptionPatternCountAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -700,163 +499,139 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="channel">The channel to get a subscriber count for.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/pubsub</remarks>
+        /// <returns>The number of subscribers on this server.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/pubsub"/></remarks>
         long SubscriptionSubscriberCount(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns the number of subscribers (not counting clients subscribed to patterns) for the specified channel.
-        /// </summary>
-        /// <param name="channel">The channel to get a subscriber count for.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/pubsub</remarks>
+        /// <inheritdoc cref="SubscriptionSubscriberCount(RedisChannel, CommandFlags)"/>
         Task<long> SubscriptionSubscriberCountAsync(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Swaps two Redis databases, so that immediately all the clients connected to a given database will see the data of the other database, and the other way around
+        /// Swaps two Redis databases, so that immediately all the clients connected to a given database will see the data of the other database, and the other way around.
         /// </summary>
         /// <param name="first">The ID of the first database.</param>
         /// <param name="second">The ID of the second database.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/swapdb</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/swapdb"/></remarks>
         void SwapDatabases(int first, int second, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Swaps two Redis databases, so that immediately all the clients connected to a given database will see the data of the other database, and the other way around
-        /// </summary>
-        /// <param name="first">The ID of the first database.</param>
-        /// <param name="second">The ID of the second database.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/swapdb</remarks>
+        /// <inheritdoc cref="SwapDatabases(int, int, CommandFlags)"/>
         Task SwapDatabasesAsync(int first, int second, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// The TIME command returns the current server time in UTC format.
-        /// Use the DateTime.ToLocalTime() method to get local time.
+        /// The <c>TIME</c> command returns the current server time in UTC format.
+        /// Use the <see cref="DateTime.ToLocalTime"/> method to get local time.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>The server's current time.</returns>
-        /// <remarks>https://redis.io/commands/time</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/time"/></remarks>
         DateTime Time(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// The TIME command returns the current server time in UTC format.
-        /// Use the DateTime.ToLocalTime() method to get local time.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>The server's current time.</returns>
-        /// <remarks>https://redis.io/commands/time</remarks>
+        /// <inheritdoc cref="Time(CommandFlags)"/>
         Task<DateTime> TimeAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Gets a text-based latency diagnostic.
         /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
-        Task<string> LatencyDoctorAsync(CommandFlags flags = CommandFlags.None);
-        /// <summary>
-        /// Gets a text-based latency diagnostic.
-        /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
+        /// <returns>The full text result of latency doctor.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/topics/latency-monitor"/>,
+        /// <seealso href="https://redis.io/commands/latency-doctor"/>
+        /// </remarks>
         string LatencyDoctor(CommandFlags flags = CommandFlags.None);
 
+        /// <inheritdoc cref="LatencyDoctor(CommandFlags)"/>
+        Task<string> LatencyDoctorAsync(CommandFlags flags = CommandFlags.None);
+
         /// <summary>
         /// Resets the given events (or all if none are specified), discarding the currently logged latency spike events, and resetting the maximum event time register.
         /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
-        Task<long> LatencyResetAsync(string[]? eventNames = null, CommandFlags flags = CommandFlags.None);
-        /// <summary>
-        /// Resets the given events (or all if none are specified), discarding the currently logged latency spike events, and resetting the maximum event time register.
-        /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
+        /// <returns>The number of events that were reset.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/topics/latency-monitor"/>,
+        /// <seealso href="https://redis.io/commands/latency-reset"/>
+        /// </remarks>
         long LatencyReset(string[]? eventNames = null, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Fetch raw latency data from the event time series, as timestamp-latency pairs
-        /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
-        Task<LatencyHistoryEntry[]> LatencyHistoryAsync(string eventName, CommandFlags flags = CommandFlags.None);
-        /// <summary>
-        /// Fetch raw latency data from the event time series, as timestamp-latency pairs
-        /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
-        LatencyHistoryEntry[] LatencyHistory(string eventName, CommandFlags flags = CommandFlags.None);
+        /// <inheritdoc cref="LatencyReset(string[], CommandFlags)"/>
+        Task<long> LatencyResetAsync(string[]? eventNames = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Fetch raw latency data from the event time series, as timestamp-latency pairs
+        /// Fetch raw latency data from the event time series, as timestamp-latency pairs.
         /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
-        Task<LatencyLatestEntry[]> LatencyLatestAsync(CommandFlags flags = CommandFlags.None);
+        /// <returns>An array of latency history entries.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/topics/latency-monitor"/>,
+        /// <seealso href="https://redis.io/commands/latency-history"/>
+        /// </remarks>
+        LatencyHistoryEntry[] LatencyHistory(string eventName, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="LatencyHistory(string, CommandFlags)"/>
+        Task<LatencyHistoryEntry[]> LatencyHistoryAsync(string eventName, CommandFlags flags = CommandFlags.None);
+
         /// <summary>
-        /// Fetch raw latency data from the event time series, as timestamp-latency pairs
+        /// Fetch raw latency data from the event time series, as timestamp-latency pairs.
         /// </summary>
-        /// <remarks>https://redis.io/topics/latency-monitor</remarks>
+        /// <returns>An array of the latest latency history entries.</returns>
+        /// <remarks>
+        /// <seealso href="https://redis.io/topics/latency-monitor"/>,
+        /// <seealso href="https://redis.io/commands/latency-latest"/>
+        /// </remarks>
         LatencyLatestEntry[] LatencyLatest(CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="LatencyLatest(CommandFlags)"/>
+        Task<LatencyLatestEntry[]> LatencyLatestAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Reports about different memory-related issues that the Redis server experiences, and advises about possible remedies.
         /// </summary>
-        /// <remarks>https://redis.io/commands/memory-doctor</remarks>
+        /// <returns>The full text result of memory doctor.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/memory-doctor"/></remarks>
+        string MemoryDoctor(CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="MemoryDoctor(CommandFlags)"/>
         Task<string> MemoryDoctorAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Reports about different memory-related issues that the Redis server experiences, and advises about possible remedies.
-        /// </summary>
-        /// <remarks>https://redis.io/commands/memory-doctor</remarks>
-        string MemoryDoctor(CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
         /// Attempts to purge dirty pages so these can be reclaimed by the allocator.
         /// </summary>
-        /// <remarks>https://redis.io/commands/memory-purge</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/memory-purge"/></remarks>
+        void MemoryPurge(CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="MemoryPurge(CommandFlags)"/>
         Task MemoryPurgeAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Attempts to purge dirty pages so these can be reclaimed by the allocator.
-        /// </summary>
-        /// <remarks>https://redis.io/commands/memory-purge</remarks>
-        void MemoryPurge(CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
         /// Returns an array reply about the memory usage of the server.
         /// </summary>
-        /// <remarks>https://redis.io/commands/memory-stats</remarks>
+        /// <returns>An array reply of memory stat metrics and values.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/memory-stats"/></remarks>
+        RedisResult MemoryStats(CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="MemoryStats(CommandFlags)"/>
         Task<RedisResult> MemoryStatsAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Returns an array reply about the memory usage of the server.
-        /// </summary>
-        /// <remarks>https://redis.io/commands/memory-stats</remarks>
-        RedisResult MemoryStats(CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
         /// Provides an internal statistics report from the memory allocator.
         /// </summary>
-        /// <remarks>https://redis.io/commands/memory-malloc-stats</remarks>
+        /// <returns>The full text result of memory allocation stats.</returns>
+        /// <remarks><seealso href="https://redis.io/commands/memory-malloc-stats"/></remarks>
+        string? MemoryAllocatorStats(CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="MemoryAllocatorStats(CommandFlags)"/>
         Task<string?> MemoryAllocatorStatsAsync(CommandFlags flags = CommandFlags.None);
 
         /// <summary>
-        /// Provides an internal statistics report from the memory allocator.
-        /// </summary>
-        /// <remarks>https://redis.io/commands/memory-malloc-stats</remarks>
-        string? MemoryAllocatorStats(CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
         /// Returns the IP and port number of the primary with that name.
         /// If a failover is in progress or terminated successfully for this primary it returns the address and port of the promoted replica.
         /// </summary>
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>The primary IP and port.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         EndPoint? SentinelGetMasterAddressByName(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns the IP and port number of the primary with that name.
-        /// If a failover is in progress or terminated successfully for this primary it returns the address and port of the promoted replica.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>The primary IP and port.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelGetMasterAddressByName(string, CommandFlags)"/>
         Task<EndPoint?> SentinelGetMasterAddressByNameAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -865,14 +640,10 @@ namespace StackExchange.Redis
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>A list of the sentinel IPs and ports.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         EndPoint[] SentinelGetSentinelAddresses(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns the IP and port numbers of all known Sentinels for the given service name.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>A list of the sentinel IPs and ports.</returns>
+        /// <inheritdoc cref="SentinelGetSentinelAddresses(string, CommandFlags)"/>
         Task<EndPoint[]> SentinelGetSentinelAddressesAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -881,14 +652,10 @@ namespace StackExchange.Redis
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>A list of the replica IPs and ports.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         EndPoint[] SentinelGetReplicaAddresses(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Returns the IP and port numbers of all known Sentinel replicas for the given service name.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>A list of the replica IPs and ports.</returns>
+        /// <inheritdoc cref="SentinelGetReplicaAddresses(string, CommandFlags)"/>
         Task<EndPoint[]> SentinelGetReplicaAddressesAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -897,16 +664,10 @@ namespace StackExchange.Redis
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>The primaries state as KeyValuePairs.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         KeyValuePair<string, string>[] SentinelMaster(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Show the state and info of the specified primary.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>The primaries state as KeyValuePairs.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelMaster(string, CommandFlags)"/>
         Task<KeyValuePair<string, string>[]> SentinelMasterAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -914,44 +675,18 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>An array of primaries state KeyValuePair arrays.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         KeyValuePair<string, string>[][] SentinelMasters(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Show a list of monitored primaries and their state.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>An array of primaries state KeyValuePair arrays.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelMasters(CommandFlags)"/>
         Task<KeyValuePair<string, string>[][]> SentinelMastersAsync(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Show a list of replicas for this primary, and their state.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>An array of replica state KeyValuePair arrays.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelReplicas(string, CommandFlags)"/>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(SentinelReplicas) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         KeyValuePair<string, string>[][] SentinelSlaves(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Show a list of replicas for this primary, and their state.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>An array of replica state KeyValuePair arrays.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
-        KeyValuePair<string, string>[][] SentinelReplicas(string serviceName, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// Show a list of replicas for this primary, and their state.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>An array of replica state KeyValuePair arrays.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelReplicas(string, CommandFlags)"/>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(SentinelReplicasAsync) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         Task<KeyValuePair<string, string>[][]> SentinelSlavesAsync(string serviceName, CommandFlags flags = CommandFlags.None);
@@ -962,7 +697,10 @@ namespace StackExchange.Redis
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>An array of replica state KeyValuePair arrays.</returns>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
+        KeyValuePair<string, string>[][] SentinelReplicas(string serviceName, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="SentinelReplicas(string, CommandFlags)"/>
         Task<KeyValuePair<string, string>[][]> SentinelReplicasAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -971,16 +709,10 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         void SentinelFailover(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Force a failover as if the primary was not reachable, and without asking for agreement to other Sentinels
-        /// (however a new version of the configuration will be published so that the other Sentinels will update their configurations).
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelFailover(string, CommandFlags)"/>
         Task SentinelFailoverAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -988,117 +720,11 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="serviceName">The sentinel service name.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         KeyValuePair<string, string>[][] SentinelSentinels(string serviceName, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Show a list of sentinels for a primary, and their state.
-        /// </summary>
-        /// <param name="serviceName">The sentinel service name.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/topics/sentinel</remarks>
+        /// <inheritdoc cref="SentinelSentinels(string, CommandFlags)"/>
         Task<KeyValuePair<string, string>[][]> SentinelSentinelsAsync(string serviceName, CommandFlags flags = CommandFlags.None);
-    }
-
-    /// <summary>
-    /// A latency entry as reported by the built-in LATENCY HISTORY command
-    /// </summary>
-    public readonly struct LatencyHistoryEntry
-    {
-        internal static readonly ResultProcessor<LatencyHistoryEntry[]> ToArray = new Processor();
-
-        private sealed class Processor : ArrayResultProcessor<LatencyHistoryEntry>
-        {
-            protected override bool TryParse(in RawResult raw, out LatencyHistoryEntry parsed)
-            {
-                if (raw.Type == ResultType.MultiBulk)
-                {
-                    var items = raw.GetItems();
-                    if (items.Length >= 2
-                        && items[0].TryGetInt64(out var timestamp)
-                        && items[1].TryGetInt64(out var duration))
-                    {
-                        parsed = new LatencyHistoryEntry(timestamp, duration);
-                        return true;
-                    }
-                }
-                parsed = default;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// The time at which this entry was recorded
-        /// </summary>
-        public DateTime Timestamp { get; }
-
-        /// <summary>
-        /// The latency recorded for this event
-        /// </summary>
-        public int DurationMilliseconds { get; }
-
-        internal LatencyHistoryEntry(long timestamp, long duration)
-        {
-            Timestamp = RedisBase.UnixEpoch.AddSeconds(timestamp);
-            DurationMilliseconds = checked((int)duration);
-        }
-    }
-
-    /// <summary>
-    /// A latency entry as reported by the built-in LATENCY LATEST command
-    /// </summary>
-    public readonly struct LatencyLatestEntry
-    {
-        internal static readonly ResultProcessor<LatencyLatestEntry[]> ToArray = new Processor();
-
-        private sealed class Processor : ArrayResultProcessor<LatencyLatestEntry>
-        {
-            protected override bool TryParse(in RawResult raw, out LatencyLatestEntry parsed)
-            {
-                if (raw.Type == ResultType.MultiBulk)
-                {
-                    var items = raw.GetItems();
-                    if (items.Length >= 4
-                        && items[1].TryGetInt64(out var timestamp)
-                        && items[2].TryGetInt64(out var duration)
-                        && items[3].TryGetInt64(out var maxDuration))
-                    {
-                        parsed = new LatencyLatestEntry(items[0].GetString()!, timestamp, duration, maxDuration);
-                        return true;
-                    }
-                }
-                parsed = default;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// The name of this event
-        /// </summary>
-        public string EventName { get; }
-
-        /// <summary>
-        /// The time at which this entry was recorded
-        /// </summary>
-        public DateTime Timestamp { get; }
-
-        /// <summary>
-        /// The latency recorded for this event
-        /// </summary>
-        public int DurationMilliseconds { get; }
-
-        /// <summary>
-        /// The max latency recorded for all events
-        /// </summary>
-        public int MaxDurationMilliseconds { get; }
-
-        internal LatencyLatestEntry(string eventName, long timestamp, long duration, long maxDuration)
-        {
-            EventName = eventName;
-            Timestamp = RedisBase.UnixEpoch.AddSeconds(timestamp);
-            DurationMilliseconds = checked((int)duration);
-            MaxDurationMilliseconds = checked((int)maxDuration);
-        }
     }
 
     internal static class IServerExtensions

--- a/src/StackExchange.Redis/Interfaces/ISubscriber.cs
+++ b/src/StackExchange.Redis/Interfaces/ISubscriber.cs
@@ -16,11 +16,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The command flags to use.</param>
         EndPoint? IdentifyEndpoint(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Indicate exactly which redis server we are talking to.
-        /// </summary>
-        /// <param name="channel">The channel to identify the server endpoint by.</param>
-        /// <param name="flags">The command flags to use.</param>
+        /// <inheritdoc cref="IdentifyEndpoint(RedisChannel, CommandFlags)"/>
         Task<EndPoint?> IdentifyEndpointAsync(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -30,6 +26,7 @@ namespace StackExchange.Redis
         /// server is chosen arbitrarily from the primaries.
         /// </summary>
         /// <param name="channel">The channel to identify the server endpoint by.</param>
+        /// <returns><see langword="true" /> if connected, <see langword="false"/> otherwise.</returns>
         bool IsConnected(RedisChannel channel = default);
 
         /// <summary>
@@ -42,20 +39,10 @@ namespace StackExchange.Redis
         /// The number of clients that received the message *on the destination server*,
         /// note that this doesn't mean much in a cluster as clients can get the message through other nodes.
         /// </returns>
-        /// <remarks>https://redis.io/commands/publish</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/publish"/></remarks>
         long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Posts a message to the given channel.
-        /// </summary>
-        /// <param name="channel">The channel to publish to.</param>
-        /// <param name="message">The message to publish.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>
-        /// The number of clients that received the message *on the destination server*,
-        /// note that this doesn't mean much in a cluster as clients can get the message through other nodes.
-        /// </returns>
-        /// <remarks>https://redis.io/commands/publish</remarks>
+        /// <inheritdoc cref="Publish(RedisChannel, RedisValue, CommandFlags)"/>
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -64,9 +51,14 @@ namespace StackExchange.Redis
         /// <param name="channel">The channel to subscribe to.</param>
         /// <param name="handler">The handler to invoke when a message is received on <paramref name="channel"/>.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/subscribe</remarks>
-        /// <remarks>https://redis.io/commands/psubscribe</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/subscribe"/>,
+        /// <seealso href="https://redis.io/commands/psubscribe"/>
+        /// </remarks>
         void Subscribe(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="Subscribe(RedisChannel, Action{RedisChannel, RedisValue}, CommandFlags)"/>
+        Task SubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// Subscribe to perform some operation when a message to the preferred/active node is broadcast, as a queue that guarantees ordered handling.
@@ -74,28 +66,13 @@ namespace StackExchange.Redis
         /// <param name="channel">The redis channel to subscribe to.</param>
         /// <param name="flags">The command flags to use.</param>
         /// <returns>A channel that represents this source</returns>
-        /// <remarks>https://redis.io/commands/subscribe</remarks>
-        /// <remarks>https://redis.io/commands/psubscribe</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/subscribe"/>,
+        /// <seealso href="https://redis.io/commands/psubscribe"/>
+        /// </remarks>
         ChannelMessageQueue Subscribe(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Subscribe to perform some operation when a change to the preferred/active node is broadcast.
-        /// </summary>
-        /// <param name="channel">The channel to subscribe to.</param>
-        /// <param name="handler">The handler to invoke when a message is received on <paramref name="channel"/>.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/subscribe</remarks>
-        /// <remarks>https://redis.io/commands/psubscribe</remarks>
-        Task SubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// Subscribe to perform some operation when a change to the preferred/active node is broadcast, as a channel.
-        /// </summary>
-        /// <param name="channel">The redis channel to subscribe to.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <returns>A channel that represents this source</returns>
-        /// <remarks>https://redis.io/commands/subscribe</remarks>
-        /// <remarks>https://redis.io/commands/psubscribe</remarks>
+        /// <inheritdoc cref="Subscribe(RedisChannel, CommandFlags)"/>
         Task<ChannelMessageQueue> SubscribeAsync(RedisChannel channel, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
@@ -113,36 +90,26 @@ namespace StackExchange.Redis
         /// <param name="channel">The channel that was subscribed to.</param>
         /// <param name="handler">The handler to no longer invoke when a message is received on <paramref name="channel"/>.</param>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/unsubscribe"/>,
+        /// <seealso href="https://redis.io/commands/punsubscribe"/>
+        /// </remarks>
         void Unsubscribe(RedisChannel channel, Action<RedisChannel, RedisValue>? handler = null, CommandFlags flags = CommandFlags.None);
 
+        /// <inheritdoc cref="Unsubscribe(RedisChannel, Action{RedisChannel, RedisValue}?, CommandFlags)"/>
+        Task UnsubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue>? handler = null, CommandFlags flags = CommandFlags.None);
+
         /// <summary>
         /// Unsubscribe all subscriptions on this instance.
         /// </summary>
         /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/unsubscribe"/>,
+        /// <seealso href="https://redis.io/commands/punsubscribe"/>
+        /// </remarks>
         void UnsubscribeAll(CommandFlags flags = CommandFlags.None);
 
-        /// <summary>
-        /// Unsubscribe all subscriptions on this instance.
-        /// </summary>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
+        /// <inheritdoc cref="UnsubscribeAll(CommandFlags)"/>
         Task UnsubscribeAllAsync(CommandFlags flags = CommandFlags.None);
-
-        /// <summary>
-        /// Unsubscribe from a specified message channel.
-        /// Note: if no handler is specified, the subscription is canceled regardless of the subscribers.
-        /// If a handler is specified, the subscription is only canceled if this handler is the last handler remaining against the channel.
-        /// </summary>
-        /// <param name="channel">The channel that was subscribed to.</param>
-        /// <param name="handler">The handler to no longer invoke when a message is received on <paramref name="channel"/>.</param>
-        /// <param name="flags">The command flags to use.</param>
-        /// <remarks>https://redis.io/commands/unsubscribe</remarks>
-        /// <remarks>https://redis.io/commands/punsubscribe</remarks>
-        Task UnsubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue>? handler = null, CommandFlags flags = CommandFlags.None);
     }
 }

--- a/src/StackExchange.Redis/Interfaces/ITransaction.cs
+++ b/src/StackExchange.Redis/Interfaces/ITransaction.cs
@@ -5,14 +5,14 @@ namespace StackExchange.Redis
     /// <summary>
     /// Represents a group of operations that will be sent to the server as a single unit,
     /// and processed on the server as a single unit. Transactions can also include constraints
-    /// (implemented via WATCH), but note that constraint checking involves will (very briefly)
-    /// block the connection, since the transaction cannot be correctly committed (EXEC),
-    /// aborted (DISCARD) or not applied in the first place (UNWATCH) until the responses from
+    /// (implemented via <c>WATCH</c>), but note that constraint checking involves will (very briefly)
+    /// block the connection, since the transaction cannot be correctly committed (<c>EXEC</c>),
+    /// aborted (<c>DISCARD</c>) or not applied in the first place (<c>UNWATCH</c>) until the responses from
     /// the constraint checks have arrived.
     /// </summary>
-    /// <remarks>https://redis.io/topics/transactions</remarks>
     /// <remarks>
-    /// Note that on a cluster, it may be required that all keys involved in the transaction (including constraints) are in the same hash-slot.
+    /// <para>Note that on a cluster, it may be required that all keys involved in the transaction (including constraints) are in the same hash-slot.</para>
+    /// <para><seealso href="https://redis.io/topics/transactions"/></para>
     /// </remarks>
     public interface ITransaction : IBatch
     {

--- a/src/StackExchange.Redis/Maintenance/AzureMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/Maintenance/AzureMaintenanceEvent.cs
@@ -9,7 +9,7 @@ using System.Buffers.Text;
 namespace StackExchange.Redis.Maintenance
 {
     /// <summary>
-    /// Azure node maintenance event. For more information, please see: https://aka.ms/redis/maintenanceevents
+    /// Azure node maintenance event. For more information, please see: <see href="https://aka.ms/redis/maintenanceevents"/>.
     /// </summary>
     public sealed class AzureMaintenanceEvent : ServerMaintenanceEvent
     {

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3689,10 +3689,11 @@ namespace StackExchange.Redis
             return Message.Create(Database, flags, RedisCommand.XADD, key, values);
         }
 
+        /// <summary>
+        /// Gets message for <see href="https://redis.io/commands/xadd"/>.
+        /// </summary>
         private Message GetStreamAddMessage(RedisKey key, RedisValue entryId, int? maxLength, bool useApproximateMaxLength, NameValueEntry[] streamPairs, CommandFlags flags)
         {
-            // See https://redis.io/commands/xadd.
-
             if (streamPairs == null) throw new ArgumentNullException(nameof(streamPairs));
             if (streamPairs.Length == 0) throw new ArgumentOutOfRangeException(nameof(streamPairs), "streamPairs must contain at least one item.");
 
@@ -3785,6 +3786,10 @@ namespace StackExchange.Redis
                 values);
         }
 
+        /// <summary>
+        /// Gets a message for <see href="https://redis.io/commands/xpending/"/>
+        /// </summary>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
         private Message GetStreamPendingMessagesMessage(RedisKey key, RedisValue groupName, RedisValue? minId, RedisValue? maxId, int count, RedisValue consumerName, CommandFlags flags)
         {
             // > XPENDING mystream mygroup - + 10 [consumer name]
@@ -3796,8 +3801,6 @@ namespace StackExchange.Redis
             //    2) "Bob"
             //    3) (integer)74170458
             //    4) (integer)1
-
-            // See https://redis.io/topics/streams-intro.
 
             if (count <= 0)
             {

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -53,157 +53,157 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Does BITOP / BITCOUNT exist?
+        /// Are <see href="https://redis.io/commands/bitop/">BITOP</see> and <see href="https://redis.io/commands/bitcount/">BITCOUNT</see> available?
         /// </summary>
         public bool BitwiseOperations => Version >= v2_6_0;
 
         /// <summary>
-        /// Is CLIENT SETNAME available?
+        /// Is <see href="https://redis.io/commands/client-setname/">CLIENT SETNAME</see> available?
         /// </summary>
         public bool ClientName => Version >= v2_6_9;
 
         /// <summary>
-        /// Does EXEC support EXECABORT if there are errors?
+        /// Does <see href="https://redis.io/commands/exec/">EXEC</see> support <c>EXECABORT</c> if there are errors?
         /// </summary>
         public bool ExecAbort => Version >= v2_6_5 && Version != v2_9_5;
 
         /// <summary>
-        /// Can EXPIRE be used to set expiration on a key that is already volatile (i.e. has an expiration)?
+        /// Can <see href="https://redis.io/commands/expire/">EXPIRE</see> be used to set expiration on a key that is already volatile (i.e. has an expiration)?
         /// </summary>
         public bool ExpireOverwrite => Version >= v2_1_3;
 
         /// <summary>
-        /// Is GETDEL available?
+        /// Is <see href="https://redis.io/commands/getdel/">GETDEL</see> available?
         /// </summary>
         public bool GetDelete => Version >= v6_2_0;
 
         /// <summary>
-        /// Is HSTRLEN available?
+        /// Is <see href="https://redis.io/commands/hstrlen/">HSTRLEN</see> available?
         /// </summary>
         public bool HashStringLength => Version >= v3_2_0;
 
         /// <summary>
-        /// Does HDEL support variadic usage?
+        /// Does <see href="https://redis.io/commands/hdel/">HDEL</see> support variadic usage?
         /// </summary>
         public bool HashVaradicDelete => Version >= v2_4_0;
 
         /// <summary>
-        /// Does INCRBYFLOAT / HINCRBYFLOAT exist?
+        /// Are <see href="https://redis.io/commands/incrbyfloat/">INCRBYFLOAT</see> and <see href="https://redis.io/commands/hincrbyfloat/">HINCRBYFLOAT</see> available?
         /// </summary>
         public bool IncrementFloat => Version >= v2_6_0;
 
         /// <summary>
-        /// Does INFO support sections?
+        /// Does <see href="https://redis.io/commands/info/">INFO</see> support sections?
         /// </summary>
         public bool InfoSections => Version >= v2_8_0;
 
         /// <summary>
-        /// Is LINSERT available?
+        /// Is <see href="https://redis.io/commands/linsert/">LINSERT</see> available?
         /// </summary>
         public bool ListInsert => Version >= v2_1_1;
 
         /// <summary>
-        /// Is MEMORY available?
+        /// Is <see href="https://redis.io/commands/memory/">MEMORY</see> available?
         /// </summary>
         public bool Memory => Version >= v4_0_0;
 
         /// <summary>
-        /// Indicates whether PEXPIRE and PTTL are supported
+        /// Are <see href="https://redis.io/commands/pexpire/">PEXPIRE</see> and <see href="https://redis.io/commands/pttl/">PTTL</see> available?
         /// </summary>
         public bool MillisecondExpiry => Version >= v2_6_0;
 
         /// <summary>
-        /// Is MODULE available?
+        /// Is <see href="https://redis.io/commands/module/">MODULE</see> available?
         /// </summary>
         public bool Module => Version >= v4_0_0;
 
         /// <summary>
-        /// Does SRANDMEMBER support "count"?
+        /// Does <see href="https://redis.io/commands/srandmember/">SRANDMEMBER</see> support the "count" option?
         /// </summary>
         public bool MultipleRandom => Version >= v2_5_14;
 
         /// <summary>
-        /// Is the PERSIST operation supported?
+        /// Is <see href="https://redis.io/commands/persist/">PERSIST</see> available?
         /// </summary>
         public bool Persist => Version >= v2_1_2;
 
         /// <summary>
-        /// Is RPUSHX and LPUSHX available?
+        /// Are <see href="https://redis.io/commands/lpushx/">LPUSHX</see> and <see href="https://redis.io/commands/rpushx/">RPUSHX</see> available?
         /// </summary>
         public bool PushIfNotExists => Version >= v2_1_1;
 
         /// <summary>
-        /// Are cursor-based scans available?
+        /// Is <see href="https://redis.io/commands/scan/">SCAN</see> (cursor-based scanning) available?
         /// </summary>
         public bool Scan => Version >= v2_8_0;
 
         /// <summary>
-        /// Does EVAL / EVALSHA / etc exist?
+        /// Are <see href="https://redis.io/commands/eval/">EVAL</see>, <see href="https://redis.io/commands/evalsha/">EVALSHA</see>, and other script commands available?
         /// </summary>
         public bool Scripting => Version >= v2_6_0;
 
         /// <summary>
-        /// Does SET support the GET option?
+        /// Does <see href="https://redis.io/commands/set/">SET</see> support the <c>GET</c> option?
         /// </summary>
         public bool SetAndGet => Version >= v6_2_0;
 
         /// <summary>
-        /// Does SET have the EX|PX|NX|XX extensions?
+        /// Does <see href="https://redis.io/commands/set/">SET</see> support the <c>EX</c>, <c>PX</c>, <c>NX</c>, and <c>XX</c> options?
         /// </summary>
         public bool SetConditional => Version >= v2_6_12;
 
         /// <summary>
-        /// Does SET have the KEEPTTL extension?
+        /// Does <see href="https://redis.io/commands/set/">SET</see> have the <c>KEEPTTL</c> option?
         /// </summary>
         public bool SetKeepTtl => Version >= v6_0_0;
 
         /// <summary>
-        /// Does SET allow the NX and GET options to be used together?
+        /// Does <see href="https://redis.io/commands/set/">SET</see> allow the <c>NX</c> and <c>GET</c> options to be used together?
         /// </summary>
         public bool SetNotExistsAndGet => Version >= v7_0_0_rc1;
 
         /// <summary>
-        /// Does SADD support variadic usage?
+        /// Does <see href="https://redis.io/commands/sadd/">SADD</see> support variadic usage?
         /// </summary>
         public bool SetVaradicAddRemove => Version >= v2_4_0;
 
         /// <summary>
-        /// Is ZPOPMAX and ZPOPMIN available?
+        /// Are <see href="https://redis.io/commands/zpopmin/">ZPOPMIN</see> and <see href="https://redis.io/commands/zpopmax/">ZPOPMAX</see> available?
         /// </summary>
         public bool SortedSetPop => Version >= v5_0_0;
 
         /// <summary>
-        /// Is ZRANGESTORE available?
+        /// Is <see href="https://redis.io/commands/zrangestore/">ZRANGESTORE</see> available?
         /// </summary>
         public bool SortedSetRangeStore => Version >= v6_2_0;
 
         /// <summary>
-        /// Are Redis Streams available?
+        /// Are <see href="https://redis.io/topics/streams-intro">Redis Streams</see> available?
         /// </summary>
         public bool Streams => Version >= v4_9_1;
 
         /// <summary>
-        /// Is STRLEN available?
+        /// Is <see href="https://redis.io/commands/strlen/">STRLEN</see> available?
         /// </summary>
         public bool StringLength => Version >= v2_1_2;
 
         /// <summary>
-        /// Is SETRANGE available?
+        /// Is <see href="https://redis.io/commands/setrange/">SETRANGE</see> available?
         /// </summary>
         public bool StringSetRange => Version >= v2_1_8;
 
         /// <summary>
-        /// Is SWAPDB available?
+        /// Is <see href="https://redis.io/commands/swapdb/">SWAPDB</see> available?
         /// </summary>
         public bool SwapDB => Version >= v4_0_0;
 
         /// <summary>
-        /// Does TIME exist?
+        /// Is <see href="https://redis.io/commands/time/">TIME</see> available?
         /// </summary>
         public bool Time => Version >= v2_6_0;
 
         /// <summary>
-        /// Does UNLINK exist?
+        /// Is <see href="https://redis.io/commands/unlink/">UNLINK</see> available?
         /// </summary>
         public bool Unlink => Version >= v4_0_0;
 
@@ -212,40 +212,38 @@ namespace StackExchange.Redis
         /// </summary>
         public bool ScriptingDatabaseSafe => Version >= v2_8_12;
 
-        /// <summary>
-        /// Is PFCOUNT supported on replicas?
-        /// </summary>
+        /// <inheritdoc cref="HyperLogLogCountReplicaSafe"/>
         [Obsolete("Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use " + nameof(HyperLogLogCountReplicaSafe) + " instead, this will be removed in 3.0.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public bool HyperLogLogCountSlaveSafe => HyperLogLogCountReplicaSafe;
 
         /// <summary>
-        /// Is PFCOUNT supported on replicas?
+        /// Is <see href="https://redis.io/commands/pfcount/">PFCOUNT</see> available on replicas?
         /// </summary>
         public bool HyperLogLogCountReplicaSafe => Version >= v2_8_18;
 
         /// <summary>
-        /// Are the GEO commands available?
+        /// Are <see href="https://redis.io/commands/?group=geo">geospatial commands</see> available?
         /// </summary>
         public bool Geo => Version >= v3_2_0;
 
         /// <summary>
-        /// Can PING be used on a subscription connection?
+        /// Can <see href="https://redis.io/commands/ping/">PING</see> be used on a subscription connection?
         /// </summary>
         internal bool PingOnSubscriber => Version >= v3_0_0;
 
         /// <summary>
-        /// Does SetPop support popping multiple items?
+        /// Does <see href="https://redis.io/commands/spop/">SPOP</see> support popping multiple items?
         /// </summary>
         public bool SetPopMultiple => Version >= v3_2_0;
 
         /// <summary>
-        /// Are the Touch command available?
+        /// Is <see href="https://redis.io/commands/touch/">TOUCH</see> available?
         /// </summary>
         public bool KeyTouch => Version >= v3_2_1;
 
         /// <summary>
-        /// Does the server prefer 'replica' terminology - 'REPLICAOF', etc?
+        /// Does the server prefer 'replica' terminology - '<see href="https://redis.io/commands/replicaof/">REPLICAOF</see>', etc?
         /// </summary>
         public bool ReplicaCommands => Version >= v5_0_0;
 

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1663,6 +1663,9 @@ The coordinates as a two items x,y array (longitude,latitude).
                 this.skipStreamName = skipStreamName;
             }
 
+            /// <summary>
+            /// Handles <see href="https://redis.io/commands/xread"/>.
+            /// </summary>
             protected override bool SetResultCore(PhysicalConnection connection, Message message, in RawResult result)
             {
                 if (result.IsNull)
@@ -1681,9 +1684,6 @@ The coordinates as a two items x,y array (longitude,latitude).
 
                 if (skipStreamName)
                 {
-                    // Skip the first element in the array (i.e., the stream name).
-                    // See https://redis.io/commands/xread.
-
                     // > XREAD COUNT 2 STREAMS mystream 0
                     // 1) 1) "mystream"                     <== Skip the stream name
                     //    2) 1) 1) 1519073278252 - 0        <== Index 1 contains the array of stream entries
@@ -1712,14 +1712,15 @@ The coordinates as a two items x,y array (longitude,latitude).
             }
         }
 
+        /// <summary>
+        /// Handles <see href="https://redis.io/commands/xread"/>.
+        /// </summary>
         internal sealed class MultiStreamProcessor : StreamProcessorBase<RedisStream[]>
         {
             /*
                 The result is similar to the XRANGE result (see SingleStreamProcessor)
                 with the addition of the stream name as the first element of top level
                 Multibulk array.
-
-                See https://redis.io/commands/xread.
 
                 > XREAD COUNT 2 STREAMS mystream writers 0-0 0-0
                 1) 1) "mystream"
@@ -2080,10 +2081,11 @@ The coordinates as a two items x,y array (longitude,latitude).
             }
         }
 
+        /// <summary>
+        /// Handles stream responses. For formats, see <see href="https://redis.io/topics/streams-intro"/>.
+        /// </summary>
         internal abstract class StreamProcessorBase<T> : ResultProcessor<T>
         {
-            // For command response formats see https://redis.io/topics/streams-intro.
-
             protected static StreamEntry ParseRedisStreamEntry(in RawResult item)
             {
                 if (item.IsNull || item.Type != ResultType.MultiBulk)

--- a/src/StackExchange.Redis/Role.cs
+++ b/src/StackExchange.Redis/Role.cs
@@ -5,7 +5,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// Result of the ROLE command. Values depend on the role: master, replica, or sentinel.
     /// </summary>
-    /// <remarks>https://redis.io/commands/role</remarks>
+    /// <remarks><seealso href="https://redis.io/commands/role"/></remarks>
     public abstract class Role
     {
         internal static Unknown Null { get; } = new Unknown("");
@@ -23,7 +23,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Result of the ROLE command for a primary node.
         /// </summary>
-        /// <remarks>https://redis.io/commands/role#master-output</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/role#master-output"/></remarks>
         public sealed class Master : Role
         {
             /// <summary>
@@ -74,7 +74,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Result of the ROLE command for a replica node.
         /// </summary>
-        /// <remarks>https://redis.io/commands/role#output-of-the-command-on-replicas</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/role#output-of-the-command-on-replicas"/></remarks>
         public sealed class Replica : Role
         {
             /// <summary>
@@ -109,7 +109,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Result of the ROLE command for a sentinel node.
         /// </summary>
-        /// <remarks>https://redis.io/commands/role#sentinel-output</remarks>
+        /// <remarks><seealso href="https://redis.io/commands/role#sentinel-output"/></remarks>
         public sealed class Sentinel : Role
         {
             /// <summary>

--- a/src/StackExchange.Redis/TaskExtensions.cs
+++ b/src/StackExchange.Redis/TaskExtensions.cs
@@ -36,9 +36,11 @@ namespace StackExchange.Redis
 
         internal static void RedisFireAndForget(this Task task) => task?.ContinueWith(t => GC.KeepAlive(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
 
-        // Inspired from https://github.com/dotnet/corefx/blob/81a246f3adf1eece3d981f1d8bb8ae9de12de9c6/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs#L15-L43
-        // Licensed to the .NET Foundation under one or more agreements.
-        // The .NET Foundation licenses this file to you under the MIT license.
+        /// <summary>
+        /// Licensed to the .NET Foundation under one or more agreements.
+        /// The .NET Foundation licenses this file to you under the MIT license.
+        /// </summary>
+        /// <remarks>Inspired from <see href="https://github.com/dotnet/corefx/blob/81a246f3adf1eece3d981f1d8bb8ae9de12de9c6/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs#L15-L43"/></remarks>
         public static async Task<bool> TimeoutAfter(this Task task, int timeoutMs)
         {
             var cts = new CancellationTokenSource();

--- a/src/StackExchange.Redis/ValueStopwatch.cs
+++ b/src/StackExchange.Redis/ValueStopwatch.cs
@@ -4,8 +4,9 @@ using System.Diagnostics;
 namespace StackExchange.Redis;
 
 /// <summary>
-/// Optimization over <see cref="Stopwatch"/>, from https://github.com/dotnet/aspnetcore/blob/main/src/Shared/ValueStopwatch/ValueStopwatch.cs
+/// Optimization over <see cref="Stopwatch"/>.
 /// </summary>
+/// <remarks>From <see href="https://github.com/dotnet/aspnetcore/blob/main/src/Shared/ValueStopwatch/ValueStopwatch.cs"/>.</remarks>
 internal struct ValueStopwatch
 {
     private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;

--- a/tests/StackExchange.Redis.Tests/Hashes.cs
+++ b/tests/StackExchange.Redis.Tests/Hashes.cs
@@ -8,8 +8,11 @@ using System.Threading.Tasks;
 
 namespace StackExchange.Redis.Tests;
 
+/// <summary>
+/// Tests for <see href="https://redis.io/commands#hash"/>.
+/// </summary>
 [Collection(SharedConnectionFixture.Key)]
-public class Hashes : TestBase // https://redis.io/commands#hash
+public class Hashes : TestBase
 {
     public Hashes(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
 
@@ -219,8 +222,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         }
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hset"/>.
+    /// </summary>
     [Fact]
-    public async Task TestSet() // https://redis.io/commands/hset
+    public async Task TestSet()
     {
         using var conn = Create();
 
@@ -258,8 +264,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Equal("", await val5);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hsetnx"/>.
+    /// </summary>
     [Fact]
-    public async Task TestSetNotExists() // https://redis.io/commands/hsetnx
+    public async Task TestSetNotExists()
     {
         using var conn = Create();
 
@@ -289,8 +298,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.False(await set3);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hdel"/>.
+    /// </summary>
     [Fact]
-    public async Task TestDelSingle() // https://redis.io/commands/hdel
+    public async Task TestDelSingle()
     {
         using var conn = Create();
 
@@ -309,8 +321,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.False(await del2);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hdel"/>.
+    /// </summary>
     [Fact]
-    public async Task TestDelMulti() // https://redis.io/commands/hdel
+    public async Task TestDelMulti()
     {
         using var conn = Create();
 
@@ -346,8 +361,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Equal(1, await removeFinal);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hdel"/>.
+    /// </summary>
     [Fact]
-    public async Task TestDelMultiInsideTransaction() // https://redis.io/commands/hdel
+    public async Task TestDelMultiInsideTransaction()
     {
         using var conn = Create();
 
@@ -382,8 +400,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         }
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hexists"/>.
+    /// </summary>
     [Fact]
-    public async Task TestExists() // https://redis.io/commands/hexists
+    public async Task TestExists()
     {
         using var conn = Create();
 
@@ -401,8 +422,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.False(await ex0);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hkeys"/>.
+    /// </summary>
     [Fact]
-    public async Task TestHashKeys() // https://redis.io/commands/hkeys
+    public async Task TestHashKeys()
     {
         using var conn = Create();
 
@@ -424,8 +448,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Equal("bar", arr[1]);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hvals"/>.
+    /// </summary>
     [Fact]
-    public async Task TestHashValues() // https://redis.io/commands/hvals
+    public async Task TestHashValues()
     {
         using var conn = Create();
 
@@ -448,8 +475,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Equal("def", Encoding.UTF8.GetString(arr[1]!));
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hlen"/>.
+    /// </summary>
     [Fact]
-    public async Task TestHashLength() // https://redis.io/commands/hlen
+    public async Task TestHashLength()
     {
         using var conn = Create();
 
@@ -468,8 +498,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Equal(2, await len1);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hmget"/>.
+    /// </summary>
     [Fact]
-    public async Task TestGetMulti() // https://redis.io/commands/hmget
+    public async Task TestGetMulti()
     {
         using var conn = Create();
 
@@ -502,8 +535,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Null((string?)arr2[2]);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hgetall"/>.
+    /// </summary>
     [Fact]
-    public void TestGetPairs() // https://redis.io/commands/hgetall
+    public void TestGetPairs()
     {
         using var conn = Create();
 
@@ -525,8 +561,11 @@ public class Hashes : TestBase // https://redis.io/commands#hash
         Assert.Equal("def", result["bar"]);
     }
 
+    /// <summary>
+    /// Tests for <see href="https://redis.io/commands/hmset"/>.
+    /// </summary>
     [Fact]
-    public void TestSetPairs() // https://redis.io/commands/hmset
+    public void TestSetPairs()
     {
         using var conn = Create();
 

--- a/tests/StackExchange.Redis.Tests/PubSub.cs
+++ b/tests/StackExchange.Redis.Tests/PubSub.cs
@@ -628,7 +628,6 @@ public class PubSub : TestBase
     [Fact]
     public async Task Issue38()
     {
-        // https://code.google.com/p/booksleeve/issues/detail?id=38
         using var conn = Create(log: Writer);
 
         var sub = conn.GetSubscriber();

--- a/tests/StackExchange.Redis.Tests/SanityChecks.cs
+++ b/tests/StackExchange.Redis.Tests/SanityChecks.cs
@@ -12,7 +12,7 @@ public sealed class SanityChecks
     /// Ensure we don't reference System.ValueTuple as it causes issues with .NET Full Framework
     /// </summary>
     /// <remarks>
-    /// Modified from https://github.com/ltrzesniewski/InlineIL.Fody/blob/137e8b57f78b08cdc3abdaaf50ac01af50c58759/src/InlineIL.Tests/AssemblyTests.cs#L14
+    /// Modified from <see href="https://github.com/ltrzesniewski/InlineIL.Fody/blob/137e8b57f78b08cdc3abdaaf50ac01af50c58759/src/InlineIL.Tests/AssemblyTests.cs#L14"/>.
     /// Thanks Lucas Trzesniewski!
     /// </remarks>
     [Fact]

--- a/tests/StackExchange.Redis.Tests/Scans.cs
+++ b/tests/StackExchange.Redis.Tests/Scans.cs
@@ -332,7 +332,10 @@ public class Scans : TestBase
         Assert.Equal(2000, count);
     }
 
-    [Fact] // See https://github.com/StackExchange/StackExchange.Redis/issues/729
+    /// <summary>
+    /// See <see href="https://github.com/StackExchange/StackExchange.Redis/issues/729"/>.
+    /// </summary>
+    [Fact]
     public void HashScanThresholds()
     {
         using var conn = Create(allowAdmin: true);

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -230,7 +230,9 @@ public class SharedConnectionFixture : IDisposable
     }
 }
 
-// https://stackoverflow.com/questions/13829737/xunit-net-run-code-once-before-and-after-all-tests
+/// <summary>
+/// See <see href="https://stackoverflow.com/questions/13829737/xunit-net-run-code-once-before-and-after-all-tests"/>.
+/// </summary>
 [CollectionDefinition(SharedConnectionFixture.Key)]
 public class ConnectionCollection : ICollectionFixture<SharedConnectionFixture>
 {

--- a/tests/StackExchange.Redis.Tests/Strings.cs
+++ b/tests/StackExchange.Redis.Tests/Strings.cs
@@ -8,8 +8,11 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests;
 
+/// <summary>
+/// Tests for <see href="https://redis.io/commands#string"/>.
+/// </summary>
 [Collection(SharedConnectionFixture.Key)]
-public class Strings : TestBase // https://redis.io/commands#string
+public class Strings : TestBase
 {
     public Strings(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
 


### PR DESCRIPTION
This does a few things globally to the interfaces:
- De-dupes `<remarks>` since evidently past the first one doesn't count/render
- Links our redis command links (and all others) so they're easily clickable!
- Moves a few types to proper class files
- In places sync/async methods are adjacent, utilizes `<inheritdoc cref="" /> to de-dupe
- ...and some other misc URL cleanup throughout.

In general: docs only change - I think we should merge this as-is to help PRs coming in, then I'll continue to iterate on docs.