### PR TITLE
SORT_RO

### DIFF
--- a/src/StackExchange.Redis/Enums/RedisCommand.cs
+++ b/src/StackExchange.Redis/Enums/RedisCommand.cs
@@ -166,6 +166,7 @@ internal enum RedisCommand
     SMISMEMBER,
     SMOVE,
     SORT,
+    SORT_RO,
     SPOP,
     SRANDMEMBER,
     SREM,
@@ -320,6 +321,7 @@ internal static class RedisCommandExtensions
             case RedisCommand.SETRANGE:
             case RedisCommand.SINTERSTORE:
             case RedisCommand.SMOVE:
+            case RedisCommand.SORT:
             case RedisCommand.SPOP:
             case RedisCommand.SREM:
             case RedisCommand.SUNIONSTORE:
@@ -428,7 +430,7 @@ internal static class RedisCommandExtensions
             case RedisCommand.SLOWLOG:
             case RedisCommand.SMEMBERS:
             case RedisCommand.SMISMEMBER:
-            case RedisCommand.SORT:
+            case RedisCommand.SORT_RO:
             case RedisCommand.SRANDMEMBER:
             case RedisCommand.STRLEN:
             case RedisCommand.SUBSCRIBE:

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -1540,6 +1540,7 @@ namespace StackExchange.Redis
         /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
         /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
         /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
+        /// Uses <a href="https://redis.io/commands/sort_ro">SORT_RO</a> when possible.
         /// </summary>
         /// <param name="key">The key of the list, set, or sorted set.</param>
         /// <param name="skip">How many entries to skip on the return.</param>
@@ -1551,6 +1552,7 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The sorted elements, or the external values if <c>get</c> is specified.</returns>
         /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
+        /// <remarks><seealso href="https://redis.io/commands/sort_ro"/></remarks>
         RedisValue[] Sort(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -1505,6 +1505,7 @@ namespace StackExchange.Redis
         /// the <c>get</c> parameter (note that <c>#</c> specifies the element itself, when used in <c>get</c>).
         /// Referring to the <a href="https://redis.io/commands/sort">redis SORT documentation </a> for examples is recommended.
         /// When used in hashes, <c>by</c> and <c>get</c> can be used to specify fields using <c>-&gt;</c> notation (again, refer to redis documentation).
+        /// Uses <a href="https://redis.io/commands/sort_ro">SORT_RO</a> when possible.
         /// </summary>
         /// <param name="key">The key of the list, set, or sorted set.</param>
         /// <param name="skip">How many entries to skip on the return.</param>

--- a/tests/StackExchange.Redis.Tests/Sets.cs
+++ b/tests/StackExchange.Redis.Tests/Sets.cs
@@ -343,4 +343,42 @@ public class Sets : TestBase
         var arr = db.SetPop(key, 1);
         Assert.Empty(arr);
     }
+
+    [Fact]
+    public async Task TestSort()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        await db.KeyDeleteAsync(key);
+
+        var random = new Random();
+        var items = Enumerable.Repeat(0, 200).Select(x => random.Next()).ToList();
+        await db.SetAddAsync(key, items.Select(x=>(RedisValue)x).ToArray());
+        items.Sort();
+
+        var result = (await db.SortAsync(key)).Select(x=>(int)x);
+        Assert.Equal(items.Count,result.Count() );
+        Assert.Equivalent(items, result);
+    }
+
+    [Fact]
+    public async Task TestSortRo()
+    {
+        using var conn = Create(require: RedisFeatures.v7_0_0_rc1);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        await db.KeyDeleteAsync(key);
+
+        var random = new Random();
+        var items = Enumerable.Repeat(0, 200).Select(x => random.Next()).ToList();
+        await db.SetAddAsync(key, items.Select(x=>(RedisValue)x).ToArray());
+        items.Sort();
+
+        var result = (await db.SortAsync(key)).Select(x=>(int)x);
+        Assert.Equal(items.Count,result.Count() );
+        Assert.Equivalent(items, result);
+    }
 }


### PR DESCRIPTION
@NickCraver - I modified the path for message creation for the Sort command to point to using `SORT_RO` when possible, this again had to do a version-check against the multiplexer, which I'm not certain is the correct way - thoughts?

Also, SORT is considered a write command and will be rejected out of hand by a replica (so I'm moving that as well)

```text
127.0.0.1:6378> SORT test
(error) READONLY You can't write against a read only replica.
```