### PR TITLE
Add .NET 6.0 env variable for color output

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,8 @@ jobs:
       run: docker-compose -f docker-compose.yml up -d
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
+      env:
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
     - uses: dorny/test-reporter@v1
       continue-on-error: true
       if: success() || failure()
@@ -75,6 +77,8 @@ jobs:
         Start-Service redis-*
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
+      env:
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
     - uses: dorny/test-reporter@v1
       continue-on-error: true
       if: success() || failure()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Enable color output, even though the console output is redirected in Actions
+      TERM: xterm # Enable color output in GitHub Actions
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -45,7 +46,8 @@ jobs:
     runs-on: windows-2022
     env:
       NUGET_CERT_REVOCATION_MODE: offline # Disabling signing because of massive perf hit, see https://github.com/NuGet/Home/issues/11548
-      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1"
+      TERM: xterm
     steps:
     - name: Checkout code
       uses: actions/checkout@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: windows-2022
     env:
       NUGET_CERT_REVOCATION_MODE: offline # Disabling signing because of massive perf hit, see https://github.com/NuGet/Home/issues/11548
-      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1"
+      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Note this doesn't work yet for Windows - see https://github.com/dotnet/runtime/issues/68340
       TERM: xterm
     steps:
     - name: Checkout code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,8 @@ jobs:
   main:
     name: StackExchange.Redis (Ubuntu)
     runs-on: ubuntu-latest
+    env:
+      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Enable color output, even though the console output is redirected in Actions
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -28,8 +30,6 @@ jobs:
       run: docker-compose -f docker-compose.yml up -d
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
-      env:
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
     - uses: dorny/test-reporter@v1
       continue-on-error: true
       if: success() || failure()
@@ -45,6 +45,7 @@ jobs:
     runs-on: windows-2022
     env:
       NUGET_CERT_REVOCATION_MODE: offline # Disabling signing because of massive perf hit, see https://github.com/NuGet/Home/issues/11548
+      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -77,8 +78,6 @@ jobs:
         Start-Service redis-*
     - name: StackExchange.Redis.Tests
       run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --results-directory ./test-results/ /p:CI=true
-      env:
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
     - uses: dorny/test-reporter@v1
       continue-on-error: true
       if: success() || failure()


### PR DESCRIPTION
See https://github.com/dotnet/runtime/pull/47935 for details, basically enables color output even though console output is redirected for a better time in GitHub actions.