### PR TITLE
for pub/sub, treat length-one arrays comparably to simple values

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,6 +29,7 @@
 - Adds: Support for `OBJECT FREQ` with `.KeyFrequency()`/`.KeyFrequencyAsync()` ([#2105 by Avital-Fine](https://github.com/StackExchange/StackExchange.Redis/pull/2105))
 - Performance: Avoids allocations when computing cluster hash slots or testing key equality ([#2110 by Marc Gravell](https://github.com/StackExchange/StackExchange.Redis/pull/2110))
 - Adds: Support for `SORT_RO` with `.Sort()`/`.SortAsync()` ([#2111 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2111))
+- Adds: Support for pub/sub payloads that are unary arrays ([#2118 by Marc Gravell](https://github.com/StackExchange/StackExchange.Redis/pull/2118))
 
 ## 2.5.61
 

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1566,7 +1566,7 @@ namespace StackExchange.Redis
                     case ResultType.BulkString:
                         parsed = value.AsRedisValue();
                         return true;
-                    case ResultType.MultiBulk when value.ItemsCount == 1:
+                    case ResultType.MultiBulk when allowArraySingleton && value.ItemsCount == 1:
                         return TryGetPubSubPayload(in value[0], out parsed, allowArraySingleton: false);
                 }
                 parsed = default;

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1498,10 +1498,10 @@ namespace StackExchange.Redis
                     // invoke the handlers
                     var channel = items[1].AsRedisChannel(ChannelPrefix, RedisChannel.PatternMode.Literal);
                     Trace("MESSAGE: " + channel);
-                    if (!channel.IsNull)
+                    if (!channel.IsNull && TryGetPubSubPayload(items[2], out var payload))
                     {
                         _readStatus = ReadStatus.InvokePubSub;
-                        muxer.OnMessage(channel, channel, items[2].AsRedisValue());
+                        muxer.OnMessage(channel, channel, payload);
                     }
                     return; // AND STOP PROCESSING!
                 }
@@ -1511,11 +1511,11 @@ namespace StackExchange.Redis
 
                     var channel = items[2].AsRedisChannel(ChannelPrefix, RedisChannel.PatternMode.Literal);
                     Trace("PMESSAGE: " + channel);
-                    if (!channel.IsNull)
+                    if (!channel.IsNull && TryGetPubSubPayload(items[3], out var payload))
                     {
                         var sub = items[1].AsRedisChannel(ChannelPrefix, RedisChannel.PatternMode.Pattern);
                         _readStatus = ReadStatus.InvokePubSub;
-                        muxer.OnMessage(sub, channel, items[3].AsRedisValue());
+                        muxer.OnMessage(sub, channel, payload);
                     }
                     return; // AND STOP PROCESSING!
                 }
@@ -1551,6 +1551,27 @@ namespace StackExchange.Redis
             }
             _readStatus = ReadStatus.MatchResultComplete;
             _activeMessage = null;
+
+            static bool TryGetPubSubPayload(in RawResult value, out RedisValue parsed, bool allowArraySingleton = true)
+            {
+                if (value.IsNull)
+                {
+                    parsed = RedisValue.Null;
+                    return true;
+                }
+                switch (value.Type)
+                {
+                    case ResultType.Integer:
+                    case ResultType.SimpleString:
+                    case ResultType.BulkString:
+                        parsed = value.AsRedisValue();
+                        return true;
+                    case ResultType.MultiBulk when value.ItemsCount == 1:
+                        return TryGetPubSubPayload(in value[0], out parsed, allowArraySingleton: false);
+                }
+                parsed = default;
+                return false;
+            }
         }
 
         private volatile Message? _activeMessage;


### PR DESCRIPTION
fix #2117

it appears that some of the RESP2 fallback support for client-side caching uses multi-bulk payloads; this currently causes a connection break, so we definitely need to stop *the failure*, but we can also interpret unary arrays similarly to simple values, which should at least allow simple cases to work