### PR TITLE
Fix race condition in Sentinel connection multiplexer

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -32,6 +32,7 @@
 - Adds: Support for `SORT_RO` with `.Sort()`/`.SortAsync()` ([#2111 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2111))
 - Adds: Support for `BIT | BYTE` to `BITCOUNT` and `BITPOS` with `.StringBitCount()`/`.StringBitCountAsync()` and `.StringBitPosition()`/`.StringBitPositionAsync()` [#2116 by Avital-Fine](https://github.com/StackExchange/StackExchange.Redis/pull/2116))
 - Adds: Support for pub/sub payloads that are unary arrays ([#2118 by Marc Gravell](https://github.com/StackExchange/StackExchange.Redis/pull/2118))
+- Fix: Sentinel timer race during dispose ([#2133 by ewisuri](https://github.com/StackExchange/StackExchange.Redis/pull/2133))
 
 ## 2.5.61
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -331,7 +331,14 @@ public partial class ConnectionMultiplexer
                 }
                 finally
                 {
-                    connection.sentinelPrimaryReconnectTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+                    try
+                    {
+                        connection.sentinelPrimaryReconnectTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+                    } catch (ObjectDisposedException)
+                    {
+                        // If we get here the managed connection was restored and the timer was
+                        // disposed by another thread, so there's no need to run the timer again.
+                    }
                 }
             }, null, TimeSpan.Zero, Timeout.InfiniteTimeSpan);
         }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -334,7 +334,8 @@ public partial class ConnectionMultiplexer
                     try
                     {
                         connection.sentinelPrimaryReconnectTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
-                    } catch (ObjectDisposedException)
+                    }
+                    catch (ObjectDisposedException)
                     {
                         // If we get here the managed connection was restored and the timer was
                         // disposed by another thread, so there's no need to run the timer again.


### PR DESCRIPTION
In the Sentinel Connection Multiplexer, since `OnManagedConnectionRestored` can be executed on a different thread, it's possible for it to dispose the timer just before `OnManagedConnectionFailed` calls `.Change()` on the timer, which leads to an `ObjectDisposedException` being thrown in `OnManagedConnectionFailed`. Since the connection was restored, it seems safe to suppress these exceptions, instead of requiring locking around the reference to `connection.sentinelPrimaryReconnectTimer`.