### PR TITLE
Update IncludePerformanceCountersInExceptions refs to new location

### DIFF
--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -154,7 +154,7 @@ namespace StackExchange.Redis
             if (multiplexer.RawConfig.IncludeDetailInExceptions)
             {
                 CopyDataToException(data, ex);
-                sb.Append("; ").Append(PerfCounterHelper.GetThreadPoolAndCPUSummary(multiplexer.IncludePerformanceCountersInExceptions));
+                sb.Append("; ").Append(PerfCounterHelper.GetThreadPoolAndCPUSummary(multiplexer.RawConfig.IncludePerformanceCountersInExceptions));
                 AddExceptionDetail(ex, message, server, commandLabel);
             }
             return ex;
@@ -349,7 +349,7 @@ namespace StackExchange.Redis
             }
             data.Add(Tuple.Create("Busy-Workers", busyWorkerCount.ToString()));
 
-            if (multiplexer.IncludePerformanceCountersInExceptions)
+            if (multiplexer.RawConfig.IncludePerformanceCountersInExceptions)
             {
                 Add(data, sb, "Local-CPU", "Local-CPU", PerfCounterHelper.GetSystemCpuPercent());
             }

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -260,7 +260,7 @@ namespace StackExchange.Redis
                                 {
                                     unableToConnectError = true;
                                     err = $"Endpoint {endpoint} serving hashslot {hashSlot} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect. "
-                                        + PerfCounterHelper.GetThreadPoolAndCPUSummary(bridge.Multiplexer.IncludePerformanceCountersInExceptions);
+                                        + PerfCounterHelper.GetThreadPoolAndCPUSummary(bridge.Multiplexer.RawConfig.IncludePerformanceCountersInExceptions);
                                 }
                             }
                         }


### PR DESCRIPTION
`ConnectionMultiplexer.IncludePerformanceCountersInExceptions` is marked for deprecation. This change redirects references to the replacement at `ConfigurationOptions.IncludePerformanceCountersInExceptions`