### PR TITLE
fix: corrected fuget.org typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@ StackExchange.Redis
 ===================
 
 - [Release Notes](ReleaseNotes)
-- [API Browser (via furget.org)](https://www.fuget.org/packages/StackExchange.Redis/)
+- [API Browser (via fuget.org)](https://www.fuget.org/packages/StackExchange.Redis/)
 
 ## Overview
 


### PR DESCRIPTION
In the "API Browser" link text, the reference to fuget.org was furget.org. This change is to correct the spelling of the site.