### PR TITLE
Implement IAsyncDisposable from IConnectionMultiplexer

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix [#2182](https://github.com/StackExchange/StackExchange.Redis/issues/2182): Be more flexible in which commands are "primary only" in order to support users with replicas that are explicitly configured to allow writes ([#2183 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2183))
+- Adds: `IConnectionMultiplexer` now implements `IAsyncDisposable` ([#2161 by kimsey0](https://github.com/StackExchange/StackExchange.Redis/pull/2161))
 
 ## 2.6.48
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2025,7 +2025,7 @@ namespace StackExchange.Redis
             await CloseAsync(!_isDisposed);
             if (sentinelConnection is ConnectionMultiplexer sentinel)
             {
-                await (sentinel?.DisposeAsync() ?? default);
+                await sentinel.DisposeAsync();
             }
             var oldTimer = Interlocked.Exchange(ref sentinelPrimaryReconnectTimer, null);
             oldTimer?.Dispose();

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2017,6 +2017,21 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// Release all resources associated with this object.
+        /// </summary>
+        public async ValueTask DisposeAsync()
+        {
+            GC.SuppressFinalize(this);
+            await CloseAsync(!_isDisposed);
+            if (sentinelConnection is not null)
+            {
+                await sentinelConnection.DisposeAsync();
+            }
+            var oldTimer = Interlocked.Exchange(ref sentinelPrimaryReconnectTimer, null);
+            oldTimer?.Dispose();
+        }
+
+        /// <summary>
         /// Close all connections and release all resources associated with this object.
         /// </summary>
         /// <param name="allowCommandsToComplete">Whether to allow all in-queue commands to complete first.</param>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2023,9 +2023,9 @@ namespace StackExchange.Redis
         {
             GC.SuppressFinalize(this);
             await CloseAsync(!_isDisposed);
-            if (sentinelConnection is not null)
+            if (sentinelConnection is ConnectionMultiplexer sentinel)
             {
-                await sentinelConnection.DisposeAsync();
+                await (sentinel?.DisposeAsync() ?? default);
             }
             var oldTimer = Interlocked.Exchange(ref sentinelPrimaryReconnectTimer, null);
             oldTimer?.Dispose();

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -20,7 +20,7 @@ namespace StackExchange.Redis
     /// <summary>
     /// Represents the abstract multiplexer API.
     /// </summary>
-    public interface IConnectionMultiplexer : IDisposable
+    public interface IConnectionMultiplexer : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Gets the client-name that will be used on all new connections.

--- a/src/StackExchange.Redis/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI.Shipped.txt
@@ -308,6 +308,7 @@ StackExchange.Redis.ConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter? l
 StackExchange.Redis.ConnectionMultiplexer.ConnectionFailed -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.ConnectionRestored -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.Dispose() -> void
+StackExchange.Redis.ConnectionMultiplexer.DisposeAsync() -> System.Threading.Tasks.ValueTask
 StackExchange.Redis.ConnectionMultiplexer.ErrorMessage -> System.EventHandler<StackExchange.Redis.RedisErrorEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.ExportConfiguration(System.IO.Stream! destination, StackExchange.Redis.ExportOptions options = (StackExchange.Redis.ExportOptions)-1) -> void
 StackExchange.Redis.ConnectionMultiplexer.GetCounters() -> StackExchange.Redis.ServerCounters!

--- a/src/StackExchange.Redis/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿StackExchange.Redis.ConnectionMultiplexer.DisposeAsync() -> System.Threading.Tasks.ValueTask

--- a/src/StackExchange.Redis/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿StackExchange.Redis.ConnectionMultiplexer.DisposeAsync() -> System.Threading.Tasks.ValueTask
+﻿

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -128,6 +128,8 @@ public class SharedConnectionFixture : IDisposable
 
         public void Dispose() { } // DO NOT call _inner.Dispose();
 
+        public ValueTask DisposeAsync() => default; // DO NOT call _inner.DisposeAsync();
+
         public ServerCounters GetCounters() => _inner.GetCounters();
 
         public IDatabase GetDatabase(int db = -1, object? asyncState = null) => _inner.GetDatabase(db, asyncState);


### PR DESCRIPTION
Fixes #2160.

We may want to implement `IAsyncDisposable` in more public `IDisposable` classes which can dispose their resources asynchronously.