### PR TITLE
Use 3 parts as assembly version

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,9 @@
 {
   "version": "2.6",
   "versionHeightOffset": -1,
-  "assemblyVersion": "2.0",
+  "assemblyVersion": {
+    "precision": "build"
+  },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
Found while implementing OpenTelemetry AutoIntrumention https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/979

It will be useful to have a possibility to detect assembly version on runtime. As you are using 3 parts as a release version, the precision should be set to `build`. If you prefer have all 4 parts, it can be changed to `revision`.

Before changes

```csharp
[assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
[assembly: System.Reflection.AssemblyFileVersionAttribute("2.6.53.65123")]
[assembly: System.Reflection.AssemblyInformationalVersionAttribute("2.6.53+63fe68c7de")]
```

After changes
```csharp
[assembly: System.Reflection.AssemblyVersionAttribute("2.6.53.0")]
[assembly: System.Reflection.AssemblyFileVersionAttribute("2.6.53.65123")]
[assembly: System.Reflection.AssemblyInformationalVersionAttribute("2.6.53+63fe68c7de")]
```