### PR TITLE
Add more error information when the cast fails

### DIFF
--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -134,14 +134,14 @@ namespace StackExchange.Redis
                     }
                     return default;
                 default:
-                    throw new InvalidCastException("Cannot convert to RedisChannel: " + Type);
+                    throw new InvalidCastException("Cannot convert to RedisChannel: " + ToString());
             }
         }
 
         internal RedisKey AsRedisKey() => Type switch
         {
             ResultType.SimpleString or ResultType.BulkString => (RedisKey)GetBlob(),
-            _ => throw new InvalidCastException("Cannot convert to RedisKey: " + Type),
+            _ => throw new InvalidCastException("Cannot convert to RedisKey: " + ToString()),
         };
 
         internal RedisValue AsRedisValue()
@@ -157,7 +157,7 @@ namespace StackExchange.Redis
                 case ResultType.BulkString:
                     return (RedisValue)GetBlob();
             }
-            throw new InvalidCastException("Cannot convert to RedisValue: " + Type);
+            throw new InvalidCastException("Cannot convert to RedisValue: " + ToString());
         }
 
         internal Lease<byte>? AsLease()
@@ -172,7 +172,7 @@ namespace StackExchange.Redis
                     payload.CopyTo(lease.Span);
                     return lease;
             }
-            throw new InvalidCastException("Cannot convert to Lease: " + Type);
+            throw new InvalidCastException("Cannot convert to Lease: " + ToString());
         }
 
         internal bool IsEqual(in CommandBytes expected)

--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -133,15 +133,17 @@ namespace StackExchange.Redis
                         return new RedisChannel(copy, mode);
                     }
                     return default;
-                default:
+                case ResultType.Error:
                     throw new InvalidCastException("Cannot convert to RedisChannel: " + ToString());
+                default:
+                    throw new InvalidCastException("Cannot convert to RedisChannel: " + Type);
             }
         }
 
         internal RedisKey AsRedisKey() => Type switch
         {
             ResultType.SimpleString or ResultType.BulkString => (RedisKey)GetBlob(),
-            _ => throw new InvalidCastException("Cannot convert to RedisKey: " + ToString()),
+            _ => throw new InvalidCastException("Cannot convert to RedisKey: " + Type),
         };
 
         internal RedisValue AsRedisValue()
@@ -156,8 +158,10 @@ namespace StackExchange.Redis
                 case ResultType.SimpleString:
                 case ResultType.BulkString:
                     return (RedisValue)GetBlob();
+                case ResultType.Error:
+                    throw new InvalidCastException("Cannot convert to RedisValue: " + ToString());
             }
-            throw new InvalidCastException("Cannot convert to RedisValue: " + ToString());
+            throw new InvalidCastException("Cannot convert to RedisValue: " + Type);
         }
 
         internal Lease<byte>? AsLease()
@@ -171,8 +175,10 @@ namespace StackExchange.Redis
                     var lease = Lease<byte>.Create(checked((int)payload.Length), false);
                     payload.CopyTo(lease.Span);
                     return lease;
+                case ResultType.Error:
+                    throw new InvalidCastException("Cannot convert to Lease: " + ToString());
             }
-            throw new InvalidCastException("Cannot convert to Lease: " + ToString());
+            throw new InvalidCastException("Cannot convert to Lease: " + Type);
         }
 
         internal bool IsEqual(in CommandBytes expected)

--- a/tests/StackExchange.Redis.Tests/RawResultTests.cs
+++ b/tests/StackExchange.Redis.Tests/RawResultTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
+using System.Text;
 using Xunit;
 
 namespace StackExchange.Redis.Tests;
@@ -61,5 +63,18 @@ public class RawResultTests
 
         var arr = (byte[]?)value;
         Assert.Null(arr);
+    }
+
+    [Fact]
+    public void ErrorTypeReturnsMessage()
+    {
+        var ascii = "expected error";
+        var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(ascii));
+
+
+        var result = new RawResult(ResultType.Error, buffer, false);
+        var ex = Assert.Throws<InvalidCastException>(() => result.AsRedisValue());
+
+        Assert.Contains(ascii, ex.Message);
     }
 }


### PR DESCRIPTION
When redis/envoy  proxy servers return error, currently we do not propagate the error string to the client. Client gets an errors

`Cannot convert to RedisValue: Error`

It will be nice to propagate the error that is sent by the upstream servers here (redis or proxy) to the client for better observability.

After this PR we should see the errors similar to the following:

`Cannot convert to RedisValue: Error: upstream link failure`