### PR TITLE
Add ConnectionMultiplexer.GetServers() API

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,7 @@
 
 - Fix [#2182](https://github.com/StackExchange/StackExchange.Redis/issues/2182): Be more flexible in which commands are "primary only" in order to support users with replicas that are explicitly configured to allow writes ([#2183 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2183))
 - Adds: `IConnectionMultiplexer` now implements `IAsyncDisposable` ([#2161 by kimsey0](https://github.com/StackExchange/StackExchange.Redis/pull/2161))
+- Adds: `IConnectionMultiplexer.GetServers()` to get all `IServer` instances for a multiplexer ([#2203 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2203))
 
 ## 2.6.48
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" Condition=" '$(DEVCONTAINER)' != 'true' " />
   </ItemGroup>
 </Project>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1030,6 +1030,20 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// Obtain configuration APIs for all servers this multiplexer.
+        /// </summary>
+        public IServer[] GetServers()
+        {
+            var snapshot = GetServerSnapshot();
+            var result = new IServer[snapshot.Length];
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                result[i] = new RedisServer(this, snapshot[i], null);
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Get the hash-slot associated with a given key, if applicable.
         /// This can be useful for grouping operations.
         /// </summary>

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1030,7 +1030,7 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// Obtain configuration APIs for all servers this multiplexer.
+        /// Obtain configuration APIs for all servers in this multiplexer.
         /// </summary>
         public IServer[] GetServers()
         {

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -191,6 +192,11 @@ namespace StackExchange.Redis
         /// <param name="endpoint">The endpoint to get a server for.</param>
         /// <param name="asyncState">The async state to pass to the created <see cref="IServer"/>.</param>
         IServer GetServer(EndPoint endpoint, object? asyncState = null);
+
+        /// <summary>
+        /// Obtain configuration APIs for all servers this multiplexer.
+        /// </summary>
+        IServer[] GetServers();
 
         /// <summary>
         /// Reconfigure the current connections based on the existing configuration.

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -194,7 +194,7 @@ namespace StackExchange.Redis
         IServer GetServer(EndPoint endpoint, object? asyncState = null);
 
         /// <summary>
-        /// Obtain configuration APIs for all servers this multiplexer.
+        /// Obtain configuration APIs for all servers in this multiplexer.
         /// </summary>
         IServer[] GetServers();
 

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -1565,8 +1565,10 @@ namespace StackExchange.Redis
         /// <param name="get">The key pattern to sort by, if any e.g. ExternalKey_* would return the value of ExternalKey_{listvalue} for each entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The sorted elements, or the external values if <c>get</c> is specified.</returns>
-        /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
-        /// <remarks><seealso href="https://redis.io/commands/sort_ro"/></remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sort"/>,
+        /// <seealso href="https://redis.io/commands/sort_ro"/>
+        /// </remarks>
         RedisValue[] Sort(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -1530,7 +1530,10 @@ namespace StackExchange.Redis
         /// <param name="get">The key pattern to sort by, if any e.g. ExternalKey_* would return the value of ExternalKey_{listvalue} for each entry.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The sorted elements, or the external values if <c>get</c> is specified.</returns>
-        /// <remarks><seealso href="https://redis.io/commands/sort"/></remarks>
+        /// <remarks>
+        /// <seealso href="https://redis.io/commands/sort"/>,
+        /// <seealso href="https://redis.io/commands/sort_ro"/>
+        /// </remarks>
         Task<RedisValue[]> SortAsync(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>

--- a/src/StackExchange.Redis/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI.Shipped.txt
@@ -320,6 +320,7 @@ StackExchange.Redis.ConnectionMultiplexer.GetServer(string! host, int port, obje
 StackExchange.Redis.ConnectionMultiplexer.GetServer(string! hostAndPort, object? asyncState = null) -> StackExchange.Redis.IServer!
 StackExchange.Redis.ConnectionMultiplexer.GetServer(System.Net.EndPoint? endpoint, object? asyncState = null) -> StackExchange.Redis.IServer!
 StackExchange.Redis.ConnectionMultiplexer.GetServer(System.Net.IPAddress! host, int port) -> StackExchange.Redis.IServer!
+StackExchange.Redis.ConnectionMultiplexer.GetServers() -> StackExchange.Redis.IServer![]!
 StackExchange.Redis.ConnectionMultiplexer.GetStatus() -> string!
 StackExchange.Redis.ConnectionMultiplexer.GetStatus(System.IO.TextWriter! log) -> void
 StackExchange.Redis.ConnectionMultiplexer.GetStormLog() -> string?
@@ -460,6 +461,7 @@ StackExchange.Redis.IConnectionMultiplexer.GetServer(string! host, int port, obj
 StackExchange.Redis.IConnectionMultiplexer.GetServer(string! hostAndPort, object? asyncState = null) -> StackExchange.Redis.IServer!
 StackExchange.Redis.IConnectionMultiplexer.GetServer(System.Net.EndPoint! endpoint, object? asyncState = null) -> StackExchange.Redis.IServer!
 StackExchange.Redis.IConnectionMultiplexer.GetServer(System.Net.IPAddress! host, int port) -> StackExchange.Redis.IServer!
+StackExchange.Redis.IConnectionMultiplexer.GetServers() -> StackExchange.Redis.IServer![]!
 StackExchange.Redis.IConnectionMultiplexer.GetStatus() -> string!
 StackExchange.Redis.IConnectionMultiplexer.GetStatus(System.IO.TextWriter! log) -> void
 StackExchange.Redis.IConnectionMultiplexer.GetStormLog() -> string?

--- a/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/SharedConnectionFixture.cs
@@ -146,6 +146,8 @@ public class SharedConnectionFixture : IDisposable
 
         public IServer GetServer(EndPoint endpoint, object? asyncState = null) => _inner.GetServer(endpoint, asyncState);
 
+        public IServer[] GetServers() => _inner.GetServers();
+
         public string GetStatus() => _inner.GetStatus();
 
         public void GetStatus(TextWriter log) => _inner.GetStatus(log);

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -221,11 +221,9 @@ public abstract class TestBase : IDisposable
 
     protected static IServer GetServer(IConnectionMultiplexer muxer)
     {
-        EndPoint[] endpoints = muxer.GetEndPoints();
         IServer? result = null;
-        foreach (var endpoint in endpoints)
+        foreach (var server in muxer.GetServers())
         {
-            var server = muxer.GetServer(endpoint);
             if (server.IsReplica || !server.IsConnected) continue;
             if (result != null) throw new InvalidOperationException("Requires exactly one primary endpoint (found " + server.EndPoint + " and " + result.EndPoint + ")");
             result = server;


### PR DESCRIPTION
Making things a bit easier for when you need to iterate over servers for a multiplexer