### PR TITLE
Sentinel: fix repeat connects

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,7 @@
 - Fix [#1968](https://github.com/StackExchange/StackExchange.Redis/issues/1968): Improved handling of EVAL scripts during server restarts and failovers, detecting and re-sending the script for a retry when needed ([#2170 by martintmk](https://github.com/StackExchange/StackExchange.Redis/pull/2170))
 - Adds: `ConfigurationOptions.SslClientAuthenticationOptions` (`netcoreapp3.1`/`net5.0`+ only) to give more control over SSL/TLS authentication ([#2224 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2224))
 - Fix [#2240](https://github.com/StackExchange/StackExchange.Redis/pull/2241): Improve support for DNS-based IPv6 endpoints ([#2241 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2241))
+- Fix [#2233](https://github.com/StackExchange/StackExchange.Redis/issues/2233): Repeated connection to Sentinel servers using the same ConfigurationOptions would fail ([#2242 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2242))
 
 
 ## 2.6.48

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -140,10 +140,10 @@ namespace StackExchange.Redis
             SetAutodetectFeatureFlags();
         }
 
-        private ConnectionMultiplexer(ConfigurationOptions configuration, ServerType? serverType = null)
+        private ConnectionMultiplexer(ConfigurationOptions configuration, ServerType? serverType = null, EndPointCollection? endpoints = null)
         {
             RawConfig = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            EndPoints = RawConfig.EndPoints.Clone();
+            EndPoints = endpoints ?? RawConfig.EndPoints.Clone();
             EndPoints.SetDefaultPorts(serverType, ssl: RawConfig.Ssl);
 
             var map = CommandMap = configuration.GetCommandMap(serverType);
@@ -169,9 +169,9 @@ namespace StackExchange.Redis
             lastHeartbeatTicks = Environment.TickCount;
         }
 
-        private static ConnectionMultiplexer CreateMultiplexer(ConfigurationOptions configuration, LogProxy? log, ServerType? serverType, out EventHandler<ConnectionFailedEventArgs>? connectHandler)
+        private static ConnectionMultiplexer CreateMultiplexer(ConfigurationOptions configuration, LogProxy? log, ServerType? serverType, out EventHandler<ConnectionFailedEventArgs>? connectHandler, EndPointCollection? endpoints = null)
         {
-            var muxer = new ConnectionMultiplexer(configuration, serverType);
+            var muxer = new ConnectionMultiplexer(configuration, serverType, endpoints);
             connectHandler = null;
             if (log is not null)
             {
@@ -679,7 +679,7 @@ namespace StackExchange.Redis
                 : ConnectImpl(configuration, log);
         }
 
-        private static ConnectionMultiplexer ConnectImpl(ConfigurationOptions configuration, TextWriter? log, ServerType? serverType = null)
+        private static ConnectionMultiplexer ConnectImpl(ConfigurationOptions configuration, TextWriter? log, ServerType? serverType = null, EndPointCollection? endpoints = null)
         {
             IDisposable? killMe = null;
             EventHandler<ConnectionFailedEventArgs>? connectHandler = null;
@@ -690,7 +690,7 @@ namespace StackExchange.Redis
                 var sw = ValueStopwatch.StartNew();
                 logProxy?.WriteLine($"Connecting (sync) on {RuntimeInformation.FrameworkDescription} (StackExchange.Redis: v{Utils.GetLibVersion()})");
 
-                muxer = CreateMultiplexer(configuration, logProxy, serverType, out connectHandler);
+                muxer = CreateMultiplexer(configuration, logProxy, serverType, out connectHandler, endpoints);
                 killMe = muxer;
                 Interlocked.Increment(ref muxer._connectAttemptCount);
                 // note that task has timeouts internally, so it might take *just over* the regular timeout

--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -228,6 +228,6 @@ namespace StackExchange.Redis
             }
         }
 
-        internal EndPointCollection Clone() => new EndPointCollection(this);
+        internal EndPointCollection Clone() => new EndPointCollection(new List<EndPoint>(Items));
     }
 }


### PR DESCRIPTION
Fixes #2233.

There were 2 issues here contributing:
1. Sentinel was modifying the config options, which we no longer clone. Now, we clone the endpoints and pass them down as explicit overrides into the child connection.
2. EndpointCollection...wasn't actually cloning. I can't believe this didn't show up elsewhere. Collection<T> takes a ref directly without copy of members when forming, so even if ew did clone...we'd be modifying the same thing.