### PR TITLE
Remove SCRIPT LOAD from ScriptEvalMessage executions

### DIFF
--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -4742,13 +4742,15 @@ namespace StackExchange.Redis
             public override int ArgCount => _args.Count;
         }
 
-        private sealed class ScriptEvalMessage : Message
+        internal sealed class ScriptEvalMessage : Message
         {
             private readonly RedisKey[] keys;
             private readonly string? script;
             private readonly RedisValue[] values;
             private byte[]? asciiHash;
             private readonly byte[]? hexHash;
+
+            public string? Script => script;
 
             public ScriptEvalMessage(int db, CommandFlags flags, string script, RedisKey[]? keys, RedisValue[]? values)
                 : this(db, flags, ResultProcessor.ScriptLoadProcessor.IsSHA1(script) ? RedisCommand.EVALSHA : RedisCommand.EVAL, script, null, keys, values)
@@ -4815,16 +4817,8 @@ namespace StackExchange.Redis
                     physical.Write(keys[i]);
                 for (int i = 0; i < values.Length; i++)
                     physical.WriteBulkString(values[i]);
-
-
-                if (asciiHash == null
-                    && script != null
-                    && bridge != null
-                    && (Flags & CommandFlags.NoScriptCache) == 0)
-                {
-                    bridge.ServerEndPoint.SetScriptHash(script, command);
-                }
             }
+
             public override int ArgCount => 2 + keys.Length + values.Length;
         }
 

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1777,7 +1777,9 @@ The coordinates as a two items x,y array (longitude,latitude).
             {
                 if (RedisResult.TryCreate(connection, result, out var value))
                 {
-                    if (message is RedisDatabase.ScriptEvalMessage el && el.Script != null)
+                    if (result.Type != ResultType.Error
+                        && message is RedisDatabase.ScriptEvalMessage el
+                        && el.Script != null)
                     {
                         connection.BridgeCouldBeNull?.ServerEndPoint?.SetScriptHash(el.Script, el.Command);
                     }

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1777,6 +1777,10 @@ The coordinates as a two items x,y array (longitude,latitude).
             {
                 if (RedisResult.TryCreate(connection, result, out var value))
                 {
+                    if (message is RedisDatabase.ScriptEvalMessage el && el.Script != null)
+                    {
+                        connection.BridgeCouldBeNull?.ServerEndPoint?.SetScriptHash(el.Script, el.Command);
+                    }
                     SetResult(message, value);
                     return true;
                 }

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -546,11 +546,11 @@ namespace StackExchange.Redis
                 return;
             }
 
-            var hash = Sha1(script);
+            var hash = Encoding.ASCII.GetBytes(Sha1(script));
 
             lock(knownScripts)
             {
-                knownScripts[script] = Encoding.ASCII.GetBytes(hash);
+                knownScripts[script] = hash;
             }
         }
 

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -547,7 +547,6 @@ namespace StackExchange.Redis
             }
 
             var hash = GetSHA1(script);
-
             lock(knownScripts)
             {
                 knownScripts[script] = hash;
@@ -901,7 +900,6 @@ namespace StackExchange.Redis
             byte[] outputBytes = sha1.ComputeHash(inputBytes);
             return Encoding.ASCII.GetBytes(BitConverter.ToString(outputBytes).Replace("-", "").ToLower());
         }
-
 
         private PhysicalBridge? CreateBridge(ConnectionType type, LogProxy? log)
         {

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -546,20 +546,12 @@ namespace StackExchange.Redis
                 return;
             }
 
-            var hash = Encoding.ASCII.GetBytes(Sha1(script));
+            var hash = GetSHA1(script);
 
             lock(knownScripts)
             {
                 knownScripts[script] = hash;
             }
-        }
-
-        internal string Sha1(string input)
-        {
-            var sha1 = SHA1.Create();
-            byte[] inputBytes = Encoding.ASCII.GetBytes(input);
-            byte[] outputBytes = sha1.ComputeHash(inputBytes);
-            return BitConverter.ToString(outputBytes).Replace("-", "").ToLower();
         }
 
         internal string? GetStormLog(Message message) => GetBridge(message)?.GetStormLog();
@@ -901,6 +893,15 @@ namespace StackExchange.Redis
             }
             return default;
         }
+
+        private static byte[] GetSHA1(string input)
+        {
+            var sha1 = SHA1.Create();
+            byte[] inputBytes = Encoding.ASCII.GetBytes(input);
+            byte[] outputBytes = sha1.ComputeHash(inputBytes);
+            return Encoding.ASCII.GetBytes(BitConverter.ToString(outputBytes).Replace("-", "").ToLower());
+        }
+
 
         private PhysicalBridge? CreateBridge(ConnectionType type, LogProxy? log)
         {


### PR DESCRIPTION
The current implementation of `ScriptEvalMessage` optimistically calls `SCRIPT LOAD <script>` before `EVAL <script>` for every new script that is seen by the client to load the script in redis cache. However, calling `SCRIPT LOAD <script>` in our implementation, is redundant. as the following `EVAL <script>` also loads the script in REDIS cache [1].

`SCRIPT LOAD` returns SHA1 of the script. In this PR,  we are calculating the SHA1 value within the client and passing on to `EVALSHA`. This change also has a nice side effect that `ScriptEvalMessage` no longer is a IMultiMessage interface.

A reference implementation in go-redis can be found here: https://github.com/go-redis/redis/blob/master/script.go#L59 Please note that, unlike the stackexchange client, it does not use a client side cache to track the loaded scripts.

[1] https://redis.io/docs/manual/programmability/eval-intro/ (scroll down to Script cache section)


Redis monitor before the change while calling `ScriptEvaluate` twice

```
1662073157.821955 [0 172.17.0.1:45914] "SCRIPT" "LOAD" "redis.call('set', ARGV[1], ARGV[2])"
1662073157.821967 [0 172.17.0.1:45914] "EVAL" "redis.call('set', ARGV[1], ARGV[2])" "1" "foo" "foo" "123"
1662073163.983800 [0 lua] "set" "foo" "123"
1662073165.117343 [0 172.17.0.1:45914] "EVALSHA" "738ee76b1389bf5e4bb46e6b3b23e24382d54905" "1" "foo" "foo" "123"
1662073165.117366 [0 lua] "set" "foo" "123"
```

Redis monitor after the change while calling `ScriptEvaluate` twice

```
1662682698.470518 [0 172.17.0.1:41268] "EVAL" "redis.call('set', ARGV[1], ARGV[2])" "1" "foo" "foo" "123"
1662682698.470551 [0 lua] "set" "foo" "123"
1662682698.476800 [0 172.17.0.1:41268] "EVALSHA" "738ee76b1389bf5e4bb46e6b3b23e24382d54905" "1" "foo" "foo" "123"
1662682698.476819 [0 lua] "set" "foo" "123"
```

`738ee76b1389bf5e4bb46e6b3b23e24382d54905` SHA1 of the script is calculated by C# in the second instance