### PR TITLE
Correction on documented behavior of 'httpRuntime targetFramework="4.5"'

### DIFF
--- a/docs/ThreadTheft.md
+++ b/docs/ThreadTheft.md
@@ -44,7 +44,7 @@ configure ASP.NET with:
 <add key="aspnet:UseTaskFriendlySynchronizationContext" value="false" />
 ```
 
-or if you do NOT add the following line:
+or if you do _not_ have a `<httpRuntime targetFramework="..." />` of at least 4.5 (which causes the above to default `true`) like this:
 
 ```xml
 <httpRuntime targetFramework="4.5" />

--- a/docs/ThreadTheft.md
+++ b/docs/ThreadTheft.md
@@ -44,7 +44,7 @@ configure ASP.NET with:
 <add key="aspnet:UseTaskFriendlySynchronizationContext" value="false" />
 ```
 
-or
+or if you do NOT add the following line:
 
 ```xml
 <httpRuntime targetFramework="4.5" />


### PR DESCRIPTION
The old wording equated `<httpRuntime targetFramework="4.5" />` to `<add key="aspnet:UseTaskFriendlySynchronizationContext" value="false" />`, when the linked citation makes it clear that the effect is the opposite: `<httpRuntime targetFramework="4.5" />` is inferred as adding the setting `<add key="aspnet:UseTaskFriendlySynchronizationContext" value="true" />`.

> Second, `<httpRuntime targetFramework="4.5" />` is a shortcut that allows the ASP.NET runtime to infer a wide array of configuration settings. If the runtime sees this setting, it will expand it out just as if you had written the following:
> ```
>     ...
>     <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true" />
> ```
https://devblogs.microsoft.com/dotnet/all-about-httpruntime-targetframework/