### PR TITLE
Configuration/Connections: Allow HTTP tunneling

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -96,7 +96,7 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | asyncTimeout={int}     | `AsyncTimeout`         | `SyncTimeout`                | Time (ms) to allow for asynchronous operations                                                            |
 | tiebreaker={string}    | `TieBreaker`           | `__Booksleeve_TieBreak`      | Key to use for selecting a server in an ambiguous primary scenario                                        |
 | version={string}       | `DefaultVersion`       | (`4.0` in Azure, else `2.0`) | Redis version level (useful when the server does not make this available)                                 |
-
+| tunnel={string}        | `Tunnel`               | `null`                       | Tunnel for connections (use `http:{proxy url}` for "connect"-based proxy server)
 
 Additional code-only options:
 - ReconnectRetryPolicy (`IReconnectRetryPolicy`) - Default: `ReconnectRetryPolicy = ExponentialRetry(ConnectTimeout / 2);`

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,9 @@ Current package versions:
 
 ## Unreleased
 
-No pending changes for the next release yet.
+<!-- No pending changes for the next release yet. -->
+
+- Adds: general-purpose tunnel support, with HTTP proxy "connect" support included
 
 ## 2.6.70
 

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -48,10 +48,6 @@ namespace StackExchange.Redis.Configuration
             {
                 if (socket is not null)
                 {
-
-                    // TODO: make write+read async
-                    // TODO: compare the response more appropriately?
-
                     var encoding = Encoding.ASCII;
                     var ep = Format.ToString(endpoint);
                     const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\r\n\r\n", ExpectedResponse = "HTTP/1.1 200 OK\r\n\r\n";

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Configuration
+{
+    /// <summary>
+    /// Allows interception of the transport used to communicate with redis.
+    /// </summary>
+    public abstract class Tunnel
+    {
+        /// <summary>
+        /// Gets the underlying endpoint to use when connecting to a logical endpoint.
+        /// </summary>
+        /// <remarks><c>null</c> should be returned if a socket is not required for this endpoint.</remarks>
+        public virtual ValueTask<EndPoint?> GetConnectEndpoint(EndPoint endpoint, CancellationToken cancellationToken) => new(endpoint);
+
+        /// <summary>
+        /// Invoked on a connected endpoint before server authentication and other handshakes occur, allowing pre-redis handshakes.
+        /// </summary>
+        public virtual ValueTask<Stream?> BeforeAuthenticate(EndPoint endpoint, ConnectionType connectionType, Socket? socket, CancellationToken cancellationToken) => new(default(Stream));
+
+        /// <inheritdoc/>
+        public abstract override string ToString();
+
+        private sealed class HttpProxyTunnel : Tunnel
+        {
+            public EndPoint Proxy { get; }
+            public HttpProxyTunnel(EndPoint proxy) => Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+
+
+            public override ValueTask<EndPoint?> GetConnectEndpoint(EndPoint endpoint, CancellationToken cancellationToken) => new(Proxy);
+
+            public override ValueTask<Stream?> BeforeAuthenticate(EndPoint endpoint, ConnectionType connectionType, Socket? socket, CancellationToken cancellationToken)
+            {
+                if (socket is not null)
+                {
+
+                    // TODO: make write+read async
+                    // TODO: compare the response more appropriately?
+
+                    var encoding = Encoding.ASCII;
+                    var ep = Format.ToString(endpoint);
+                    const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\r\n\r\n", ExpectedResponse = "HTTP/1.1 200 OK\r\n\r\n";
+                    byte[] chunk = ArrayPool<byte>.Shared.Rent(Math.Max(
+                        encoding.GetByteCount(Prefix) + encoding.GetByteCount(ep) + encoding.GetByteCount(Suffix),
+                        encoding.GetByteCount(ExpectedResponse)
+                    ));
+                    var offset = 0;
+                    offset += encoding.GetBytes(Prefix, 0, Prefix.Length, chunk, offset);
+                    offset += encoding.GetBytes(ep, 0, ep.Length, chunk, offset);
+                    offset += encoding.GetBytes(Suffix, 0, Suffix.Length, chunk, offset);
+                    socket.Send(chunk, offset, SocketFlags.None);
+
+                    // we expect to see: "HTTP/1.1 200 OK\n"; note our buffer is definitely big enough already
+                    int toRead = encoding.GetByteCount(ExpectedResponse), read;
+                    offset = 0;
+                    while (toRead > 0 && (read = socket.Receive(chunk, offset, toRead, SocketFlags.None)) > 0)
+                    {
+                        toRead -= read;
+                        offset += read;
+                    }
+                    if (toRead != 0) throw new EndOfStreamException("EOF negotiating HTTP tunnel");
+                    // lazy
+                    var actualResponse = encoding.GetString(chunk, 0, offset);
+                    if (ExpectedResponse != actualResponse)
+                    {
+                        throw new InvalidOperationException("Unexpected response negotiating HTTP tunnel");
+                    }
+                    ArrayPool<byte>.Shared.Return(chunk);
+                }
+                return new(default(Stream));
+            }
+
+            public override string ToString() => "http:" + Format.ToString(Proxy);
+        }
+
+        /// <summary>
+        /// Create a tunnel via an HTTP proxy server.
+        /// </summary>
+        /// <param name="proxy">The endpoint to use as an HTTP proxy server.</param>
+        public static Tunnel HttpProxy(EndPoint proxy) => new HttpProxyTunnel(proxy);
+    }
+
+    
+}

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -1,5 +1,4 @@
-﻿using Pipelines.Sockets.Unofficial;
-using System;
+﻿using System;
 using System.Buffers;
 using System.IO;
 using System.Net;
@@ -7,6 +6,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Pipelines.Sockets.Unofficial;
 
 namespace StackExchange.Redis.Configuration
 {
@@ -40,7 +40,6 @@ namespace StackExchange.Redis.Configuration
         {
             public EndPoint Proxy { get; }
             public HttpProxyTunnel(EndPoint proxy) => Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
-
 
             public override ValueTask<EndPoint?> GetSocketConnectEndpointAsync(EndPoint endpoint, CancellationToken cancellationToken) => new(Proxy);
 
@@ -112,6 +111,4 @@ namespace StackExchange.Redis.Configuration
         /// <param name="proxy">The endpoint to use as an HTTP proxy server.</param>
         public static Tunnel HttpProxy(EndPoint proxy) => new HttpProxyTunnel(proxy);
     }
-
-    
 }

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -16,10 +16,17 @@ namespace StackExchange.Redis.Configuration
     public abstract class Tunnel
     {
         /// <summary>
-        /// Gets the underlying endpoint to use when connecting to a logical endpoint.
+        /// Gets the underlying socket endpoint to use when connecting to a logical endpoint.
         /// </summary>
         /// <remarks><c>null</c> should be returned if a socket is not required for this endpoint.</remarks>
         public virtual ValueTask<EndPoint?> GetSocketConnectEndpointAsync(EndPoint endpoint, CancellationToken cancellationToken) => new(endpoint);
+
+        /// <summary>
+        /// Allows modification of a <see cref="Socket"/> between creation and connection.
+        /// Passed in is the endpoint we're connecting to, which type of connection it is, and the socket itself.
+        /// For example, a specific local IP endpoint could be bound, linger time altered, etc.
+        /// </summary>
+        public virtual ValueTask BeforeSocketConnectAsync(EndPoint endPoint, ConnectionType connectionType, Socket? socket, CancellationToken cancellationToken) => default;
 
         /// <summary>
         /// Invoked on a connected endpoint before server authentication and other handshakes occur, allowing pre-redis handshakes.

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -11,7 +11,7 @@ using Pipelines.Sockets.Unofficial;
 namespace StackExchange.Redis.Configuration
 {
     /// <summary>
-    /// Allows interception of the transport used to communicate with redis.
+    /// Allows interception of the transport used to communicate with Redis.
     /// </summary>
     public abstract class Tunnel
     {

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -29,7 +29,8 @@ namespace StackExchange.Redis.Configuration
         public virtual ValueTask BeforeSocketConnectAsync(EndPoint endPoint, ConnectionType connectionType, Socket? socket, CancellationToken cancellationToken) => default;
 
         /// <summary>
-        /// Invoked on a connected endpoint before server authentication and other handshakes occur, allowing pre-redis handshakes.
+        /// Invoked on a connected endpoint before server authentication and other handshakes occur, allowing pre-redis handshakes. By returning a custom <see cref="Stream"/>,
+        /// the entire data flow can be intercepted, providing entire custom transports.
         /// </summary>
         public virtual ValueTask<Stream?> BeforeAuthenticateAsync(EndPoint endpoint, ConnectionType connectionType, Socket? socket, CancellationToken cancellationToken) => default;
         /// <inheritdoc/>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -1,9 +1,6 @@
-﻿using StackExchange.Redis.Configuration;
-using System;
-using System.Buffers;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
@@ -13,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using StackExchange.Redis.Configuration;
 
 namespace StackExchange.Redis
 {

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -731,7 +731,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.ConfigCheckSeconds, configCheckSeconds);
             Append(sb, OptionKeys.ResponseTimeout, responseTimeout);
             Append(sb, OptionKeys.DefaultDatabase, DefaultDatabase);
-            if (Tunnel is { } tunnel)
+            if (Tunnel is Tunnel tunnel)
             {
                 Append(sb, OptionKeys.Tunnel, tunnel.ToString());
             }
@@ -940,7 +940,9 @@ namespace StackExchange.Redis
             return this;
         }
 
-        /// <summary>Allows custom transport implementations, such as http-tunneling via a proxy.</summary>
+        /// <summary>
+        /// Allows custom transport implementations, such as http-tunneling via a proxy.
+        /// </summary>
         public Tunnel? Tunnel { get; set; }
     }
 }

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -661,6 +661,7 @@ namespace StackExchange.Redis
             SslClientAuthenticationOptions = SslClientAuthenticationOptions,
 #endif
             Gateway = Gateway,
+            BeforeAuthenticate = BeforeAuthenticate,
         };
 
         /// <summary>
@@ -956,7 +957,10 @@ namespace StackExchange.Redis
             var encoding = Encoding.ASCII;
             var ep = Format.ToString(endpoint);
             const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\n", ExpectedResponse = "HTTP/1.1 200 OK";
-            byte[] chunk = ArrayPool<byte>.Shared.Rent(encoding.GetByteCount(Prefix) + encoding.GetByteCount(ep)  + encoding.GetByteCount(Suffix));
+            byte[] chunk = ArrayPool<byte>.Shared.Rent(Math.Max(
+                encoding.GetByteCount(Prefix) + encoding.GetByteCount(ep)  + encoding.GetByteCount(Suffix),
+                encoding.GetByteCount(ExpectedResponse)
+            ));
             var offset = 0;
             offset += encoding.GetBytes(Prefix, 0, Prefix.Length, chunk, offset);
             offset += encoding.GetBytes(ep, 0, ep.Length, chunk, offset);

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -962,7 +962,6 @@ namespace StackExchange.Redis
             offset += encoding.GetBytes(ep, 0, ep.Length, chunk, offset);
             offset += encoding.GetBytes(Suffix, 0, Suffix.Length, chunk, offset);
             socket.Send(chunk, offset, SocketFlags.None);
-            ArrayPool<byte>.Shared.Return(chunk);
 
             // we expect to see: "HTTP/1.1 200 OK\n"; note our buffer is definitely big enough already
             int toRead = encoding.GetByteCount(ExpectedResponse), read;
@@ -979,6 +978,7 @@ namespace StackExchange.Redis
             {
                 throw new InvalidOperationException("Unexpected response negotiating HTTP tunnel");
             }
+            ArrayPool<byte>.Shared.Return(chunk);
             return Task.CompletedTask;
         }
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -893,7 +893,7 @@ namespace StackExchange.Redis
                                 value = value.Substring(5);
                                 if (!Format.TryParseEndPoint(value, out var ep))
                                 {
-                                    throw new ArgumentException("Http tunnel cannot be parsed: " + value);
+                                    throw new ArgumentException("HTTP tunnel cannot be parsed: " + value);
                                 }
                                 Tunnel = Tunnel.HttpProxy(ep);
                             }

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -956,7 +956,7 @@ namespace StackExchange.Redis
 
             var encoding = Encoding.ASCII;
             var ep = Format.ToString(endpoint);
-            const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\n", ExpectedResponse = "HTTP/1.1 200 OK\n";
+            const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\r\n\r\n", ExpectedResponse = "HTTP/1.1 200 OK\r\n\r\n";
             byte[] chunk = ArrayPool<byte>.Shared.Rent(Math.Max(
                 encoding.GetByteCount(Prefix) + encoding.GetByteCount(ep)  + encoding.GetByteCount(Suffix),
                 encoding.GetByteCount(ExpectedResponse)

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -956,7 +956,7 @@ namespace StackExchange.Redis
 
             var encoding = Encoding.ASCII;
             var ep = Format.ToString(endpoint);
-            const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\n", ExpectedResponse = "HTTP/1.1 200 OK";
+            const string Prefix = "CONNECT ", Suffix = " HTTP/1.1\n", ExpectedResponse = "HTTP/1.1 200 OK\n";
             byte[] chunk = ArrayPool<byte>.Shared.Rent(Math.Max(
                 encoding.GetByteCount(Prefix) + encoding.GetByteCount(ep)  + encoding.GetByteCount(Suffix),
                 encoding.GetByteCount(ExpectedResponse)

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -114,6 +114,10 @@ namespace StackExchange.Redis
             if (_socket is not null)
             {
                 bridge.Multiplexer.RawConfig.BeforeSocketConnect?.Invoke(endpoint, bridge.ConnectionType, _socket);
+                if (tunnel is not null)
+                {   // same functionality as part of a tunnel
+                    await tunnel.BeforeSocketConnectAsync(endpoint, bridge.ConnectionType, _socket, CancellationToken.None).ForAwait();
+                }
             }
             bridge.Multiplexer.OnConnecting(endpoint, bridge.ConnectionType);
             log?.WriteLine($"{Format.ToString(endpoint)}: BeginConnectAsync");

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1416,7 +1416,10 @@ namespace StackExchange.Redis
                 var config = bridge.Multiplexer.RawConfig;
 
                 var beforeAuth = config.BeforeAuthenticate;
-                if (beforeAuth is not null) await beforeAuth.Invoke(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None);
+                if (beforeAuth is not null)
+                {
+                    await beforeAuth.Invoke(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None).ForAwait();
+                }
 
                 if (config.Ssl)
                 {

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -100,7 +100,8 @@ namespace StackExchange.Redis
             }
 
             Trace("Connecting...");
-            _socket = SocketManager.CreateSocket(bridge.Multiplexer.RawConfig.Gateway ?? endpoint);
+            var connectTo = bridge.Multiplexer.RawConfig.Gateway ?? endpoint;
+            _socket = SocketManager.CreateSocket(connectTo);
             bridge.Multiplexer.RawConfig.BeforeSocketConnect?.Invoke(endpoint, bridge.ConnectionType, _socket);
             bridge.Multiplexer.OnConnecting(endpoint, bridge.ConnectionType);
             log?.WriteLine($"{Format.ToString(endpoint)}: BeginConnectAsync");
@@ -110,7 +111,7 @@ namespace StackExchange.Redis
             {
                 using (var args = new SocketAwaitableEventArgs
                 {
-                    RemoteEndPoint = endpoint,
+                    RemoteEndPoint = connectTo,
                 })
                 {
                     var x = VolatileSocket;

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -100,16 +100,28 @@ namespace StackExchange.Redis
             }
 
             Trace("Connecting...");
-            var connectTo = bridge.Multiplexer.RawConfig.Gateway ?? endpoint;
-            _socket = SocketManager.CreateSocket(connectTo);
-            bridge.Multiplexer.RawConfig.BeforeSocketConnect?.Invoke(endpoint, bridge.ConnectionType, _socket);
+            var tunnel = bridge.Multiplexer.RawConfig.Tunnel;
+            var connectTo = endpoint;
+            if (tunnel is not null)
+            {
+                connectTo = await tunnel.GetConnectEndpoint(endpoint, CancellationToken.None).ForAwait();
+            }
+            if (connectTo is not null)
+            {
+                _socket = SocketManager.CreateSocket(connectTo);
+            }
+
+            if (_socket is not null)
+            {
+                bridge.Multiplexer.RawConfig.BeforeSocketConnect?.Invoke(endpoint, bridge.ConnectionType, _socket);
+            }
             bridge.Multiplexer.OnConnecting(endpoint, bridge.ConnectionType);
             log?.WriteLine($"{Format.ToString(endpoint)}: BeginConnectAsync");
 
             CancellationTokenSource? timeoutSource = null;
             try
             {
-                using (var args = new SocketAwaitableEventArgs
+                using (var args = connectTo is null ? null : new SocketAwaitableEventArgs
                 {
                     RemoteEndPoint = connectTo,
                 })
@@ -117,15 +129,15 @@ namespace StackExchange.Redis
                     var x = VolatileSocket;
                     if (x == null)
                     {
-                        args.Abort();
+                        args?.Abort();
                     }
-                    else if (x.ConnectAsync(args))
+                    else if (args is not null && x.ConnectAsync(args))
                     {   // asynchronous operation is pending
                         timeoutSource = ConfigureTimeout(args, bridge.Multiplexer.RawConfig.ConnectTimeout);
                     }
                     else
                     {   // completed synchronously
-                        args.Complete();
+                        args?.Complete();
                     }
 
                     // Complete connection
@@ -134,7 +146,10 @@ namespace StackExchange.Redis
                         // If we're told to ignore connect, abort here
                         if (BridgeCouldBeNull?.Multiplexer?.IgnoreConnect ?? false) return;
 
-                        await args; // wait for the connect to complete or fail (will throw)
+                        if (args is not null)
+                        {
+                            await args; // wait for the connect to complete or fail (will throw)
+                        }
                         if (timeoutSource != null)
                         {
                             timeoutSource.Cancel();
@@ -142,7 +157,7 @@ namespace StackExchange.Redis
                         }
 
                         x = VolatileSocket;
-                        if (x == null)
+                        if (x == null && args is not null)
                         {
                             ConnectionMultiplexer.TraceWithoutContext("Socket was already aborted");
                         }
@@ -1399,7 +1414,7 @@ namespace StackExchange.Redis
             return null;
         }
 
-        internal async ValueTask<bool> ConnectedAsync(Socket socket, LogProxy? log, SocketManager manager)
+        internal async ValueTask<bool> ConnectedAsync(Socket? socket, LogProxy? log, SocketManager manager)
         {
             var bridge = BridgeCouldBeNull;
             if (bridge == null) return false;
@@ -1416,10 +1431,11 @@ namespace StackExchange.Redis
 
                 var config = bridge.Multiplexer.RawConfig;
 
-                var beforeAuth = config.BeforeAuthenticate;
-                if (beforeAuth is not null)
+                var tunnel = config.Tunnel;
+                Stream? stream = null;
+                if (tunnel is not null)
                 {
-                    await beforeAuth.Invoke(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None).ForAwait();
+                    stream = await tunnel.BeforeAuthenticate(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None).ForAwait();
                 }
 
                 if (config.Ssl)
@@ -1431,7 +1447,8 @@ namespace StackExchange.Redis
                         host = Format.ToStringHostOnly(bridge.ServerEndPoint.EndPoint);
                     }
 
-                    var ssl = new SslStream(new NetworkStream(socket), false,
+                    stream ??= new NetworkStream(socket ?? throw new InvalidOperationException("No socket or stream available - possibly a tunnel error"));
+                    var ssl = new SslStream(stream, false,
                         config.CertificateValidationCallback ?? GetAmbientIssuerCertificateCallback(),
                         config.CertificateSelectionCallback ?? GetAmbientClientCertificateCallback(),
                         EncryptionPolicy.RequireEncryption);
@@ -1467,7 +1484,12 @@ namespace StackExchange.Redis
                         bridge.Multiplexer.Trace("Encryption failure");
                         return false;
                     }
-                    pipe = StreamConnection.GetDuplex(ssl, manager.SendPipeOptions, manager.ReceivePipeOptions, name: bridge.Name);
+                    stream = ssl;
+                }
+
+                if (stream is not null)
+                {
+                    pipe = StreamConnection.GetDuplex(stream, manager.SendPipeOptions, manager.ReceivePipeOptions, name: bridge.Name);
                 }
                 else
                 {

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -104,7 +104,7 @@ namespace StackExchange.Redis
             var connectTo = endpoint;
             if (tunnel is not null)
             {
-                connectTo = await tunnel.GetConnectEndpoint(endpoint, CancellationToken.None).ForAwait();
+                connectTo = await tunnel.GetSocketConnectEndpointAsync(endpoint, CancellationToken.None).ForAwait();
             }
             if (connectTo is not null)
             {
@@ -1435,7 +1435,7 @@ namespace StackExchange.Redis
                 Stream? stream = null;
                 if (tunnel is not null)
                 {
-                    stream = await tunnel.BeforeAuthenticate(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None).ForAwait();
+                    stream = await tunnel.BeforeAuthenticateAsync(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None).ForAwait();
                 }
 
                 if (config.Ssl)

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -100,7 +100,7 @@ namespace StackExchange.Redis
             }
 
             Trace("Connecting...");
-            _socket = SocketManager.CreateSocket(endpoint);
+            _socket = SocketManager.CreateSocket(bridge.Multiplexer.RawConfig.Gateway ?? endpoint);
             bridge.Multiplexer.RawConfig.BeforeSocketConnect?.Invoke(endpoint, bridge.ConnectionType, _socket);
             bridge.Multiplexer.OnConnecting(endpoint, bridge.ConnectionType);
             log?.WriteLine($"{Format.ToString(endpoint)}: BeginConnectAsync");
@@ -1414,6 +1414,9 @@ namespace StackExchange.Redis
                 // TLS:     [Socket]<==[NetworkStream]<==[SslStream]<==[StreamConnection:IDuplexPipe]
 
                 var config = bridge.Multiplexer.RawConfig;
+
+                var beforeAuth = config.BeforeAuthenticate;
+                if (beforeAuth is not null) await beforeAuth.Invoke(bridge.ServerEndPoint.EndPoint, bridge.ConnectionType, socket, CancellationToken.None);
 
                 if (config.Ssl)
                 {

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -180,6 +180,13 @@ StackExchange.Redis.Configuration.AzureOptionsProvider.AzureOptionsProvider() ->
 StackExchange.Redis.Configuration.DefaultOptionsProvider
 StackExchange.Redis.Configuration.DefaultOptionsProvider.ClientName.get -> string!
 StackExchange.Redis.Configuration.DefaultOptionsProvider.DefaultOptionsProvider() -> void
+StackExchange.Redis.Configuration.Tunnel
+StackExchange.Redis.Configuration.Tunnel.Tunnel() -> void
+override abstract StackExchange.Redis.Configuration.Tunnel.ToString() -> string!
+static StackExchange.Redis.Configuration.Tunnel.HttpProxy(System.Net.EndPoint! proxy) -> StackExchange.Redis.Configuration.Tunnel!
+virtual StackExchange.Redis.Configuration.Tunnel.BeforeAuthenticateAsync(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Stream?>
+virtual StackExchange.Redis.Configuration.Tunnel.BeforeSocketConnectAsync(System.Net.EndPoint! endPoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+virtual StackExchange.Redis.Configuration.Tunnel.GetSocketConnectEndpointAsync(System.Net.EndPoint! endpoint, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.EndPoint?>
 StackExchange.Redis.ConfigurationOptions
 StackExchange.Redis.ConfigurationOptions.AbortOnConnectFail.get -> bool
 StackExchange.Redis.ConfigurationOptions.AbortOnConnectFail.set -> void
@@ -260,6 +267,8 @@ StackExchange.Redis.ConfigurationOptions.TieBreaker.set -> void
 StackExchange.Redis.ConfigurationOptions.ToString(bool includePassword) -> string!
 StackExchange.Redis.ConfigurationOptions.TrustIssuer(string! issuerCertificatePath) -> void
 StackExchange.Redis.ConfigurationOptions.TrustIssuer(System.Security.Cryptography.X509Certificates.X509Certificate2! issuer) -> void
+StackExchange.Redis.ConfigurationOptions.Tunnel.get -> StackExchange.Redis.Configuration.Tunnel?
+StackExchange.Redis.ConfigurationOptions.Tunnel.set -> void
 StackExchange.Redis.ConfigurationOptions.User.get -> string?
 StackExchange.Redis.ConfigurationOptions.User.set -> void
 StackExchange.Redis.ConfigurationOptions.UseSsl.get -> bool

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
-﻿StackExchange.Redis.ConfigurationOptions.BeforeAuthenticate.get -> System.Func<System.Net.EndPoint!, StackExchange.Redis.ConnectionType, System.Net.Sockets.Socket!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>?
-StackExchange.Redis.ConfigurationOptions.BeforeAuthenticate.set -> void
-StackExchange.Redis.ConfigurationOptions.Gateway.get -> System.Net.EndPoint?
-StackExchange.Redis.ConfigurationOptions.Gateway.set -> void
+﻿override abstract StackExchange.Redis.Configuration.Tunnel.ToString() -> string!
+StackExchange.Redis.Configuration.Tunnel
+StackExchange.Redis.Configuration.Tunnel.Tunnel() -> void
+StackExchange.Redis.ConfigurationOptions.Tunnel.get -> StackExchange.Redis.Configuration.Tunnel?
+StackExchange.Redis.ConfigurationOptions.Tunnel.set -> void
+static StackExchange.Redis.Configuration.Tunnel.HttpProxy(System.Net.EndPoint! proxy) -> StackExchange.Redis.Configuration.Tunnel!
+virtual StackExchange.Redis.Configuration.Tunnel.BeforeAuthenticate(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Stream?>
+virtual StackExchange.Redis.Configuration.Tunnel.GetConnectEndpoint(System.Net.EndPoint! endpoint, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.EndPoint?>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
-﻿
+﻿StackExchange.Redis.ConfigurationOptions.BeforeAuthenticate.get -> System.Func<System.Net.EndPoint!, StackExchange.Redis.ConnectionType, System.Net.Sockets.Socket!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>?
+StackExchange.Redis.ConfigurationOptions.BeforeAuthenticate.set -> void
+StackExchange.Redis.ConfigurationOptions.Gateway.get -> System.Net.EndPoint?
+StackExchange.Redis.ConfigurationOptions.Gateway.set -> void

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -4,5 +4,5 @@ StackExchange.Redis.Configuration.Tunnel.Tunnel() -> void
 StackExchange.Redis.ConfigurationOptions.Tunnel.get -> StackExchange.Redis.Configuration.Tunnel?
 StackExchange.Redis.ConfigurationOptions.Tunnel.set -> void
 static StackExchange.Redis.Configuration.Tunnel.HttpProxy(System.Net.EndPoint! proxy) -> StackExchange.Redis.Configuration.Tunnel!
-virtual StackExchange.Redis.Configuration.Tunnel.BeforeAuthenticate(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Stream?>
-virtual StackExchange.Redis.Configuration.Tunnel.GetConnectEndpoint(System.Net.EndPoint! endpoint, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.EndPoint?>
+virtual StackExchange.Redis.Configuration.Tunnel.BeforeAuthenticateAsync(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Stream?>
+virtual StackExchange.Redis.Configuration.Tunnel.GetSocketConnectEndpointAsync(System.Net.EndPoint! endpoint, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.EndPoint?>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -5,4 +5,5 @@ StackExchange.Redis.ConfigurationOptions.Tunnel.get -> StackExchange.Redis.Confi
 StackExchange.Redis.ConfigurationOptions.Tunnel.set -> void
 static StackExchange.Redis.Configuration.Tunnel.HttpProxy(System.Net.EndPoint! proxy) -> StackExchange.Redis.Configuration.Tunnel!
 virtual StackExchange.Redis.Configuration.Tunnel.BeforeAuthenticateAsync(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Stream?>
+virtual StackExchange.Redis.Configuration.Tunnel.BeforeSocketConnectAsync(System.Net.EndPoint! endPoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 virtual StackExchange.Redis.Configuration.Tunnel.GetSocketConnectEndpointAsync(System.Net.EndPoint! endpoint, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.EndPoint?>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,9 +1,1 @@
-﻿override abstract StackExchange.Redis.Configuration.Tunnel.ToString() -> string!
-StackExchange.Redis.Configuration.Tunnel
-StackExchange.Redis.Configuration.Tunnel.Tunnel() -> void
-StackExchange.Redis.ConfigurationOptions.Tunnel.get -> StackExchange.Redis.Configuration.Tunnel?
-StackExchange.Redis.ConfigurationOptions.Tunnel.set -> void
-static StackExchange.Redis.Configuration.Tunnel.HttpProxy(System.Net.EndPoint! proxy) -> StackExchange.Redis.Configuration.Tunnel!
-virtual StackExchange.Redis.Configuration.Tunnel.BeforeAuthenticateAsync(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Stream?>
-virtual StackExchange.Redis.Configuration.Tunnel.BeforeSocketConnectAsync(System.Net.EndPoint! endPoint, StackExchange.Redis.ConnectionType connectionType, System.Net.Sockets.Socket? socket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
-virtual StackExchange.Redis.Configuration.Tunnel.GetSocketConnectEndpointAsync(System.Net.EndPoint! endpoint, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.EndPoint?>
+﻿

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -615,21 +615,15 @@ public class Config : TestBase
     [Fact]
     public void HttpTunnel()
     {
-        var config = ConfigurationOptions.Parse("127.0.0.1:6380,gateway=http:somewhere:22");
+        var config = ConfigurationOptions.Parse("127.0.0.1:6380,tunnel=http:somewhere:22");
         var ip = Assert.IsType<IPEndPoint>(Assert.Single(config.EndPoints));
         Assert.Equal(6380, ip.Port);
         Assert.Equal("127.0.0.1", ip.Address.ToString());
-        var dns = Assert.IsType<DnsEndPoint>(config.Gateway);
-        Assert.Equal(22, dns.Port);
-        Assert.Equal("somewhere", dns.Host);
-        Assert.Null(config.BeforeSocketConnect);
-        Assert.NotNull(config.BeforeAuthenticate);
-        var method = Assert.Single(config.BeforeAuthenticate.GetInvocationList());
-        Assert.Null(method.Target);
-        Assert.Equal("HttpTunnelAsync", method.Method.Name);
-        Assert.Equal(nameof(ConfigurationOptions), method.Method.DeclaringType!.Name);
+
+        Assert.NotNull(config.Tunnel);
+        Assert.Equal("http:somewhere:22", config.Tunnel.ToString());
 
         var cs = config.ToString();
-        Assert.Equal("127.0.0.1:6380,gateway=http:somewhere:22", cs);
+        Assert.Equal("127.0.0.1:6380,tunnel=http:somewhere:22", cs);
     }
 }

--- a/tests/StackExchange.Redis.Tests/Config.cs
+++ b/tests/StackExchange.Redis.Tests/Config.cs
@@ -611,4 +611,25 @@ public class Config : TestBase
         var newPass = options.Password = "newPassword";
         Assert.Equal(newPass, conn.RawConfig.Password);
     }
+
+    [Fact]
+    public void HttpTunnel()
+    {
+        var config = ConfigurationOptions.Parse("127.0.0.1:6380,gateway=http:somewhere:22");
+        var ip = Assert.IsType<IPEndPoint>(Assert.Single(config.EndPoints));
+        Assert.Equal(6380, ip.Port);
+        Assert.Equal("127.0.0.1", ip.Address.ToString());
+        var dns = Assert.IsType<DnsEndPoint>(config.Gateway);
+        Assert.Equal(22, dns.Port);
+        Assert.Equal("somewhere", dns.Host);
+        Assert.Null(config.BeforeSocketConnect);
+        Assert.NotNull(config.BeforeAuthenticate);
+        var method = Assert.Single(config.BeforeAuthenticate.GetInvocationList());
+        Assert.Null(method.Target);
+        Assert.Equal("HttpTunnelAsync", method.Method.Name);
+        Assert.Equal(nameof(ConfigurationOptions), method.Method.DeclaringType!.Name);
+
+        var cs = config.ToString();
+        Assert.Equal("127.0.0.1:6380,gateway=http:somewhere:22", cs);
+    }
 }

--- a/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
+++ b/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
@@ -12,7 +12,7 @@ namespace StackExchange.Redis.Tests
         public HttpTunnelConnect(ITestOutputHelper log) => Log = log;
         [Theory]
         [InlineData("")]
-        [InlineData(",gateway=http:127.0.0.1:8080")]
+        [InlineData(",tunnel=http:127.0.0.1:8080")]
         public async Task Connect(string suffix)
         {
             var cs = Environment.GetEnvironmentVariable("HACK_TUNNEL_ENDPOINT");
@@ -23,8 +23,7 @@ namespace StackExchange.Redis.Tests
             var config = ConfigurationOptions.Parse(cs + suffix);
             if (!string.IsNullOrWhiteSpace(suffix))
             {
-                Assert.NotNull(config.Gateway);
-                Assert.NotNull(config.BeforeAuthenticate);
+                Assert.NotNull(config.Tunnel);
             }
             await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
             var db = conn.GetDatabase();

--- a/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
+++ b/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests
+{
+    public class HttpTunnelConnect
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(",gateway=http:127.0.0.1:8080")]
+        public async Task Connect(string suffix)
+        {
+            var cs = Environment.GetEnvironmentVariable("HACK_TUNNEL_ENDPOINT");
+            if (string.IsNullOrWhiteSpace(cs)) return; // not testable
+            var config = ConfigurationOptions.Parse(cs + suffix);
+            if (!string.IsNullOrWhiteSpace(suffix))
+            {
+                Assert.NotNull(config.Gateway);
+                Assert.NotNull(config.BeforeAuthenticate);
+            }
+            await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+            await conn.GetDatabase().PingAsync();
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
+++ b/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
@@ -12,7 +12,10 @@ namespace StackExchange.Redis.Tests
         public async Task Connect(string suffix)
         {
             var cs = Environment.GetEnvironmentVariable("HACK_TUNNEL_ENDPOINT");
-            if (string.IsNullOrWhiteSpace(cs)) return; // not testable
+            if (string.IsNullOrWhiteSpace(cs))
+            {
+                Skip.Inconclusive("Need HACK_TUNNEL_ENDPOINT environment variable");
+            }
             var config = ConfigurationOptions.Parse(cs + suffix);
             if (!string.IsNullOrWhiteSpace(suffix))
             {

--- a/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
+++ b/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests
 {
     public class HttpTunnelConnect
     {
+        private ITestOutputHelper Log { get; }
+        public HttpTunnelConnect(ITestOutputHelper log) => Log = log;
         [Theory]
         [InlineData("")]
         [InlineData(",gateway=http:127.0.0.1:8080")]
@@ -23,7 +27,37 @@ namespace StackExchange.Redis.Tests
                 Assert.NotNull(config.BeforeAuthenticate);
             }
             await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
-            await conn.GetDatabase().PingAsync();
+            var db = conn.GetDatabase();
+            await db.PingAsync();
+            RedisKey key = "HttpTunnel";
+            await db.KeyDeleteAsync(key);
+
+            // latency test
+            var watch = Stopwatch.StartNew();
+            const int LATENCY_LOOP = 25, BANDWIDTH_LOOP = 10;
+            for (int i = 0; i < LATENCY_LOOP; i++)
+            {
+                await db.StringIncrementAsync(key);
+            }
+            watch.Stop();
+            int count = (int)await db.StringGetAsync(key);
+            Log.WriteLine($"{LATENCY_LOOP}xINCR: {watch.ElapsedMilliseconds}ms");
+            Assert.Equal(LATENCY_LOOP, count);
+
+            // bandwidth test
+            var chunk = new byte[4096];
+            var rand = new Random(1234);
+            for (int i = 0; i < BANDWIDTH_LOOP; i++)
+            {
+                rand.NextBytes(chunk);
+                watch = Stopwatch.StartNew();
+                await db.StringSetAsync(key, chunk);
+                using var fetch = await db.StringGetLeaseAsync(key);
+                watch.Stop();
+                Assert.NotNull(fetch);
+                Log.WriteLine($"SET+GET {chunk.Length} bytes: {watch.ElapsedMilliseconds}ms");
+                Assert.True(fetch.Span.SequenceEqual(chunk));
+            }
         }
     }
 }

--- a/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
+++ b/tests/StackExchange.Redis.Tests/HttpTunnelConnect.cs
@@ -10,6 +10,7 @@ namespace StackExchange.Redis.Tests
     {
         private ITestOutputHelper Log { get; }
         public HttpTunnelConnect(ITestOutputHelper log) => Log = log;
+
         [Theory]
         [InlineData("")]
         [InlineData(",tunnel=http:127.0.0.1:8080")]


### PR DESCRIPTION
1. add a tunnel config option, which is used to influence connection creation
2. implement http-tunnel as a well-known tunnel, integrated via the `http:` prefix on the tunnel option

tunnels are implemented as concrete subclasses of the `Tunnel` type; an HTTP proxy "connect" implementation is provided as a well-known version that is supported inside `Parse` - but custom 3rd-party tunnel implementations can also be provided via the object-model (not `Parse`)

A `Tunnel` allows:

- overriding the `EndPoint` used to create `Socket` connections, or to suppress `Socket` creation entirely (by default, the same logical endpoint requested is provided back out)
- provide a "before socket connect" twin (mirrors delegate approach, but: async; by default, do nothing)
- provide a "before authenticate" injection point, which can a: perform additional handshake operations, and b: subvert the entire `Stream` (by default, nothing is done and no custom stream is returned)