### PR TITLE
Internals Rename: *Wrapper -> "KeyPrefixed"

### DIFF
--- a/src/StackExchange.Redis/KeyspaceIsolation/BatchWrapper.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/BatchWrapper.cs
@@ -1,9 +1,0 @@
-﻿namespace StackExchange.Redis.KeyspaceIsolation
-{
-    internal sealed class BatchWrapper : WrapperBase<IBatch>, IBatch
-    {
-        public BatchWrapper(IBatch inner, byte[] prefix) : base(inner, prefix) { }
-
-        public void Execute() => Inner.Execute();
-    }
-}

--- a/src/StackExchange.Redis/KeyspaceIsolation/DatabaseExtension.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/DatabaseExtension.cs
@@ -54,14 +54,14 @@ namespace StackExchange.Redis.KeyspaceIsolation
                 return database; // fine - you can keep using the original, then
             }
 
-            if (database is DatabaseWrapper wrapper)
+            if (database is KeyPrefixedDatabase prefixed)
             {
                 // combine the key in advance to minimize indirection
-                keyPrefix = wrapper.ToInner(keyPrefix);
-                database = wrapper.Inner;
+                keyPrefix = prefixed.ToInner(keyPrefix);
+                database = prefixed.Inner;
             }
 
-            return new DatabaseWrapper(database, keyPrefix.AsPrefix()!);
+            return new KeyPrefixedDatabase(database, keyPrefix.AsPrefix()!);
         }
     }
 }

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace StackExchange.Redis.KeyspaceIsolation
 {
-    internal class WrapperBase<TInner> : IDatabaseAsync where TInner : IDatabaseAsync
+    internal class KeyPrefixed<TInner> : IDatabaseAsync where TInner : IDatabaseAsync
     {
-        internal WrapperBase(TInner inner, byte[] keyPrefix)
+        internal KeyPrefixed(TInner inner, byte[] keyPrefix)
         {
             Inner = inner;
             Prefix = keyPrefix;

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedBatch.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedBatch.cs
@@ -1,0 +1,9 @@
+﻿namespace StackExchange.Redis.KeyspaceIsolation
+{
+    internal sealed class KeyPrefixedBatch : KeyPrefixed<IBatch>, IBatch
+    {
+        public KeyPrefixedBatch(IBatch inner, byte[] prefix) : base(inner, prefix) { }
+
+        public void Execute() => Inner.Execute();
+    }
+}

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -4,17 +4,17 @@ using System.Net;
 
 namespace StackExchange.Redis.KeyspaceIsolation
 {
-    internal sealed class DatabaseWrapper : WrapperBase<IDatabase>, IDatabase
+    internal sealed class KeyPrefixedDatabase : KeyPrefixed<IDatabase>, IDatabase
     {
-        public DatabaseWrapper(IDatabase inner, byte[] prefix) : base(inner, prefix)
+        public KeyPrefixedDatabase(IDatabase inner, byte[] prefix) : base(inner, prefix)
         {
         }
 
         public IBatch CreateBatch(object? asyncState = null) =>
-            new BatchWrapper(Inner.CreateBatch(asyncState), Prefix);
+            new KeyPrefixedBatch(Inner.CreateBatch(asyncState), Prefix);
 
         public ITransaction CreateTransaction(object? asyncState = null) =>
-            new TransactionWrapper(Inner.CreateTransaction(asyncState), Prefix);
+            new KeyPrefixedTransaction(Inner.CreateTransaction(asyncState), Prefix);
 
         public int Database => Inner.Database;
 

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedTransaction.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedTransaction.cs
@@ -2,9 +2,9 @@
 
 namespace StackExchange.Redis.KeyspaceIsolation
 {
-    internal sealed class TransactionWrapper : WrapperBase<ITransaction>, ITransaction
+    internal sealed class KeyPrefixedTransaction : KeyPrefixed<ITransaction>, ITransaction
     {
-        public TransactionWrapper(ITransaction inner, byte[] prefix) : base(inner, prefix) { }
+        public KeyPrefixedTransaction(ITransaction inner, byte[] prefix) : base(inner, prefix) { }
 
         public ConditionResult AddCondition(Condition condition) => Inner.AddCondition(condition.MapKeys(GetMapFunction()));
 

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedBatchTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedBatchTests.cs
@@ -6,21 +6,21 @@ using Xunit;
 namespace StackExchange.Redis.Tests;
 
 [Collection(nameof(MoqDependentCollection))]
-public sealed class BatchWrapperTests
+public sealed class KeyPrefixedBatchTests
 {
     private readonly Mock<IBatch> mock;
-    private readonly BatchWrapper wrapper;
+    private readonly KeyPrefixedBatch prefixed;
 
-    public BatchWrapperTests()
+    public KeyPrefixedBatchTests()
     {
         mock = new Mock<IBatch>();
-        wrapper = new BatchWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+        prefixed = new KeyPrefixedBatch(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
     }
 
     [Fact]
     public void Execute()
     {
-        wrapper.Execute();
+        prefixed.Execute();
         mock.Verify(_ => _.Execute(), Times.Once());
     }
 }

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
@@ -13,15 +13,15 @@ namespace StackExchange.Redis.Tests;
 public class MoqDependentCollection { }
 
 [Collection(nameof(MoqDependentCollection))]
-public sealed class DatabaseWrapperTests
+public sealed class KeyPrefixedDatabaseTests
 {
     private readonly Mock<IDatabase> mock;
-    private readonly IDatabase wrapper;
+    private readonly IDatabase prefixed;
 
-    public DatabaseWrapperTests()
+    public KeyPrefixedDatabaseTests()
     {
         mock = new Mock<IDatabase>();
-        wrapper = new DatabaseWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+        prefixed = new KeyPrefixedDatabase(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
     }
 
     [Fact]
@@ -30,10 +30,10 @@ public sealed class DatabaseWrapperTests
         object asyncState = new();
         IBatch innerBatch = new Mock<IBatch>().Object;
         mock.Setup(_ => _.CreateBatch(asyncState)).Returns(innerBatch);
-        IBatch wrappedBatch = wrapper.CreateBatch(asyncState);
+        IBatch wrappedBatch = prefixed.CreateBatch(asyncState);
         mock.Verify(_ => _.CreateBatch(asyncState));
-        Assert.IsType<BatchWrapper>(wrappedBatch);
-        Assert.Same(innerBatch, ((BatchWrapper)wrappedBatch).Inner);
+        Assert.IsType<KeyPrefixedBatch>(wrappedBatch);
+        Assert.Same(innerBatch, ((KeyPrefixedBatch)wrappedBatch).Inner);
     }
 
     [Fact]
@@ -42,16 +42,16 @@ public sealed class DatabaseWrapperTests
         object asyncState = new();
         ITransaction innerTransaction = new Mock<ITransaction>().Object;
         mock.Setup(_ => _.CreateTransaction(asyncState)).Returns(innerTransaction);
-        ITransaction wrappedTransaction = wrapper.CreateTransaction(asyncState);
+        ITransaction wrappedTransaction = prefixed.CreateTransaction(asyncState);
         mock.Verify(_ => _.CreateTransaction(asyncState));
-        Assert.IsType<TransactionWrapper>(wrappedTransaction);
-        Assert.Same(innerTransaction, ((TransactionWrapper)wrappedTransaction).Inner);
+        Assert.IsType<KeyPrefixedTransaction>(wrappedTransaction);
+        Assert.Same(innerTransaction, ((KeyPrefixedTransaction)wrappedTransaction).Inner);
     }
 
     [Fact]
     public void DebugObject()
     {
-        wrapper.DebugObject("key", CommandFlags.None);
+        prefixed.DebugObject("key", CommandFlags.None);
         mock.Verify(_ => _.DebugObject("prefix:key", CommandFlags.None));
     }
 
@@ -59,27 +59,27 @@ public sealed class DatabaseWrapperTests
     public void Get_Database()
     {
         mock.SetupGet(_ => _.Database).Returns(123);
-        Assert.Equal(123, wrapper.Database);
+        Assert.Equal(123, prefixed.Database);
     }
 
     [Fact]
     public void HashDecrement_1()
     {
-        wrapper.HashDecrement("key", "hashField", 123, CommandFlags.None);
+        prefixed.HashDecrement("key", "hashField", 123, CommandFlags.None);
         mock.Verify(_ => _.HashDecrement("prefix:key", "hashField", 123, CommandFlags.None));
     }
 
     [Fact]
     public void HashDecrement_2()
     {
-        wrapper.HashDecrement("key", "hashField", 1.23, CommandFlags.None);
+        prefixed.HashDecrement("key", "hashField", 1.23, CommandFlags.None);
         mock.Verify(_ => _.HashDecrement("prefix:key", "hashField", 1.23, CommandFlags.None));
     }
 
     [Fact]
     public void HashDelete_1()
     {
-        wrapper.HashDelete("key", "hashField", CommandFlags.None);
+        prefixed.HashDelete("key", "hashField", CommandFlags.None);
         mock.Verify(_ => _.HashDelete("prefix:key", "hashField", CommandFlags.None));
     }
 
@@ -87,21 +87,21 @@ public sealed class DatabaseWrapperTests
     public void HashDelete_2()
     {
         RedisValue[] hashFields = Array.Empty<RedisValue>();
-        wrapper.HashDelete("key", hashFields, CommandFlags.None);
+        prefixed.HashDelete("key", hashFields, CommandFlags.None);
         mock.Verify(_ => _.HashDelete("prefix:key", hashFields, CommandFlags.None));
     }
 
     [Fact]
     public void HashExists()
     {
-        wrapper.HashExists("key", "hashField", CommandFlags.None);
+        prefixed.HashExists("key", "hashField", CommandFlags.None);
         mock.Verify(_ => _.HashExists("prefix:key", "hashField", CommandFlags.None));
     }
 
     [Fact]
     public void HashGet_1()
     {
-        wrapper.HashGet("key", "hashField", CommandFlags.None);
+        prefixed.HashGet("key", "hashField", CommandFlags.None);
         mock.Verify(_ => _.HashGet("prefix:key", "hashField", CommandFlags.None));
     }
 
@@ -109,56 +109,56 @@ public sealed class DatabaseWrapperTests
     public void HashGet_2()
     {
         RedisValue[] hashFields = Array.Empty<RedisValue>();
-        wrapper.HashGet("key", hashFields, CommandFlags.None);
+        prefixed.HashGet("key", hashFields, CommandFlags.None);
         mock.Verify(_ => _.HashGet("prefix:key", hashFields, CommandFlags.None));
     }
 
     [Fact]
     public void HashGetAll()
     {
-        wrapper.HashGetAll("key", CommandFlags.None);
+        prefixed.HashGetAll("key", CommandFlags.None);
         mock.Verify(_ => _.HashGetAll("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void HashIncrement_1()
     {
-        wrapper.HashIncrement("key", "hashField", 123, CommandFlags.None);
+        prefixed.HashIncrement("key", "hashField", 123, CommandFlags.None);
         mock.Verify(_ => _.HashIncrement("prefix:key", "hashField", 123, CommandFlags.None));
     }
 
     [Fact]
     public void HashIncrement_2()
     {
-        wrapper.HashIncrement("key", "hashField", 1.23, CommandFlags.None);
+        prefixed.HashIncrement("key", "hashField", 1.23, CommandFlags.None);
         mock.Verify(_ => _.HashIncrement("prefix:key", "hashField", 1.23, CommandFlags.None));
     }
 
     [Fact]
     public void HashKeys()
     {
-        wrapper.HashKeys("key", CommandFlags.None);
+        prefixed.HashKeys("key", CommandFlags.None);
         mock.Verify(_ => _.HashKeys("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void HashLength()
     {
-        wrapper.HashLength("key", CommandFlags.None);
+        prefixed.HashLength("key", CommandFlags.None);
         mock.Verify(_ => _.HashLength("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void HashScan()
     {
-        wrapper.HashScan("key", "pattern", 123, flags: CommandFlags.None);
+        prefixed.HashScan("key", "pattern", 123, flags: CommandFlags.None);
         mock.Verify(_ => _.HashScan("prefix:key", "pattern", 123, CommandFlags.None));
     }
 
     [Fact]
     public void HashScan_Full()
     {
-        wrapper.HashScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
+        prefixed.HashScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
         mock.Verify(_ => _.HashScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
     }
 
@@ -166,35 +166,35 @@ public sealed class DatabaseWrapperTests
     public void HashSet_1()
     {
         HashEntry[] hashFields = Array.Empty<HashEntry>();
-        wrapper.HashSet("key", hashFields, CommandFlags.None);
+        prefixed.HashSet("key", hashFields, CommandFlags.None);
         mock.Verify(_ => _.HashSet("prefix:key", hashFields, CommandFlags.None));
     }
 
     [Fact]
     public void HashSet_2()
     {
-        wrapper.HashSet("key", "hashField", "value", When.Exists, CommandFlags.None);
+        prefixed.HashSet("key", "hashField", "value", When.Exists, CommandFlags.None);
         mock.Verify(_ => _.HashSet("prefix:key", "hashField", "value", When.Exists, CommandFlags.None));
     }
 
     [Fact]
     public void HashStringLength()
     {
-        wrapper.HashStringLength("key", "field", CommandFlags.None);
+        prefixed.HashStringLength("key", "field", CommandFlags.None);
         mock.Verify(_ => _.HashStringLength("prefix:key", "field", CommandFlags.None));
     }
 
     [Fact]
     public void HashValues()
     {
-        wrapper.HashValues("key", CommandFlags.None);
+        prefixed.HashValues("key", CommandFlags.None);
         mock.Verify(_ => _.HashValues("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void HyperLogLogAdd_1()
     {
-        wrapper.HyperLogLogAdd("key", "value", CommandFlags.None);
+        prefixed.HyperLogLogAdd("key", "value", CommandFlags.None);
         mock.Verify(_ => _.HyperLogLogAdd("prefix:key", "value", CommandFlags.None));
     }
 
@@ -202,21 +202,21 @@ public sealed class DatabaseWrapperTests
     public void HyperLogLogAdd_2()
     {
         RedisValue[] values = Array.Empty<RedisValue>();
-        wrapper.HyperLogLogAdd("key", values, CommandFlags.None);
+        prefixed.HyperLogLogAdd("key", values, CommandFlags.None);
         mock.Verify(_ => _.HyperLogLogAdd("prefix:key", values, CommandFlags.None));
     }
 
     [Fact]
     public void HyperLogLogLength()
     {
-        wrapper.HyperLogLogLength("key", CommandFlags.None);
+        prefixed.HyperLogLogLength("key", CommandFlags.None);
         mock.Verify(_ => _.HyperLogLogLength("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void HyperLogLogMerge_1()
     {
-        wrapper.HyperLogLogMerge("destination", "first", "second", CommandFlags.None);
+        prefixed.HyperLogLogMerge("destination", "first", "second", CommandFlags.None);
         mock.Verify(_ => _.HyperLogLogMerge("prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
     }
 
@@ -225,28 +225,28 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.HyperLogLogMerge("destination", keys, CommandFlags.None);
+        prefixed.HyperLogLogMerge("destination", keys, CommandFlags.None);
         mock.Verify(_ => _.HyperLogLogMerge("prefix:destination", It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void IdentifyEndpoint()
     {
-        wrapper.IdentifyEndpoint("key", CommandFlags.None);
+        prefixed.IdentifyEndpoint("key", CommandFlags.None);
         mock.Verify(_ => _.IdentifyEndpoint("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyCopy()
     {
-        wrapper.KeyCopy("key", "destination", flags: CommandFlags.None);
+        prefixed.KeyCopy("key", "destination", flags: CommandFlags.None);
         mock.Verify(_ => _.KeyCopy("prefix:key", "prefix:destination", -1, false, CommandFlags.None));
     }
 
     [Fact]
     public void KeyDelete_1()
     {
-        wrapper.KeyDelete("key", CommandFlags.None);
+        prefixed.KeyDelete("key", CommandFlags.None);
         mock.Verify(_ => _.KeyDelete("prefix:key", CommandFlags.None));
     }
 
@@ -255,28 +255,28 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.KeyDelete(keys, CommandFlags.None);
+        prefixed.KeyDelete(keys, CommandFlags.None);
         mock.Verify(_ => _.KeyDelete(It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void KeyDump()
     {
-        wrapper.KeyDump("key", CommandFlags.None);
+        prefixed.KeyDump("key", CommandFlags.None);
         mock.Verify(_ => _.KeyDump("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyEncoding()
     {
-        wrapper.KeyEncoding("key", CommandFlags.None);
+        prefixed.KeyEncoding("key", CommandFlags.None);
         mock.Verify(_ => _.KeyEncoding("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyExists()
     {
-        wrapper.KeyExists("key", CommandFlags.None);
+        prefixed.KeyExists("key", CommandFlags.None);
         mock.Verify(_ => _.KeyExists("prefix:key", CommandFlags.None));
     }
 
@@ -284,7 +284,7 @@ public sealed class DatabaseWrapperTests
     public void KeyExpire_1()
     {
         TimeSpan expiry = TimeSpan.FromSeconds(123);
-        wrapper.KeyExpire("key", expiry, CommandFlags.None);
+        prefixed.KeyExpire("key", expiry, CommandFlags.None);
         mock.Verify(_ => _.KeyExpire("prefix:key", expiry, CommandFlags.None));
     }
 
@@ -292,7 +292,7 @@ public sealed class DatabaseWrapperTests
     public void KeyExpire_2()
     {
         DateTime expiry = DateTime.Now;
-        wrapper.KeyExpire("key", expiry, CommandFlags.None);
+        prefixed.KeyExpire("key", expiry, CommandFlags.None);
         mock.Verify(_ => _.KeyExpire("prefix:key", expiry, CommandFlags.None));
     }
 
@@ -300,7 +300,7 @@ public sealed class DatabaseWrapperTests
     public void KeyExpire_3()
     {
         TimeSpan expiry = TimeSpan.FromSeconds(123);
-        wrapper.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
+        prefixed.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
         mock.Verify(_ => _.KeyExpire("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
     }
 
@@ -308,21 +308,21 @@ public sealed class DatabaseWrapperTests
     public void KeyExpire_4()
     {
         DateTime expiry = DateTime.Now;
-        wrapper.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
+        prefixed.KeyExpire("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
         mock.Verify(_ => _.KeyExpire("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
     }
 
     [Fact]
     public void KeyExpireTime()
     {
-        wrapper.KeyExpireTime("key", CommandFlags.None);
+        prefixed.KeyExpireTime("key", CommandFlags.None);
         mock.Verify(_ => _.KeyExpireTime("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyFrequency()
     {
-        wrapper.KeyFrequency("key", CommandFlags.None);
+        prefixed.KeyFrequency("key", CommandFlags.None);
         mock.Verify(_ => _.KeyFrequency("prefix:key", CommandFlags.None));
     }
 
@@ -330,41 +330,41 @@ public sealed class DatabaseWrapperTests
     public void KeyMigrate()
     {
         EndPoint toServer = new IPEndPoint(IPAddress.Loopback, 123);
-        wrapper.KeyMigrate("key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None);
+        prefixed.KeyMigrate("key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None);
         mock.Verify(_ => _.KeyMigrate("prefix:key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None));
     }
 
     [Fact]
     public void KeyMove()
     {
-        wrapper.KeyMove("key", 123, CommandFlags.None);
+        prefixed.KeyMove("key", 123, CommandFlags.None);
         mock.Verify(_ => _.KeyMove("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void KeyPersist()
     {
-        wrapper.KeyPersist("key", CommandFlags.None);
+        prefixed.KeyPersist("key", CommandFlags.None);
         mock.Verify(_ => _.KeyPersist("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyRandom()
     {
-        Assert.Throws<NotSupportedException>(() => wrapper.KeyRandom());
+        Assert.Throws<NotSupportedException>(() => prefixed.KeyRandom());
     }
 
     [Fact]
     public void KeyRefCount()
     {
-        wrapper.KeyRefCount("key", CommandFlags.None);
+        prefixed.KeyRefCount("key", CommandFlags.None);
         mock.Verify(_ => _.KeyRefCount("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyRename()
     {
-        wrapper.KeyRename("key", "newKey", When.Exists, CommandFlags.None);
+        prefixed.KeyRename("key", "newKey", When.Exists, CommandFlags.None);
         mock.Verify(_ => _.KeyRename("prefix:key", "prefix:newKey", When.Exists, CommandFlags.None));
     }
 
@@ -373,63 +373,63 @@ public sealed class DatabaseWrapperTests
     {
         byte[] value = Array.Empty<byte>();
         TimeSpan expiry = TimeSpan.FromSeconds(123);
-        wrapper.KeyRestore("key", value, expiry, CommandFlags.None);
+        prefixed.KeyRestore("key", value, expiry, CommandFlags.None);
         mock.Verify(_ => _.KeyRestore("prefix:key", value, expiry, CommandFlags.None));
     }
 
     [Fact]
     public void KeyTimeToLive()
     {
-        wrapper.KeyTimeToLive("key", CommandFlags.None);
+        prefixed.KeyTimeToLive("key", CommandFlags.None);
         mock.Verify(_ => _.KeyTimeToLive("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void KeyType()
     {
-        wrapper.KeyType("key", CommandFlags.None);
+        prefixed.KeyType("key", CommandFlags.None);
         mock.Verify(_ => _.KeyType("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void ListGetByIndex()
     {
-        wrapper.ListGetByIndex("key", 123, CommandFlags.None);
+        prefixed.ListGetByIndex("key", 123, CommandFlags.None);
         mock.Verify(_ => _.ListGetByIndex("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void ListInsertAfter()
     {
-        wrapper.ListInsertAfter("key", "pivot", "value", CommandFlags.None);
+        prefixed.ListInsertAfter("key", "pivot", "value", CommandFlags.None);
         mock.Verify(_ => _.ListInsertAfter("prefix:key", "pivot", "value", CommandFlags.None));
     }
 
     [Fact]
     public void ListInsertBefore()
     {
-        wrapper.ListInsertBefore("key", "pivot", "value", CommandFlags.None);
+        prefixed.ListInsertBefore("key", "pivot", "value", CommandFlags.None);
         mock.Verify(_ => _.ListInsertBefore("prefix:key", "pivot", "value", CommandFlags.None));
     }
 
     [Fact]
     public void ListLeftPop()
     {
-        wrapper.ListLeftPop("key", CommandFlags.None);
+        prefixed.ListLeftPop("key", CommandFlags.None);
         mock.Verify(_ => _.ListLeftPop("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void ListLeftPop_1()
     {
-        wrapper.ListLeftPop("key", 123, CommandFlags.None);
+        prefixed.ListLeftPop("key", 123, CommandFlags.None);
         mock.Verify(_ => _.ListLeftPop("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void ListLeftPush_1()
     {
-        wrapper.ListLeftPush("key", "value", When.Exists, CommandFlags.None);
+        prefixed.ListLeftPush("key", "value", When.Exists, CommandFlags.None);
         mock.Verify(_ => _.ListLeftPush("prefix:key", "value", When.Exists, CommandFlags.None));
     }
 
@@ -437,7 +437,7 @@ public sealed class DatabaseWrapperTests
     public void ListLeftPush_2()
     {
         RedisValue[] values = Array.Empty<RedisValue>();
-        wrapper.ListLeftPush("key", values, CommandFlags.None);
+        prefixed.ListLeftPush("key", values, CommandFlags.None);
         mock.Verify(_ => _.ListLeftPush("prefix:key", values, CommandFlags.None));
     }
 
@@ -445,63 +445,63 @@ public sealed class DatabaseWrapperTests
     public void ListLeftPush_3()
     {
         RedisValue[] values = new RedisValue[] { "value1", "value2" };
-        wrapper.ListLeftPush("key", values, When.Exists, CommandFlags.None);
+        prefixed.ListLeftPush("key", values, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.ListLeftPush("prefix:key", values, When.Exists, CommandFlags.None));
     }
 
     [Fact]
     public void ListLength()
     {
-        wrapper.ListLength("key", CommandFlags.None);
+        prefixed.ListLength("key", CommandFlags.None);
         mock.Verify(_ => _.ListLength("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void ListMove()
     {
-        wrapper.ListMove("key", "destination", ListSide.Left, ListSide.Right, CommandFlags.None);
+        prefixed.ListMove("key", "destination", ListSide.Left, ListSide.Right, CommandFlags.None);
         mock.Verify(_ => _.ListMove("prefix:key", "prefix:destination", ListSide.Left, ListSide.Right, CommandFlags.None));
     }
 
     [Fact]
     public void ListRange()
     {
-        wrapper.ListRange("key", 123, 456, CommandFlags.None);
+        prefixed.ListRange("key", 123, 456, CommandFlags.None);
         mock.Verify(_ => _.ListRange("prefix:key", 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void ListRemove()
     {
-        wrapper.ListRemove("key", "value", 123, CommandFlags.None);
+        prefixed.ListRemove("key", "value", 123, CommandFlags.None);
         mock.Verify(_ => _.ListRemove("prefix:key", "value", 123, CommandFlags.None));
     }
 
     [Fact]
     public void ListRightPop()
     {
-        wrapper.ListRightPop("key", CommandFlags.None);
+        prefixed.ListRightPop("key", CommandFlags.None);
         mock.Verify(_ => _.ListRightPop("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void ListRightPop_1()
     {
-        wrapper.ListRightPop("key", 123, CommandFlags.None);
+        prefixed.ListRightPop("key", 123, CommandFlags.None);
         mock.Verify(_ => _.ListRightPop("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void ListRightPopLeftPush()
     {
-        wrapper.ListRightPopLeftPush("source", "destination", CommandFlags.None);
+        prefixed.ListRightPopLeftPush("source", "destination", CommandFlags.None);
         mock.Verify(_ => _.ListRightPopLeftPush("prefix:source", "prefix:destination", CommandFlags.None));
     }
 
     [Fact]
     public void ListRightPush_1()
     {
-        wrapper.ListRightPush("key", "value", When.Exists, CommandFlags.None);
+        prefixed.ListRightPush("key", "value", When.Exists, CommandFlags.None);
         mock.Verify(_ => _.ListRightPush("prefix:key", "value", When.Exists, CommandFlags.None));
     }
 
@@ -509,7 +509,7 @@ public sealed class DatabaseWrapperTests
     public void ListRightPush_2()
     {
         RedisValue[] values = Array.Empty<RedisValue>();
-        wrapper.ListRightPush("key", values, CommandFlags.None);
+        prefixed.ListRightPush("key", values, CommandFlags.None);
         mock.Verify(_ => _.ListRightPush("prefix:key", values, CommandFlags.None));
     }
 
@@ -517,21 +517,21 @@ public sealed class DatabaseWrapperTests
     public void ListRightPush_3()
     {
         RedisValue[] values = new RedisValue[] { "value1", "value2" };
-        wrapper.ListRightPush("key", values, When.Exists, CommandFlags.None);
+        prefixed.ListRightPush("key", values, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.ListRightPush("prefix:key", values, When.Exists, CommandFlags.None));
     }
 
     [Fact]
     public void ListSetByIndex()
     {
-        wrapper.ListSetByIndex("key", 123, "value", CommandFlags.None);
+        prefixed.ListSetByIndex("key", 123, "value", CommandFlags.None);
         mock.Verify(_ => _.ListSetByIndex("prefix:key", 123, "value", CommandFlags.None));
     }
 
     [Fact]
     public void ListTrim()
     {
-        wrapper.ListTrim("key", 123, 456, CommandFlags.None);
+        prefixed.ListTrim("key", 123, 456, CommandFlags.None);
         mock.Verify(_ => _.ListTrim("prefix:key", 123, 456, CommandFlags.None));
     }
 
@@ -539,21 +539,21 @@ public sealed class DatabaseWrapperTests
     public void LockExtend()
     {
         TimeSpan expiry = TimeSpan.FromSeconds(123);
-        wrapper.LockExtend("key", "value", expiry, CommandFlags.None);
+        prefixed.LockExtend("key", "value", expiry, CommandFlags.None);
         mock.Verify(_ => _.LockExtend("prefix:key", "value", expiry, CommandFlags.None));
     }
 
     [Fact]
     public void LockQuery()
     {
-        wrapper.LockQuery("key", CommandFlags.None);
+        prefixed.LockQuery("key", CommandFlags.None);
         mock.Verify(_ => _.LockQuery("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void LockRelease()
     {
-        wrapper.LockRelease("key", "value", CommandFlags.None);
+        prefixed.LockRelease("key", "value", CommandFlags.None);
         mock.Verify(_ => _.LockRelease("prefix:key", "value", CommandFlags.None));
     }
 
@@ -561,14 +561,14 @@ public sealed class DatabaseWrapperTests
     public void LockTake()
     {
         TimeSpan expiry = TimeSpan.FromSeconds(123);
-        wrapper.LockTake("key", "value", expiry, CommandFlags.None);
+        prefixed.LockTake("key", "value", expiry, CommandFlags.None);
         mock.Verify(_ => _.LockTake("prefix:key", "value", expiry, CommandFlags.None));
     }
 
     [Fact]
     public void Publish()
     {
-        wrapper.Publish("channel", "message", CommandFlags.None);
+        prefixed.Publish("channel", "message", CommandFlags.None);
         mock.Verify(_ => _.Publish("prefix:channel", "message", CommandFlags.None));
     }
 
@@ -579,7 +579,7 @@ public sealed class DatabaseWrapperTests
         RedisValue[] values = Array.Empty<RedisValue>();
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.ScriptEvaluate(hash, keys, values, CommandFlags.None);
+        prefixed.ScriptEvaluate(hash, keys, values, CommandFlags.None);
         mock.Verify(_ => _.ScriptEvaluate(hash, It.Is(valid), values, CommandFlags.None));
     }
 
@@ -589,14 +589,14 @@ public sealed class DatabaseWrapperTests
         RedisValue[] values = Array.Empty<RedisValue>();
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.ScriptEvaluate("script", keys, values, CommandFlags.None);
+        prefixed.ScriptEvaluate("script", keys, values, CommandFlags.None);
         mock.Verify(_ => _.ScriptEvaluate("script", It.Is(valid), values, CommandFlags.None));
     }
 
     [Fact]
     public void SetAdd_1()
     {
-        wrapper.SetAdd("key", "value", CommandFlags.None);
+        prefixed.SetAdd("key", "value", CommandFlags.None);
         mock.Verify(_ => _.SetAdd("prefix:key", "value", CommandFlags.None));
     }
 
@@ -604,14 +604,14 @@ public sealed class DatabaseWrapperTests
     public void SetAdd_2()
     {
         RedisValue[] values = Array.Empty<RedisValue>();
-        wrapper.SetAdd("key", values, CommandFlags.None);
+        prefixed.SetAdd("key", values, CommandFlags.None);
         mock.Verify(_ => _.SetAdd("prefix:key", values, CommandFlags.None));
     }
 
     [Fact]
     public void SetCombine_1()
     {
-        wrapper.SetCombine(SetOperation.Intersect, "first", "second", CommandFlags.None);
+        prefixed.SetCombine(SetOperation.Intersect, "first", "second", CommandFlags.None);
         mock.Verify(_ => _.SetCombine(SetOperation.Intersect, "prefix:first", "prefix:second", CommandFlags.None));
     }
 
@@ -620,14 +620,14 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.SetCombine(SetOperation.Intersect, keys, CommandFlags.None);
+        prefixed.SetCombine(SetOperation.Intersect, keys, CommandFlags.None);
         mock.Verify(_ => _.SetCombine(SetOperation.Intersect, It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void SetCombineAndStore_1()
     {
-        wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", CommandFlags.None);
+        prefixed.SetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", CommandFlags.None);
         mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
     }
 
@@ -636,14 +636,14 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
+        prefixed.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
         mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void SetContains()
     {
-        wrapper.SetContains("key", "value", CommandFlags.None);
+        prefixed.SetContains("key", "value", CommandFlags.None);
         mock.Verify(_ => _.SetContains("prefix:key", "value", CommandFlags.None));
     }
 
@@ -651,7 +651,7 @@ public sealed class DatabaseWrapperTests
     public void SetContains_2()
     {
         RedisValue[] values = new RedisValue[] { "value1", "value2" };
-        wrapper.SetContains("key", values, CommandFlags.None);
+        prefixed.SetContains("key", values, CommandFlags.None);
         mock.Verify(_ => _.SetContains("prefix:key", values, CommandFlags.None));
     }
 
@@ -659,66 +659,66 @@ public sealed class DatabaseWrapperTests
     public void SetIntersectionLength()
     {
         var keys = new RedisKey[] { "key1", "key2" };
-        wrapper.SetIntersectionLength(keys);
+        prefixed.SetIntersectionLength(keys);
         mock.Verify(_ => _.SetIntersectionLength(keys, 0, CommandFlags.None));
     }
 
     [Fact]
     public void SetLength()
     {
-        wrapper.SetLength("key", CommandFlags.None);
+        prefixed.SetLength("key", CommandFlags.None);
         mock.Verify(_ => _.SetLength("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void SetMembers()
     {
-        wrapper.SetMembers("key", CommandFlags.None);
+        prefixed.SetMembers("key", CommandFlags.None);
         mock.Verify(_ => _.SetMembers("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void SetMove()
     {
-        wrapper.SetMove("source", "destination", "value", CommandFlags.None);
+        prefixed.SetMove("source", "destination", "value", CommandFlags.None);
         mock.Verify(_ => _.SetMove("prefix:source", "prefix:destination", "value", CommandFlags.None));
     }
 
     [Fact]
     public void SetPop_1()
     {
-        wrapper.SetPop("key", CommandFlags.None);
+        prefixed.SetPop("key", CommandFlags.None);
         mock.Verify(_ => _.SetPop("prefix:key", CommandFlags.None));
 
-        wrapper.SetPop("key", 5, CommandFlags.None);
+        prefixed.SetPop("key", 5, CommandFlags.None);
         mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.None));
     }
 
     [Fact]
     public void SetPop_2()
     {
-        wrapper.SetPop("key", 5, CommandFlags.None);
+        prefixed.SetPop("key", 5, CommandFlags.None);
         mock.Verify(_ => _.SetPop("prefix:key", 5, CommandFlags.None));
     }
 
     [Fact]
     public void SetRandomMember()
     {
-        wrapper.SetRandomMember("key", CommandFlags.None);
+        prefixed.SetRandomMember("key", CommandFlags.None);
         mock.Verify(_ => _.SetRandomMember("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void SetRandomMembers()
     {
-        wrapper.SetRandomMembers("key", 123, CommandFlags.None);
+        prefixed.SetRandomMembers("key", 123, CommandFlags.None);
         mock.Verify(_ => _.SetRandomMembers("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void SetRemove_1()
     {
-        wrapper.SetRemove("key", "value", CommandFlags.None);
+        prefixed.SetRemove("key", "value", CommandFlags.None);
         mock.Verify(_ => _.SetRemove("prefix:key", "value", CommandFlags.None));
     }
 
@@ -726,21 +726,21 @@ public sealed class DatabaseWrapperTests
     public void SetRemove_2()
     {
         RedisValue[] values = Array.Empty<RedisValue>();
-        wrapper.SetRemove("key", values, CommandFlags.None);
+        prefixed.SetRemove("key", values, CommandFlags.None);
         mock.Verify(_ => _.SetRemove("prefix:key", values, CommandFlags.None));
     }
 
     [Fact]
     public void SetScan()
     {
-        wrapper.SetScan("key", "pattern", 123, flags: CommandFlags.None);
+        prefixed.SetScan("key", "pattern", 123, flags: CommandFlags.None);
         mock.Verify(_ => _.SetScan("prefix:key", "pattern", 123, CommandFlags.None));
     }
 
     [Fact]
     public void SetScan_Full()
     {
-        wrapper.SetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
+        prefixed.SetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
         mock.Verify(_ => _.SetScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
     }
 
@@ -750,8 +750,8 @@ public sealed class DatabaseWrapperTests
         RedisValue[] get = new RedisValue[] { "a", "#" };
         Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
 
-        wrapper.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
-        wrapper.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
+        prefixed.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
+        prefixed.Sort("key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
 
         mock.Verify(_ => _.Sort("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
         mock.Verify(_ => _.Sort("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
@@ -763,8 +763,8 @@ public sealed class DatabaseWrapperTests
         RedisValue[] get = new RedisValue[] { "a", "#" };
         Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
 
-        wrapper.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
-        wrapper.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
+        prefixed.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
+        prefixed.SortAndStore("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
 
         mock.Verify(_ => _.SortAndStore("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
         mock.Verify(_ => _.SortAndStore("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
@@ -773,7 +773,7 @@ public sealed class DatabaseWrapperTests
     [Fact]
     public void SortedSetAdd_1()
     {
-        wrapper.SortedSetAdd("key", "member", 1.23, When.Exists, CommandFlags.None);
+        prefixed.SortedSetAdd("key", "member", 1.23, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.SortedSetAdd("prefix:key", "member", 1.23, When.Exists, CommandFlags.None));
     }
 
@@ -781,7 +781,7 @@ public sealed class DatabaseWrapperTests
     public void SortedSetAdd_2()
     {
         SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-        wrapper.SortedSetAdd("key", values, When.Exists, CommandFlags.None);
+        prefixed.SortedSetAdd("key", values, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.SortedSetAdd("prefix:key", values, When.Exists, CommandFlags.None));
     }
 
@@ -789,7 +789,7 @@ public sealed class DatabaseWrapperTests
     public void SortedSetAdd_3()
     {
         SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-        wrapper.SortedSetAdd("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
+        prefixed.SortedSetAdd("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
         mock.Verify(_ => _.SortedSetAdd("prefix:key", values, SortedSetWhen.GreaterThan, CommandFlags.None));
     }
 
@@ -797,7 +797,7 @@ public sealed class DatabaseWrapperTests
     public void SortedSetCombine()
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
-        wrapper.SortedSetCombine(SetOperation.Intersect, keys);
+        prefixed.SortedSetCombine(SetOperation.Intersect, keys);
         mock.Verify(_ => _.SortedSetCombine(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
     }
 
@@ -805,14 +805,14 @@ public sealed class DatabaseWrapperTests
     public void SortedSetCombineWithScores()
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
-        wrapper.SortedSetCombineWithScores(SetOperation.Intersect, keys);
+        prefixed.SortedSetCombineWithScores(SetOperation.Intersect, keys);
         mock.Verify(_ => _.SortedSetCombineWithScores(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetCombineAndStore_1()
     {
-        wrapper.SortedSetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", Aggregate.Max, CommandFlags.None);
+        prefixed.SortedSetCombineAndStore(SetOperation.Intersect, "destination", "first", "second", Aggregate.Max, CommandFlags.None);
         mock.Verify(_ => _.SortedSetCombineAndStore(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", Aggregate.Max, CommandFlags.None));
     }
 
@@ -821,21 +821,21 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
+        prefixed.SetCombineAndStore(SetOperation.Intersect, "destination", keys, CommandFlags.None);
         mock.Verify(_ => _.SetCombineAndStore(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetDecrement()
     {
-        wrapper.SortedSetDecrement("key", "member", 1.23, CommandFlags.None);
+        prefixed.SortedSetDecrement("key", "member", 1.23, CommandFlags.None);
         mock.Verify(_ => _.SortedSetDecrement("prefix:key", "member", 1.23, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetIncrement()
     {
-        wrapper.SortedSetIncrement("key", "member", 1.23, CommandFlags.None);
+        prefixed.SortedSetIncrement("key", "member", 1.23, CommandFlags.None);
         mock.Verify(_ => _.SortedSetIncrement("prefix:key", "member", 1.23, CommandFlags.None));
     }
 
@@ -843,98 +843,98 @@ public sealed class DatabaseWrapperTests
     public void SortedSetIntersectionLength()
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
-        wrapper.SortedSetIntersectionLength(keys, 1, CommandFlags.None);
+        prefixed.SortedSetIntersectionLength(keys, 1, CommandFlags.None);
         mock.Verify(_ => _.SortedSetIntersectionLength(keys, 1, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetLength()
     {
-        wrapper.SortedSetLength("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
+        prefixed.SortedSetLength("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
         mock.Verify(_ => _.SortedSetLength("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRandomMember()
     {
-        wrapper.SortedSetRandomMember("key", CommandFlags.None);
+        prefixed.SortedSetRandomMember("key", CommandFlags.None);
         mock.Verify(_ => _.SortedSetRandomMember("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRandomMembers()
     {
-        wrapper.SortedSetRandomMembers("key", 2, CommandFlags.None);
+        prefixed.SortedSetRandomMembers("key", 2, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRandomMembers("prefix:key", 2, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRandomMembersWithScores()
     {
-        wrapper.SortedSetRandomMembersWithScores("key", 2, CommandFlags.None);
+        prefixed.SortedSetRandomMembersWithScores("key", 2, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRandomMembersWithScores("prefix:key", 2, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetLengthByValue()
     {
-        wrapper.SortedSetLengthByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
+        prefixed.SortedSetLengthByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
         mock.Verify(_ => _.SortedSetLengthByValue("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRangeByRank()
     {
-        wrapper.SortedSetRangeByRank("key", 123, 456, Order.Descending, CommandFlags.None);
+        prefixed.SortedSetRangeByRank("key", 123, 456, Order.Descending, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRangeByRank("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRangeByRankWithScores()
     {
-        wrapper.SortedSetRangeByRankWithScores("key", 123, 456, Order.Descending, CommandFlags.None);
+        prefixed.SortedSetRangeByRankWithScores("key", 123, 456, Order.Descending, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRangeByRankWithScores("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRangeByScore()
     {
-        wrapper.SortedSetRangeByScore("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+        prefixed.SortedSetRangeByScore("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRangeByScore("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRangeByScoreWithScores()
     {
-        wrapper.SortedSetRangeByScoreWithScores("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+        prefixed.SortedSetRangeByScoreWithScores("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRangeByScoreWithScores("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRangeByValue()
     {
-        wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.None);
+        prefixed.SortedSetRangeByValue("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, Order.Ascending, 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRangeByValueDesc()
     {
-        wrapper.SortedSetRangeByValue("key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+        prefixed.SortedSetRangeByValue("key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRangeByValue("prefix:key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRank()
     {
-        wrapper.SortedSetRank("key", "member", Order.Descending, CommandFlags.None);
+        prefixed.SortedSetRank("key", "member", Order.Descending, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRank("prefix:key", "member", Order.Descending, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRemove_1()
     {
-        wrapper.SortedSetRemove("key", "member", CommandFlags.None);
+        prefixed.SortedSetRemove("key", "member", CommandFlags.None);
         mock.Verify(_ => _.SortedSetRemove("prefix:key", "member", CommandFlags.None));
     }
 
@@ -942,56 +942,56 @@ public sealed class DatabaseWrapperTests
     public void SortedSetRemove_2()
     {
         RedisValue[] members = Array.Empty<RedisValue>();
-        wrapper.SortedSetRemove("key", members, CommandFlags.None);
+        prefixed.SortedSetRemove("key", members, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRemove("prefix:key", members, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRemoveRangeByRank()
     {
-        wrapper.SortedSetRemoveRangeByRank("key", 123, 456, CommandFlags.None);
+        prefixed.SortedSetRemoveRangeByRank("key", 123, 456, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRemoveRangeByRank("prefix:key", 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRemoveRangeByScore()
     {
-        wrapper.SortedSetRemoveRangeByScore("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
+        prefixed.SortedSetRemoveRangeByScore("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRemoveRangeByScore("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetRemoveRangeByValue()
     {
-        wrapper.SortedSetRemoveRangeByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
+        prefixed.SortedSetRemoveRangeByValue("key", "min", "max", Exclude.Start, CommandFlags.None);
         mock.Verify(_ => _.SortedSetRemoveRangeByValue("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetScan()
     {
-        wrapper.SortedSetScan("key", "pattern", 123, flags: CommandFlags.None);
+        prefixed.SortedSetScan("key", "pattern", 123, flags: CommandFlags.None);
         mock.Verify(_ => _.SortedSetScan("prefix:key", "pattern", 123, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetScan_Full()
     {
-        wrapper.SortedSetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
+        prefixed.SortedSetScan("key", "pattern", 123, 42, 64, flags: CommandFlags.None);
         mock.Verify(_ => _.SortedSetScan("prefix:key", "pattern", 123, 42, 64, CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetScore()
     {
-        wrapper.SortedSetScore("key", "member", CommandFlags.None);
+        prefixed.SortedSetScore("key", "member", CommandFlags.None);
         mock.Verify(_ => _.SortedSetScore("prefix:key", "member", CommandFlags.None));
     }
 
     [Fact]
     public void SortedSetScore_Multiple()
     {
-        wrapper.SortedSetScores("key", new RedisValue[] { "member1", "member2" }, CommandFlags.None);
+        prefixed.SortedSetScores("key", new RedisValue[] { "member1", "member2" }, CommandFlags.None);
         mock.Verify(_ => _.SortedSetScores("prefix:key", new RedisValue[] { "member1", "member2" }, CommandFlags.None));
     }
 
@@ -999,14 +999,14 @@ public sealed class DatabaseWrapperTests
     public void SortedSetUpdate()
     {
         SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-        wrapper.SortedSetUpdate("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
+        prefixed.SortedSetUpdate("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
         mock.Verify(_ => _.SortedSetUpdate("prefix:key", values, SortedSetWhen.GreaterThan, CommandFlags.None));
     }
 
     [Fact]
     public void StreamAcknowledge_1()
     {
-        wrapper.StreamAcknowledge("key", "group", "0-0", CommandFlags.None);
+        prefixed.StreamAcknowledge("key", "group", "0-0", CommandFlags.None);
         mock.Verify(_ => _.StreamAcknowledge("prefix:key", "group", "0-0", CommandFlags.None));
     }
 
@@ -1014,14 +1014,14 @@ public sealed class DatabaseWrapperTests
     public void StreamAcknowledge_2()
     {
         var messageIds = new RedisValue[] { "0-0", "0-1", "0-2" };
-        wrapper.StreamAcknowledge("key", "group", messageIds, CommandFlags.None);
+        prefixed.StreamAcknowledge("key", "group", messageIds, CommandFlags.None);
         mock.Verify(_ => _.StreamAcknowledge("prefix:key", "group", messageIds, CommandFlags.None));
     }
 
     [Fact]
     public void StreamAdd_1()
     {
-        wrapper.StreamAdd("key", "field1", "value1", "*", 1000, true, CommandFlags.None);
+        prefixed.StreamAdd("key", "field1", "value1", "*", 1000, true, CommandFlags.None);
         mock.Verify(_ => _.StreamAdd("prefix:key", "field1", "value1", "*", 1000, true, CommandFlags.None));
     }
 
@@ -1029,21 +1029,21 @@ public sealed class DatabaseWrapperTests
     public void StreamAdd_2()
     {
         var fields = Array.Empty<NameValueEntry>();
-        wrapper.StreamAdd("key", fields, "*", 1000, true, CommandFlags.None);
+        prefixed.StreamAdd("key", fields, "*", 1000, true, CommandFlags.None);
         mock.Verify(_ => _.StreamAdd("prefix:key", fields, "*", 1000, true, CommandFlags.None));
     }
 
     [Fact]
     public void StreamAutoClaim()
     {
-        wrapper.StreamAutoClaim("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
+        prefixed.StreamAutoClaim("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
         mock.Verify(_ => _.StreamAutoClaim("prefix:key", "group", "consumer", 0, "0-0", 100, CommandFlags.None));
     }
 
     [Fact]
     public void StreamAutoClaimIdsOnly()
     {
-        wrapper.StreamAutoClaimIdsOnly("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
+        prefixed.StreamAutoClaimIdsOnly("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
         mock.Verify(_ => _.StreamAutoClaimIdsOnly("prefix:key", "group", "consumer", 0, "0-0", 100, CommandFlags.None));
     }
 
@@ -1051,7 +1051,7 @@ public sealed class DatabaseWrapperTests
     public void StreamClaimMessages()
     {
         var messageIds = Array.Empty<RedisValue>();
-        wrapper.StreamClaim("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
+        prefixed.StreamClaim("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
         mock.Verify(_ => _.StreamClaim("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
     }
 
@@ -1059,49 +1059,49 @@ public sealed class DatabaseWrapperTests
     public void StreamClaimMessagesReturningIds()
     {
         var messageIds = Array.Empty<RedisValue>();
-        wrapper.StreamClaimIdsOnly("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
+        prefixed.StreamClaimIdsOnly("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
         mock.Verify(_ => _.StreamClaimIdsOnly("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
     }
 
     [Fact]
     public void StreamConsumerGroupSetPosition()
     {
-        wrapper.StreamConsumerGroupSetPosition("key", "group", StreamPosition.Beginning, CommandFlags.None);
+        prefixed.StreamConsumerGroupSetPosition("key", "group", StreamPosition.Beginning, CommandFlags.None);
         mock.Verify(_ => _.StreamConsumerGroupSetPosition("prefix:key", "group", StreamPosition.Beginning, CommandFlags.None));
     }
 
     [Fact]
     public void StreamConsumerInfoGet()
     {
-        wrapper.StreamConsumerInfo("key", "group", CommandFlags.None);
+        prefixed.StreamConsumerInfo("key", "group", CommandFlags.None);
         mock.Verify(_ => _.StreamConsumerInfo("prefix:key", "group", CommandFlags.None));
     }
 
     [Fact]
     public void StreamCreateConsumerGroup()
     {
-        wrapper.StreamCreateConsumerGroup("key", "group", StreamPosition.Beginning, false, CommandFlags.None);
+        prefixed.StreamCreateConsumerGroup("key", "group", StreamPosition.Beginning, false, CommandFlags.None);
         mock.Verify(_ => _.StreamCreateConsumerGroup("prefix:key", "group", StreamPosition.Beginning, false, CommandFlags.None));
     }
 
     [Fact]
     public void StreamGroupInfoGet()
     {
-        wrapper.StreamGroupInfo("key", CommandFlags.None);
+        prefixed.StreamGroupInfo("key", CommandFlags.None);
         mock.Verify(_ => _.StreamGroupInfo("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void StreamInfoGet()
     {
-        wrapper.StreamInfo("key", CommandFlags.None);
+        prefixed.StreamInfo("key", CommandFlags.None);
         mock.Verify(_ => _.StreamInfo("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void StreamLength()
     {
-        wrapper.StreamLength("key", CommandFlags.None);
+        prefixed.StreamLength("key", CommandFlags.None);
         mock.Verify(_ => _.StreamLength("prefix:key", CommandFlags.None));
     }
 
@@ -1109,42 +1109,42 @@ public sealed class DatabaseWrapperTests
     public void StreamMessagesDelete()
     {
         var messageIds = Array.Empty<RedisValue>();
-        wrapper.StreamDelete("key", messageIds, CommandFlags.None);
+        prefixed.StreamDelete("key", messageIds, CommandFlags.None);
         mock.Verify(_ => _.StreamDelete("prefix:key", messageIds, CommandFlags.None));
     }
 
     [Fact]
     public void StreamDeleteConsumer()
     {
-        wrapper.StreamDeleteConsumer("key", "group", "consumer", CommandFlags.None);
+        prefixed.StreamDeleteConsumer("key", "group", "consumer", CommandFlags.None);
         mock.Verify(_ => _.StreamDeleteConsumer("prefix:key", "group", "consumer", CommandFlags.None));
     }
 
     [Fact]
     public void StreamDeleteConsumerGroup()
     {
-        wrapper.StreamDeleteConsumerGroup("key", "group", CommandFlags.None);
+        prefixed.StreamDeleteConsumerGroup("key", "group", CommandFlags.None);
         mock.Verify(_ => _.StreamDeleteConsumerGroup("prefix:key", "group", CommandFlags.None));
     }
 
     [Fact]
     public void StreamPendingInfoGet()
     {
-        wrapper.StreamPending("key", "group", CommandFlags.None);
+        prefixed.StreamPending("key", "group", CommandFlags.None);
         mock.Verify(_ => _.StreamPending("prefix:key", "group", CommandFlags.None));
     }
 
     [Fact]
     public void StreamPendingMessageInfoGet()
     {
-        wrapper.StreamPendingMessages("key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None);
+        prefixed.StreamPendingMessages("key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None);
         mock.Verify(_ => _.StreamPendingMessages("prefix:key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None));
     }
 
     [Fact]
     public void StreamRange()
     {
-        wrapper.StreamRange("key", "-", "+", null, Order.Ascending, CommandFlags.None);
+        prefixed.StreamRange("key", "-", "+", null, Order.Ascending, CommandFlags.None);
         mock.Verify(_ => _.StreamRange("prefix:key", "-", "+", null, Order.Ascending, CommandFlags.None));
     }
 
@@ -1152,21 +1152,21 @@ public sealed class DatabaseWrapperTests
     public void StreamRead_1()
     {
         var streamPositions = Array.Empty<StreamPosition>();
-        wrapper.StreamRead(streamPositions, null, CommandFlags.None);
+        prefixed.StreamRead(streamPositions, null, CommandFlags.None);
         mock.Verify(_ => _.StreamRead(streamPositions, null, CommandFlags.None));
     }
 
     [Fact]
     public void StreamRead_2()
     {
-        wrapper.StreamRead("key", "0-0", null, CommandFlags.None);
+        prefixed.StreamRead("key", "0-0", null, CommandFlags.None);
         mock.Verify(_ => _.StreamRead("prefix:key", "0-0", null, CommandFlags.None));
     }
 
     [Fact]
     public void StreamStreamReadGroup_1()
     {
-        wrapper.StreamReadGroup("key", "group", "consumer", "0-0", 10, false, CommandFlags.None);
+        prefixed.StreamReadGroup("key", "group", "consumer", "0-0", 10, false, CommandFlags.None);
         mock.Verify(_ => _.StreamReadGroup("prefix:key", "group", "consumer", "0-0", 10, false, CommandFlags.None));
     }
 
@@ -1174,42 +1174,42 @@ public sealed class DatabaseWrapperTests
     public void StreamStreamReadGroup_2()
     {
         var streamPositions = Array.Empty<StreamPosition>();
-        wrapper.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
+        prefixed.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
         mock.Verify(_ => _.StreamReadGroup(streamPositions, "group", "consumer", 10, false, CommandFlags.None));
     }
 
     [Fact]
     public void StreamTrim()
     {
-        wrapper.StreamTrim("key", 1000, true, CommandFlags.None);
+        prefixed.StreamTrim("key", 1000, true, CommandFlags.None);
         mock.Verify(_ => _.StreamTrim("prefix:key", 1000, true, CommandFlags.None));
     }
 
     [Fact]
     public void StringAppend()
     {
-        wrapper.StringAppend("key", "value", CommandFlags.None);
+        prefixed.StringAppend("key", "value", CommandFlags.None);
         mock.Verify(_ => _.StringAppend("prefix:key", "value", CommandFlags.None));
     }
 
     [Fact]
     public void StringBitCount()
     {
-        wrapper.StringBitCount("key", 123, 456, CommandFlags.None);
+        prefixed.StringBitCount("key", 123, 456, CommandFlags.None);
         mock.Verify(_ => _.StringBitCount("prefix:key", 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void StringBitCount_2()
     {
-        wrapper.StringBitCount("key", 123, 456, StringIndexType.Byte, CommandFlags.None);
+        prefixed.StringBitCount("key", 123, 456, StringIndexType.Byte, CommandFlags.None);
         mock.Verify(_ => _.StringBitCount("prefix:key", 123, 456, StringIndexType.Byte, CommandFlags.None));
     }
 
     [Fact]
     public void StringBitOperation_1()
     {
-        wrapper.StringBitOperation(Bitwise.Xor, "destination", "first", "second", CommandFlags.None);
+        prefixed.StringBitOperation(Bitwise.Xor, "destination", "first", "second", CommandFlags.None);
         mock.Verify(_ => _.StringBitOperation(Bitwise.Xor, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
     }
 
@@ -1218,42 +1218,42 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.StringBitOperation(Bitwise.Xor, "destination", keys, CommandFlags.None);
+        prefixed.StringBitOperation(Bitwise.Xor, "destination", keys, CommandFlags.None);
         mock.Verify(_ => _.StringBitOperation(Bitwise.Xor, "prefix:destination", It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void StringBitPosition()
     {
-        wrapper.StringBitPosition("key", true, 123, 456, CommandFlags.None);
+        prefixed.StringBitPosition("key", true, 123, 456, CommandFlags.None);
         mock.Verify(_ => _.StringBitPosition("prefix:key", true, 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void StringBitPosition_2()
     {
-        wrapper.StringBitPosition("key", true, 123, 456, StringIndexType.Byte, CommandFlags.None);
+        prefixed.StringBitPosition("key", true, 123, 456, StringIndexType.Byte, CommandFlags.None);
         mock.Verify(_ => _.StringBitPosition("prefix:key", true, 123, 456, StringIndexType.Byte, CommandFlags.None));
     }
 
     [Fact]
     public void StringDecrement_1()
     {
-        wrapper.StringDecrement("key", 123, CommandFlags.None);
+        prefixed.StringDecrement("key", 123, CommandFlags.None);
         mock.Verify(_ => _.StringDecrement("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void StringDecrement_2()
     {
-        wrapper.StringDecrement("key", 1.23, CommandFlags.None);
+        prefixed.StringDecrement("key", 1.23, CommandFlags.None);
         mock.Verify(_ => _.StringDecrement("prefix:key", 1.23, CommandFlags.None));
     }
 
     [Fact]
     public void StringGet_1()
     {
-        wrapper.StringGet("key", CommandFlags.None);
+        prefixed.StringGet("key", CommandFlags.None);
         mock.Verify(_ => _.StringGet("prefix:key", CommandFlags.None));
     }
 
@@ -1262,63 +1262,63 @@ public sealed class DatabaseWrapperTests
     {
         RedisKey[] keys = new RedisKey[] { "a", "b" };
         Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-        wrapper.StringGet(keys, CommandFlags.None);
+        prefixed.StringGet(keys, CommandFlags.None);
         mock.Verify(_ => _.StringGet(It.Is(valid), CommandFlags.None));
     }
 
     [Fact]
     public void StringGetBit()
     {
-        wrapper.StringGetBit("key", 123, CommandFlags.None);
+        prefixed.StringGetBit("key", 123, CommandFlags.None);
         mock.Verify(_ => _.StringGetBit("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void StringGetRange()
     {
-        wrapper.StringGetRange("key", 123, 456, CommandFlags.None);
+        prefixed.StringGetRange("key", 123, 456, CommandFlags.None);
         mock.Verify(_ => _.StringGetRange("prefix:key", 123, 456, CommandFlags.None));
     }
 
     [Fact]
     public void StringGetSet()
     {
-        wrapper.StringGetSet("key", "value", CommandFlags.None);
+        prefixed.StringGetSet("key", "value", CommandFlags.None);
         mock.Verify(_ => _.StringGetSet("prefix:key", "value", CommandFlags.None));
     }
 
     [Fact]
     public void StringGetDelete()
     {
-        wrapper.StringGetDelete("key", CommandFlags.None);
+        prefixed.StringGetDelete("key", CommandFlags.None);
         mock.Verify(_ => _.StringGetDelete("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void StringGetWithExpiry()
     {
-        wrapper.StringGetWithExpiry("key", CommandFlags.None);
+        prefixed.StringGetWithExpiry("key", CommandFlags.None);
         mock.Verify(_ => _.StringGetWithExpiry("prefix:key", CommandFlags.None));
     }
 
     [Fact]
     public void StringIncrement_1()
     {
-        wrapper.StringIncrement("key", 123, CommandFlags.None);
+        prefixed.StringIncrement("key", 123, CommandFlags.None);
         mock.Verify(_ => _.StringIncrement("prefix:key", 123, CommandFlags.None));
     }
 
     [Fact]
     public void StringIncrement_2()
     {
-        wrapper.StringIncrement("key", 1.23, CommandFlags.None);
+        prefixed.StringIncrement("key", 1.23, CommandFlags.None);
         mock.Verify(_ => _.StringIncrement("prefix:key", 1.23, CommandFlags.None));
     }
 
     [Fact]
     public void StringLength()
     {
-        wrapper.StringLength("key", CommandFlags.None);
+        prefixed.StringLength("key", CommandFlags.None);
         mock.Verify(_ => _.StringLength("prefix:key", CommandFlags.None));
     }
 
@@ -1326,7 +1326,7 @@ public sealed class DatabaseWrapperTests
     public void StringSet_1()
     {
         TimeSpan expiry = TimeSpan.FromSeconds(123);
-        wrapper.StringSet("key", "value", expiry, When.Exists, CommandFlags.None);
+        prefixed.StringSet("key", "value", expiry, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, When.Exists, CommandFlags.None));
     }
 
@@ -1334,7 +1334,7 @@ public sealed class DatabaseWrapperTests
     public void StringSet_2()
     {
         TimeSpan? expiry = null;
-        wrapper.StringSet("key", "value", expiry, true, When.Exists, CommandFlags.None);
+        prefixed.StringSet("key", "value", expiry, true, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, true, When.Exists, CommandFlags.None));
     }
 
@@ -1343,7 +1343,7 @@ public sealed class DatabaseWrapperTests
     {
         KeyValuePair<RedisKey, RedisValue>[] values = new KeyValuePair<RedisKey, RedisValue>[] { new KeyValuePair<RedisKey, RedisValue>("a", "x"), new KeyValuePair<RedisKey, RedisValue>("b", "y") };
         Expression<Func<KeyValuePair<RedisKey, RedisValue>[], bool>> valid = _ => _.Length == 2 && _[0].Key == "prefix:a" && _[0].Value == "x" && _[1].Key == "prefix:b" && _[1].Value == "y";
-        wrapper.StringSet(values, When.Exists, CommandFlags.None);
+        prefixed.StringSet(values, When.Exists, CommandFlags.None);
         mock.Verify(_ => _.StringSet(It.Is(valid), When.Exists, CommandFlags.None));
     }
 
@@ -1351,21 +1351,21 @@ public sealed class DatabaseWrapperTests
     public void StringSet_Compat()
     {
         TimeSpan? expiry = null;
-        wrapper.StringSet("key", "value", expiry, When.Exists);
+        prefixed.StringSet("key", "value", expiry, When.Exists);
         mock.Verify(_ => _.StringSet("prefix:key", "value", expiry, When.Exists));
     }
 
     [Fact]
     public void StringSetBit()
     {
-        wrapper.StringSetBit("key", 123, true, CommandFlags.None);
+        prefixed.StringSetBit("key", 123, true, CommandFlags.None);
         mock.Verify(_ => _.StringSetBit("prefix:key", 123, true, CommandFlags.None));
     }
 
     [Fact]
     public void StringSetRange()
     {
-        wrapper.StringSetRange("key", 123, "value", CommandFlags.None);
+        prefixed.StringSetRange("key", 123, "value", CommandFlags.None);
         mock.Verify(_ => _.StringSetRange("prefix:key", 123, "value", CommandFlags.None));
     }
 }

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
@@ -233,7 +233,6 @@ namespace StackExchange.Redis.Tests
             mock.Verify(_ => _.KeyEncodingAsync("prefix:key", CommandFlags.None));
         }
 
-
         [Fact]
         public void KeyExistsAsync()
         {

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
@@ -11,42 +11,42 @@ using System.Threading.Tasks;
 namespace StackExchange.Redis.Tests
 {
     [Collection(nameof(MoqDependentCollection))]
-    public sealed class WrapperBaseTests
+    public sealed class KeyPrefixedTests
     {
         private readonly Mock<IDatabaseAsync> mock;
-        private readonly WrapperBase<IDatabaseAsync> wrapper;
+        private readonly KeyPrefixed<IDatabaseAsync> prefixed;
 
-        public WrapperBaseTests()
+        public KeyPrefixedTests()
         {
             mock = new Mock<IDatabaseAsync>();
-            wrapper = new WrapperBase<IDatabaseAsync>(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+            prefixed = new KeyPrefixed<IDatabaseAsync>(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
         }
 
         [Fact]
         public async Task DebugObjectAsync()
         {
-            await wrapper.DebugObjectAsync("key", CommandFlags.None);
+            await prefixed.DebugObjectAsync("key", CommandFlags.None);
             mock.Verify(_ => _.DebugObjectAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void HashDecrementAsync_1()
         {
-            wrapper.HashDecrementAsync("key", "hashField", 123, CommandFlags.None);
+            prefixed.HashDecrementAsync("key", "hashField", 123, CommandFlags.None);
             mock.Verify(_ => _.HashDecrementAsync("prefix:key", "hashField", 123, CommandFlags.None));
         }
 
         [Fact]
         public void HashDecrementAsync_2()
         {
-            wrapper.HashDecrementAsync("key", "hashField", 1.23, CommandFlags.None);
+            prefixed.HashDecrementAsync("key", "hashField", 1.23, CommandFlags.None);
             mock.Verify(_ => _.HashDecrementAsync("prefix:key", "hashField", 1.23, CommandFlags.None));
         }
 
         [Fact]
         public void HashDeleteAsync_1()
         {
-            wrapper.HashDeleteAsync("key", "hashField", CommandFlags.None);
+            prefixed.HashDeleteAsync("key", "hashField", CommandFlags.None);
             mock.Verify(_ => _.HashDeleteAsync("prefix:key", "hashField", CommandFlags.None));
         }
 
@@ -54,28 +54,28 @@ namespace StackExchange.Redis.Tests
         public void HashDeleteAsync_2()
         {
             RedisValue[] hashFields = Array.Empty<RedisValue>();
-            wrapper.HashDeleteAsync("key", hashFields, CommandFlags.None);
+            prefixed.HashDeleteAsync("key", hashFields, CommandFlags.None);
             mock.Verify(_ => _.HashDeleteAsync("prefix:key", hashFields, CommandFlags.None));
         }
 
         [Fact]
         public void HashExistsAsync()
         {
-            wrapper.HashExistsAsync("key", "hashField", CommandFlags.None);
+            prefixed.HashExistsAsync("key", "hashField", CommandFlags.None);
             mock.Verify(_ => _.HashExistsAsync("prefix:key", "hashField", CommandFlags.None));
         }
 
         [Fact]
         public void HashGetAllAsync()
         {
-            wrapper.HashGetAllAsync("key", CommandFlags.None);
+            prefixed.HashGetAllAsync("key", CommandFlags.None);
             mock.Verify(_ => _.HashGetAllAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void HashGetAsync_1()
         {
-            wrapper.HashGetAsync("key", "hashField", CommandFlags.None);
+            prefixed.HashGetAsync("key", "hashField", CommandFlags.None);
             mock.Verify(_ => _.HashGetAsync("prefix:key", "hashField", CommandFlags.None));
         }
 
@@ -83,35 +83,35 @@ namespace StackExchange.Redis.Tests
         public void HashGetAsync_2()
         {
             RedisValue[] hashFields = Array.Empty<RedisValue>();
-            wrapper.HashGetAsync("key", hashFields, CommandFlags.None);
+            prefixed.HashGetAsync("key", hashFields, CommandFlags.None);
             mock.Verify(_ => _.HashGetAsync("prefix:key", hashFields, CommandFlags.None));
         }
 
         [Fact]
         public void HashIncrementAsync_1()
         {
-            wrapper.HashIncrementAsync("key", "hashField", 123, CommandFlags.None);
+            prefixed.HashIncrementAsync("key", "hashField", 123, CommandFlags.None);
             mock.Verify(_ => _.HashIncrementAsync("prefix:key", "hashField", 123, CommandFlags.None));
         }
 
         [Fact]
         public void HashIncrementAsync_2()
         {
-            wrapper.HashIncrementAsync("key", "hashField", 1.23, CommandFlags.None);
+            prefixed.HashIncrementAsync("key", "hashField", 1.23, CommandFlags.None);
             mock.Verify(_ => _.HashIncrementAsync("prefix:key", "hashField", 1.23, CommandFlags.None));
         }
 
         [Fact]
         public void HashKeysAsync()
         {
-            wrapper.HashKeysAsync("key", CommandFlags.None);
+            prefixed.HashKeysAsync("key", CommandFlags.None);
             mock.Verify(_ => _.HashKeysAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void HashLengthAsync()
         {
-            wrapper.HashLengthAsync("key", CommandFlags.None);
+            prefixed.HashLengthAsync("key", CommandFlags.None);
             mock.Verify(_ => _.HashLengthAsync("prefix:key", CommandFlags.None));
         }
 
@@ -119,35 +119,35 @@ namespace StackExchange.Redis.Tests
         public void HashSetAsync_1()
         {
             HashEntry[] hashFields = Array.Empty<HashEntry>();
-            wrapper.HashSetAsync("key", hashFields, CommandFlags.None);
+            prefixed.HashSetAsync("key", hashFields, CommandFlags.None);
             mock.Verify(_ => _.HashSetAsync("prefix:key", hashFields, CommandFlags.None));
         }
 
         [Fact]
         public void HashSetAsync_2()
         {
-            wrapper.HashSetAsync("key", "hashField", "value", When.Exists, CommandFlags.None);
+            prefixed.HashSetAsync("key", "hashField", "value", When.Exists, CommandFlags.None);
             mock.Verify(_ => _.HashSetAsync("prefix:key", "hashField", "value", When.Exists, CommandFlags.None));
         }
 
         [Fact]
         public void HashStringLengthAsync()
         {
-            wrapper.HashStringLengthAsync("key","field", CommandFlags.None);
+            prefixed.HashStringLengthAsync("key","field", CommandFlags.None);
             mock.Verify(_ => _.HashStringLengthAsync("prefix:key", "field", CommandFlags.None));
         }
 
         [Fact]
         public void HashValuesAsync()
         {
-            wrapper.HashValuesAsync("key", CommandFlags.None);
+            prefixed.HashValuesAsync("key", CommandFlags.None);
             mock.Verify(_ => _.HashValuesAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void HyperLogLogAddAsync_1()
         {
-            wrapper.HyperLogLogAddAsync("key", "value", CommandFlags.None);
+            prefixed.HyperLogLogAddAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.HyperLogLogAddAsync("prefix:key", "value", CommandFlags.None));
         }
 
@@ -155,21 +155,21 @@ namespace StackExchange.Redis.Tests
         public void HyperLogLogAddAsync_2()
         {
             var values = Array.Empty<RedisValue>();
-            wrapper.HyperLogLogAddAsync("key", values, CommandFlags.None);
+            prefixed.HyperLogLogAddAsync("key", values, CommandFlags.None);
             mock.Verify(_ => _.HyperLogLogAddAsync("prefix:key", values, CommandFlags.None));
         }
 
         [Fact]
         public void HyperLogLogLengthAsync()
         {
-            wrapper.HyperLogLogLengthAsync("key", CommandFlags.None);
+            prefixed.HyperLogLogLengthAsync("key", CommandFlags.None);
             mock.Verify(_ => _.HyperLogLogLengthAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void HyperLogLogMergeAsync_1()
         {
-            wrapper.HyperLogLogMergeAsync("destination", "first", "second", CommandFlags.None);
+            prefixed.HyperLogLogMergeAsync("destination", "first", "second", CommandFlags.None);
             mock.Verify(_ => _.HyperLogLogMergeAsync("prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
         }
 
@@ -178,35 +178,35 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.HyperLogLogMergeAsync("destination", keys, CommandFlags.None);
+            prefixed.HyperLogLogMergeAsync("destination", keys, CommandFlags.None);
             mock.Verify(_ => _.HyperLogLogMergeAsync("prefix:destination", It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void IdentifyEndpointAsync()
         {
-            wrapper.IdentifyEndpointAsync("key", CommandFlags.None);
+            prefixed.IdentifyEndpointAsync("key", CommandFlags.None);
             mock.Verify(_ => _.IdentifyEndpointAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void IsConnected()
         {
-            wrapper.IsConnected("key", CommandFlags.None);
+            prefixed.IsConnected("key", CommandFlags.None);
             mock.Verify(_ => _.IsConnected("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void KeyCopyAsync()
         {
-            wrapper.KeyCopyAsync("key", "destination", flags: CommandFlags.None);
+            prefixed.KeyCopyAsync("key", "destination", flags: CommandFlags.None);
             mock.Verify(_ => _.KeyCopyAsync("prefix:key", "prefix:destination", -1, false, CommandFlags.None));
         }
 
         [Fact]
         public void KeyDeleteAsync_1()
         {
-            wrapper.KeyDeleteAsync("key", CommandFlags.None);
+            prefixed.KeyDeleteAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyDeleteAsync("prefix:key", CommandFlags.None));
         }
 
@@ -215,21 +215,21 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.KeyDeleteAsync(keys, CommandFlags.None);
+            prefixed.KeyDeleteAsync(keys, CommandFlags.None);
             mock.Verify(_ => _.KeyDeleteAsync(It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void KeyDumpAsync()
         {
-            wrapper.KeyDumpAsync("key", CommandFlags.None);
+            prefixed.KeyDumpAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyDumpAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void KeyEncodingAsync()
         {
-            wrapper.KeyEncodingAsync("key", CommandFlags.None);
+            prefixed.KeyEncodingAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyEncodingAsync("prefix:key", CommandFlags.None));
         }
 
@@ -237,7 +237,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void KeyExistsAsync()
         {
-            wrapper.KeyExistsAsync("key", CommandFlags.None);
+            prefixed.KeyExistsAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyExistsAsync("prefix:key", CommandFlags.None));
         }
 
@@ -245,7 +245,7 @@ namespace StackExchange.Redis.Tests
         public void KeyExpireAsync_1()
         {
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.KeyExpireAsync("key", expiry, CommandFlags.None);
+            prefixed.KeyExpireAsync("key", expiry, CommandFlags.None);
             mock.Verify(_ => _.KeyExpireAsync("prefix:key", expiry, CommandFlags.None));
         }
 
@@ -253,7 +253,7 @@ namespace StackExchange.Redis.Tests
         public void KeyExpireAsync_2()
         {
             DateTime expiry = DateTime.Now;
-            wrapper.KeyExpireAsync("key", expiry, CommandFlags.None);
+            prefixed.KeyExpireAsync("key", expiry, CommandFlags.None);
             mock.Verify(_ => _.KeyExpireAsync("prefix:key", expiry, CommandFlags.None));
         }
 
@@ -261,7 +261,7 @@ namespace StackExchange.Redis.Tests
         public void KeyExpireAsync_3()
         {
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.KeyExpireAsync("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
+            prefixed.KeyExpireAsync("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
             mock.Verify(_ => _.KeyExpireAsync("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
         }
 
@@ -269,21 +269,21 @@ namespace StackExchange.Redis.Tests
         public void KeyExpireAsync_4()
         {
             DateTime expiry = DateTime.Now;
-            wrapper.KeyExpireAsync("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
+            prefixed.KeyExpireAsync("key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None);
             mock.Verify(_ => _.KeyExpireAsync("prefix:key", expiry, ExpireWhen.HasNoExpiry, CommandFlags.None));
         }
 
         [Fact]
         public void KeyExpireTimeAsync()
         {
-            wrapper.KeyExpireTimeAsync("key", CommandFlags.None);
+            prefixed.KeyExpireTimeAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyExpireTimeAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void KeyFrequencyAsync()
         {
-            wrapper.KeyFrequencyAsync("key", CommandFlags.None);
+            prefixed.KeyFrequencyAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyFrequencyAsync("prefix:key", CommandFlags.None));
         }
 
@@ -291,41 +291,41 @@ namespace StackExchange.Redis.Tests
         public void KeyMigrateAsync()
         {
             EndPoint toServer = new IPEndPoint(IPAddress.Loopback, 123);
-            wrapper.KeyMigrateAsync("key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None);
+            prefixed.KeyMigrateAsync("key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None);
             mock.Verify(_ => _.KeyMigrateAsync("prefix:key", toServer, 123, 456, MigrateOptions.Copy, CommandFlags.None));
         }
 
         [Fact]
         public void KeyMoveAsync()
         {
-            wrapper.KeyMoveAsync("key", 123, CommandFlags.None);
+            prefixed.KeyMoveAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.KeyMoveAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void KeyPersistAsync()
         {
-            wrapper.KeyPersistAsync("key", CommandFlags.None);
+            prefixed.KeyPersistAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyPersistAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public Task KeyRandomAsync()
         {
-            return Assert.ThrowsAsync<NotSupportedException>(() => wrapper.KeyRandomAsync());
+            return Assert.ThrowsAsync<NotSupportedException>(() => prefixed.KeyRandomAsync());
         }
 
         [Fact]
         public void KeyRefCountAsync()
         {
-            wrapper.KeyRefCountAsync("key", CommandFlags.None);
+            prefixed.KeyRefCountAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyRefCountAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void KeyRenameAsync()
         {
-            wrapper.KeyRenameAsync("key", "newKey", When.Exists, CommandFlags.None);
+            prefixed.KeyRenameAsync("key", "newKey", When.Exists, CommandFlags.None);
             mock.Verify(_ => _.KeyRenameAsync("prefix:key", "prefix:newKey", When.Exists, CommandFlags.None));
         }
 
@@ -334,63 +334,63 @@ namespace StackExchange.Redis.Tests
         {
             byte[] value = Array.Empty<byte>();
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.KeyRestoreAsync("key", value, expiry, CommandFlags.None);
+            prefixed.KeyRestoreAsync("key", value, expiry, CommandFlags.None);
             mock.Verify(_ => _.KeyRestoreAsync("prefix:key", value, expiry, CommandFlags.None));
         }
 
         [Fact]
         public void KeyTimeToLiveAsync()
         {
-            wrapper.KeyTimeToLiveAsync("key", CommandFlags.None);
+            prefixed.KeyTimeToLiveAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyTimeToLiveAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void KeyTypeAsync()
         {
-            wrapper.KeyTypeAsync("key", CommandFlags.None);
+            prefixed.KeyTypeAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyTypeAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void ListGetByIndexAsync()
         {
-            wrapper.ListGetByIndexAsync("key", 123, CommandFlags.None);
+            prefixed.ListGetByIndexAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.ListGetByIndexAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void ListInsertAfterAsync()
         {
-            wrapper.ListInsertAfterAsync("key", "pivot", "value", CommandFlags.None);
+            prefixed.ListInsertAfterAsync("key", "pivot", "value", CommandFlags.None);
             mock.Verify(_ => _.ListInsertAfterAsync("prefix:key", "pivot", "value", CommandFlags.None));
         }
 
         [Fact]
         public void ListInsertBeforeAsync()
         {
-            wrapper.ListInsertBeforeAsync("key", "pivot", "value", CommandFlags.None);
+            prefixed.ListInsertBeforeAsync("key", "pivot", "value", CommandFlags.None);
             mock.Verify(_ => _.ListInsertBeforeAsync("prefix:key", "pivot", "value", CommandFlags.None));
         }
 
         [Fact]
         public void ListLeftPopAsync()
         {
-            wrapper.ListLeftPopAsync("key", CommandFlags.None);
+            prefixed.ListLeftPopAsync("key", CommandFlags.None);
             mock.Verify(_ => _.ListLeftPopAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void ListLeftPopAsync_1()
         {
-            wrapper.ListLeftPopAsync("key", 123, CommandFlags.None);
+            prefixed.ListLeftPopAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.ListLeftPopAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void ListLeftPushAsync_1()
         {
-            wrapper.ListLeftPushAsync("key", "value", When.Exists, CommandFlags.None);
+            prefixed.ListLeftPushAsync("key", "value", When.Exists, CommandFlags.None);
             mock.Verify(_ => _.ListLeftPushAsync("prefix:key", "value", When.Exists, CommandFlags.None));
         }
 
@@ -398,7 +398,7 @@ namespace StackExchange.Redis.Tests
         public void ListLeftPushAsync_2()
         {
             RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.ListLeftPushAsync("key", values, CommandFlags.None);
+            prefixed.ListLeftPushAsync("key", values, CommandFlags.None);
             mock.Verify(_ => _.ListLeftPushAsync("prefix:key", values, CommandFlags.None));
         }
 
@@ -406,63 +406,63 @@ namespace StackExchange.Redis.Tests
         public void ListLeftPushAsync_3()
         {
             RedisValue[] values = new RedisValue[] { "value1", "value2" };
-            wrapper.ListLeftPushAsync("key", values, When.Exists, CommandFlags.None);
+            prefixed.ListLeftPushAsync("key", values, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.ListLeftPushAsync("prefix:key", values, When.Exists, CommandFlags.None));
         }
 
         [Fact]
         public void ListLengthAsync()
         {
-            wrapper.ListLengthAsync("key", CommandFlags.None);
+            prefixed.ListLengthAsync("key", CommandFlags.None);
             mock.Verify(_ => _.ListLengthAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void ListMoveAsync()
         {
-            wrapper.ListMoveAsync("key", "destination", ListSide.Left, ListSide.Right, CommandFlags.None);
+            prefixed.ListMoveAsync("key", "destination", ListSide.Left, ListSide.Right, CommandFlags.None);
             mock.Verify(_ => _.ListMoveAsync("prefix:key", "prefix:destination", ListSide.Left, ListSide.Right, CommandFlags.None));
         }
 
         [Fact]
         public void ListRangeAsync()
         {
-            wrapper.ListRangeAsync("key", 123, 456, CommandFlags.None);
+            prefixed.ListRangeAsync("key", 123, 456, CommandFlags.None);
             mock.Verify(_ => _.ListRangeAsync("prefix:key", 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void ListRemoveAsync()
         {
-            wrapper.ListRemoveAsync("key", "value", 123, CommandFlags.None);
+            prefixed.ListRemoveAsync("key", "value", 123, CommandFlags.None);
             mock.Verify(_ => _.ListRemoveAsync("prefix:key", "value", 123, CommandFlags.None));
         }
 
         [Fact]
         public void ListRightPopAsync()
         {
-            wrapper.ListRightPopAsync("key", CommandFlags.None);
+            prefixed.ListRightPopAsync("key", CommandFlags.None);
             mock.Verify(_ => _.ListRightPopAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void ListRightPopAsync_1()
         {
-            wrapper.ListRightPopAsync("key", 123, CommandFlags.None);
+            prefixed.ListRightPopAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.ListRightPopAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void ListRightPopLeftPushAsync()
         {
-            wrapper.ListRightPopLeftPushAsync("source", "destination", CommandFlags.None);
+            prefixed.ListRightPopLeftPushAsync("source", "destination", CommandFlags.None);
             mock.Verify(_ => _.ListRightPopLeftPushAsync("prefix:source", "prefix:destination", CommandFlags.None));
         }
 
         [Fact]
         public void ListRightPushAsync_1()
         {
-            wrapper.ListRightPushAsync("key", "value", When.Exists, CommandFlags.None);
+            prefixed.ListRightPushAsync("key", "value", When.Exists, CommandFlags.None);
             mock.Verify(_ => _.ListRightPushAsync("prefix:key", "value", When.Exists, CommandFlags.None));
         }
 
@@ -470,7 +470,7 @@ namespace StackExchange.Redis.Tests
         public void ListRightPushAsync_2()
         {
             RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.ListRightPushAsync("key", values, CommandFlags.None);
+            prefixed.ListRightPushAsync("key", values, CommandFlags.None);
             mock.Verify(_ => _.ListRightPushAsync("prefix:key", values, CommandFlags.None));
         }
 
@@ -478,21 +478,21 @@ namespace StackExchange.Redis.Tests
         public void ListRightPushAsync_3()
         {
             RedisValue[] values = new RedisValue[] { "value1", "value2" };
-            wrapper.ListRightPushAsync("key", values, When.Exists, CommandFlags.None);
+            prefixed.ListRightPushAsync("key", values, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.ListRightPushAsync("prefix:key", values, When.Exists, CommandFlags.None));
         }
 
         [Fact]
         public void ListSetByIndexAsync()
         {
-            wrapper.ListSetByIndexAsync("key", 123, "value", CommandFlags.None);
+            prefixed.ListSetByIndexAsync("key", 123, "value", CommandFlags.None);
             mock.Verify(_ => _.ListSetByIndexAsync("prefix:key", 123, "value", CommandFlags.None));
         }
 
         [Fact]
         public void ListTrimAsync()
         {
-            wrapper.ListTrimAsync("key", 123, 456, CommandFlags.None);
+            prefixed.ListTrimAsync("key", 123, 456, CommandFlags.None);
             mock.Verify(_ => _.ListTrimAsync("prefix:key", 123, 456, CommandFlags.None));
         }
 
@@ -500,21 +500,21 @@ namespace StackExchange.Redis.Tests
         public void LockExtendAsync()
         {
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.LockExtendAsync("key", "value", expiry, CommandFlags.None);
+            prefixed.LockExtendAsync("key", "value", expiry, CommandFlags.None);
             mock.Verify(_ => _.LockExtendAsync("prefix:key", "value", expiry, CommandFlags.None));
         }
 
         [Fact]
         public void LockQueryAsync()
         {
-            wrapper.LockQueryAsync("key", CommandFlags.None);
+            prefixed.LockQueryAsync("key", CommandFlags.None);
             mock.Verify(_ => _.LockQueryAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void LockReleaseAsync()
         {
-            wrapper.LockReleaseAsync("key", "value", CommandFlags.None);
+            prefixed.LockReleaseAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.LockReleaseAsync("prefix:key", "value", CommandFlags.None));
         }
 
@@ -522,14 +522,14 @@ namespace StackExchange.Redis.Tests
         public void LockTakeAsync()
         {
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.LockTakeAsync("key", "value", expiry, CommandFlags.None);
+            prefixed.LockTakeAsync("key", "value", expiry, CommandFlags.None);
             mock.Verify(_ => _.LockTakeAsync("prefix:key", "value", expiry, CommandFlags.None));
         }
 
         [Fact]
         public void PublishAsync()
         {
-            wrapper.PublishAsync("channel", "message", CommandFlags.None);
+            prefixed.PublishAsync("channel", "message", CommandFlags.None);
             mock.Verify(_ => _.PublishAsync("prefix:channel", "message", CommandFlags.None));
         }
 
@@ -540,7 +540,7 @@ namespace StackExchange.Redis.Tests
             RedisValue[] values = Array.Empty<RedisValue>();
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.ScriptEvaluateAsync(hash, keys, values, CommandFlags.None);
+            prefixed.ScriptEvaluateAsync(hash, keys, values, CommandFlags.None);
             mock.Verify(_ => _.ScriptEvaluateAsync(hash, It.Is(valid), values, CommandFlags.None));
         }
 
@@ -550,14 +550,14 @@ namespace StackExchange.Redis.Tests
             RedisValue[] values = Array.Empty<RedisValue>();
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.ScriptEvaluateAsync("script", keys, values, CommandFlags.None);
+            prefixed.ScriptEvaluateAsync("script", keys, values, CommandFlags.None);
             mock.Verify(_ => _.ScriptEvaluateAsync("script", It.Is(valid), values, CommandFlags.None));
         }
 
         [Fact]
         public void SetAddAsync_1()
         {
-            wrapper.SetAddAsync("key", "value", CommandFlags.None);
+            prefixed.SetAddAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.SetAddAsync("prefix:key", "value", CommandFlags.None));
         }
 
@@ -565,14 +565,14 @@ namespace StackExchange.Redis.Tests
         public void SetAddAsync_2()
         {
             RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.SetAddAsync("key", values, CommandFlags.None);
+            prefixed.SetAddAsync("key", values, CommandFlags.None);
             mock.Verify(_ => _.SetAddAsync("prefix:key", values, CommandFlags.None));
         }
 
         [Fact]
         public void SetCombineAndStoreAsync_1()
         {
-            wrapper.SetCombineAndStoreAsync(SetOperation.Intersect, "destination", "first", "second", CommandFlags.None);
+            prefixed.SetCombineAndStoreAsync(SetOperation.Intersect, "destination", "first", "second", CommandFlags.None);
             mock.Verify(_ => _.SetCombineAndStoreAsync(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
         }
 
@@ -581,14 +581,14 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.SetCombineAndStoreAsync(SetOperation.Intersect, "destination", keys, CommandFlags.None);
+            prefixed.SetCombineAndStoreAsync(SetOperation.Intersect, "destination", keys, CommandFlags.None);
             mock.Verify(_ => _.SetCombineAndStoreAsync(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void SetCombineAsync_1()
         {
-            wrapper.SetCombineAsync(SetOperation.Intersect, "first", "second", CommandFlags.None);
+            prefixed.SetCombineAsync(SetOperation.Intersect, "first", "second", CommandFlags.None);
             mock.Verify(_ => _.SetCombineAsync(SetOperation.Intersect, "prefix:first", "prefix:second", CommandFlags.None));
         }
 
@@ -597,14 +597,14 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.SetCombineAsync(SetOperation.Intersect, keys, CommandFlags.None);
+            prefixed.SetCombineAsync(SetOperation.Intersect, keys, CommandFlags.None);
             mock.Verify(_ => _.SetCombineAsync(SetOperation.Intersect, It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void SetContainsAsync()
         {
-            wrapper.SetContainsAsync("key", "value", CommandFlags.None);
+            prefixed.SetContainsAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.SetContainsAsync("prefix:key", "value", CommandFlags.None));
         }
 
@@ -612,7 +612,7 @@ namespace StackExchange.Redis.Tests
         public void SetContainsAsync_2()
         {
             RedisValue[] values = new RedisValue[] { "value1", "value2" };
-            wrapper.SetContainsAsync("key", values, CommandFlags.None);
+            prefixed.SetContainsAsync("key", values, CommandFlags.None);
             mock.Verify(_ => _.SetContainsAsync("prefix:key", values, CommandFlags.None));
         }
 
@@ -620,66 +620,66 @@ namespace StackExchange.Redis.Tests
         public void SetIntersectionLengthAsync()
         {
             var keys = new RedisKey[] { "key1", "key2" };
-            wrapper.SetIntersectionLengthAsync(keys);
+            prefixed.SetIntersectionLengthAsync(keys);
             mock.Verify(_ => _.SetIntersectionLengthAsync(keys, 0, CommandFlags.None));
         }
 
         [Fact]
         public void SetLengthAsync()
         {
-            wrapper.SetLengthAsync("key", CommandFlags.None);
+            prefixed.SetLengthAsync("key", CommandFlags.None);
             mock.Verify(_ => _.SetLengthAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void SetMembersAsync()
         {
-            wrapper.SetMembersAsync("key", CommandFlags.None);
+            prefixed.SetMembersAsync("key", CommandFlags.None);
             mock.Verify(_ => _.SetMembersAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void SetMoveAsync()
         {
-            wrapper.SetMoveAsync("source", "destination", "value", CommandFlags.None);
+            prefixed.SetMoveAsync("source", "destination", "value", CommandFlags.None);
             mock.Verify(_ => _.SetMoveAsync("prefix:source", "prefix:destination", "value", CommandFlags.None));
         }
 
         [Fact]
         public void SetPopAsync_1()
         {
-            wrapper.SetPopAsync("key", CommandFlags.None);
+            prefixed.SetPopAsync("key", CommandFlags.None);
             mock.Verify(_ => _.SetPopAsync("prefix:key", CommandFlags.None));
 
-            wrapper.SetPopAsync("key", 5, CommandFlags.None);
+            prefixed.SetPopAsync("key", 5, CommandFlags.None);
             mock.Verify(_ => _.SetPopAsync("prefix:key", 5, CommandFlags.None));
         }
 
         [Fact]
         public void SetPopAsync_2()
         {
-            wrapper.SetPopAsync("key", 5, CommandFlags.None);
+            prefixed.SetPopAsync("key", 5, CommandFlags.None);
             mock.Verify(_ => _.SetPopAsync("prefix:key", 5, CommandFlags.None));
         }
 
         [Fact]
         public void SetRandomMemberAsync()
         {
-            wrapper.SetRandomMemberAsync("key", CommandFlags.None);
+            prefixed.SetRandomMemberAsync("key", CommandFlags.None);
             mock.Verify(_ => _.SetRandomMemberAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void SetRandomMembersAsync()
         {
-            wrapper.SetRandomMembersAsync("key", 123, CommandFlags.None);
+            prefixed.SetRandomMembersAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.SetRandomMembersAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void SetRemoveAsync_1()
         {
-            wrapper.SetRemoveAsync("key", "value", CommandFlags.None);
+            prefixed.SetRemoveAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.SetRemoveAsync("prefix:key", "value", CommandFlags.None));
         }
 
@@ -687,7 +687,7 @@ namespace StackExchange.Redis.Tests
         public void SetRemoveAsync_2()
         {
             RedisValue[] values = Array.Empty<RedisValue>();
-            wrapper.SetRemoveAsync("key", values, CommandFlags.None);
+            prefixed.SetRemoveAsync("key", values, CommandFlags.None);
             mock.Verify(_ => _.SetRemoveAsync("prefix:key", values, CommandFlags.None));
         }
 
@@ -697,8 +697,8 @@ namespace StackExchange.Redis.Tests
             RedisValue[] get = new RedisValue[] { "a", "#" };
             Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
 
-            wrapper.SortAndStoreAsync("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
-            wrapper.SortAndStoreAsync("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
+            prefixed.SortAndStoreAsync("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
+            prefixed.SortAndStoreAsync("destination", "key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
 
             mock.Verify(_ => _.SortAndStoreAsync("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
             mock.Verify(_ => _.SortAndStoreAsync("prefix:destination", "prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
@@ -710,8 +710,8 @@ namespace StackExchange.Redis.Tests
             RedisValue[] get = new RedisValue[] { "a", "#" };
             Expression<Func<RedisValue[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "#";
 
-            wrapper.SortAsync("key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
-            wrapper.SortAsync("key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
+            prefixed.SortAsync("key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", get, CommandFlags.None);
+            prefixed.SortAsync("key", 123, 456, Order.Descending, SortType.Alphabetic, "by", get, CommandFlags.None);
 
             mock.Verify(_ => _.SortAsync("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "nosort", It.Is(valid), CommandFlags.None));
             mock.Verify(_ => _.SortAsync("prefix:key", 123, 456, Order.Descending, SortType.Alphabetic, "prefix:by", It.Is(valid), CommandFlags.None));
@@ -720,7 +720,7 @@ namespace StackExchange.Redis.Tests
         [Fact]
         public void SortedSetAddAsync_1()
         {
-            wrapper.SortedSetAddAsync("key", "member", 1.23, When.Exists, CommandFlags.None);
+            prefixed.SortedSetAddAsync("key", "member", 1.23, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.SortedSetAddAsync("prefix:key", "member", 1.23, When.Exists, CommandFlags.None));
         }
 
@@ -728,7 +728,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetAddAsync_2()
         {
             SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-            wrapper.SortedSetAddAsync("key", values, When.Exists, CommandFlags.None);
+            prefixed.SortedSetAddAsync("key", values, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.SortedSetAddAsync("prefix:key", values, When.Exists, CommandFlags.None));
         }
 
@@ -736,7 +736,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetAddAsync_3()
         {
             SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-            wrapper.SortedSetAddAsync("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
+            prefixed.SortedSetAddAsync("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
             mock.Verify(_ => _.SortedSetAddAsync("prefix:key", values, SortedSetWhen.GreaterThan, CommandFlags.None));
         }
 
@@ -744,7 +744,7 @@ namespace StackExchange.Redis.Tests
         public void SortedSetCombineAsync()
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
-            wrapper.SortedSetCombineAsync(SetOperation.Intersect, keys);
+            prefixed.SortedSetCombineAsync(SetOperation.Intersect, keys);
             mock.Verify(_ => _.SortedSetCombineAsync(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
         }
 
@@ -752,14 +752,14 @@ namespace StackExchange.Redis.Tests
         public void SortedSetCombineWithScoresAsync()
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
-            wrapper.SortedSetCombineWithScoresAsync(SetOperation.Intersect, keys);
+            prefixed.SortedSetCombineWithScoresAsync(SetOperation.Intersect, keys);
             mock.Verify(_ => _.SortedSetCombineWithScoresAsync(SetOperation.Intersect, keys, null, Aggregate.Sum, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetCombineAndStoreAsync_1()
         {
-            wrapper.SortedSetCombineAndStoreAsync(SetOperation.Intersect, "destination", "first", "second", Aggregate.Max, CommandFlags.None);
+            prefixed.SortedSetCombineAndStoreAsync(SetOperation.Intersect, "destination", "first", "second", Aggregate.Max, CommandFlags.None);
             mock.Verify(_ => _.SortedSetCombineAndStoreAsync(SetOperation.Intersect, "prefix:destination", "prefix:first", "prefix:second", Aggregate.Max, CommandFlags.None));
         }
 
@@ -768,21 +768,21 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.SetCombineAndStoreAsync(SetOperation.Intersect, "destination", keys, CommandFlags.None);
+            prefixed.SetCombineAndStoreAsync(SetOperation.Intersect, "destination", keys, CommandFlags.None);
             mock.Verify(_ => _.SetCombineAndStoreAsync(SetOperation.Intersect, "prefix:destination", It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetDecrementAsync()
         {
-            wrapper.SortedSetDecrementAsync("key", "member", 1.23, CommandFlags.None);
+            prefixed.SortedSetDecrementAsync("key", "member", 1.23, CommandFlags.None);
             mock.Verify(_ => _.SortedSetDecrementAsync("prefix:key", "member", 1.23, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetIncrementAsync()
         {
-            wrapper.SortedSetIncrementAsync("key", "member", 1.23, CommandFlags.None);
+            prefixed.SortedSetIncrementAsync("key", "member", 1.23, CommandFlags.None);
             mock.Verify(_ => _.SortedSetIncrementAsync("prefix:key", "member", 1.23, CommandFlags.None));
         }
 
@@ -790,98 +790,98 @@ namespace StackExchange.Redis.Tests
         public void SortedSetIntersectionLengthAsync()
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
-            wrapper.SortedSetIntersectionLengthAsync(keys, 1, CommandFlags.None);
+            prefixed.SortedSetIntersectionLengthAsync(keys, 1, CommandFlags.None);
             mock.Verify(_ => _.SortedSetIntersectionLengthAsync(keys, 1, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetLengthAsync()
         {
-            wrapper.SortedSetLengthAsync("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
+            prefixed.SortedSetLengthAsync("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
             mock.Verify(_ => _.SortedSetLengthAsync("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetLengthByValueAsync()
         {
-            wrapper.SortedSetLengthByValueAsync("key", "min", "max", Exclude.Start, CommandFlags.None);
+            prefixed.SortedSetLengthByValueAsync("key", "min", "max", Exclude.Start, CommandFlags.None);
             mock.Verify(_ => _.SortedSetLengthByValueAsync("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRandomMemberAsync()
         {
-            wrapper.SortedSetRandomMemberAsync("key", CommandFlags.None);
+            prefixed.SortedSetRandomMemberAsync("key", CommandFlags.None);
             mock.Verify(_ => _.SortedSetRandomMemberAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRandomMembersAsync()
         {
-            wrapper.SortedSetRandomMembersAsync("key", 2, CommandFlags.None);
+            prefixed.SortedSetRandomMembersAsync("key", 2, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRandomMembersAsync("prefix:key", 2, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRandomMemberWithScoresAsync()
         {
-            wrapper.SortedSetRandomMembersWithScoresAsync("key", 2, CommandFlags.None);
+            prefixed.SortedSetRandomMembersWithScoresAsync("key", 2, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRandomMembersWithScoresAsync("prefix:key", 2, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRangeByRankAsync()
         {
-            wrapper.SortedSetRangeByRankAsync("key", 123, 456, Order.Descending, CommandFlags.None);
+            prefixed.SortedSetRangeByRankAsync("key", 123, 456, Order.Descending, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRangeByRankAsync("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRangeByRankWithScoresAsync()
         {
-            wrapper.SortedSetRangeByRankWithScoresAsync("key", 123, 456, Order.Descending, CommandFlags.None);
+            prefixed.SortedSetRangeByRankWithScoresAsync("key", 123, 456, Order.Descending, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRangeByRankWithScoresAsync("prefix:key", 123, 456, Order.Descending, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRangeByScoreAsync()
         {
-            wrapper.SortedSetRangeByScoreAsync("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+            prefixed.SortedSetRangeByScoreAsync("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRangeByScoreAsync("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRangeByScoreWithScoresAsync()
         {
-            wrapper.SortedSetRangeByScoreWithScoresAsync("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+            prefixed.SortedSetRangeByScoreWithScoresAsync("key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRangeByScoreWithScoresAsync("prefix:key", 1.23, 1.23, Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRangeByValueAsync()
         {
-            wrapper.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.None);
+            prefixed.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, 123, 456, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRangeByValueAsync("prefix:key", "min", "max", Exclude.Start, Order.Ascending, 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRangeByValueDescAsync()
         {
-            wrapper.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
+            prefixed.SortedSetRangeByValueAsync("key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRangeByValueAsync("prefix:key", "min", "max", Exclude.Start, Order.Descending, 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRankAsync()
         {
-            wrapper.SortedSetRankAsync("key", "member", Order.Descending, CommandFlags.None);
+            prefixed.SortedSetRankAsync("key", "member", Order.Descending, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRankAsync("prefix:key", "member", Order.Descending, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRemoveAsync_1()
         {
-            wrapper.SortedSetRemoveAsync("key", "member", CommandFlags.None);
+            prefixed.SortedSetRemoveAsync("key", "member", CommandFlags.None);
             mock.Verify(_ => _.SortedSetRemoveAsync("prefix:key", "member", CommandFlags.None));
         }
 
@@ -889,42 +889,42 @@ namespace StackExchange.Redis.Tests
         public void SortedSetRemoveAsync_2()
         {
             RedisValue[] members = Array.Empty<RedisValue>();
-            wrapper.SortedSetRemoveAsync("key", members, CommandFlags.None);
+            prefixed.SortedSetRemoveAsync("key", members, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRemoveAsync("prefix:key", members, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRemoveRangeByRankAsync()
         {
-            wrapper.SortedSetRemoveRangeByRankAsync("key", 123, 456, CommandFlags.None);
+            prefixed.SortedSetRemoveRangeByRankAsync("key", 123, 456, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRemoveRangeByRankAsync("prefix:key", 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRemoveRangeByScoreAsync()
         {
-            wrapper.SortedSetRemoveRangeByScoreAsync("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
+            prefixed.SortedSetRemoveRangeByScoreAsync("key", 1.23, 1.23, Exclude.Start, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRemoveRangeByScoreAsync("prefix:key", 1.23, 1.23, Exclude.Start, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetRemoveRangeByValueAsync()
         {
-            wrapper.SortedSetRemoveRangeByValueAsync("key", "min", "max", Exclude.Start, CommandFlags.None);
+            prefixed.SortedSetRemoveRangeByValueAsync("key", "min", "max", Exclude.Start, CommandFlags.None);
             mock.Verify(_ => _.SortedSetRemoveRangeByValueAsync("prefix:key", "min", "max", Exclude.Start, CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetScoreAsync()
         {
-            wrapper.SortedSetScoreAsync("key", "member", CommandFlags.None);
+            prefixed.SortedSetScoreAsync("key", "member", CommandFlags.None);
             mock.Verify(_ => _.SortedSetScoreAsync("prefix:key", "member", CommandFlags.None));
         }
 
         [Fact]
         public void SortedSetScoreAsync_Multiple()
         {
-            wrapper.SortedSetScoresAsync("key", new RedisValue[] { "member1", "member2" }, CommandFlags.None);
+            prefixed.SortedSetScoresAsync("key", new RedisValue[] { "member1", "member2" }, CommandFlags.None);
             mock.Verify(_ => _.SortedSetScoresAsync("prefix:key", new RedisValue[] { "member1", "member2" }, CommandFlags.None));
         }
 
@@ -932,14 +932,14 @@ namespace StackExchange.Redis.Tests
         public void SortedSetUpdateAsync()
         {
             SortedSetEntry[] values = Array.Empty<SortedSetEntry>();
-            wrapper.SortedSetUpdateAsync("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
+            prefixed.SortedSetUpdateAsync("key", values, SortedSetWhen.GreaterThan, CommandFlags.None);
             mock.Verify(_ => _.SortedSetUpdateAsync("prefix:key", values, SortedSetWhen.GreaterThan, CommandFlags.None));
         }
 
         [Fact]
         public void StreamAcknowledgeAsync_1()
         {
-            wrapper.StreamAcknowledgeAsync("key", "group", "0-0", CommandFlags.None);
+            prefixed.StreamAcknowledgeAsync("key", "group", "0-0", CommandFlags.None);
             mock.Verify(_ => _.StreamAcknowledgeAsync("prefix:key", "group", "0-0", CommandFlags.None));
         }
 
@@ -947,14 +947,14 @@ namespace StackExchange.Redis.Tests
         public void StreamAcknowledgeAsync_2()
         {
             var messageIds = new RedisValue[] { "0-0", "0-1", "0-2" };
-            wrapper.StreamAcknowledgeAsync("key", "group", messageIds, CommandFlags.None);
+            prefixed.StreamAcknowledgeAsync("key", "group", messageIds, CommandFlags.None);
             mock.Verify(_ => _.StreamAcknowledgeAsync("prefix:key", "group", messageIds, CommandFlags.None));
         }
 
         [Fact]
         public void StreamAddAsync_1()
         {
-            wrapper.StreamAddAsync("key", "field1", "value1", "*", 1000, true, CommandFlags.None);
+            prefixed.StreamAddAsync("key", "field1", "value1", "*", 1000, true, CommandFlags.None);
             mock.Verify(_ => _.StreamAddAsync("prefix:key", "field1", "value1", "*", 1000, true, CommandFlags.None));
         }
 
@@ -962,21 +962,21 @@ namespace StackExchange.Redis.Tests
         public void StreamAddAsync_2()
         {
             var fields = Array.Empty<NameValueEntry>();
-            wrapper.StreamAddAsync("key", fields, "*", 1000, true, CommandFlags.None);
+            prefixed.StreamAddAsync("key", fields, "*", 1000, true, CommandFlags.None);
             mock.Verify(_ => _.StreamAddAsync("prefix:key", fields, "*", 1000, true, CommandFlags.None));
         }
 
         [Fact]
         public void StreamAutoClaimAsync()
         {
-            wrapper.StreamAutoClaimAsync("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
+            prefixed.StreamAutoClaimAsync("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
             mock.Verify(_ => _.StreamAutoClaimAsync("prefix:key", "group", "consumer", 0, "0-0", 100, CommandFlags.None));
         }
 
         [Fact]
         public void StreamAutoClaimIdsOnlyAsync()
         {
-            wrapper.StreamAutoClaimIdsOnlyAsync("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
+            prefixed.StreamAutoClaimIdsOnlyAsync("key", "group", "consumer", 0, "0-0", 100, CommandFlags.None);
             mock.Verify(_ => _.StreamAutoClaimIdsOnlyAsync("prefix:key", "group", "consumer", 0, "0-0", 100, CommandFlags.None));
         }
 
@@ -984,7 +984,7 @@ namespace StackExchange.Redis.Tests
         public void StreamClaimMessagesAsync()
         {
             var messageIds = Array.Empty<RedisValue>();
-            wrapper.StreamClaimAsync("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
+            prefixed.StreamClaimAsync("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
             mock.Verify(_ => _.StreamClaimAsync("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
         }
 
@@ -992,49 +992,49 @@ namespace StackExchange.Redis.Tests
         public void StreamClaimMessagesReturningIdsAsync()
         {
             var messageIds = Array.Empty<RedisValue>();
-            wrapper.StreamClaimIdsOnlyAsync("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
+            prefixed.StreamClaimIdsOnlyAsync("key", "group", "consumer", 1000, messageIds, CommandFlags.None);
             mock.Verify(_ => _.StreamClaimIdsOnlyAsync("prefix:key", "group", "consumer", 1000, messageIds, CommandFlags.None));
         }
 
         [Fact]
         public void StreamConsumerInfoGetAsync()
         {
-            wrapper.StreamConsumerInfoAsync("key", "group", CommandFlags.None);
+            prefixed.StreamConsumerInfoAsync("key", "group", CommandFlags.None);
             mock.Verify(_ => _.StreamConsumerInfoAsync("prefix:key", "group", CommandFlags.None));
         }
 
         [Fact]
         public void StreamConsumerGroupSetPositionAsync()
         {
-            wrapper.StreamConsumerGroupSetPositionAsync("key", "group", StreamPosition.Beginning, CommandFlags.None);
+            prefixed.StreamConsumerGroupSetPositionAsync("key", "group", StreamPosition.Beginning, CommandFlags.None);
             mock.Verify(_ => _.StreamConsumerGroupSetPositionAsync("prefix:key", "group", StreamPosition.Beginning, CommandFlags.None));
         }
 
         [Fact]
         public void StreamCreateConsumerGroupAsync()
         {
-            wrapper.StreamCreateConsumerGroupAsync("key", "group", "0-0", false, CommandFlags.None);
+            prefixed.StreamCreateConsumerGroupAsync("key", "group", "0-0", false, CommandFlags.None);
             mock.Verify(_ => _.StreamCreateConsumerGroupAsync("prefix:key", "group", "0-0", false, CommandFlags.None));
         }
 
         [Fact]
         public void StreamGroupInfoGetAsync()
         {
-            wrapper.StreamGroupInfoAsync("key", CommandFlags.None);
+            prefixed.StreamGroupInfoAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StreamGroupInfoAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void StreamInfoGetAsync()
         {
-            wrapper.StreamInfoAsync("key", CommandFlags.None);
+            prefixed.StreamInfoAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StreamInfoAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void StreamLengthAsync()
         {
-            wrapper.StreamLengthAsync("key", CommandFlags.None);
+            prefixed.StreamLengthAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StreamLengthAsync("prefix:key", CommandFlags.None));
         }
 
@@ -1042,42 +1042,42 @@ namespace StackExchange.Redis.Tests
         public void StreamMessagesDeleteAsync()
         {
             var messageIds = Array.Empty<RedisValue>();
-            wrapper.StreamDeleteAsync("key", messageIds, CommandFlags.None);
+            prefixed.StreamDeleteAsync("key", messageIds, CommandFlags.None);
             mock.Verify(_ => _.StreamDeleteAsync("prefix:key", messageIds, CommandFlags.None));
         }
 
         [Fact]
         public void StreamDeleteConsumerAsync()
         {
-            wrapper.StreamDeleteConsumerAsync("key", "group", "consumer", CommandFlags.None);
+            prefixed.StreamDeleteConsumerAsync("key", "group", "consumer", CommandFlags.None);
             mock.Verify(_ => _.StreamDeleteConsumerAsync("prefix:key", "group", "consumer", CommandFlags.None));
         }
 
         [Fact]
         public void StreamDeleteConsumerGroupAsync()
         {
-            wrapper.StreamDeleteConsumerGroupAsync("key", "group", CommandFlags.None);
+            prefixed.StreamDeleteConsumerGroupAsync("key", "group", CommandFlags.None);
             mock.Verify(_ => _.StreamDeleteConsumerGroupAsync("prefix:key", "group", CommandFlags.None));
         }
 
         [Fact]
         public void StreamPendingInfoGetAsync()
         {
-            wrapper.StreamPendingAsync("key", "group", CommandFlags.None);
+            prefixed.StreamPendingAsync("key", "group", CommandFlags.None);
             mock.Verify(_ => _.StreamPendingAsync("prefix:key", "group", CommandFlags.None));
         }
 
         [Fact]
         public void StreamPendingMessageInfoGetAsync()
         {
-            wrapper.StreamPendingMessagesAsync("key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None);
+            prefixed.StreamPendingMessagesAsync("key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None);
             mock.Verify(_ => _.StreamPendingMessagesAsync("prefix:key", "group", 10, RedisValue.Null, "-", "+", CommandFlags.None));
         }
 
         [Fact]
         public void StreamRangeAsync()
         {
-            wrapper.StreamRangeAsync("key", "-", "+", null, Order.Ascending, CommandFlags.None);
+            prefixed.StreamRangeAsync("key", "-", "+", null, Order.Ascending, CommandFlags.None);
             mock.Verify(_ => _.StreamRangeAsync("prefix:key", "-", "+", null, Order.Ascending, CommandFlags.None));
         }
 
@@ -1085,21 +1085,21 @@ namespace StackExchange.Redis.Tests
         public void StreamReadAsync_1()
         {
             var streamPositions = Array.Empty<StreamPosition>();
-            wrapper.StreamReadAsync(streamPositions, null, CommandFlags.None);
+            prefixed.StreamReadAsync(streamPositions, null, CommandFlags.None);
             mock.Verify(_ => _.StreamReadAsync(streamPositions, null, CommandFlags.None));
         }
 
         [Fact]
         public void StreamReadAsync_2()
         {
-            wrapper.StreamReadAsync("key", "0-0", null, CommandFlags.None);
+            prefixed.StreamReadAsync("key", "0-0", null, CommandFlags.None);
             mock.Verify(_ => _.StreamReadAsync("prefix:key", "0-0", null, CommandFlags.None));
         }
 
         [Fact]
         public void StreamReadGroupAsync_1()
         {
-            wrapper.StreamReadGroupAsync("key", "group", "consumer", StreamPosition.Beginning, 10, false, CommandFlags.None);
+            prefixed.StreamReadGroupAsync("key", "group", "consumer", StreamPosition.Beginning, 10, false, CommandFlags.None);
             mock.Verify(_ => _.StreamReadGroupAsync("prefix:key", "group", "consumer", StreamPosition.Beginning, 10, false, CommandFlags.None));
         }
 
@@ -1107,42 +1107,42 @@ namespace StackExchange.Redis.Tests
         public void StreamStreamReadGroupAsync_2()
         {
             var streamPositions = Array.Empty<StreamPosition>();
-            wrapper.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
+            prefixed.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, false, CommandFlags.None);
             mock.Verify(_ => _.StreamReadGroupAsync(streamPositions, "group", "consumer", 10, false, CommandFlags.None));
         }
 
         [Fact]
         public void StreamTrimAsync()
         {
-            wrapper.StreamTrimAsync("key", 1000, true, CommandFlags.None);
+            prefixed.StreamTrimAsync("key", 1000, true, CommandFlags.None);
             mock.Verify(_ => _.StreamTrimAsync("prefix:key", 1000, true, CommandFlags.None));
         }
 
         [Fact]
         public void StringAppendAsync()
         {
-            wrapper.StringAppendAsync("key", "value", CommandFlags.None);
+            prefixed.StringAppendAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.StringAppendAsync("prefix:key", "value", CommandFlags.None));
         }
 
         [Fact]
         public void StringBitCountAsync()
         {
-            wrapper.StringBitCountAsync("key", 123, 456, CommandFlags.None);
+            prefixed.StringBitCountAsync("key", 123, 456, CommandFlags.None);
             mock.Verify(_ => _.StringBitCountAsync("prefix:key", 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void StringBitCountAsync_2()
         {
-            wrapper.StringBitCountAsync("key", 123, 456, StringIndexType.Byte, CommandFlags.None);
+            prefixed.StringBitCountAsync("key", 123, 456, StringIndexType.Byte, CommandFlags.None);
             mock.Verify(_ => _.StringBitCountAsync("prefix:key", 123, 456, StringIndexType.Byte, CommandFlags.None));
         }
 
         [Fact]
         public void StringBitOperationAsync_1()
         {
-            wrapper.StringBitOperationAsync(Bitwise.Xor, "destination", "first", "second", CommandFlags.None);
+            prefixed.StringBitOperationAsync(Bitwise.Xor, "destination", "first", "second", CommandFlags.None);
             mock.Verify(_ => _.StringBitOperationAsync(Bitwise.Xor, "prefix:destination", "prefix:first", "prefix:second", CommandFlags.None));
         }
 
@@ -1151,42 +1151,42 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.StringBitOperationAsync(Bitwise.Xor, "destination", keys, CommandFlags.None);
+            prefixed.StringBitOperationAsync(Bitwise.Xor, "destination", keys, CommandFlags.None);
             mock.Verify(_ => _.StringBitOperationAsync(Bitwise.Xor, "prefix:destination", It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void StringBitPositionAsync()
         {
-            wrapper.StringBitPositionAsync("key", true, 123, 456, CommandFlags.None);
+            prefixed.StringBitPositionAsync("key", true, 123, 456, CommandFlags.None);
             mock.Verify(_ => _.StringBitPositionAsync("prefix:key", true, 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void StringBitPositionAsync_2()
         {
-            wrapper.StringBitPositionAsync("key", true, 123, 456, StringIndexType.Byte, CommandFlags.None);
+            prefixed.StringBitPositionAsync("key", true, 123, 456, StringIndexType.Byte, CommandFlags.None);
             mock.Verify(_ => _.StringBitPositionAsync("prefix:key", true, 123, 456, StringIndexType.Byte, CommandFlags.None));
         }
 
         [Fact]
         public void StringDecrementAsync_1()
         {
-            wrapper.StringDecrementAsync("key", 123, CommandFlags.None);
+            prefixed.StringDecrementAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.StringDecrementAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void StringDecrementAsync_2()
         {
-            wrapper.StringDecrementAsync("key", 1.23, CommandFlags.None);
+            prefixed.StringDecrementAsync("key", 1.23, CommandFlags.None);
             mock.Verify(_ => _.StringDecrementAsync("prefix:key", 1.23, CommandFlags.None));
         }
 
         [Fact]
         public void StringGetAsync_1()
         {
-            wrapper.StringGetAsync("key", CommandFlags.None);
+            prefixed.StringGetAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StringGetAsync("prefix:key", CommandFlags.None));
         }
 
@@ -1195,63 +1195,63 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.StringGetAsync(keys, CommandFlags.None);
+            prefixed.StringGetAsync(keys, CommandFlags.None);
             mock.Verify(_ => _.StringGetAsync(It.Is(valid), CommandFlags.None));
         }
 
         [Fact]
         public void StringGetBitAsync()
         {
-            wrapper.StringGetBitAsync("key", 123, CommandFlags.None);
+            prefixed.StringGetBitAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.StringGetBitAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void StringGetRangeAsync()
         {
-            wrapper.StringGetRangeAsync("key", 123, 456, CommandFlags.None);
+            prefixed.StringGetRangeAsync("key", 123, 456, CommandFlags.None);
             mock.Verify(_ => _.StringGetRangeAsync("prefix:key", 123, 456, CommandFlags.None));
         }
 
         [Fact]
         public void StringGetSetAsync()
         {
-            wrapper.StringGetSetAsync("key", "value", CommandFlags.None);
+            prefixed.StringGetSetAsync("key", "value", CommandFlags.None);
             mock.Verify(_ => _.StringGetSetAsync("prefix:key", "value", CommandFlags.None));
         }
 
         [Fact]
         public void StringGetDeleteAsync()
         {
-            wrapper.StringGetDeleteAsync("key", CommandFlags.None);
+            prefixed.StringGetDeleteAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StringGetDeleteAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void StringGetWithExpiryAsync()
         {
-            wrapper.StringGetWithExpiryAsync("key", CommandFlags.None);
+            prefixed.StringGetWithExpiryAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StringGetWithExpiryAsync("prefix:key", CommandFlags.None));
         }
 
         [Fact]
         public void StringIncrementAsync_1()
         {
-            wrapper.StringIncrementAsync("key", 123, CommandFlags.None);
+            prefixed.StringIncrementAsync("key", 123, CommandFlags.None);
             mock.Verify(_ => _.StringIncrementAsync("prefix:key", 123, CommandFlags.None));
         }
 
         [Fact]
         public void StringIncrementAsync_2()
         {
-            wrapper.StringIncrementAsync("key", 1.23, CommandFlags.None);
+            prefixed.StringIncrementAsync("key", 1.23, CommandFlags.None);
             mock.Verify(_ => _.StringIncrementAsync("prefix:key", 1.23, CommandFlags.None));
         }
 
         [Fact]
         public void StringLengthAsync()
         {
-            wrapper.StringLengthAsync("key", CommandFlags.None);
+            prefixed.StringLengthAsync("key", CommandFlags.None);
             mock.Verify(_ => _.StringLengthAsync("prefix:key", CommandFlags.None));
         }
 
@@ -1259,7 +1259,7 @@ namespace StackExchange.Redis.Tests
         public void StringSetAsync_1()
         {
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.StringSetAsync("key", "value", expiry, When.Exists, CommandFlags.None);
+            prefixed.StringSetAsync("key", "value", expiry, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.StringSetAsync("prefix:key", "value", expiry, When.Exists, CommandFlags.None));
         }
 
@@ -1267,7 +1267,7 @@ namespace StackExchange.Redis.Tests
         public void StringSetAsync_2()
         {
             TimeSpan? expiry = null;
-            wrapper.StringSetAsync("key", "value", expiry, true, When.Exists, CommandFlags.None);
+            prefixed.StringSetAsync("key", "value", expiry, true, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.StringSetAsync("prefix:key", "value", expiry, true, When.Exists, CommandFlags.None));
         }
 
@@ -1276,7 +1276,7 @@ namespace StackExchange.Redis.Tests
         {
             KeyValuePair<RedisKey, RedisValue>[] values = new KeyValuePair<RedisKey, RedisValue>[] { new KeyValuePair<RedisKey, RedisValue>("a", "x"), new KeyValuePair<RedisKey, RedisValue>("b", "y") };
             Expression<Func<KeyValuePair<RedisKey, RedisValue>[], bool>> valid = _ => _.Length == 2 && _[0].Key == "prefix:a" && _[0].Value == "x" && _[1].Key == "prefix:b" && _[1].Value == "y";
-            wrapper.StringSetAsync(values, When.Exists, CommandFlags.None);
+            prefixed.StringSetAsync(values, When.Exists, CommandFlags.None);
             mock.Verify(_ => _.StringSetAsync(It.Is(valid), When.Exists, CommandFlags.None));
         }
 
@@ -1284,28 +1284,28 @@ namespace StackExchange.Redis.Tests
         public void StringSetAsync_Compat()
         {
             TimeSpan expiry = TimeSpan.FromSeconds(123);
-            wrapper.StringSetAsync("key", "value", expiry, When.Exists);
+            prefixed.StringSetAsync("key", "value", expiry, When.Exists);
             mock.Verify(_ => _.StringSetAsync("prefix:key", "value", expiry, When.Exists));
         }
 
         [Fact]
         public void StringSetBitAsync()
         {
-            wrapper.StringSetBitAsync("key", 123, true, CommandFlags.None);
+            prefixed.StringSetBitAsync("key", 123, true, CommandFlags.None);
             mock.Verify(_ => _.StringSetBitAsync("prefix:key", 123, true, CommandFlags.None));
         }
 
         [Fact]
         public void StringSetRangeAsync()
         {
-            wrapper.StringSetRangeAsync("key", 123, "value", CommandFlags.None);
+            prefixed.StringSetRangeAsync("key", 123, "value", CommandFlags.None);
             mock.Verify(_ => _.StringSetRangeAsync("prefix:key", 123, "value", CommandFlags.None));
         }
 
         [Fact]
         public void KeyTouchAsync_1()
         {
-            wrapper.KeyTouchAsync("key", CommandFlags.None);
+            prefixed.KeyTouchAsync("key", CommandFlags.None);
             mock.Verify(_ => _.KeyTouchAsync("prefix:key", CommandFlags.None));
         }
 
@@ -1314,7 +1314,7 @@ namespace StackExchange.Redis.Tests
         {
             RedisKey[] keys = new RedisKey[] { "a", "b" };
             Expression<Func<RedisKey[], bool>> valid = _ => _.Length == 2 && _[0] == "prefix:a" && _[1] == "prefix:b";
-            wrapper.KeyTouchAsync(keys, CommandFlags.None);
+            prefixed.KeyTouchAsync(keys, CommandFlags.None);
             mock.Verify(_ => _.KeyTouchAsync(It.Is(valid), CommandFlags.None));
         }
     }

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedTransactionTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedTransactionTests.cs
@@ -7,126 +7,126 @@ using Xunit;
 namespace StackExchange.Redis.Tests;
 
 [Collection(nameof(MoqDependentCollection))]
-public sealed class TransactionWrapperTests
+public sealed class KeyPrefixedTransactionTests
 {
     private readonly Mock<ITransaction> mock;
-    private readonly TransactionWrapper wrapper;
+    private readonly KeyPrefixedTransaction prefixed;
 
-    public TransactionWrapperTests()
+    public KeyPrefixedTransactionTests()
     {
         mock = new Mock<ITransaction>();
-        wrapper = new TransactionWrapper(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
+        prefixed = new KeyPrefixedTransaction(mock.Object, Encoding.UTF8.GetBytes("prefix:"));
     }
 
     [Fact]
     public void AddCondition_HashEqual()
     {
-        wrapper.AddCondition(Condition.HashEqual("key", "field", "value"));
+        prefixed.AddCondition(Condition.HashEqual("key", "field", "value"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field == value" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_HashNotEqual()
     {
-        wrapper.AddCondition(Condition.HashNotEqual("key", "field", "value"));
+        prefixed.AddCondition(Condition.HashNotEqual("key", "field", "value"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field != value" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_HashExists()
     {
-        wrapper.AddCondition(Condition.HashExists("key", "field"));
+        prefixed.AddCondition(Condition.HashExists("key", "field"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field exists" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_HashNotExists()
     {
-        wrapper.AddCondition(Condition.HashNotExists("key", "field"));
+        prefixed.AddCondition(Condition.HashNotExists("key", "field"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key Hash > field does not exists" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_KeyExists()
     {
-        wrapper.AddCondition(Condition.KeyExists("key"));
+        prefixed.AddCondition(Condition.KeyExists("key"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key exists" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_KeyNotExists()
     {
-        wrapper.AddCondition(Condition.KeyNotExists("key"));
+        prefixed.AddCondition(Condition.KeyNotExists("key"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key does not exists" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_StringEqual()
     {
-        wrapper.AddCondition(Condition.StringEqual("key", "value"));
+        prefixed.AddCondition(Condition.StringEqual("key", "value"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key == value" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_StringNotEqual()
     {
-        wrapper.AddCondition(Condition.StringNotEqual("key", "value"));
+        prefixed.AddCondition(Condition.StringNotEqual("key", "value"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key != value" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_SortedSetEqual()
     {
-        wrapper.AddCondition(Condition.SortedSetEqual("key", "member", "score"));
+        prefixed.AddCondition(Condition.SortedSetEqual("key", "member", "score"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key SortedSet > member == score" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_SortedSetNotEqual()
     {
-        wrapper.AddCondition(Condition.SortedSetNotEqual("key", "member", "score"));
+        prefixed.AddCondition(Condition.SortedSetNotEqual("key", "member", "score"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key SortedSet > member != score" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_SortedSetScoreExists()
     {
-        wrapper.AddCondition(Condition.SortedSetScoreExists("key", "score"));
+        prefixed.AddCondition(Condition.SortedSetScoreExists("key", "score"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key not contains 0 members with score: score" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_SortedSetScoreNotExists()
     {
-        wrapper.AddCondition(Condition.SortedSetScoreNotExists("key", "score"));
+        prefixed.AddCondition(Condition.SortedSetScoreNotExists("key", "score"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key contains 0 members with score: score" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_SortedSetScoreCountExists()
     {
-        wrapper.AddCondition(Condition.SortedSetScoreExists("key", "score", "count"));
+        prefixed.AddCondition(Condition.SortedSetScoreExists("key", "score", "count"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key contains count members with score: score" == value.ToString())));
     }
 
     [Fact]
     public void AddCondition_SortedSetScoreCountNotExists()
     {
-        wrapper.AddCondition(Condition.SortedSetScoreNotExists("key", "score", "count"));
+        prefixed.AddCondition(Condition.SortedSetScoreNotExists("key", "score", "count"));
         mock.Verify(_ => _.AddCondition(It.Is<Condition>(value => "prefix:key not contains count members with score: score" == value.ToString())));
     }
 
     [Fact]
     public async Task ExecuteAsync()
     {
-        await wrapper.ExecuteAsync(CommandFlags.None);
+        await prefixed.ExecuteAsync(CommandFlags.None);
         mock.Verify(_ => _.ExecuteAsync(CommandFlags.None), Times.Once());
     }
 
     [Fact]
     public void Execute()
     {
-        wrapper.Execute(CommandFlags.None);
+        prefixed.Execute(CommandFlags.None);
         mock.Verify(_ => _.Execute(CommandFlags.None), Times.Once());
     }
 }

--- a/tests/StackExchange.Redis.Tests/LockingTests.cs
+++ b/tests/StackExchange.Redis.Tests/LockingTests.cs
@@ -34,7 +34,7 @@ public class LockingTests : TestBase
         int errorCount = 0;
         int bgErrorCount = 0;
         var evt = new ManualResetEvent(false);
-        var key = Me();
+        var key = Me() + testMode;
         using (var conn1 = Create(testMode))
         using (var conn2 = Create(testMode))
         {
@@ -111,21 +111,21 @@ public class LockingTests : TestBase
     };
 
     [Theory, MemberData(nameof(TestModes))]
-    public async Task TakeLockAndExtend(TestMode mode)
+    public async Task TakeLockAndExtend(TestMode testMode)
     {
-        using var conn = Create(mode);
+        using var conn = Create(testMode);
 
         RedisValue right = Guid.NewGuid().ToString(),
             wrong = Guid.NewGuid().ToString();
 
-        int DB = mode == TestMode.Twemproxy ? 0 : 7;
-        RedisKey Key = Me();
+        int DB = testMode == TestMode.Twemproxy ? 0 : 7;
+        RedisKey Key = Me() + testMode;
 
         var db = conn.GetDatabase(DB);
 
         db.KeyDelete(Key, CommandFlags.FireAndForget);
 
-        bool withTran = mode == TestMode.MultiExec;
+        bool withTran = testMode == TestMode.MultiExec;
         var t1 = db.LockTakeAsync(Key, right, TimeSpan.FromSeconds(20));
         var t1b = db.LockTakeAsync(Key, wrong, TimeSpan.FromSeconds(10));
         var t2 = db.LockQueryAsync(Key);
@@ -175,7 +175,7 @@ public class LockingTests : TestBase
 
         const int LOOP = 50;
         var db = conn.GetDatabase();
-        var key = Me();
+        var key = Me() + testMode;
         for (int i = 0; i < LOOP; i++)
         {
             _ = db.KeyDeleteAsync(key);
@@ -197,7 +197,7 @@ public class LockingTests : TestBase
         using var conn = Create(testMode);
 
         var db = conn.GetDatabase();
-        var key = Me();
+        var key = Me() + testMode;
         db.KeyDelete(key, CommandFlags.FireAndForget);
         db.StringSet(key, "old-value", TimeSpan.FromSeconds(20), flags: CommandFlags.FireAndForget);
         var taken = db.LockTakeAsync(key, "new-value", TimeSpan.FromSeconds(10));


### PR DESCRIPTION
This renames the various wrappers to IMO more intuitive "KeyPrefixedX" - just couldn't get used to the previous model when touching N files for an API addition, hoping this makes it a little clearer overall, also has the benefit of batching them in UI due to common prefix.