### PR TITLE
Dependencies: remove System.Diagnostics.PerformanceCounter

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ Current package versions:
 
 - Adds: `last-in` and `cur-in` (bytes) to timeout exceptions to help identify timeouts that were just-behind another large payload off the wire ([#2276 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2276))
 - Adds: general-purpose tunnel support, with HTTP proxy "connect" support included ([#2274 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2274))
+- Removes: Package dependency (`System.Diagnostics.PerformanceCounter`) ([#2285 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2285))
 
 ## 2.6.70
 

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -156,7 +156,7 @@ namespace StackExchange.Redis
             if (multiplexer.RawConfig.IncludeDetailInExceptions)
             {
                 CopyDataToException(data, ex);
-                sb.Append("; ").Append(PerfCounterHelper.GetThreadPoolAndCPUSummary(multiplexer.RawConfig.IncludePerformanceCountersInExceptions));
+                sb.Append("; ").Append(PerfCounterHelper.GetThreadPoolAndCPUSummary());
                 AddExceptionDetail(ex, message, server, commandLabel);
             }
             return ex;
@@ -352,11 +352,6 @@ namespace StackExchange.Redis
                 Add(data, sb, "ThreadPool-Items", "POOL", workItems);
             }
             data.Add(Tuple.Create("Busy-Workers", busyWorkerCount.ToString()));
-
-            if (multiplexer.RawConfig.IncludePerformanceCountersInExceptions)
-            {
-                Add(data, sb, "Local-CPU", "Local-CPU", PerfCounterHelper.GetSystemCpuPercent());
-            }
 
             Add(data, sb, "Version", "v", Utils.GetLibVersion());
         }

--- a/src/StackExchange.Redis/PerfCounterHelper.cs
+++ b/src/StackExchange.Redis/PerfCounterHelper.cs
@@ -1,72 +1,14 @@
-﻿using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
-#if NET5_0_OR_GREATER
-using System.Runtime.Versioning;
-#endif
+﻿using System.Threading;
 
 namespace StackExchange.Redis
 {
     internal static class PerfCounterHelper
     {
-        private static readonly object staticLock = new();
-        private static volatile PerformanceCounter? _cpu;
-        private static volatile bool _disabled = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-#if NET5_0_OR_GREATER
-        [SupportedOSPlatform("Windows")]
-#endif
-        public static bool TryGetSystemCPU(out float value)
-        {
-            value = -1;
-
-            try
-            {
-                if (!_disabled && _cpu == null)
-                {
-                    lock (staticLock)
-                    {
-                        if (_cpu == null)
-                        {
-                            _cpu = new PerformanceCounter("Processor", "% Processor Time", "_Total");
-
-                            // First call always returns 0, so get that out of the way.
-                            _cpu.NextValue();
-                        }
-                    }
-                }
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // Some environments don't allow access to Performance Counters, so stop trying.
-                _disabled = true;
-            }
-            catch (Exception e)
-            {
-                // this shouldn't happen, but just being safe...
-                Trace.WriteLine(e);
-            }
-
-            if (!_disabled && _cpu != null)
-            {
-                value = _cpu.NextValue();
-                return true;
-            }
-            return false;
-        }
-
-        internal static string GetThreadPoolAndCPUSummary(bool includePerformanceCounters)
+        internal static string GetThreadPoolAndCPUSummary()
         {
             GetThreadPoolStats(out string iocp, out string worker, out string? workItems);
-            var cpu = includePerformanceCounters ? GetSystemCpuPercent() : "n/a";
-            return $"IOCP: {iocp}, WORKER: {worker}, POOL: {workItems ?? "n/a"}, Local-CPU: {cpu}";
+            return $"IOCP: {iocp}, WORKER: {worker}, POOL: {workItems ?? "n/a"}";
         }
-
-        internal static string GetSystemCpuPercent() =>
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && TryGetSystemCPU(out float systemCPU)
-                ? Math.Round(systemCPU, 2) + "%"
-                : "unavailable";
 
         internal static int GetThreadPoolStats(out string iocp, out string worker, out string? workItems)
         {

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -282,7 +282,7 @@ namespace StackExchange.Redis
                                     if (bridge.Multiplexer.IncludeDetailInExceptions)
                                     {
                                         err = $"Endpoint {endpoint} serving hashslot {hashSlot} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect. "
-                                            + PerfCounterHelper.GetThreadPoolAndCPUSummary(bridge.Multiplexer.RawConfig.IncludePerformanceCountersInExceptions);
+                                            + PerfCounterHelper.GetThreadPoolAndCPUSummary();
                                     }
                                     else
                                     {

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <!-- needed everywhere -->
     <PackageReference Include="Pipelines.Sockets.Unofficial" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" />
 
     <!-- built into .NET core now -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'" />


### PR DESCRIPTION
The original purpose of this was to get system-level CPU to help advise people filing issues that their machine overall was under too much load and that's why we were seeing timeouts. However, due to ecosystem changes and shifts the actual reporting of this counter has dropped off so dramatically it's not actually doing what it's supposed to be doing and giving us signal data to help.

Given it's a dependency chain that also depends ultimately on some problematic packages now (e.g. System.Drawing.Common) and isn't cross-platform correctly...let's just remove it. It's not a net win anymore.

Fixes #2283.