### PR TITLE
Counters: add sync-ops, async-ops, and how long a server has been connected

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,7 @@ Current package versions:
 - Fix [#1520](https://github.com/StackExchange/StackExchange.Redis/issues/1520) & [#1660](https://github.com/StackExchange/StackExchange.Redis/issues/1660): When `MOVED` is encountered from a cluster, a reconfigure will happen proactively to react to cluster changes ASAP ([#2286 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2286))
 - Fix [#2249](https://github.com/StackExchange/StackExchange.Redis/issues/2249): Properly handle a `fail` state (new `ClusterNode.IsFail` property) for `CLUSTER NODES` and expose `fail?` as a property (`IsPossiblyFail`) as well ([#2288 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2288))
 - Adds: `IConnectionMultiplexer.ServerMaintenanceEvent` (was on `ConnectionMultiplexer` but not the interface) ([#2306 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2306))
+- Adds: To timeout messages, additional debug information: `Sync-Ops` (synchronous operations), `Async-Ops` (asynchronous operations), and `Server-Connected-Seconds` (how long the connection in question has been connected, or `"n/a"`) ([#2300 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2300))
 
 
 ## 2.6.80

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -31,6 +31,7 @@ namespace StackExchange.Redis
         /// Tracks overall connection multiplexer counts.
         /// </summary>
         internal int _connectAttemptCount = 0, _connectCompletedCount = 0, _connectionCloseCount = 0;
+        internal long syncOps, asyncOps;
         private long syncTimeouts, fireAndForgets, asyncTimeouts;
         private string? failureMessage, activeConfigCause;
         private IDisposable? pulse;
@@ -1867,6 +1868,8 @@ namespace StackExchange.Redis
                 return defaultValue;
             }
 
+            Interlocked.Increment(ref syncOps);
+
             if (message.IsFireAndForget)
             {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -1929,6 +1932,8 @@ namespace StackExchange.Redis
                 return CompletedTask<T>.FromDefault(defaultValue, state);
             }
 
+            Interlocked.Increment(ref asyncOps);
+
             TaskCompletionSource<T>? tcs = null;
             IResultBox<T>? source = null;
             if (!message.IsFireAndForget)
@@ -1977,6 +1982,8 @@ namespace StackExchange.Redis
             {
                 return CompletedTask<T?>.Default(state);
             }
+
+            Interlocked.Increment(ref asyncOps);
 
             TaskCompletionSource<T?>? tcs = null;
             IResultBox<T?>? source = null;

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
@@ -333,7 +332,7 @@ namespace StackExchange.Redis
                     else Interlocked.Exchange(ref multiplexer.stormLogSnapshot, log);
                 }
                 Add(data, sb, "Server-Endpoint", "serverEndpoint", (server.EndPoint.ToString() ?? "Unknown").Replace("Unspecified/", ""));
-                Add(data, sb, "Server-Connected-Seconds", "conn-sec", server.LastConnectTime.HasValue ? (DateTime.UtcNow - server.LastConnectTime.Value).TotalSeconds.ToString("0.##") : "n/a");
+                Add(data, sb, "Server-Connected-Seconds", "conn-sec", bs.ConnectedAt is DateTime dt ? (DateTime.UtcNow - dt).TotalSeconds.ToString("0.##") : "n/a");
             }
             Add(data, sb, "Multiplexer-Connects", "mc", $"{multiplexer._connectAttemptCount}/{multiplexer._connectCompletedCount}/{multiplexer._connectionCloseCount}");
             Add(data, sb, "Manager", "mgr", multiplexer.SocketManager?.GetState());

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -323,6 +323,9 @@ namespace StackExchange.Redis
                 Add(data, sb, "Last-Result-Bytes", "last-in", bs.Connection.BytesLastResult.ToString());
                 Add(data, sb, "Inbound-Buffer-Bytes", "cur-in", bs.Connection.BytesInBuffer.ToString());
 
+                Add(data, sb, "Sync-Ops", "sync-ops", multiplexer.syncOps.ToString());
+                Add(data, sb, "Async-Ops", "async-ops", multiplexer.asyncOps.ToString());
+
                 if (multiplexer.StormLogThreshold >= 0 && bs.Connection.MessagesSentAwaitingResponse >= multiplexer.StormLogThreshold && Interlocked.CompareExchange(ref multiplexer.haveStormLog, 1, 0) == 0)
                 {
                     var log = server.GetStormLog(message);
@@ -330,6 +333,7 @@ namespace StackExchange.Redis
                     else Interlocked.Exchange(ref multiplexer.stormLogSnapshot, log);
                 }
                 Add(data, sb, "Server-Endpoint", "serverEndpoint", (server.EndPoint.ToString() ?? "Unknown").Replace("Unspecified/", ""));
+                Add(data, sb, "Server-Connected-Seconds", "conn-sec", server.LastConnectTime.HasValue ? (DateTime.UtcNow - server.LastConnectTime.Value).TotalSeconds.ToString("0.##") : "n/a");
             }
             Add(data, sb, "Multiplexer-Connects", "mc", $"{multiplexer._connectAttemptCount}/{multiplexer._connectCompletedCount}/{multiplexer._connectionCloseCount}");
             Add(data, sb, "Manager", "mgr", multiplexer.SocketManager?.GetState());

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -37,8 +37,6 @@ namespace StackExchange.Redis
         private volatile UnselectableFlags unselectableReasons;
         private Version version;
 
-        public DateTime? LastConnectTime { get; private set; }
-
         internal void ResetNonConnected()
         {
             interactive?.ResetNonConnected();
@@ -126,11 +124,7 @@ namespace StackExchange.Redis
             {
                 log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync init (State={interactive?.ConnectionState})");
                 var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-                _ = tcs.Task.ContinueWith(t =>
-                {
-                    LastConnectTime ??= DateTime.UtcNow;
-                    log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed ({t.Result})");
-                });
+                _ = tcs.Task.ContinueWith(t => log?.WriteLine($"{Format.ToString(this)}: OnConnectedAsync completed ({t.Result})"));
                 lock (_pendingConnectionMonitors)
                 {
                     _pendingConnectionMonitors.Add(tcs);
@@ -616,7 +610,6 @@ namespace StackExchange.Redis
             {
                 Multiplexer.UpdateSubscriptions();
             }
-            LastConnectTime = default;
         }
 
         internal Task OnEstablishingAsync(PhysicalConnection connection, LogProxy? log)

--- a/tests/BasicTest/BasicTest.csproj
+++ b/tests/BasicTest/BasicTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>StackExchange.Redis.BasicTest .NET Core</Description>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AssemblyName>BasicTest</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BasicTest</PackageId>

--- a/tests/BasicTestBaseline/BasicTestBaseline.csproj
+++ b/tests/BasicTestBaseline/BasicTestBaseline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>StackExchange.Redis.BasicTest .NET Core</Description>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AssemblyName>BasicTestBaseline</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BasicTestBaseline</PackageId>

--- a/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
+++ b/tests/StackExchange.Redis.Tests/ExceptionFactoryTests.cs
@@ -121,6 +121,9 @@ public class ExceptionFactoryTests : TestBase
             Assert.Contains("serverEndpoint: " + server.EndPoint, ex.Message);
             Assert.Contains("IOCP: ", ex.Message);
             Assert.Contains("WORKER: ", ex.Message);
+            Assert.Contains("sync-ops: ", ex.Message);
+            Assert.Contains("async-ops: ", ex.Message);
+            Assert.Contains("conn-sec: n/a", ex.Message);
 #if NETCOREAPP
                 Assert.Contains("POOL: ", ex.Message);
 #endif

--- a/tests/StackExchange.Redis.Tests/SentinelTests.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelTests.cs
@@ -451,8 +451,12 @@ public class SentinelTests : SentinelBase
     public async Task ReadOnlyConnectionReplicasTest()
     {
         var replicas = SentinelServerA.SentinelGetReplicaAddresses(ServiceName);
-        var config = new ConfigurationOptions();
+        if (replicas.Length == 0)
+        {
+            Skip.Inconclusive("Sentinel race: 0 replicas to test against.");
+        }
 
+        var config = new ConfigurationOptions();
         foreach (var replica in replicas)
         {
             config.EndPoints.Add(replica);

--- a/toys/KestrelRedisServer/KestrelRedisServer.csproj
+++ b/toys/KestrelRedisServer/KestrelRedisServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 

--- a/toys/TestConsole/TestConsole.csproj
+++ b/toys/TestConsole/TestConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net50;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <DefineConstants>SEV2</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/toys/TestConsoleBaseline/TestConsoleBaseline.csproj
+++ b/toys/TestConsoleBaseline/TestConsoleBaseline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net50;net461;net462;net47;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net461;net462;net47;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Computername)'=='OCHO' or '$(Computername)'=='SKINK'">


### PR DESCRIPTION
More info to help us advise and debug timeouts for users! 

Overall adds for timeout messages:
- `Sync-Ops`: A count of synchronous operation calls
- `Async-Ops`: A count of asynchronous operation calls
- `Server-Connected-Seconds`: How long the bridge in question has been connected ("n/a" if not connected)