### PR TITLE
Drop unsupported versions of .NET, Update LangVersion to 11, Update .NET SDK to 7.0.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
   push:
     branches:
-    - main
+      - main
     paths:
-    - '*'
-    - '!/docs/*' # Don't run workflow when files are only in the /docs directory
+      - "*"
+      - "!/docs/*" # Don't run workflow when files are only in the /docs directory
 
 jobs:
   main:
@@ -17,29 +17,29 @@ jobs:
       DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Enable color output, even though the console output is redirected in Actions
       TERM: xterm # Enable color output in GitHub Actions
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v1
-    - name: Install .NET SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: | 
-          6.0.x
-    - name: .NET Build
-      run: dotnet build Build.csproj -c Release /p:CI=true
-    - name: Start Redis Services (docker-compose)
-      working-directory: ./tests/RedisConfigs
-      run: docker-compose -f docker-compose.yml up -d
-    - name: StackExchange.Redis.Tests
-      run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --logger GitHubActions --results-directory ./test-results/ /p:CI=true
-    - uses: dorny/test-reporter@v1
-      continue-on-error: true
-      if: success() || failure()
-      with:
-        name: Test Results - Ubuntu
-        path: 'test-results/*.trx'
-        reporter: dotnet-trx
-    - name: .NET Lib Pack
-      run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+          7.0.x
+      - name: .NET Build
+        run: dotnet build Build.csproj -c Release /p:CI=true
+      - name: Start Redis Services (docker-compose)
+        working-directory: ./tests/RedisConfigs
+        run: docker-compose -f docker-compose.yml up -d
+      - name: StackExchange.Redis.Tests
+        run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --logger GitHubActions --results-directory ./test-results/ /p:CI=true
+      - uses: dorny/test-reporter@v1
+        continue-on-error: true
+        if: success() || failure()
+        with:
+          name: Test Results - Ubuntu
+          path: "test-results/*.trx"
+          reporter: dotnet-trx
+      - name: .NET Lib Pack
+        run: dotnet pack src/StackExchange.Redis/StackExchange.Redis.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
 
   windows:
     name: StackExchange.Redis (Windows Server 2022)
@@ -49,41 +49,41 @@ jobs:
       DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Note this doesn't work yet for Windows - see https://github.com/dotnet/runtime/issues/68340
       TERM: xterm
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v1
-    # - name: Install .NET SDK
-    #   uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: | 
-    #       6.0.x
-    - name: .NET Build
-      run: dotnet build Build.csproj -c Release /p:CI=true
-    - name: Start Redis Services (v3.0.503)
-      working-directory: .\tests\RedisConfigs\3.0.503
-      run: |
-        .\redis-server.exe --service-install --service-name "redis-6379" "..\Basic\primary-6379-3.0.conf"
-        .\redis-server.exe --service-install --service-name "redis-6380" "..\Basic\replica-6380.conf"
-        .\redis-server.exe --service-install --service-name "redis-6381" "..\Basic\secure-6381.conf"
-        .\redis-server.exe --service-install --service-name "redis-6382" "..\Failover\primary-6382.conf"
-        .\redis-server.exe --service-install --service-name "redis-6383" "..\Failover\replica-6383.conf"
-        .\redis-server.exe --service-install --service-name "redis-7000" "..\Cluster\cluster-7000.conf" --dir "..\Cluster"
-        .\redis-server.exe --service-install --service-name "redis-7001" "..\Cluster\cluster-7001.conf" --dir "..\Cluster"
-        .\redis-server.exe --service-install --service-name "redis-7002" "..\Cluster\cluster-7002.conf" --dir "..\Cluster"
-        .\redis-server.exe --service-install --service-name "redis-7003" "..\Cluster\cluster-7003.conf" --dir "..\Cluster"
-        .\redis-server.exe --service-install --service-name "redis-7004" "..\Cluster\cluster-7004.conf" --dir "..\Cluster"
-        .\redis-server.exe --service-install --service-name "redis-7005" "..\Cluster\cluster-7005.conf" --dir "..\Cluster"
-        .\redis-server.exe --service-install --service-name "redis-7010" "..\Sentinel\redis-7010.conf"
-        .\redis-server.exe --service-install --service-name "redis-7011" "..\Sentinel\redis-7011.conf"
-        .\redis-server.exe --service-install --service-name "redis-26379" "..\Sentinel\sentinel-26379.conf" --sentinel
-        .\redis-server.exe --service-install --service-name "redis-26380" "..\Sentinel\sentinel-26380.conf" --sentinel
-        .\redis-server.exe --service-install --service-name "redis-26381" "..\Sentinel\sentinel-26381.conf" --sentinel
-        Start-Service redis-*
-    - name: StackExchange.Redis.Tests
-      run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --logger GitHubActions --results-directory ./test-results/ /p:CI=true
-    - uses: dorny/test-reporter@v1
-      continue-on-error: true
-      if: success() || failure()
-      with:
-        name: Tests Results - Windows Server 2022
-        path: 'test-results/*.trx'
-        reporter: dotnet-trx
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            7.0.x
+      - name: .NET Build
+        run: dotnet build Build.csproj -c Release /p:CI=true
+      - name: Start Redis Services (v3.0.503)
+        working-directory: .\tests\RedisConfigs\3.0.503
+        run: |
+          .\redis-server.exe --service-install --service-name "redis-6379" "..\Basic\primary-6379-3.0.conf"
+          .\redis-server.exe --service-install --service-name "redis-6380" "..\Basic\replica-6380.conf"
+          .\redis-server.exe --service-install --service-name "redis-6381" "..\Basic\secure-6381.conf"
+          .\redis-server.exe --service-install --service-name "redis-6382" "..\Failover\primary-6382.conf"
+          .\redis-server.exe --service-install --service-name "redis-6383" "..\Failover\replica-6383.conf"
+          .\redis-server.exe --service-install --service-name "redis-7000" "..\Cluster\cluster-7000.conf" --dir "..\Cluster"
+          .\redis-server.exe --service-install --service-name "redis-7001" "..\Cluster\cluster-7001.conf" --dir "..\Cluster"
+          .\redis-server.exe --service-install --service-name "redis-7002" "..\Cluster\cluster-7002.conf" --dir "..\Cluster"
+          .\redis-server.exe --service-install --service-name "redis-7003" "..\Cluster\cluster-7003.conf" --dir "..\Cluster"
+          .\redis-server.exe --service-install --service-name "redis-7004" "..\Cluster\cluster-7004.conf" --dir "..\Cluster"
+          .\redis-server.exe --service-install --service-name "redis-7005" "..\Cluster\cluster-7005.conf" --dir "..\Cluster"
+          .\redis-server.exe --service-install --service-name "redis-7010" "..\Sentinel\redis-7010.conf"
+          .\redis-server.exe --service-install --service-name "redis-7011" "..\Sentinel\redis-7011.conf"
+          .\redis-server.exe --service-install --service-name "redis-26379" "..\Sentinel\sentinel-26379.conf" --sentinel
+          .\redis-server.exe --service-install --service-name "redis-26380" "..\Sentinel\sentinel-26380.conf" --sentinel
+          .\redis-server.exe --service-install --service-name "redis-26381" "..\Sentinel\sentinel-26381.conf" --sentinel
+          Start-Service redis-*
+      - name: StackExchange.Redis.Tests
+        run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --logger GitHubActions --results-directory ./test-results/ /p:CI=true
+      - uses: dorny/test-reporter@v1
+        continue-on-error: true
+        if: success() || failure()
+        with:
+          name: Tests Results - Windows Server 2022
+          path: "test-results/*.trx"
+          reporter: dotnet-trx

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://github.com/StackExchange/StackExchange.Redis/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/StackExchange.Redis/</RepositoryUrl>
 

--- a/src/StackExchange.Redis/NullableHacks.cs
+++ b/src/StackExchange.Redis/NullableHacks.cs
@@ -8,7 +8,7 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
-#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+#if NETSTANDARD2_0 || NET462 || NET47 || NET471 || NET472 || NET48
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
     internal sealed class AllowNullAttribute : Attribute { }
@@ -87,7 +87,7 @@ namespace System.Diagnostics.CodeAnalysis
     }
 #endif
 
-#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+#if NETSTANDARD2_0 ||  NETCOREAPP3_1 || NET462 || NET47 || NET471 || NET472 || NET48
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     internal sealed class MemberNotNullAttribute : Attribute

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -3,7 +3,7 @@
     <Nullable>enable</Nullable>
     <!-- extend the default lib targets for the main lib; mostly because of "vectors" -->
     <!-- Note: we're NOT building for .NET 6 because the thread pool changes are not wins yet -->
-    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>
@@ -11,8 +11,8 @@
     <PackageTags>Async;Redis;Cache;PubSub;Messaging</PackageTags>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);VECTOR_SAFE</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0'">$(DefineConstants);UNIX_SOCKET</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'net462'">$(DefineConstants);VECTOR_SAFE</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0'">$(DefineConstants);UNIX_SOCKET</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,14 +20,14 @@
     <PackageReference Include="Pipelines.Sockets.Unofficial" />
 
     <!-- built into .NET core now -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Threading.Channels" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Threading.Channels" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'" />
 
-    <!-- net461 needs this for OSPlatform et al -->
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Condition="'$(TargetFramework)' == 'net461' " />
+    <!-- net462 needs this for OSPlatform et al -->
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Condition="'$(TargetFramework)' == 'net462' " />
     
     <!-- netfx needs this for ZipArchive -->
-    <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net461' " />
+    <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net462' " />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
     <!-- APIs for netcoreapp3.1+ -->
-    <AdditionalFiles Include="PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt" Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0'" />
+    <AdditionalFiles Include="PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt" Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
What was changed:
1) Now minimal supported .NET framework is 4.6.2
2) .NET 5 was replaced by .NET 6
3) .NET SDK was updated to 7,0.x
4) LangVersion now is 11

Motivation:

- NET Framework 4.6.1 is out of support, .NET Framework 4.6.2 is the older version that is still supported
https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/

- .NET 5 is out of support
https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update

- C# 11 has some perf improvements for delegates
https://devblogs.microsoft.com/dotnet/welcome-to-csharp-11/