### PR TITLE
Honor select disposition in transactions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,7 +12,7 @@ Current package versions:
 - Fix [#2249](https://github.com/StackExchange/StackExchange.Redis/issues/2249): Properly handle a `fail` state (new `ClusterNode.IsFail` property) for `CLUSTER NODES` and expose `fail?` as a property (`IsPossiblyFail`) as well ([#2288 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2288))
 - Adds: `IConnectionMultiplexer.ServerMaintenanceEvent` (was on `ConnectionMultiplexer` but not the interface) ([#2306 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2306))
 - Adds: To timeout messages, additional debug information: `Sync-Ops` (synchronous operations), `Async-Ops` (asynchronous operations), and `Server-Connected-Seconds` (how long the connection in question has been connected, or `"n/a"`) ([#2300 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2300))
-
+- Fix: [#2321](https://github.com/StackExchange/StackExchange.Redis/issues/2321): Honor disposition of select command in Command Map for transactions [(#2322 by slorello89)](https://github.com/StackExchange/StackExchange.Redis/pull/2322)
 
 ## 2.6.80
 

--- a/src/StackExchange.Redis/RedisTransaction.cs
+++ b/src/StackExchange.Redis/RedisTransaction.cs
@@ -121,7 +121,8 @@ namespace StackExchange.Redis
                     case RedisCommand.UNKNOWN:
                     case RedisCommand.EVAL:
                     case RedisCommand.EVALSHA:
-                        if (multiplexer.CommandMap.IsAvailable(RedisCommand.SELECT))
+                        var server = multiplexer.SelectServer(message);
+                        if (server != null && server.SupportsDatabases)
                         {
                             // people can do very naughty things in an EVAL
                             // including change the DB; change it back to what we

--- a/tests/StackExchange.Redis.Tests/TransactionTests.cs
+++ b/tests/StackExchange.Redis.Tests/TransactionTests.cs
@@ -1218,6 +1218,22 @@ public class TransactionTests : TestBase
         Assert.Equal(30, count);
     }
 
+    [Fact]
+    public async Task TransactionWithAdHocCommandsAndSelectDisabled()
+    {
+        using var conn = Create(disabledCommands: new string[] { "SELECT" });
+        RedisKey key = Me();
+        var db = conn.GetDatabase();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        Assert.False(db.KeyExists(key));
+
+        var tran = db.CreateTransaction("state");
+        var a = tran.ExecuteAsync("SET", "foo", "bar");
+        Assert.True(await tran.ExecuteAsync());
+        var setting = db.StringGet("foo");
+        Assert.Equal("bar",setting);
+    }
+
 #if VERBOSE
     [Fact]
     public async Task WatchAbort_StringEqual()


### PR DESCRIPTION
Fixes #2321 

For transactions, if you remove `SELECT` from the command map, it will still try to send one if you issue an unknown/eval/evalsha command - this adds a bit of logic when enqueuing messages to interrogate the multiplexer to see if SELECT is in the command map.