### PR TITLE
better API support on ServerSnapshot

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -349,8 +349,7 @@ public partial class ConnectionMultiplexer
     }
 
     internal EndPoint? GetConfiguredPrimaryForService(string serviceName) =>
-        GetServerSnapshot()
-            .ToArray()
+        _serverSnapshot // same as GetServerSnapshot, but without forcing span
             .Where(s => s.ServerType == ServerType.Sentinel)
             .AsParallel()
             .Select(s =>
@@ -361,8 +360,7 @@ public partial class ConnectionMultiplexer
             .FirstOrDefault(r => r != null);
 
     internal EndPoint[]? GetReplicasForService(string serviceName) =>
-        GetServerSnapshot()
-            .ToArray()
+        _serverSnapshot // same as GetServerSnapshot, but without forcing span
             .Where(s => s.ServerType == ServerType.Sentinel)
             .AsParallel()
             .Select(s =>
@@ -425,8 +423,7 @@ public partial class ConnectionMultiplexer
 
     internal void UpdateSentinelAddressList(string serviceName)
     {
-        var firstCompleteRequest = GetServerSnapshot()
-                                    .ToArray()
+        var firstCompleteRequest = _serverSnapshot // same as GetServerSnapshot, but without forcing span
                                     .Where(s => s.ServerType == ServerType.Sentinel)
                                     .AsParallel()
                                     .Select(s =>

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -267,7 +267,7 @@ namespace StackExchange.Redis
                             {
                                 if (isMoved && wasNoRedirect)
                                 {
-                                    if (bridge.Multiplexer.IncludeDetailInExceptions)
+                                    if (bridge.Multiplexer.RawConfig.IncludeDetailInExceptions)
                                     {
                                         err = $"Key has MOVED to Endpoint {endpoint} and hashslot {hashSlot} but CommandFlags.NoRedirect was specified - redirect not followed for {message.CommandAndKey}. ";
                                     }
@@ -279,7 +279,7 @@ namespace StackExchange.Redis
                                 else
                                 {
                                     unableToConnectError = true;
-                                    if (bridge.Multiplexer.IncludeDetailInExceptions)
+                                    if (bridge.Multiplexer.RawConfig.IncludeDetailInExceptions)
                                     {
                                         err = $"Endpoint {endpoint} serving hashslot {hashSlot} is not reachable at this point of time. Please check connectTimeout value. If it is low, try increasing it to give the ConnectionMultiplexer a chance to recover from the network disconnect. "
                                             + PerfCounterHelper.GetThreadPoolAndCPUSummary();


### PR DESCRIPTION
so we aren't limited *just* to `ReadOnlySpan<ServerEndpoint>`, and don't need the allocatey `ToArray()`

implemented as custom iterator which allows `async` and LINQ to work directly' existing code still uses span for efficiency, with the new API used in limited scenarios only