### PR TITLE
PhysicalBridge: Fix orphaning cases of PhysicalConnection where it never finishes

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -576,6 +576,7 @@ namespace StackExchange.Redis
                                 else
                                 {
                                     OnDisconnected(ConnectionFailureType.SocketFailure, tmp, out bool ignore, out State oldState);
+                                    using (tmp) { } // dispose etc
                                 }
                             }
                             else if (writeEverySeconds <= 0 && tmp.IsIdle()
@@ -613,9 +614,6 @@ namespace StackExchange.Redis
                 if (runThisTime) Interlocked.Exchange(ref beating, 0);
             }
         }
-
-        internal void RemovePhysical(PhysicalConnection connection) =>
-            Interlocked.CompareExchange(ref physical, null, connection);
 
         [Conditional("VERBOSE")]
         internal void Trace(string message) => Multiplexer.Trace(message, ToString());


### PR DESCRIPTION
What happens here is that `PhysicalConnection` attempts to connect but never hears back, so it's stuck in `State.ConnectedEstablishing` state, which is handled in the heartbeat code. In the situation where the "last write seconds ago" passes in the heartbeat and we haven't heard back, we fire an `PhysicalBridge.OnDisconnected()` which clears out `physical` and orphans the socket listening forever. This now properly disposes of that `PhysicalConnection` mirroring like we do in `State.Connecting` which will properly fire `OnDisconnected()` and clean up the orphan socket.

The situation manifests where we establish a TCP connection, but not a Redis connection. All of the cases in the memory dump we're analyzing are some bytes sent and 0 received. Likely a Redis server issue, but the client is then handling it incorrectly and leaking.

I nuked the unused `RemovePhysical` method just to prevent further oops here.