### PR TITLE
LuaScript: use invariant regex on parameter parsing (fixes #2350)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-No pending changes for the next release yet.
+- Fix [#2350](https://github.com/StackExchange/StackExchange.Redis/issues/2350): Properly parse lua script paramters in all cultures ([#2351 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2351))
 
 ## 2.6.90
 

--- a/src/StackExchange.Redis/ScriptParameterMapper.cs
+++ b/src/StackExchange.Redis/ScriptParameterMapper.cs
@@ -24,7 +24,7 @@ namespace StackExchange.Redis
             }
         }
 
-        private static readonly Regex ParameterExtractor = new Regex(@"@(?<paramName> ([a-z]|_) ([a-z]|_|\d)*)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        private static readonly Regex ParameterExtractor = new Regex(@"@(?<paramName> ([a-z]|_) ([a-z]|_|\d)*)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.CultureInvariant);
 
         private static string[] ExtractParameters(string script)
         {

--- a/tests/StackExchange.Redis.Tests/ScriptingTests.cs
+++ b/tests/StackExchange.Redis.Tests/ScriptingTests.cs
@@ -1113,6 +1113,29 @@ return arr;
         Assert.Equal("bar", result.ToString());
     }
 
+    [Fact, TestCulture("en-US")]
+    public void LuaScriptEnglishParameters() => LuaScriptParameterShared();
+
+    [Fact, TestCulture("tr-TR")]
+    public void LuaScriptTurkishParameters() => LuaScriptParameterShared();
+
+    private void LuaScriptParameterShared()
+    {
+        const string Script = "redis.call('set', @key, @testIId)";
+        var prepared = LuaScript.Prepare(Script);
+        var key = Me();
+        var p = new { key = (RedisKey)key, testIId = "hello" };
+
+        prepared.ExtractParameters(p, null, out RedisKey[]? keys, out RedisValue[]? args);
+        Assert.NotNull(keys);
+        Assert.Single(keys);
+        Assert.Equal(key, keys[0]);
+        Assert.NotNull(args);
+        Assert.Equal(2, args.Length);
+        Assert.Equal(key, args[0]);
+        Assert.Equal("hello", args[1]);
+    }
+
     private static void TestNullValue(RedisResult? value)
     {
         Assert.True(value == null || value.IsNull);


### PR DESCRIPTION
This changes the regex to use `RegexOptions.CultureInvariant` and adds an easy way to do tests like this in the future with `[Fact, TestCulture("tr-TR")]` for example, which will set and restore the culture for a specific test.

Before/after break/fix test included for the Turkish case.