### PR TITLE
Fix #2362: Set FailureType to AuthenticationFailure for auth exceptions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ Current package versions:
 ## Unreleased
 
 - Fix [#2350](https://github.com/StackExchange/StackExchange.Redis/issues/2350): Properly parse lua script paramters in all cultures ([#2351 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2351))
+- Fix [#2362](https://github.com/StackExchange/StackExchange.Redis/issues/2362): Set `RedisConnectionException.FailureType` to `AuthenticationFailure` on all authentication scenarios for better handling ([#2367 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2367))
 
 ## 2.6.90
 

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -386,10 +386,12 @@ namespace StackExchange.Redis
         {
             var sb = new StringBuilder("It was not possible to connect to the redis server(s).");
             Exception? inner = null;
+            var failureType = ConnectionFailureType.UnableToConnect;
             if (muxer is not null)
             {
                 if (muxer.AuthException is Exception aex)
                 {
+                    failureType = ConnectionFailureType.AuthenticationFailure;
                     sb.Append(" There was an authentication failure; check that passwords (or client certificates) are configured correctly: (").Append(aex.GetType().Name).Append(") ").Append(aex.Message);
                     inner = aex;
                     if (aex is AuthenticationException && aex.InnerException is Exception iaex)
@@ -407,7 +409,7 @@ namespace StackExchange.Redis
                 sb.Append(' ').Append(failureMessage.Trim());
             }
 
-            return new RedisConnectionException(ConnectionFailureType.UnableToConnect, sb.ToString(), inner);
+            return new RedisConnectionException(failureType, sb.ToString(), inner);
         }
 
         internal static Exception BeganProfilingWithDuplicateContext(object forContext)

--- a/tests/StackExchange.Redis.Tests/SecureTests.cs
+++ b/tests/StackExchange.Redis.Tests/SecureTests.cs
@@ -76,7 +76,8 @@ public class SecureTests : TestBase
 
             conn.GetDatabase().Ping();
         }).ConfigureAwait(false);
-        Log("Exception: " + ex.Message);
+        Log($"Exception ({ex.FailureType}): {ex.Message}");
+        Assert.Equal(ConnectionFailureType.AuthenticationFailure, ex.FailureType);
         Assert.StartsWith("It was not possible to connect to the redis server(s). There was an authentication failure; check that passwords (or client certificates) are configured correctly: (RedisServerException) ", ex.Message);
 
         // This changed in some version...not sure which. For our purposes, splitting on v3 vs v6+


### PR DESCRIPTION
I improved the auth fail handling/message a while back in #2224, but we should set the `ConnectionFailureType` more specifically as well here so that people can handle it much easier. Fixing!