### PR TITLE
Implement RedisValue.Length for all underlying storage kinds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          6.0.x
+          7.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (docker-compose)
@@ -55,7 +55,7 @@ jobs:
     #   uses: actions/setup-dotnet@v1
     #   with:
     #     dotnet-version: | 
-    #       6.0.x
+    #       7.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
     - name: Start Redis Services (v3.0.503)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
+          6.0.x
           7.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true
@@ -55,6 +56,7 @@ jobs:
     #   uses: actions/setup-dotnet@v1
     #   with:
     #     dotnet-version: | 
+    #       6.0.x
     #       7.0.x
     - name: .NET Build
       run: dotnet build Build.csproj -c Release /p:CI=true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://stackexchange.github.io/StackExchange.Redis/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/StackExchange.Redis/</RepositoryUrl>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://stackexchange.github.io/StackExchange.Redis/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>11</LangVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/StackExchange/StackExchange.Redis/</RepositoryUrl>
 

--- a/StackExchange.Redis.sln
+++ b/StackExchange.Redis.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.cmd = build.cmd
 		Build.csproj = Build.csproj
 		build.ps1 = build.ps1
+		.github\workflows\CI.yml = .github\workflows\CI.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 7.0.101
+    choco install dotnet-sdk --version 7.0.102
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 7.0.102
+    choco install dotnet-sdk --version 7.0.101
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 6.0.101
+    choco install dotnet-sdk --version 7.0.102
 
     cd tests\RedisConfigs\3.0.503
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ Current package versions:
 
 - Fix [#2350](https://github.com/StackExchange/StackExchange.Redis/issues/2350): Properly parse lua script paramters in all cultures ([#2351 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2351))
 - Fix [#2362](https://github.com/StackExchange/StackExchange.Redis/issues/2362): Set `RedisConnectionException.FailureType` to `AuthenticationFailure` on all authentication scenarios for better handling ([#2367 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2367))
+- Fix [#2368](https://github.com/StackExchange/StackExchange.Redis/issues/2368): Support `RedisValue.Length()` for all storage types ([#2370 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2370))
 
 ## 2.6.90
 

--- a/src/StackExchange.Redis/BufferReader.cs
+++ b/src/StackExchange.Redis/BufferReader.cs
@@ -44,7 +44,7 @@ namespace StackExchange.Redis
             return true;
         }
 
-        public BufferReader(ReadOnlySequence<byte> buffer)
+        public BufferReader(scoped in ReadOnlySequence<byte> buffer)
         {
             _buffer = buffer;
             _lastSnapshotPosition = buffer.Start;

--- a/src/StackExchange.Redis/Format.cs
+++ b/src/StackExchange.Redis/Format.cs
@@ -376,28 +376,17 @@ namespace StackExchange.Redis
             {
                 if (double.IsPositiveInfinity(value))
                 {
-                    if (!"+inf"u8.TryCopyTo(destination))
-                    {
-                        ThrowFormatFailed();
-                    }
-                    return 4;
+                    if (!"+inf"u8.TryCopyTo(destination)) ThrowFormatFailed();
                 }
-                if (double.IsNegativeInfinity(value))
+                else
                 {
-                    if (!"-inf"u8.TryCopyTo(destination))
-                    {
-                        ThrowFormatFailed();
-                    }
-                    return 4;
+                    if (!"-inf"u8.TryCopyTo(destination)) ThrowFormatFailed();
                 }
+                return 4;
             }
-            if (!Utf8Formatter.TryFormat(value, destination, out var len))
-                ThrowFormatFailed();
             var s = value.ToString("G17", NumberFormatInfo.InvariantInfo); // this looks inefficient, but is how Utf8Formatter works too, just: more direct
-            if (s.Length > destination.Length)
-            {
-                ThrowFormatFailed();
-            }
+            if (s.Length > destination.Length) ThrowFormatFailed();
+
             var chars = s.AsSpan();
             for (int i = 0; i < chars.Length; i++)
             {

--- a/src/StackExchange.Redis/RawResult.cs
+++ b/src/StackExchange.Redis/RawResult.cs
@@ -77,7 +77,7 @@ namespace StackExchange.Redis
             public Tokenizer GetEnumerator() => this;
             private BufferReader _value;
 
-            public Tokenizer(in ReadOnlySequence<byte> value)
+            public Tokenizer(scoped in ReadOnlySequence<byte> value)
             {
                 _value = new BufferReader(value);
                 Current = default;
@@ -384,7 +384,7 @@ namespace StackExchange.Redis
 
         internal bool TryGetInt64(out long value)
         {
-            if (IsNull || Payload.IsEmpty || Payload.Length > PhysicalConnection.MaxInt64TextLen)
+            if (IsNull || Payload.IsEmpty || Payload.Length > Format.MaxInt64TextLen)
             {
                 value = 0;
                 return false;

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -333,6 +333,9 @@ namespace StackExchange.Redis
             StorageType.Null => 0,
             StorageType.Raw => _memory.Length,
             StorageType.String => Encoding.UTF8.GetByteCount((string)_objectOrSentinel!),
+            StorageType.Int64 => Format.MeasureInt64(OverlappedValueInt64),
+            StorageType.UInt64 => Format.MeasureUInt64(OverlappedValueUInt64),
+            StorageType.Double => Format.MeasureDouble(OverlappedValueDouble),
             _ => throw new InvalidOperationException("Unable to compute length of type: " + Type),
         };
 
@@ -824,16 +827,15 @@ namespace StackExchange.Redis
 
                     return value._memory.ToArray();
                 case StorageType.Int64:
-                    Span<byte> span = stackalloc byte[PhysicalConnection.MaxInt64TextLen + 2];
+                    Span<byte> span = stackalloc byte[Format.MaxInt64TextLen + 2];
                     int len = PhysicalConnection.WriteRaw(span, value.OverlappedValueInt64, false, 0);
                     arr = new byte[len - 2]; // don't need the CRLF
                     span.Slice(0, arr.Length).CopyTo(arr);
                     return arr;
                 case StorageType.UInt64:
                     // we know it is a huge value - just jump straight to Utf8Formatter
-                    span = stackalloc byte[PhysicalConnection.MaxInt64TextLen];
-                    if (!Utf8Formatter.TryFormat(value.OverlappedValueUInt64, span, out len))
-                        throw new InvalidOperationException("TryFormat failed");
+                    span = stackalloc byte[Format.MaxInt64TextLen];
+                    len = Format.FormatUInt64(value.OverlappedValueUInt64, span);
                     arr = new byte[len];
                     span.Slice(0, len).CopyTo(arr);
                     return arr;
@@ -1123,11 +1125,11 @@ namespace StackExchange.Redis
                     s = Format.ToString(OverlappedValueDouble);
                     goto HaveString;
                 case StorageType.Int64:
-                    leased = ArrayPool<byte>.Shared.Rent(PhysicalConnection.MaxInt64TextLen + 2); // reused code has CRLF terminator
+                    leased = ArrayPool<byte>.Shared.Rent(Format.MaxInt64TextLen + 2); // reused code has CRLF terminator
                     len = PhysicalConnection.WriteRaw(leased, OverlappedValueInt64) - 2; // drop the CRLF
                     return new ReadOnlyMemory<byte>(leased, 0, len);
                 case StorageType.UInt64:
-                    leased = ArrayPool<byte>.Shared.Rent(PhysicalConnection.MaxInt64TextLen); // reused code has CRLF terminator
+                    leased = ArrayPool<byte>.Shared.Rent(Format.MaxInt64TextLen); // reused code has CRLF terminator
                     // value is huge, jump direct to Utf8Formatter
                     if (!Utf8Formatter.TryFormat(OverlappedValueUInt64, leased, out len))
                         throw new InvalidOperationException("TryFormat failed");

--- a/tests/StackExchange.Redis.Tests/FormatTests.cs
+++ b/tests/StackExchange.Redis.Tests/FormatTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
+using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -78,4 +80,85 @@ public class FormatTests : TestBase
     [InlineData(ReplicationChangeOptions.Broadcast | ReplicationChangeOptions.SetTiebreaker | ReplicationChangeOptions.ReplicateToOtherEndpoints, "All")]
     public void ReplicationChangeOptionsFormatting(ReplicationChangeOptions value, string expected)
         => Assert.Equal(expected, value.ToString());
+
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    [InlineData(-1, "-1")]
+    [InlineData(100, "100")]
+    [InlineData(-100, "-100")]
+    [InlineData(int.MaxValue, "2147483647")]
+    [InlineData(int.MinValue, "-2147483648")]
+    public unsafe void FormatInt32(int value, string expectedValue)
+    {
+        Span<byte> dest = stackalloc byte[expectedValue.Length];
+        Assert.Equal(expectedValue.Length, Format.FormatInt32(value, dest));
+        fixed (byte* s = dest)
+        {
+            Assert.Equal(expectedValue, Encoding.ASCII.GetString(s, expectedValue.Length));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    [InlineData(-1, "-1")]
+    [InlineData(100, "100")]
+    [InlineData(-100, "-100")]
+    [InlineData(long.MaxValue, "9223372036854775807")]
+    [InlineData(long.MinValue, "-9223372036854775808")]
+    public unsafe void FormatInt64(long value, string expectedValue)
+    {
+        Assert.Equal(expectedValue.Length, Format.MeasureInt64(value));
+        Span<byte> dest = stackalloc byte[expectedValue.Length];
+        Assert.Equal(expectedValue.Length, Format.FormatInt64(value, dest));
+        fixed (byte* s = dest)
+        {
+            Assert.Equal(expectedValue, Encoding.ASCII.GetString(s, expectedValue.Length));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    [InlineData(100, "100")]
+    [InlineData(ulong.MaxValue, "18446744073709551615")]
+    public unsafe void FormatUInt64(ulong value, string expectedValue)
+    {
+        Assert.Equal(expectedValue.Length, Format.MeasureUInt64(value));
+        Span<byte> dest = stackalloc byte[expectedValue.Length];
+        Assert.Equal(expectedValue.Length, Format.FormatUInt64(value, dest));
+        fixed (byte* s = dest)
+        {
+            Assert.Equal(expectedValue, Encoding.ASCII.GetString(s, expectedValue.Length));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    [InlineData(-1, "-1")]
+    [InlineData(0.5, "0.5")]
+    [InlineData(0.50001, "0.50000999999999995")]
+    [InlineData(Math.PI, "3.1415926535897931")]
+    [InlineData(100, "100")]
+    [InlineData(-100, "-100")]
+    [InlineData(double.MaxValue, "1.7976931348623157E+308")]
+    [InlineData(double.MinValue, "-1.7976931348623157E+308")]
+    [InlineData(double.Epsilon, "4.9406564584124654E-324")]
+    [InlineData(double.PositiveInfinity, "+inf")]
+    [InlineData(double.NegativeInfinity, "-inf")]
+    [InlineData(double.NaN, "NaN")] // never used in normal code
+
+    public unsafe void FormatDouble(double value, string expectedValue)
+    {
+        Assert.Equal(expectedValue.Length, Format.MeasureDouble(value));
+        Span<byte> dest = stackalloc byte[expectedValue.Length];
+        Assert.Equal(expectedValue.Length, Format.FormatDouble(value, dest));
+        fixed (byte* s = dest)
+        {
+            Assert.Equal(expectedValue, Encoding.ASCII.GetString(s, expectedValue.Length));
+        }
+    }
 }

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
 
@@ -277,5 +278,53 @@ public class RedisValueEquivalency
         Assert.Equal(123.1, d);
 
         Assert.False(((RedisValue)"abc").TryParse(out double _));
+    }
+
+    [Fact]
+    public void RedisValueLengthString()
+    {
+        RedisValue value = "abc";
+        Assert.Equal(RedisValue.StorageType.String, value.Type);
+        Assert.Equal(3, value.Length());
+    }
+
+    [Fact]
+    public void RedisValueLengthDouble()
+    {
+        RedisValue value = Math.PI;
+        Assert.Equal(RedisValue.StorageType.Double, value.Type);
+        Assert.Equal(18, value.Length());
+    }
+
+    [Fact]
+    public void RedisValueLengthInt64()
+    {
+        RedisValue value = 123;
+        Assert.Equal(RedisValue.StorageType.Int64, value.Type);
+        Assert.Equal(3, value.Length());
+    }
+
+    [Fact]
+    public void RedisValueLengthUInt64()
+    {
+        RedisValue value = ulong.MaxValue - 5;
+        Assert.Equal(RedisValue.StorageType.UInt64, value.Type);
+        Assert.Equal(20, value.Length());
+    }
+
+    [Fact]
+    public void RedisValueLengthRaw()
+    {
+        RedisValue value = new byte[] { 0, 1, 2 };
+        Assert.Equal(RedisValue.StorageType.Raw, value.Type);
+        Assert.Equal(3, value.Length());
+    }
+
+    [Fact]
+    public void RedisValueLengthNull()
+    {
+        RedisValue value = RedisValue.Null;
+        Assert.Equal(RedisValue.StorageType.Null, value.Type);
+        Assert.Equal(0, value.Length());
     }
 }

--- a/toys/StackExchange.Redis.Server/RedisRequest.cs
+++ b/toys/StackExchange.Redis.Server/RedisRequest.cs
@@ -28,7 +28,7 @@ namespace StackExchange.Redis.Server
             => string.Equals(value, _inner[index].GetString(), StringComparison.OrdinalIgnoreCase);
 
         public override int GetHashCode() => throw new NotSupportedException();
-        internal RedisRequest(in RawResult result)
+        internal RedisRequest(scoped in RawResult result)
         {
             _inner = result;
             Count = result.ItemsCount;


### PR DESCRIPTION
fix #2368

- implement Length() for other encodings (using format layout)
- unify format code
- switch to C# 11 for u8 strings (needed a few "scoped" modifiers adding)
- tests for format and Length