### PR TITLE
fix #2376 - avoid deadlock scenario when completing dead connections

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,7 @@ Current package versions:
 - Fix [#2350](https://github.com/StackExchange/StackExchange.Redis/issues/2350): Properly parse lua script paramters in all cultures ([#2351 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2351))
 - Fix [#2362](https://github.com/StackExchange/StackExchange.Redis/issues/2362): Set `RedisConnectionException.FailureType` to `AuthenticationFailure` on all authentication scenarios for better handling ([#2367 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2367))
 - Fix [#2368](https://github.com/StackExchange/StackExchange.Redis/issues/2368): Support `RedisValue.Length()` for all storage types ([#2370 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2370))
+- Fix [#2376](https://github.com/StackExchange/StackExchange.Redis/issues/2376): Avoid a (rare) deadlock scenario ([#2378 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2378))
 
 ## 2.6.90
 

--- a/src/StackExchange.Redis/ExtensionMethods.Internal.cs
+++ b/src/StackExchange.Redis/ExtensionMethods.Internal.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace StackExchange.Redis
 {
@@ -9,5 +10,28 @@ namespace StackExchange.Redis
 
         internal static bool IsNullOrWhiteSpace([NotNullWhen(false)] this string? s) =>
             string.IsNullOrWhiteSpace(s);
+
+#if !NETCOREAPP3_1_OR_GREATER
+        internal static bool TryDequeue<T>(this Queue<T> queue, [NotNullWhen(true)] out T? result)
+        {
+            if (queue.Count == 0)
+            {
+                result = default;
+                return false;
+            }
+            result = queue.Dequeue()!;
+            return true;
+        }
+        internal static bool TryPeek<T>(this Queue<T> queue, [NotNullWhen(true)] out T? result)
+        {
+            if (queue.Count == 0)
+            {
+                result = default;
+                return false;
+            }
+            result = queue.Peek()!;
+            return true;
+        }
+#endif
     }
 }

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -1566,5 +1566,15 @@ namespace StackExchange.Redis
             }
             public override int ArgCount => 1;
         }
+
+        // this is a placeholder message for use when (for example) unable to queue the
+        // connection queue due to a lock timeout
+        internal sealed class UnknownMessage : Message
+        {
+            public static UnknownMessage Instance { get; } = new();
+            private UnknownMessage() : base(0, CommandFlags.None, RedisCommand.UNKNOWN) { }
+            public override int ArgCount => 0;
+            protected override void WriteImpl(PhysicalConnection physical) => throw new InvalidOperationException("This message cannot be written");
+        }
     }
 }

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -17,6 +17,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using static StackExchange.Redis.Message;
 
 namespace StackExchange.Redis
 {
@@ -1643,7 +1644,7 @@ namespace StackExchange.Redis
                 }
                 else
                 {
-                    next = null;
+                    next = UnknownMessage.Instance;
                 }
             }
             finally


### PR DESCRIPTION
Deadlock scenario reported with one path (`RecordConnectionFailed`) taking queue then message locks, and another path (`ExecuteSyncImpl`) taking message then queue locks; change *both* paths to only take one lock at a time - never nested.

1. in `RecordConnectionFailed` don't hold the queue lock when we abort things - only hold it when fetching next
2. in `ExecuteSyncImpl`, don't hold the message lock when throwing for timeout
3. to avoid similar not yet seen: in `GetHeadMessages`, don't blindly wait forever on the message lock

also standardise on `TryPeek`/`TryDequeue`