### PR TITLE
API: ConfigureEndpoints for Proxies

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1212,7 +1212,7 @@ namespace StackExchange.Redis
             endpoints.Split(',').ToList().ForEach(endpoint => {
                 if (!string.IsNullOrWhiteSpace(endpoint)) return;
                 var parsedEndpoint = EndPointCollection.TryParse(endpoint);
-                if (!parsedEndpoint) return;
+                if (parsedEndpoint == null) return;
                 newEndpoints.TryAdd(parsedEndpoint);
             });
 
@@ -1256,7 +1256,7 @@ namespace StackExchange.Redis
             endpoints.Split(',').ToList().ForEach(endpoint => {
                 if (!string.IsNullOrWhiteSpace(endpoint)) return;
                 var parsedEndpoint = EndPointCollection.TryParse(endpoint);
-                if (!parsedEndpoint) return;
+                if (parsedEndpoint == null) return;
                 newEndpoints.TryAdd(parsedEndpoint);
             });
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1210,11 +1210,10 @@ namespace StackExchange.Redis
         {
             var newEndpoints = new EndPointCollection();
             endpoints.Split(',').ToList().ForEach(endpoint => {
-                if (!string.IsNullOrWhiteSpace(endpoint))
-                {
-                    return;
-                }
-                newEndpoints.TryAdd(EndPointCollection.TryParse(endpoint));
+                if (!string.IsNullOrWhiteSpace(endpoint)) return;
+                var parsedEndpoint = EndPointCollection.TryParse(endpoint);
+                if (!parsedEndpoint) return;
+                newEndpoints.TryAdd(parsedEndpoint);
             });
 
             if (newEndpoints.Equals(EndPoints))
@@ -1255,11 +1254,10 @@ namespace StackExchange.Redis
         {
             var newEndpoints = new EndPointCollection();
             endpoints.Split(',').ToList().ForEach(endpoint => {
-                if (!string.IsNullOrWhiteSpace(endpoint))
-                {
-                    return;
-                }
-                newEndpoints.TryAdd(EndPointCollection.TryParse(endpoint));
+                if (!string.IsNullOrWhiteSpace(endpoint)) return;
+                var parsedEndpoint = EndPointCollection.TryParse(endpoint);
+                if (!parsedEndpoint) return;
+                newEndpoints.TryAdd(parsedEndpoint);
             });
 
             if (newEndpoints.Equals(EndPoints))

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1214,7 +1214,7 @@ namespace StackExchange.Redis
                 {
                     return;
                 }
-                newEndpoints.TryAdd(endpoint);
+                newEndpoints.TryAdd(EndPointCollection.TryParse(endpoint));
             });
 
             if (newEndpoints.Equals(EndPoints))
@@ -1259,7 +1259,7 @@ namespace StackExchange.Redis
                 {
                     return;
                 }
-                newEndpoints.TryAdd(endpoint);
+                newEndpoints.TryAdd(EndPointCollection.TryParse(endpoint));
             });
 
             if (newEndpoints.Equals(EndPoints))

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1209,15 +1209,15 @@ namespace StackExchange.Redis
         public bool ConfigureEndPoints(string endpoints, TextWriter? log = null)
         {
             var newEndpoints = new EndPointCollection();
-            endpoints.Split(',').ToList().ForEach(endpoints => {
-                if (!string.IsNullOrWhiteSpace())
+            endpoints.Split(',').ToList().ForEach(endpoint => {
+                if (!string.IsNullOrWhiteSpace(endpoint))
                 {
                     return;
                 }
                 newEndpoints.TryAdd(endpoint);
             });
 
-            if (newEndpoints.Equals(Endpoints))
+            if (newEndpoints.Equals(EndPoints))
             {
                 return true;
             }
@@ -1226,11 +1226,11 @@ namespace StackExchange.Redis
             var obsoleteEndpoints = EndPoints.ToList().Except(newEndpoints).ToList();
             foreach (var oldEndpoint in obsoleteEndpoints)
             {
-                ((ServerEndpoint?)servers[oldEndpoint])?.SetUnselectable(UnselectableFlags.DidNotRespond);
+                ((ServerEndPoint?)servers[oldEndpoint])?.SetUnselectable(UnselectableFlags.DidNotRespond);
             }
 
             // Reconfigure with new connections
-            EndPoints = new EndPointCollection(endpoints);
+            EndPoints = new EndPointCollection(newEndpoints);
 
             if (!Configure(log))
             {
@@ -1254,15 +1254,15 @@ namespace StackExchange.Redis
         public async Task<bool> ConfigureEndPointsAsync(string endpoints, TextWriter? log = null)
         {
             var newEndpoints = new EndPointCollection();
-            endpoints.Split(',').ToList().ForEach(endpoints => {
-                if (!string.IsNullOrWhiteSpace())
+            endpoints.Split(',').ToList().ForEach(endpoint => {
+                if (!string.IsNullOrWhiteSpace(endpoint))
                 {
                     return;
                 }
                 newEndpoints.TryAdd(endpoint);
             });
 
-            if (newEndpoints.Equals(Endpoints))
+            if (newEndpoints.Equals(EndPoints))
             {
                 return true;
             }
@@ -1271,11 +1271,11 @@ namespace StackExchange.Redis
             var obsoleteEndpoints = EndPoints.ToList().Except(newEndpoints).ToList();
             foreach (var oldEndpoint in obsoleteEndpoints)
             {
-                ((ServerEndpoint?)servers[oldEndpoint])?.SetUnselectable(UnselectableFlags.DidNotRespond);
+                ((ServerEndPoint?)servers[oldEndpoint])?.SetUnselectable(UnselectableFlags.DidNotRespond);
             }
 
             // Reconfigure with new connections
-            EndPoints = new EndPointCollection(endpoints);
+            EndPoints = new EndPointCollection(newEndpoints);
 
             if (!await ConfigureAsync(log))
             {

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -219,16 +219,16 @@ namespace StackExchange.Redis
         /// <summary>
         /// Reconfigure the connections based on a new endpoint string
         /// </summary>
-        /// <param name="endpoints">Comma delimited string of new endpoints to configure with</param>
+        /// <param name="endpoints">Set of new endpoints to configure with</param>
         /// <param name="log">The log to write output to.</param>
-        Task<bool> ConfigureEndPoints(string endpoints, TextWriter? log = null);
+        Task<bool> ConfigureEndPointsAsync(string endpoints, TextWriter? log = null);
 
         /// <summary>
         /// Reconfigure the connections based on a new endpoint string
         /// </summary>
-        /// <param name="endpoints">Set of new endpoints to configure with</param>
+        /// <param name="endpoints">Comma delimited string of new endpoints to configure with</param>
         /// <param name="log">The log to write output to.</param>
-        Task<bool> ConfigureEndPointsAsync(string endpoints, TextWriter? log = null);
+        bool ConfigureEndPoints(string endpoints, TextWriter? log = null);
 
         /// <summary>
         /// Provides a text overview of the status of all connections.

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -217,6 +217,20 @@ namespace StackExchange.Redis
         bool Configure(TextWriter? log = null);
 
         /// <summary>
+        /// Reconfigure the connections based on a new endpoint string
+        /// </summary>
+        /// <param name="endpoints">Comma delimited string of new endpoints to configure with</param>
+        /// <param name="log">The log to write output to.</param>
+        Task<bool> ConfigureEndPoints(string endpoints, TextWriter? log = null);
+
+        /// <summary>
+        /// Reconfigure the connections based on a new endpoint string
+        /// </summary>
+        /// <param name="endpoints">Set of new endpoints to configure with</param>
+        /// <param name="log">The log to write output to.</param>
+        Task<bool> ConfigureEndPointsAsync(string endpoints, TextWriter? log = null);
+
+        /// <summary>
         /// Provides a text overview of the status of all connections.
         /// </summary>
         string GetStatus();

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -317,8 +317,8 @@ StackExchange.Redis.ConnectionMultiplexer.ConfigurationChanged -> System.EventHa
 StackExchange.Redis.ConnectionMultiplexer.ConfigurationChangedBroadcast -> System.EventHandler<StackExchange.Redis.EndPointEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.Configure(System.IO.TextWriter? log = null) -> bool
 StackExchange.Redis.ConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter? log = null) -> System.Threading.Tasks.Task<bool>!
-StackExchange.Redis.ConnectionMultiplexer.ConfigureEndPoints(string! endpoints) -> bool
-StackExchange.Redis.ConnectionMultiplexer.ConfigureEndPointsAsync(string! endpoints) -> System.Threading.Tasks.Task<bool>!
+StackExchange.Redis.ConnectionMultiplexer.ConfigureEndPoints(string! endpoints, System.IO.TextWriter? log = null) -> bool
+StackExchange.Redis.ConnectionMultiplexer.ConfigureEndPointsAsync(string! endpoints, System.IO.TextWriter? log = null) -> System.Threading.Tasks.Task<bool>!
 StackExchange.Redis.ConnectionMultiplexer.ConnectionFailed -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.ConnectionRestored -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.Dispose() -> void
@@ -463,8 +463,8 @@ StackExchange.Redis.IConnectionMultiplexer.ConfigurationChanged -> System.EventH
 StackExchange.Redis.IConnectionMultiplexer.ConfigurationChangedBroadcast -> System.EventHandler<StackExchange.Redis.EndPointEventArgs!>!
 StackExchange.Redis.IConnectionMultiplexer.Configure(System.IO.TextWriter? log = null) -> bool
 StackExchange.Redis.IConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter? log = null) -> System.Threading.Tasks.Task<bool>!
-StackExchange.Redis.IConnectionMultiplexer.ConfigureEndPoints(string! endpoints) -> bool
-StackExchange.Redis.IConnectionMultiplexer.ConfigureEndPointsAsync(string! endpoints) -> System.Threading.Tasks.Task<bool>!
+StackExchange.Redis.IConnectionMultiplexer.ConfigureEndPoints(string! endpoints, System.IO.TextWriter? log = null) -> bool
+StackExchange.Redis.IConnectionMultiplexer.ConfigureEndPointsAsync(string! endpoints, System.IO.TextWriter? log = null) -> System.Threading.Tasks.Task<bool>!
 StackExchange.Redis.IConnectionMultiplexer.ConnectionFailed -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>!
 StackExchange.Redis.IConnectionMultiplexer.ConnectionRestored -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>!
 StackExchange.Redis.IConnectionMultiplexer.ErrorMessage -> System.EventHandler<StackExchange.Redis.RedisErrorEventArgs!>!

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -317,6 +317,8 @@ StackExchange.Redis.ConnectionMultiplexer.ConfigurationChanged -> System.EventHa
 StackExchange.Redis.ConnectionMultiplexer.ConfigurationChangedBroadcast -> System.EventHandler<StackExchange.Redis.EndPointEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.Configure(System.IO.TextWriter? log = null) -> bool
 StackExchange.Redis.ConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter? log = null) -> System.Threading.Tasks.Task<bool>!
+StackExchange.Redis.ConnectionMultiplexer.ConfigureEndPoints(string! endpoints) -> bool
+StackExchange.Redis.ConnectionMultiplexer.ConfigureEndPointsAsync(string! endpoints) -> System.Threading.Tasks.Task<bool>!
 StackExchange.Redis.ConnectionMultiplexer.ConnectionFailed -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.ConnectionRestored -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>?
 StackExchange.Redis.ConnectionMultiplexer.Dispose() -> void
@@ -461,6 +463,8 @@ StackExchange.Redis.IConnectionMultiplexer.ConfigurationChanged -> System.EventH
 StackExchange.Redis.IConnectionMultiplexer.ConfigurationChangedBroadcast -> System.EventHandler<StackExchange.Redis.EndPointEventArgs!>!
 StackExchange.Redis.IConnectionMultiplexer.Configure(System.IO.TextWriter? log = null) -> bool
 StackExchange.Redis.IConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter? log = null) -> System.Threading.Tasks.Task<bool>!
+StackExchange.Redis.IConnectionMultiplexer.ConfigureEndPoints(string! endpoints) -> bool
+StackExchange.Redis.IConnectionMultiplexer.ConfigureEndPointsAsync(string! endpoints) -> System.Threading.Tasks.Task<bool>!
 StackExchange.Redis.IConnectionMultiplexer.ConnectionFailed -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>!
 StackExchange.Redis.IConnectionMultiplexer.ConnectionRestored -> System.EventHandler<StackExchange.Redis.ConnectionFailedEventArgs!>!
 StackExchange.Redis.IConnectionMultiplexer.ErrorMessage -> System.EventHandler<StackExchange.Redis.RedisErrorEventArgs!>!

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -264,6 +264,11 @@ namespace StackExchange.Redis
             }
         }
 
+        internal void ResetMap()
+        {
+            map = new ServerEndPoint[RedisClusterSlotCount];
+        }
+
         private static unsafe int IndexOf(byte* ptr, byte value, int start, int end)
         {
             for (int offset = start; offset < end; offset++)

--- a/tests/StackExchange.Redis.Tests/Helpers/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/SharedConnectionFixture.cs
@@ -133,6 +133,10 @@ public class SharedConnectionFixture : IDisposable
 
         public Task<bool> ConfigureAsync(TextWriter? log = null) => _inner.ConfigureAsync(log);
 
+        public bool ConfigureEndPoints(string endpoints, TextWriter? log = null) => _inner.ConfigureEndPoints(endpoints, log);
+
+        public bool ConfigureEndPointsAsync(string endpoints, TextWriter? log = null) => _inner.ConfigureEndPointsAsync(endpoints, log);
+
         public void Dispose() { } // DO NOT call _inner.Dispose();
 
         public ValueTask DisposeAsync() => default; // DO NOT call _inner.DisposeAsync();

--- a/tests/StackExchange.Redis.Tests/Helpers/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/SharedConnectionFixture.cs
@@ -135,7 +135,7 @@ public class SharedConnectionFixture : IDisposable
 
         public bool ConfigureEndPoints(string endpoints, TextWriter? log = null) => _inner.ConfigureEndPoints(endpoints, log);
 
-        public bool ConfigureEndPointsAsync(string endpoints, TextWriter? log = null) => _inner.ConfigureEndPointsAsync(endpoints, log);
+        public Task<bool> ConfigureEndPointsAsync(string endpoints, TextWriter? log = null) => _inner.ConfigureEndPointsAsync(endpoints, log);
 
         public void Dispose() { } // DO NOT call _inner.Dispose();
 


### PR DESCRIPTION
Hi team, this PR is a proposal to add new interface APIs `ConfigureEndpoints` and `ConfigureEndpointsAsync` to ConnectionMultiplexer. 

In a distributed environment, we frequently have updates in endpoints from service discovery - due to node refreshes, expansion / shrinking of instances, reschedules from hardware issues, etc. 

For Redis Clusters, this is not an issue since the library is able to rebalance slots using `CLUSTER NODES`. However for proxies, this command is not supported. The current solution we use is to delete and recreate a new ConnectionMultiplexer, which is not ideal due to the incurred downtime. 

The new changes allow for obsolete proxy connections to be replaced, without losing availability of the ConnectionMultiplexer as a whole.

Would like to hear thoughts on this.