### PR TITLE
AppVeyor: move to VS 2022 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
 install:
 - cmd: >-
     choco install dotnet-sdk --version 6.0.406 --force
-    choco install dotnet-sdk --version 7.0.201 --force
+    choco install dotnet-sdk --version 7.0.200 --force
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,11 @@
 image:
-- Visual Studio 2019
+- Visual Studio 2022
 
 init:
   - git config --global core.autocrlf input
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 7.0.102
-
     cd tests\RedisConfigs\3.0.503
 
     redis-server.exe --service-install --service-name "redis-6379" "..\Basic\primary-6379-3.0.conf"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 6.0.309
+    choco install dotnet-sdk --version 6.0.406
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 6.0.406
-    choco install dotnet-sdk --version 7.0.201
+    choco install dotnet-sdk --version 6.0.406 --force
+    choco install dotnet-sdk --version 7.0.201 --force
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ init:
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 6.0.406 --force
-    choco install dotnet-sdk --version 7.0.200 --force
+    choco install dotnet-6.0-sdk
+    choco install dotnet-7.0-sdk
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ init:
 install:
 - cmd: >-
     choco install dotnet-sdk --version 6.0.309
-    choco install dotnet-sdk --version 7.0.201
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ init:
 install:
 - cmd: >-
     choco install dotnet-6.0-sdk
+
     choco install dotnet-7.0-sdk
 
     cd tests\RedisConfigs\3.0.503

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ init:
 install:
 - cmd: >-
     choco install dotnet-sdk --version 6.0.406
+    choco install dotnet-sdk --version 7.0.201
 
     cd tests\RedisConfigs\3.0.503
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,14 @@
 image:
-- Visual Studio 2022
+- Visual Studio 2019
 
 init:
   - git config --global core.autocrlf input
 
 install:
 - cmd: >-
+    choco install dotnet-sdk --version 6.0.309
+    choco install dotnet-sdk --version 7.0.201
+
     cd tests\RedisConfigs\3.0.503
 
     redis-server.exe --service-install --service-name "redis-6379" "..\Basic\primary-6379-3.0.conf"


### PR DESCRIPTION
The update blog post (https://www.appveyor.com/updates/2023/02/24/) doesn't match the inventory (https://www.appveyor.com/docs/windows-images-software/), primarily: .NET 6 SDK which is LTS is no longer on the 2019 image which seems like an oops. Bypassing the issue for now by getting on the 2022 image.