### PR TITLE
expose IAsyncEnumerable on ChannelMessageQueue

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-- Fix [#2400](https://github.com/StackExchange/StackExchange.Redis/issues/2400): Expose `ChannelMessageQueue` as `IAsyncEnumerable<ChannelMessage>` ([#???? by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/????))
+- Fix [#2400](https://github.com/StackExchange/StackExchange.Redis/issues/2400): Expose `ChannelMessageQueue` as `IAsyncEnumerable<ChannelMessage>` ([#2402 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2402))
 
 ## 2.6.96
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,11 +8,11 @@ Current package versions:
 
 ## Unreleased
 
-No pending changes.
+- Fix [#2400](https://github.com/StackExchange/StackExchange.Redis/issues/2400): Expose `ChannelMessageQueue` as `IAsyncEnumerable<ChannelMessage>` ([#???? by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/????))
 
 ## 2.6.96
 
-- Fix [#2350](https://github.com/StackExchange/StackExchange.Redis/issues/2350): Properly parse lua script paramters in all cultures ([#2351 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2351))
+- Fix [#2350](https://github.com/StackExchange/StackExchange.Redis/issues/2350): Properly parse lua script parameters in all cultures ([#2351 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2351))
 - Fix [#2362](https://github.com/StackExchange/StackExchange.Redis/issues/2362): Set `RedisConnectionException.FailureType` to `AuthenticationFailure` on all authentication scenarios for better handling ([#2367 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2367))
 - Fix [#2368](https://github.com/StackExchange/StackExchange.Redis/issues/2368): Support `RedisValue.Length()` for all storage types ([#2370 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2370))
 - Fix [#2376](https://github.com/StackExchange/StackExchange.Redis/issues/2376): Avoid a (rare) deadlock scenario ([#2378 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2378))

--- a/src/StackExchange.Redis/ChannelMessageQueue.cs
+++ b/src/StackExchange.Redis/ChannelMessageQueue.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -66,7 +68,7 @@ namespace StackExchange.Redis
     /// To create a ChannelMessageQueue, use <see cref="ISubscriber.Subscribe(RedisChannel, CommandFlags)"/>
     /// or <see cref="ISubscriber.SubscribeAsync(RedisChannel, CommandFlags)"/>.
     /// </remarks>
-    public sealed class ChannelMessageQueue
+    public sealed class ChannelMessageQueue : IAsyncEnumerable<ChannelMessage>
     {
         private readonly Channel<ChannelMessage> _queue;
         /// <summary>
@@ -319,10 +321,7 @@ namespace StackExchange.Redis
         {
             var parent = _parent;
             _parent = null;
-            if (parent != null)
-            {
-                parent.UnsubscribeAsync(Channel, null, this, flags);
-            }
+            parent?.UnsubscribeAsync(Channel, null, this, flags);
             _queue.Writer.TryComplete(error);
         }
 
@@ -348,5 +347,22 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="flags">The flags to use when unsubscribing.</param>
         public Task UnsubscribeAsync(CommandFlags flags = CommandFlags.None) => UnsubscribeAsyncImpl(null, flags);
+
+        /// <inheritdoc cref="IAsyncEnumerable{ChannelMessage}.GetAsyncEnumerator(CancellationToken)"/>
+#if NETCOREAPP3_0_OR_GREATER
+        public IAsyncEnumerator<ChannelMessage> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => _queue.Reader.ReadAllAsync().GetAsyncEnumerator(cancellationToken);
+#else
+        public async IAsyncEnumerator<ChannelMessage> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            while (await _queue.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (_queue.Reader.TryRead(out var item))
+                {
+                    yield return item;
+                }
+            }
+        }
+#endif
     }
 }

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -79,6 +79,7 @@ StackExchange.Redis.ChannelMessage.SubscriptionChannel.get -> StackExchange.Redi
 StackExchange.Redis.ChannelMessageQueue
 StackExchange.Redis.ChannelMessageQueue.Channel.get -> StackExchange.Redis.RedisChannel
 StackExchange.Redis.ChannelMessageQueue.Completion.get -> System.Threading.Tasks.Task!
+StackExchange.Redis.ChannelMessageQueue.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<StackExchange.Redis.ChannelMessage>!
 StackExchange.Redis.ChannelMessageQueue.OnMessage(System.Action<StackExchange.Redis.ChannelMessage>! handler) -> void
 StackExchange.Redis.ChannelMessageQueue.OnMessage(System.Func<StackExchange.Redis.ChannelMessage, System.Threading.Tasks.Task!>! handler) -> void
 StackExchange.Redis.ChannelMessageQueue.ReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<StackExchange.Redis.ChannelMessage>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿StackExchange.Redis.ChannelMessageQueue.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<StackExchange.Redis.ChannelMessage>!
+﻿

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿StackExchange.Redis.ChannelMessageQueue.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<StackExchange.Redis.ChannelMessage>!


### PR DESCRIPTION
fix #2400

note in particular that we create the queue with multi-reader mode, so there are no unusual concurrency concerns here