### PR TITLE
Reference the correct default retry policy

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -238,7 +238,7 @@ These settings are also used by the `IServer.MakeMaster()` method, which can set
 ReconnectRetryPolicy
 ---
 StackExchange.Redis automatically tries to reconnect in the background when the connection is lost for any reason. It keeps retrying  until the connection has been restored. It would use ReconnectRetryPolicy to decide how long it should wait between the retries.
-ReconnectRetryPolicy can be linear (default), exponential or a custom retry policy.
+ReconnectRetryPolicy can be exponential (default), linear or a custom retry policy.
 
 
 Examples:


### PR DESCRIPTION
Update the 'Configuration' documentation page with the correct default 'ReconnectRetryPolicy' value.
Reference: 
- [src/StackExchange.Redis/ConfigurationOptions.cs](https://github.com/SonnyRR/StackExchange.Redis/blob/improvement/configuration-docs-retry-policy/src/StackExchange.Redis/ConfigurationOptions.cs#L466)
- [src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs](https://github.com/SonnyRR/StackExchange.Redis/blob/improvement/configuration-docs-retry-policy/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs#L152)