### PR TITLE
Update Pipelines.Sockets.Unofficial to v2.2.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <!-- Packages we depend on for StackExchange.Redis, upgrades can create binding redirect pain! -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.2" />
+    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="5.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />


### PR DESCRIPTION
This version contains fixes for supporting NativeAOT.

Contributes to #2449

cc @mgravell @NickCraver 