### PR TITLE
add DIM for Publish[Async]

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,8 @@ Current package versions:
 
 ## Unreleased
 
+- Adds: support for `Publish(string, ...)` and `PublishAsync(string, ...)` to minimize CS0618 flags from changes in 2.6.116 ([#2483 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2483))
+
 ## 2.6.116
 
 - Fix [#2479](https://github.com/StackExchange/StackExchange.Redis/issues/2479): Add `RedisChannel.UseImplicitAutoPattern` (global) and `RedisChannel.IsPattern` ([#2480 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2480))

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -1229,6 +1229,13 @@ namespace StackExchange.Redis
         /// <remarks><seealso href="https://redis.io/commands/publish"/></remarks>
         long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
+
+#if NETCOREAPP3_1_OR_GREATER
+        /// <inheritdoc cref="Publish(RedisChannel, RedisValue, CommandFlags)"/>
+        long Publish(string channel, RedisValue message, CommandFlags flags = CommandFlags.None)
+            => Publish(RedisChannel.Literal(channel), message, flags);
+#endif
+
         /// <summary>
         /// Execute an arbitrary command against the server; this is primarily intended for executing modules,
         /// but may also be used to provide access to new features that lack a direct API.

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -1205,6 +1205,12 @@ namespace StackExchange.Redis
         /// <remarks><seealso href="https://redis.io/commands/publish"/></remarks>
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
+#if NETCOREAPP3_1_OR_GREATER
+        /// <inheritdoc cref="PublishAsync(RedisChannel, RedisValue, CommandFlags)"/>
+        Task<long> PublishAsync(string channel, RedisValue message, CommandFlags flags = CommandFlags.None)
+            => PublishAsync(RedisChannel.Literal(channel), message, flags);
+#endif
+
         /// <summary>
         /// Execute an arbitrary command against the server; this is primarily intended for executing modules,
         /// but may also be used to provide access to new features that lack a direct API.

--- a/src/StackExchange.Redis/Interfaces/ISubscriber.cs
+++ b/src/StackExchange.Redis/Interfaces/ISubscriber.cs
@@ -45,6 +45,16 @@ namespace StackExchange.Redis
         /// <inheritdoc cref="Publish(RedisChannel, RedisValue, CommandFlags)"/>
         Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None);
 
+#if NETCOREAPP3_1_OR_GREATER
+        /// <inheritdoc cref="Publish(RedisChannel, RedisValue, CommandFlags)"/>
+        long Publish(string channel, RedisValue message, CommandFlags flags = CommandFlags.None)
+            => Publish(RedisChannel.Literal(channel), message, flags);
+
+        /// <inheritdoc cref="PublishAsync(RedisChannel, RedisValue, CommandFlags)"/>
+        Task<long> PublishAsync(string channel, RedisValue message, CommandFlags flags = CommandFlags.None)
+            => PublishAsync(RedisChannel.Literal(channel), message, flags);
+#endif
+
         /// <summary>
         /// Subscribe to perform some operation when a message to the preferred/active node is broadcast, without any guarantee of ordered handling.
         /// </summary>

--- a/src/StackExchange.Redis/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -1,2 +1,6 @@
 ﻿StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.get -> System.Func<string!, System.Net.Security.SslClientAuthenticationOptions!>?
 StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.set -> void
+StackExchange.Redis.IDatabase.Publish(string! channel, StackExchange.Redis.RedisValue message, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long
+StackExchange.Redis.IDatabaseAsync.PublishAsync(string! channel, StackExchange.Redis.RedisValue message, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long>!
+StackExchange.Redis.ISubscriber.Publish(string! channel, StackExchange.Redis.RedisValue message, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long
+StackExchange.Redis.ISubscriber.PublishAsync(string! channel, StackExchange.Redis.RedisValue message, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long>!

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
@@ -568,10 +568,15 @@ public sealed class KeyPrefixedDatabaseTests
     [Fact]
     public void Publish()
     {
+#if NETFRAMEWORK // #if here to show we don't get the CS0618 on up-level
 #pragma warning disable CS0618
         prefixed.Publish("channel", "message", CommandFlags.None);
         mock.Verify(_ => _.Publish("prefix:channel", "message", CommandFlags.None));
 #pragma warning restore CS0618
+#else
+        prefixed.Publish("channel", "message", CommandFlags.None);
+        mock.Verify(_ => _.Publish("prefix:channel", "message", CommandFlags.None));
+#endif
     }
 
     [Fact]

--- a/tests/StackExchange.Redis.Tests/PreserveOrderTests.cs
+++ b/tests/StackExchange.Redis.Tests/PreserveOrderTests.cs
@@ -42,7 +42,11 @@ public class PreserveOrderTests : TestBase
             // it all goes to the server and back
             for (int i = 0; i < COUNT; i++)
             {
+#if NET472      // #if here is to show that we don't get the CS0618 on up-level frameworks
                 sub.Publish(RedisChannel.Literal(channel), i, CommandFlags.FireAndForget);
+#else
+                sub.Publish(channel, i, CommandFlags.FireAndForget);
+#endif
             }
 
             Log("Allowing time for delivery etc...");


### PR DESCRIPTION
The recent change to `RedisChannel` doesn't impact `Publish`/`PublishAsync`, as publish is always single-channel; to minimize the code-changes required, this PR adds Default Interface Methods (DIMs) to shim `Publish[Async](channel, ...)` via `Publish[Async](RedisChannel.Literal(channel), ...)`

This means that - at least on modern runtimes - code that uses `Publish(string)` today will not need to be adjusted.

It was investigated whether the same could be achieved via an extension method, and: it could not (the non-extension overload with implicit conversion ranks as preferable). Adding regular interface methods seems unnecessary when the implementation is always the same.

It is not seen as necessary to add `byte[]` overloads, as `byte[]` channels are so niche as to be irrelevant.

Question: is this overkill?