### PR TITLE
Fix nullability annotation of IConnectionMultiplexer.RegisterProfiler

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-- Fix: Fix nullability annotation of IConnectionMultiplexer.RegisterProfiler ([#XXX by eerhardt](https://github.com/StackExchange/StackExchange.Redis/pull/XXX))
+- Fix: Fix nullability annotation of IConnectionMultiplexer.RegisterProfiler ([#2494 by eerhardt](https://github.com/StackExchange/StackExchange.Redis/pull/2494))
 
 ## 2.6.116
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,8 @@ Current package versions:
 
 ## Unreleased
 
+- Fix: Fix nullability annotation of IConnectionMultiplexer.RegisterProfiler ([#XXX by eerhardt](https://github.com/StackExchange/StackExchange.Redis/pull/XXX))
+
 ## 2.6.116
 
 - Fix [#2479](https://github.com/StackExchange/StackExchange.Redis/issues/2479): Add `RedisChannel.UseImplicitAutoPattern` (global) and `RedisChannel.IsPattern` ([#2480 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2480))

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Profiling.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Profiling.cs
@@ -5,7 +5,7 @@ namespace StackExchange.Redis;
 
 public partial class ConnectionMultiplexer
 {
-    private Func<ProfilingSession>? _profilingSessionProvider;
+    private Func<ProfilingSession?>? _profilingSessionProvider;
 
     /// <summary>
     /// Register a callback to provide an on-demand ambient session provider based on the
@@ -13,5 +13,5 @@ public partial class ConnectionMultiplexer
     /// based on ambient context, or returning null to not profile
     /// </summary>
     /// <param name="profilingSessionProvider">The session provider to register.</param>
-    public void RegisterProfiler(Func<ProfilingSession> profilingSessionProvider) => _profilingSessionProvider = profilingSessionProvider;
+    public void RegisterProfiler(Func<ProfilingSession?> profilingSessionProvider) => _profilingSessionProvider = profilingSessionProvider;
 }

--- a/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/Interfaces/IConnectionMultiplexer.cs
@@ -78,7 +78,7 @@ namespace StackExchange.Redis
         /// based on ambient context, or returning null to not profile.
         /// </summary>
         /// <param name="profilingSessionProvider">The profiling session provider.</param>
-        void RegisterProfiler(Func<ProfilingSession> profilingSessionProvider);
+        void RegisterProfiler(Func<ProfilingSession?> profilingSessionProvider);
 
         /// <summary>
         /// Get summary statistics associates with this server.

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -359,7 +359,7 @@ StackExchange.Redis.ConnectionMultiplexer.PreserveAsyncOrder.set -> void
 StackExchange.Redis.ConnectionMultiplexer.PublishReconfigure(StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long
 StackExchange.Redis.ConnectionMultiplexer.PublishReconfigureAsync(StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long>!
 StackExchange.Redis.ConnectionMultiplexer.ReconfigureAsync(string! reason) -> System.Threading.Tasks.Task<bool>!
-StackExchange.Redis.ConnectionMultiplexer.RegisterProfiler(System.Func<StackExchange.Redis.Profiling.ProfilingSession!>! profilingSessionProvider) -> void
+StackExchange.Redis.ConnectionMultiplexer.RegisterProfiler(System.Func<StackExchange.Redis.Profiling.ProfilingSession?>! profilingSessionProvider) -> void
 StackExchange.Redis.ConnectionMultiplexer.ResetStormLog() -> void
 StackExchange.Redis.ConnectionMultiplexer.ServerMaintenanceEvent -> System.EventHandler<StackExchange.Redis.Maintenance.ServerMaintenanceEvent!>?
 StackExchange.Redis.ConnectionMultiplexer.StormLogThreshold.get -> int
@@ -497,7 +497,7 @@ StackExchange.Redis.IConnectionMultiplexer.PreserveAsyncOrder.get -> bool
 StackExchange.Redis.IConnectionMultiplexer.PreserveAsyncOrder.set -> void
 StackExchange.Redis.IConnectionMultiplexer.PublishReconfigure(StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long
 StackExchange.Redis.IConnectionMultiplexer.PublishReconfigureAsync(StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long>!
-StackExchange.Redis.IConnectionMultiplexer.RegisterProfiler(System.Func<StackExchange.Redis.Profiling.ProfilingSession!>! profilingSessionProvider) -> void
+StackExchange.Redis.IConnectionMultiplexer.RegisterProfiler(System.Func<StackExchange.Redis.Profiling.ProfilingSession?>! profilingSessionProvider) -> void
 StackExchange.Redis.IConnectionMultiplexer.ResetStormLog() -> void
 StackExchange.Redis.IConnectionMultiplexer.ServerMaintenanceEvent -> System.EventHandler<StackExchange.Redis.Maintenance.ServerMaintenanceEvent!>!
 StackExchange.Redis.IConnectionMultiplexer.StormLogThreshold.get -> int

--- a/tests/StackExchange.Redis.Tests/Helpers/SharedConnectionFixture.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/SharedConnectionFixture.cs
@@ -169,7 +169,7 @@ public class SharedConnectionFixture : IDisposable
 
         public Task<long> PublishReconfigureAsync(CommandFlags flags = CommandFlags.None) => _inner.PublishReconfigureAsync(flags);
 
-        public void RegisterProfiler(Func<ProfilingSession> profilingSessionProvider) => _inner.RegisterProfiler(profilingSessionProvider);
+        public void RegisterProfiler(Func<ProfilingSession?> profilingSessionProvider) => _inner.RegisterProfiler(profilingSessionProvider);
 
         public void ResetStormLog() => _inner.ResetStormLog();
 


### PR DESCRIPTION
RegisterProfiler allows for a null ProfilingSession to be returned - it is even documented with "or returning null to not profile".

Fixing the nullable annotation to indicate that null is an acceptable result of the profilingSessionProvider function.