### PR TITLE
Enable net6.0 build

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,7 @@ Current package versions:
 
 ## Unreleased
 
+- Change: Target net6.0 instead of net5.0, since net5.0 is end of life. ([#2497 by eerhardt](https://github.com/StackExchange/StackExchange.Redis/pull/2497))
 - Fix: Fix nullability annotation of IConnectionMultiplexer.RegisterProfiler ([#2494 by eerhardt](https://github.com/StackExchange/StackExchange.Redis/pull/2494))
 
 ## 2.6.116

--- a/src/StackExchange.Redis/ConnectionMultiplexer.ReaderWriter.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.ReaderWriter.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace StackExchange.Redis;
 
@@ -9,27 +9,11 @@ public partial class ConnectionMultiplexer
     [MemberNotNull(nameof(SocketManager))]
     private void OnCreateReaderWriter(ConfigurationOptions configuration)
     {
-        SocketManager = configuration.SocketManager ?? GetDefaultSocketManager();
+        SocketManager = configuration.SocketManager ?? SocketManager.Shared;
     }
 
     private void OnCloseReaderWriter()
     {
         SocketManager = null;
-    }
-
-    /// <summary>
-    /// .NET 6.0+ has changes to sync-over-async stalls in the .NET primary thread pool
-    /// If we're in that environment, by default remove the overhead of our own threadpool
-    /// This will eliminate some context-switching overhead and better-size threads on both large
-    /// and small environments, from 16 core machines to single core VMs where the default 10 threads
-    /// isn't an ideal situation.
-    /// </summary>
-    internal static SocketManager GetDefaultSocketManager()
-    {
-#if NET6_0_OR_GREATER
-        return SocketManager.ThreadPool;
-#else
-        return SocketManager.Shared;
-#endif
     }
 }

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -855,10 +855,6 @@ namespace StackExchange.Redis
             {
                 _backlogStatus = BacklogStatus.Activating;
 
-#if NET6_0_OR_GREATER
-                // In .NET 6, use the thread pool stall semantics to our advantage and use a lighter-weight Task
-                Task.Run(ProcessBacklogAsync);
-#else
                 // Start the backlog processor; this is a bit unorthodox, as you would *expect* this to just
                 // be Task.Run; that would work fine when healthy, but when we're falling on our face, it is
                 // easy to get into a thread-pool-starvation "spiral of death" if we rely on the thread-pool
@@ -871,7 +867,6 @@ namespace StackExchange.Redis
                     Name = "StackExchange.Redis Backlog", // help anyone looking at thread-dumps
                 };
                 thread.Start(this);
-#endif
             }
             else
             {

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <!-- extend the default lib targets for the main lib; mostly because of "vectors" -->
-    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <!-- extend the default lib targets for the main lib; mostly because of "vectors" -->
-    <!-- Note: we're NOT building for .NET 6 because the thread pool changes are not wins yet -->
-    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>
@@ -35,7 +34,7 @@
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
     <!-- APIs for netcoreapp3.1+ -->
-    <AdditionalFiles Include="PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt" Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net5.0'" />
+    <AdditionalFiles Include="PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -468,7 +468,7 @@ public class ConfigTests : TestBase
 
         using var conn = ConnectionMultiplexer.Connect(config);
 
-        Assert.Same(ConnectionMultiplexer.GetDefaultSocketManager().Scheduler, conn.SocketManager?.Scheduler);
+        Assert.Same(SocketManager.Shared.Scheduler, conn.SocketManager?.Scheduler);
     }
 
     [Theory]


### PR DESCRIPTION
This allows for using new APIs introduced in net6.0.

In order to enable building for net6.0, we also need to revert the thread pool changes in #1939 and #1950. This was already effectively reverted in #1992 by not building for net6.0. Now that we are building for net6.0 again, these if-defs need to be removed.

Questions:

1. Does this need a ReleaseNotes entry? I don't think there is any user-visible affect to this change.
1. Should `net5.0` be removed? It has been end-of-life for over a year. I left it in, for now. It can be removed in the future, if we think it should be removed.

cc @NickCraver @mgravell 