### PR TITLE
Test: Fix Issue2507 and add String.SetEmpty

### DIFF
--- a/tests/StackExchange.Redis.Tests/Issues/Issue2507.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue2507.cs
@@ -6,6 +6,7 @@ using Xunit.Abstractions;
 
 namespace StackExchange.Redis.Tests.Issues
 {
+    [Collection(NonParallelCollection.Name)]
     public class Issue2507 : TestBase
     {
         public Issue2507(ITestOutputHelper output, SharedConnectionFixture? fixture = null)
@@ -14,25 +15,31 @@ namespace StackExchange.Redis.Tests.Issues
         [Fact]
         public async Task Execute()
         {
-            using var conn = Create();
+            using var conn = Create(shared: false);
             var db = conn.GetDatabase();
             var pubsub = conn.GetSubscriber();
             var queue = await pubsub.SubscribeAsync(RedisChannel.Literal("__redis__:invalidate"));
             await Task.Delay(100);
             var connectionId = conn.GetConnectionId(conn.GetEndPoints().Single(), ConnectionType.Subscription);
             if (connectionId is null) Skip.Inconclusive("Connection id not available");
-            await db.StringSetAsync(new KeyValuePair<RedisKey, RedisValue>[] { new("abc", "def"), new("ghi", "jkl"), new("mno", "pqr") });
+
+            string baseKey = Me();
+            RedisKey key1 = baseKey + "abc",
+                     key2 = baseKey + "ghi",
+                     key3 = baseKey + "mno";
+
+            await db.StringSetAsync(new KeyValuePair<RedisKey, RedisValue>[] { new(key1, "def"), new(key2, "jkl"), new(key3, "pqr") });
             // this is not supported, but: we want it to at least not fail
             await db.ExecuteAsync("CLIENT", "TRACKING", "on", "REDIRECT", connectionId!.Value, "BCAST");
-            await db.KeyDeleteAsync(new RedisKey[] { "abc", "ghi", "mno" });
+            await db.KeyDeleteAsync(new RedisKey[] { key1, key2, key3 });
             await Task.Delay(100);
             queue.Unsubscribe();
             Assert.True(queue.TryRead(out var message));
-            Assert.Equal("abc", message.Message);
+            Assert.Equal(key1, message.Message);
             Assert.True(queue.TryRead(out message));
-            Assert.Equal("ghi", message.Message);
+            Assert.Equal(key2, message.Message);
             Assert.True(queue.TryRead(out message));
-            Assert.Equal("mno", message.Message);
+            Assert.Equal(key3, message.Message);
             Assert.False(queue.TryRead(out message));
         }
     }

--- a/tests/StackExchange.Redis.Tests/StringTests.cs
+++ b/tests/StackExchange.Redis.Tests/StringTests.cs
@@ -70,6 +70,24 @@ public class StringTests : TestBase
     }
 
     [Fact]
+    public async Task SetEmpty()
+    {
+        using var conn = Create();
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        db.StringSet(key, new byte[] { });
+        var exists = await db.KeyExistsAsync(key);
+        var val = await db.StringGetAsync(key);
+
+        Assert.True(exists);
+        Log("Value: " + val);
+        Assert.Equal(0, val.Length());
+    }
+
+    [Fact]
     public async Task StringGetSetExpiryNoValue()
     {
         using var conn = Create(require: RedisFeatures.v6_2_0);


### PR DESCRIPTION
Fixing the current tests stalling PRs. Issue2507 fundamentally can't play nice either others, especially shared connections and simultaneous, so fixing that case, and adding `SetEmpty`) which has come up a few times as an example of this working.