### PR TITLE
Add (ReadOnly)Memory<byte> implicit conversions to RedisKey

### DIFF
--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace StackExchange.Redis.KeyspaceIsolation
@@ -843,7 +844,8 @@ namespace StackExchange.Redis.KeyspaceIsolation
 
         protected RedisChannel ToInner(RedisChannel outer)
         {
-            var combined = RedisKey.ConcatenateBytes(Prefix, null, (byte[]?)outer);
+            var combined = RedisKey.ConcatenateBytesArray(Prefix, null, (byte[]?)outer);
+
             return new RedisChannel(combined, outer.IsPattern ? RedisChannel.PatternMode.Pattern : RedisChannel.PatternMode.Literal);
         }
 

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1148,19 +1148,30 @@ namespace StackExchange.Redis
             return value < 10 ? (byte)('0' + value) : (byte)('a' - 10 + value);
         }
 
-        internal static void WriteUnifiedPrefixedString(PipeWriter writer, byte[]? prefix, string? value)
+        internal static void WriteUnifiedPrefixedString(PipeWriter writer, ReadOnlyMemory<byte> prefix, string? value)
         {
-            if (value == null)
+            if (prefix.IsEmpty && value == null)
             {
                 // special case
                 writer.Write(NullBulkString.Span);
+            }
+            else if (value == null)
+            {
+                int totalLength = prefix.Length;
+
+                var span = writer.GetSpan(3 + Format.MaxInt32TextLen);
+                span[0] = (byte)'$';
+                int bytes = WriteRaw(span, totalLength, offset: 1);
+                writer.Advance(bytes);
+
+                writer.Write(prefix.Span);
             }
             else
             {
                 // ${total-len}\r\n         3 + MaxInt32TextLen
                 // {prefix}{value}\r\n
                 int encodedLength = Encoding.UTF8.GetByteCount(value),
-                    prefixLength = prefix?.Length ?? 0,
+                    prefixLength = prefix.Length,
                     totalLength = prefixLength + encodedLength;
 
                 if (totalLength == 0)
@@ -1175,7 +1186,7 @@ namespace StackExchange.Redis
                     int bytes = WriteRaw(span, totalLength, offset: 1);
                     writer.Advance(bytes);
 
-                    if (prefixLength != 0) writer.Write(prefix);
+                    if (prefixLength != 0) writer.Write(prefix.Span);
                     if (encodedLength != 0) WriteRaw(writer, value, encodedLength);
                     WriteCrlf(writer);
                 }
@@ -1251,11 +1262,11 @@ namespace StackExchange.Redis
             }
         }
 
-        private static void WriteUnifiedPrefixedBlob(PipeWriter writer, byte[]? prefix, byte[]? value)
+        private static void WriteUnifiedPrefixedBlob(PipeWriter writer, ReadOnlyMemory<byte> prefix, byte[]? value)
         {
             // ${total-len}\r\n 
             // {prefix}{value}\r\n
-            if (prefix == null || prefix.Length == 0 || value == null)
+            if (prefix.Length == 0 || value == null)
             {   // if no prefix, just use the non-prefixed version;
                 // even if prefixed, a null value writes as null, so can use the non-prefixed version
                 WriteUnifiedBlob(writer, value);
@@ -1264,10 +1275,10 @@ namespace StackExchange.Redis
             {
                 var span = writer.GetSpan(3 + Format.MaxInt32TextLen); // note even with 2 max-len, we're still in same text range
                 span[0] = (byte)'$';
-                int bytes = WriteRaw(span, prefix.LongLength + value.LongLength, offset: 1);
+                int bytes = WriteRaw(span, prefix.Length + value.LongLength, offset: 1);
                 writer.Advance(bytes);
 
-                writer.Write(prefix);
+                writer.Write(prefix.Span);
                 writer.Write(value);
 
                 span = writer.GetSpan(2);

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ StackExchange.Redis.IServer.Protocol.get -> StackExchange.Redis.RedisProtocol
 StackExchange.Redis.RedisFeatures.ClientId.get -> bool
 StackExchange.Redis.RedisFeatures.Equals(StackExchange.Redis.RedisFeatures other) -> bool
 StackExchange.Redis.RedisFeatures.Resp3.get -> bool
+StackExchange.Redis.RedisKey.RedisKey(System.ReadOnlyMemory<byte> key) -> void
 StackExchange.Redis.RedisProtocol
 StackExchange.Redis.RedisProtocol.Resp2 = 20000 -> StackExchange.Redis.RedisProtocol
 StackExchange.Redis.RedisProtocol.Resp3 = 30000 -> StackExchange.Redis.RedisProtocol
@@ -25,6 +26,8 @@ StackExchange.Redis.ResultType.Null = 8 -> StackExchange.Redis.ResultType
 StackExchange.Redis.ResultType.Push = 37 -> StackExchange.Redis.ResultType
 StackExchange.Redis.ResultType.Set = 21 -> StackExchange.Redis.ResultType
 StackExchange.Redis.ResultType.VerbatimString = 12 -> StackExchange.Redis.ResultType
+static StackExchange.Redis.RedisKey.implicit operator StackExchange.Redis.RedisKey(System.Memory<byte> key) -> StackExchange.Redis.RedisKey
+static StackExchange.Redis.RedisKey.implicit operator StackExchange.Redis.RedisKey(System.ReadOnlyMemory<byte> key) -> StackExchange.Redis.RedisKey
 static StackExchange.Redis.RedisResult.Create(StackExchange.Redis.RedisResult![]! values, StackExchange.Redis.ResultType resultType) -> StackExchange.Redis.RedisResult!
 static StackExchange.Redis.RedisResult.Create(StackExchange.Redis.RedisValue[]! values, StackExchange.Redis.ResultType resultType) -> StackExchange.Redis.RedisResult!
 virtual StackExchange.Redis.RedisResult.Length.get -> int

--- a/tests/StackExchange.Redis.Tests/KeyTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyTests.cs
@@ -191,7 +191,7 @@ public class KeyTests : TestBase
             var key4 = key3.Append("buzz");
 
             var key5 = key2.Append(key4);
-            Assert.Equal("helloworldfizz", key5);
+            Assert.Equal("helloworldfizzbuzz", key5);
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/KeyTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyTests.cs
@@ -89,8 +89,6 @@ public class KeyTests : TestBase
             RedisKey key1 = "world";
             RedisKey key2 = Encoding.UTF8.GetBytes("hello");
             var key3 = key1.Prepend(key2);
-            Assert.True(ReferenceEquals(key1.KeyValue, key3.KeyValue));
-            Assert.True(ReferenceEquals(key2.KeyValue, key3.KeyPrefix));
             Assert.Equal("helloworld", key3);
         }
 
@@ -104,9 +102,96 @@ public class KeyTests : TestBase
             RedisKey key1 = Encoding.UTF8.GetBytes("hello");
             RedisKey key2 = "world";
             var key3 = key1.Append(key2);
-            Assert.True(ReferenceEquals(key2.KeyValue, key3.KeyValue));
-            Assert.True(ReferenceEquals(key1.KeyValue, key3.KeyPrefix));
             Assert.Equal("helloworld", key3);
+        }
+
+        {
+            RedisKey key1 = Encoding.UTF8.GetBytes("hello");
+            var key2 = key1.Append(RedisKey.Null);
+            Assert.Equal("hello", key2);
+        }
+
+        {
+            RedisKey key1 = Encoding.UTF8.GetBytes("hello");
+            var key2 = RedisKey.Null.Append(key1);
+            Assert.Equal("hello", key2);
+        }
+
+        {
+            RedisKey key1 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("hello");
+            RedisKey key2 = "world";
+            var key3 = key1.Append(key2);
+            Assert.Equal("helloworld", key3);
+        }
+
+        {
+            RedisKey key1 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("hello");
+            RedisKey key2 = "world";
+            var key3 = key2.Append(key1);
+            Assert.Equal("worldhello", key3);
+        }
+
+        {
+            var mem = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("abcdhello");
+            RedisKey key1 = mem.Slice(4);
+            RedisKey key2 = "world";
+            var key3 = key1.Append(key2);
+            Assert.Equal("helloworld", key3);
+        }
+
+        {
+            var mem1 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("abcdhello");
+            RedisKey key1 = mem1.Slice(4);
+
+            var mem2 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("worldefgh");
+            RedisKey key2 = mem2.Slice(0, 5);
+            var key3 = key1.Append(key2);
+            Assert.Equal("helloworld", key3);
+        }
+
+        {
+            var mem1 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("abcdhello");
+            RedisKey key1 = mem1.Slice(4);
+
+            var mem2 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("worldefgh");
+            RedisKey key2 = mem2.Slice(0, 5);
+            var key3 = key2.Append("fizz");
+
+            var key4 = key1.Append(key3);
+            Assert.Equal("helloworldfizz", key4);
+        }
+
+        {
+            var mem1 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("abcdhello");
+            RedisKey key1 = mem1.Slice(4);
+            var key2 = key1.Append("world");
+
+            RedisKey key3 = "fizz";
+            RedisKey key4 = key2.Append(key3);
+
+            Assert.Equal("helloworldfizz", key4);
+        }
+
+        {
+            RedisKey key1 = new RedisKey(default, Encoding.UTF8.GetBytes("hello"));
+
+            var mem2 = (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("worldefgh");
+            RedisKey key2 = mem2.Slice(0, 5);
+            var key3 = key2.Append("fizz");
+
+            var key4 = key1.Append(key3);
+            Assert.Equal("helloworldfizz", key4);
+        }
+
+        {
+            RedisKey key1 = Encoding.UTF8.GetBytes("hello");
+            var key2 = key1.Append("world");
+
+            RedisKey key3 = Encoding.UTF8.GetBytes("fizz");
+            var key4 = key3.Append("buzz");
+
+            var key5 = key2.Append(key4);
+            Assert.Equal("helloworldfizz", key5);
         }
     }
 


### PR DESCRIPTION
At a high level, this just changes RedisKey.KeyPrefix to a ReadOnlyMemory<byte> (from a byte[]).

The change is slightly more complicated to deal with Prepend/Append.

Also noticed [this line](https://github.com/kevin-montrose/StackExchange.Redis/blob/5504ed9a93f729f204e6cb53280cb4efa1ccd390/src/StackExchange.Redis/PhysicalConnection.cs#L1153C31-L1153C31) ; which looks like a place where prefix wouldn't be written?  "Fixed" it and all tests still seem to pass.