### PR TITLE
Logging: fix race in disposal of a passed-in TextWriter

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -638,7 +638,7 @@ namespace StackExchange.Redis
             {
                 if (connectHandler != null && muxer != null) muxer.ConnectionFailed -= connectHandler;
                 if (killMe != null) try { killMe.Dispose(); } catch { }
-                if (log is TextWriterLogger twLogger) twLogger.Dispose();
+                if (log is TextWriterLogger twLogger) twLogger.Release();
             }
         }
 
@@ -740,7 +740,7 @@ namespace StackExchange.Redis
             {
                 if (connectHandler != null && muxer != null) muxer.ConnectionFailed -= connectHandler;
                 if (killMe != null) try { killMe.Dispose(); } catch { }
-                if (log is TextWriterLogger twLogger) twLogger.Dispose();
+                if (log is TextWriterLogger twLogger) twLogger.Release();
             }
         }
 


### PR DESCRIPTION
Occasionally we'd see `chunkLength` errors from `StringWriter` `.ToString()` calls after connecting. I think we've isolated this (via test stress runs) down to a write happening post-lock on the `TextWriterLogger` disposal. This lock in dispose ensures we're not trying to write to a writer we should have fully released at the end of a `.Connect()`/`.ConnectAsync()` call.