### PR TITLE
Sentinel: Add HELLO support

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,8 @@ Current package versions:
 
 ## Unreleased
 
-- Fix [#2593](https://github.com/StackExchange/StackExchange.Redis/pull/2593): `EXPIRETIME` and `PEXPIRETIME` miscategorized as `PrimaryOnly` commands causing them to fail when issued against a read-only replica.
+- Fix [#2593](https://github.com/StackExchange/StackExchange.Redis/pull/2593): `EXPIRETIME` and `PEXPIRETIME` miscategorized as `PrimaryOnly` commands causing them to fail when issued against a read-only replica ([#2593 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2593))
+- Fix [#2591](https://github.com/StackExchange/StackExchange.Redis/pull/2591): Add `HELLO` to Sentinel connections so they can support RESP3 ([#2601 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2601))
 
 ## 2.7.4
 

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -93,7 +93,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks><seealso href="https://redis.io/topics/sentinel"/></remarks>
         public static CommandMap Sentinel { get; } = Create(new HashSet<string> {
-            "auth", "ping", "info", "role", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);
+            "auth", "hello", "ping", "info", "role", "sentinel", "subscribe", "shutdown", "psubscribe", "unsubscribe", "punsubscribe" }, true);
 
         /// <summary>
         /// Create a new <see cref="CommandMap"/>, customizing some commands.

--- a/tests/StackExchange.Redis.Tests/SentinelTests.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelTests.cs
@@ -86,6 +86,7 @@ public class SentinelTests : SentinelBase
     }
 
     [Fact]
+    [RunPerProtocol]
     public void SentinelConnectTest()
     {
         var options = ServiceOptions.Clone();


### PR DESCRIPTION
This allows connections through Sentinel via RESP3 by adding `HELLO` to the command map.

Fixes #2591.