### PR TITLE
Connections: detect and handle the Linux dead socket case

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,8 +8,9 @@ Current package versions:
 
 ## Unreleased
 
-- Fix [#2593](https://github.com/StackExchange/StackExchange.Redis/pull/2593): `EXPIRETIME` and `PEXPIRETIME` miscategorized as `PrimaryOnly` commands causing them to fail when issued against a read-only replica ([#2593 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2593))
-- Fix [#2591](https://github.com/StackExchange/StackExchange.Redis/pull/2591): Add `HELLO` to Sentinel connections so they can support RESP3 ([#2601 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2601))
+- Fix [#2593](https://github.com/StackExchange/StackExchange.Redis/issues/2593): `EXPIRETIME` and `PEXPIRETIME` miscategorized as `PrimaryOnly` commands causing them to fail when issued against a read-only replica ([#2593 by slorello89](https://github.com/StackExchange/StackExchange.Redis/pull/2593))
+- Fix [#2591](https://github.com/StackExchange/StackExchange.Redis/issues/2591): Add `HELLO` to Sentinel connections so they can support RESP3 ([#2601 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2601))
+- Fix [#2595](https://github.com/StackExchange/StackExchange.Redis/issues/2595): Add detection handling for dead sockets that the OS says are okay, seen especially in Linux environments (https://github.com/StackExchange/StackExchange.Redis/pull/2610)
 
 ## 2.7.4
 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -624,13 +624,13 @@ namespace StackExchange.Redis
                                 KeepAlive();
                             }
                             else if (timedOutThisHeartbeat > 0
-                                && tmp.LastReadSecondsAgo > (tmp.BridgeCouldBeNull?.Multiplexer.AsyncTimeoutMilliseconds * 4000))
+                                && tmp.LastReadSecondsAgo * 1_000 > (tmp.BridgeCouldBeNull?.Multiplexer.AsyncTimeoutMilliseconds * 4))
                             {
                                 // If we've received *NOTHING* on the pipe in 4 timeouts worth of time and we're timing out commands, issue a connection failure so that we reconnect
                                 // This is meant to address the scenario we see often in Linux configs where TCP retries will happen for 15 minutes.
                                 // To us as a client, we'll see the socket as green/open/fine when writing but we'll bet getting nothing back.
                                 // Since we can't depend on the pipe to fail in that case, we want to error here based on the criteria above so we reconnect broken clients much faster.
-                                tmp.BridgeCouldBeNull?.Multiplexer.Logger?.LogWarning("Dead socket detected, no reads in " + tmp.LastReadSecondsAgo + " seconds, issuing disconnect");
+                                tmp.BridgeCouldBeNull?.Multiplexer.Logger?.LogWarning($"Dead socket detected, no reads in {tmp.LastReadSecondsAgo} seconds with {timedOutThisHeartbeat} timeouts, issuing disconnect");
                                 OnDisconnected(ConnectionFailureType.SocketFailure, tmp, out _, out State oldState);
                                 tmp.Dispose(); // Cleanup the existing connection/socket if any, otherwise it will wait reading indefinitely
                             }

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -591,7 +591,7 @@ namespace StackExchange.Redis
                                 Interlocked.Exchange(ref connectTimeoutRetryCount, 0);
                                 tmp.BridgeCouldBeNull?.ServerEndPoint?.ClearUnselectable(UnselectableFlags.DidNotRespond);
                             }
-                            tmp.OnBridgeHeartbeat();
+                            int timedOutThisHeartbeat = tmp.OnBridgeHeartbeat();
                             int writeEverySeconds = ServerEndPoint.WriteEverySeconds,
                                 checkConfigSeconds = ServerEndPoint.ConfigCheckSeconds;
 
@@ -622,6 +622,17 @@ namespace StackExchange.Redis
                                 // up a bit, so if we have an empty unsent queue and a non-empty sent
                                 // queue, test the socket
                                 KeepAlive();
+                            }
+                            else if (timedOutThisHeartbeat > 0
+                                && tmp.LastReadSecondsAgo > (tmp.BridgeCouldBeNull?.Multiplexer.AsyncTimeoutMilliseconds * 4000))
+                            {
+                                // If we've received *NOTHING* on the pipe in 4 timeouts worth of time and we're timing out commands, issue a connection failure so that we reconnect
+                                // This is meant to address the scenario we see often in Linux configs where TCP retries will happen for 15 minutes.
+                                // To us as a client, we'll see the socket as green/open/fine when writing but we'll bet getting nothing back.
+                                // Since we can't depend on the pipe to fail in that case, we want to error here based on the criteria above so we reconnect broken clients much faster.
+                                tmp.BridgeCouldBeNull?.Multiplexer.Logger?.LogWarning("Dead socket detected, no reads in " + tmp.LastReadSecondsAgo + " seconds, issuing disconnect");
+                                OnDisconnected(ConnectionFailureType.SocketFailure, tmp, out _, out State oldState);
+                                tmp.Dispose(); // Cleanup the existing connection/socket if any, otherwise it will wait reading indefinitely
                             }
                         }
                         break;


### PR DESCRIPTION
In Linux, we see 15 minute socket stalls due to OS-level TCP retries. What this means is the PhysicalConnection detects no issues on the pipe that's retrying, but is also not receiving data at all leading to long stalls in client applications. The goal here is to detect that we're timing out commands people have issued to the connection but we're getting _NOTHING_ back on the socket at all. In this case, we should assume the socket is dead and issue a reconnect so that we get out of the hung situation much faster.

For an initial go at this, we've chosen 4x the timeout interval as a threshold, but could make this configurable if needed.