### PR TITLE
add type-forward on IsExternalInit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <!-- Packages only used in the solution, upgrade at will -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.0-alpha" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4-beta1.22362.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,8 @@ Current package versions:
 | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
 ## Unreleased
-No unreleased changes yet!
+
+- Fix [#2619](https://github.com/StackExchange/StackExchange.Redis/issues/2619): Type-forward `IsExternalInit` to support down-level TFMs ([#2621 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2621))
 
 ## 2.7.10
 

--- a/src/StackExchange.Redis/Hacks.cs
+++ b/src/StackExchange.Redis/Hacks.cs
@@ -1,5 +1,7 @@
-﻿#if !NET5_0_OR_GREATER
-
+﻿#if NET5_0_OR_GREATER
+// context: https://github.com/StackExchange/StackExchange.Redis/issues/2619
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+#else
 // To support { get; init; } properties
 using System.ComponentModel;
 
@@ -8,5 +10,4 @@ namespace System.Runtime.CompilerServices
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal static class IsExternalInit { }
 }
-
 #endif

--- a/src/StackExchange.Redis/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,3 @@
+﻿StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.get -> System.Func<string!, System.Net.Security.SslClientAuthenticationOptions!>?
+StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.set -> void
+System.Runtime.CompilerServices.IsExternalInit (forwarded, contained in System.Runtime)

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -35,7 +35,7 @@
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
     <!-- APIs for netcoreapp3.1+ -->
-    <AdditionalFiles Include="PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fix #2619

as per guidance from the runtime folks, we should declare a type-forward for `IsExternalInit`, so that it gets correctly bound (in particular when netstandard is involved, as the build and execution environments are more likely to differ, leading to modreq confusion)