### PR TITLE
Support Alibaba pseudo-cluster configurations

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,8 @@ Current package versions:
 | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
 ## Unreleased
-No unreleased changes
+
+- Fix [#2642](https://github.com/StackExchange/StackExchange.Redis/issues/2642): Detect and support multi-DB pseudo-cluster/proxy scenarios ([#2646](https://github.com/StackExchange/StackExchange.Redis/pull/2646) by mgravell)
 
 ## 2.7.17
 

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -95,6 +95,9 @@ namespace StackExchange.Redis
             OnCreateEcho();
         }
 
+        // *definitely* multi-database; this can help identify some unusual config scenarios
+        internal bool MultiDatabasesOverride { get; set; } // switch to flags-enum if more needed later
+
         internal async Task BeginConnectAsync(ILogger? log)
         {
             var bridge = BridgeCouldBeNull;
@@ -262,6 +265,7 @@ namespace StackExchange.Redis
 
         private RedisProtocol _protocol; // note starts at **zero**, not RESP2
         public RedisProtocol? Protocol => _protocol == 0 ? null : _protocol;
+
         internal void SetProtocol(RedisProtocol value) => _protocol = value;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -929,6 +929,10 @@ namespace StackExchange.Redis
                                     int dbCount = checked((int)i64);
                                     Log?.LogInformation($"{Format.ToString(server)}: Auto-configured (CONFIG) databases: " + dbCount);
                                     server.Databases = dbCount;
+                                    if (dbCount > 1)
+                                    {
+                                        connection.MultiDatabasesOverride = true;
+                                    }
                                 }
                                 else if (key.IsEqual(CommonReplies.slave_read_only) || key.IsEqual(CommonReplies.replica_read_only))
                                 {
@@ -1110,11 +1114,8 @@ namespace StackExchange.Redis
                         var bridge = connection.BridgeCouldBeNull;
                         var config = Parse(connection, nodes);
 
-                        // note: some setups self-report as a cluster with a single
-                        // endpoint (in two pieces - replica+primary, same path);
-                        // don't treat that as a real cluster; see
-                        // https://github.com/StackExchange/StackExchange.Redis/issues/2642
-                        if (bridge != null && config.Nodes.Count >= 2)
+                        // re multi-db: https://github.com/StackExchange/StackExchange.Redis/issues/2642
+                        if (bridge != null && !connection.MultiDatabasesOverride)
                         {
                             bridge.ServerEndPoint.ServerType = ServerType.Cluster;
                         }

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -415,6 +415,10 @@ namespace StackExchange.Redis
                 lastInfoReplicationCheckTicks = Environment.TickCount;
                 if (features.InfoSections)
                 {
+                    // note: Redis 7.0 has a multi-section usage, but we don't know
+                    // the server version at this point; we *could* use the optional
+                    // value on the config, but let's keep things simple: these
+                    // commands are suitably cheap
                     msg = Message.Create(-1, flags, RedisCommand.INFO, RedisLiterals.replication);
                     msg.SetInternalCall();
                     await WriteDirectOrQueueFireAndForgetAsync(connection, msg, autoConfigProcessor).ForAwait();


### PR DESCRIPTION
1: don't treat trivial clusters as clusters - Alibaba uses this config
2: report synchronous failures immidiately and accurately

fix #2642

For context, Alibaba reports from `cluster nodes` as 2 nodes:

``` txt
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {proxy endpoint} myself,master - 0 0 0 connected 0-16383
bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {proxy endpoint} slave aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0 0 0 connected
```

which confuses things somewhat; this isn't a valid/normal cluster configuration, so: ignore it!

Other relevant metadata:

from `config`:

```
databases=256
```

from `info`:

```
# Cluster
cluster_enabled:1
databases:256
nodecount:2
```

