### PR TITLE
Support `HeartbeatConsistencyChecks` in `Clone()`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-- Support `HeartbeatConsistencyChecks` in `Clone()` ([#2657 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2657))
+- Support `HeartbeatConsistencyChecks` in `Clone()` ([#2658 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2658))
 
 ## 2.7.23
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,8 @@ Current package versions:
 | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
 ## Unreleased
-No pending unreleased changes.
+
+- Support `HeartbeatConsistencyChecks` in `Clone()` ([#2657 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2657))
 
 ## 2.7.23
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-- Support `HeartbeatConsistencyChecks` in `Clone()` ([#2658 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2658))
+- Support `HeartbeatConsistencyChecks` and `HeartbeatInterval` in `Clone()` ([#2658 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2658))
 
 ## 2.7.23
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -721,6 +721,7 @@ namespace StackExchange.Redis
             setClientLibrary = setClientLibrary,
             LibraryName = LibraryName,
             Protocol = Protocol,
+            heartbeatInterval = heartbeatInterval,
             heartbeatConsistencyChecks = heartbeatConsistencyChecks,
         };
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -721,6 +721,7 @@ namespace StackExchange.Redis
             setClientLibrary = setClientLibrary,
             LibraryName = LibraryName,
             Protocol = Protocol,
+            heartbeatConsistencyChecks = heartbeatConsistencyChecks,
         };
 
         /// <summary>

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
-using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Authentication;
@@ -35,7 +34,7 @@ public class ConfigTests : TestBase
         // this is a simple but pragmatic "have you considered?" check
 
         var fields = Array.ConvertAll(typeof(ConfigurationOptions).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
-            x => Regex.Replace(x.Name, """<(\w+)>k__BackingField""", "$1"));
+            x => Regex.Replace(x.Name, """^<(\w+)>k__BackingField$""", "$1"));
         Array.Sort(fields);
         Assert.Equal(new[] {
             "abortOnConnectFail", "allowAdmin", "asyncTimeout", "backlogPolicy", "BeforeSocketConnect",

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -1,4 +1,5 @@
-﻿using StackExchange.Redis.Configuration;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis.Configuration;
 using System;
 using System.Globalization;
 using System.IO;
@@ -6,11 +7,12 @@ using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Security.Authentication;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,6 +26,33 @@ public class ConfigTests : TestBase
 
     public Version DefaultVersion = new (3, 0, 0);
     public Version DefaultAzureVersion = new (4, 0, 0);
+
+    [Fact]
+    public void ExpectedFields()
+    {
+        // if this test fails: check that you've updated ConfigurationOptions.Clone(), then: fix the test!
+        // this is simple but pragmatic "have you considered?" check
+
+        var fields = Array.ConvertAll(typeof(ConfigurationOptions).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
+            x => Regex.Replace(x.Name, """<(\w+)>k__BackingField""", "$1"));
+        Array.Sort(fields);
+        Assert.Equal(new[] {
+            "abortOnConnectFail", "allowAdmin", "asyncTimeout", "backlogPolicy", "BeforeSocketConnect",
+            "CertificateSelection", "CertificateValidation", "ChannelPrefix",
+            "checkCertificateRevocation", "ClientName", "commandMap",
+            "configChannel", "configCheckSeconds", "connectRetry",
+            "connectTimeout", "DefaultDatabase", "defaultOptions",
+            "defaultVersion", "EndPoints", "heartbeatConsistencyChecks",
+            "heartbeatInterval", "includeDetailInExceptions", "includePerformanceCountersInExceptions",
+            "keepAlive", "LibraryName", "loggerFactory",
+            "password", "Protocol", "proxy",
+            "reconnectRetryPolicy", "resolveDns", "responseTimeout",
+            "ServiceName", "setClientLibrary", "SocketManager",
+            "ssl", "sslHost", "SslProtocols",
+            "syncTimeout", "tieBreaker", "Tunnel",
+            "user"
+            }, fields);
+    }
 
     [Fact]
     public void SslProtocols_SingleValue()

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -30,8 +30,8 @@ public class ConfigTests : TestBase
     [Fact]
     public void ExpectedFields()
     {
-        // if this test fails: check that you've updated ConfigurationOptions.Clone(), then: fix the test!
-        // this is simple but pragmatic "have you considered?" check
+        // if this test fails, check that you've updated ConfigurationOptions.Clone(), then: fix the test!
+        // this is a simple but pragmatic "have you considered?" check
 
         var fields = Array.ConvertAll(typeof(ConfigurationOptions).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
             x => Regex.Replace(x.Name, """<(\w+)>k__BackingField""", "$1"));

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Authentication;
@@ -48,7 +49,11 @@ public class ConfigTests : TestBase
             "password", "Protocol", "proxy",
             "reconnectRetryPolicy", "resolveDns", "responseTimeout",
             "ServiceName", "setClientLibrary", "SocketManager",
-            "ssl", "sslHost", "SslProtocols",
+            "ssl",
+#if !NETFRAMEWORK
+            "SslClientAuthenticationOptions",
+#endif
+            "sslHost", "SslProtocols",
             "syncTimeout", "tieBreaker", "Tunnel",
             "user"
             }, fields);


### PR DESCRIPTION
release [2.7.23](https://github.com/StackExchange/StackExchange.Redis/releases/tag/2.7.23) added a `ConfigurationOptions.HeartbeatConsistencyChecks` option, but that option is not represented in `Clone()`; fix that