### PR TITLE
update to handle null messages in FailNoServer method

### DIFF
--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -112,7 +112,7 @@ namespace StackExchange.Redis
         internal override T ExecuteSync<T>(Message? message, ResultProcessor<T>? processor, ServerEndPoint? server = null, T? defaultValue = default) where T : default =>
             throw new NotSupportedException("ExecuteSync cannot be used inside a batch");
 
-        private static void FailNoServer(ConnectionMultiplexer muxer, List<Message> messages)
+        private static void FailNoServer(ConnectionMultiplexer muxer, List<Message>? messages)
         {
             if (messages == null) return;
             foreach(var msg in messages)


### PR DESCRIPTION
After this exception:
> System.NullReferenceException: Object reference not set to an instance of an object.
>        at StackExchange.Redis.RedisBatch.FailNoServer(ConnectionMultiplexer muxer, List`1 messages) in /_/src/StackExchange.Redis/RedisBatch.cs:line 120
>               at StackExchange.Redis.RedisBatch.Execute() in /_/src/StackExchange.Redis/RedisBatch.cs:line 30

I was able to have a look at the code and found this:
`(messages == null)` expression is always false because of the nullable annotation.