### PR TITLE
Implement high integrity mode for commands

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -99,6 +99,7 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | tunnel={string}        | `Tunnel`               | `null`                       | Tunnel for connections (use `http:{proxy url}` for "connect"-based proxy server)                          |
 | setlib={bool}          | `SetClientLibrary`     | `true`                       | Whether to attempt to use `CLIENT SETINFO` to set the library name/version on the connection              |
 | protocol={string}      | `Protocol`             | `null`                       | Redis protocol to use; see section below                                                                  |
+| highIntegrity={bool}   | `HighIntegrity`        | `false`                      | High integrity (incurs overhead) sequence checking on every command; see section below                    |
 
 Additional code-only options:
 - LoggerFactory (`ILoggerFactory`) - Default: `null`
@@ -115,6 +116,10 @@ Additional code-only options:
   - The thread pool to use for scheduling work to and from the socket connected to Redis, one of...
     - `SocketManager.Shared`: Use a shared dedicated thread pool for _all_ multiplexers (defaults to 10 threads) - best balance for most scenarios.
     - `SocketManager.ThreadPool`: Use the build-in .NET thread pool for scheduling. This can perform better for very small numbers of cores or with large apps on large machines that need to use more than 10 threads (total, across all multiplexers) under load. **Important**: this option isn't the default because it's subject to thread pool growth/starvation and if for example synchronous calls are waiting on a redis command to come back to unblock other threads, stalls/hangs can result. Use with caution, especially if you have sync-over-async work in play.
+- HighIntegrity - Default: `false`
+  - This enables sending a sequence check command after _every single command_ sent to Redis. This is an opt-in option that incurs overhead to add this integrity check which isn't in the Redis protocol (RESP2/3) itself. The impact on this for a given workload depends on the number of commands, size of payloads, etc. as to how proportionately impactful it will be - you should test with your workloads to assess this.
+  - This is especially relevant if your primary use case is all strings (e.g. key/value caching) where the protocol would otherwise not error.
+  - Intended for cases where network drops (e.g. bytes from the Redis stream, not packet loss) are suspected and integrity of responses is critical.
 - HeartbeatConsistencyChecks - Default: `false`
   - Allows _always_ sending keepalive checks even if a connection isn't idle. This trades extra commands (per `HeartbeatInterval` - default 1 second) to check the network stream for consistency. If any data was lost, the result won't be as expected and the connection will be terminated ASAP. This is a check to react to any data loss at the network layer as soon as possible.
 - HeartbeatInterval - Default: `1000ms`

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -108,10 +108,12 @@ namespace StackExchange.Redis.Configuration
         /// A Boolean value that specifies whether to use per-command validation of strict protocol validity.
         /// This sends an additional command after EVERY command which incurs measurable overhead.
         /// </summary>
-        /// <remarks>The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
+        /// <remarks>
+        /// The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
         /// scenarios, protocol desynchronization can occur, which may not be noticed immediately; this option adds additional data
-        /// to ensure that this cannot occur, at the cost of some (small) additional bandwidth usage.</remarks>
-        public virtual bool HighIntegrity => true;
+        /// to ensure that this cannot occur, at the cost of some (small) additional bandwidth usage.
+        /// </remarks>
+        public virtual bool HighIntegrity => false;
 
         /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly.

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -105,7 +105,8 @@ namespace StackExchange.Redis.Configuration
         public virtual bool CheckCertificateRevocation => true;
 
         /// <summary>
-        /// A Boolean value that specifies whether to use per-command validation of strict protocol validity
+        /// A Boolean value that specifies whether to use per-command validation of strict protocol validity.
+        /// This sends an additional command after EVERY command which incurs measurable overhead.
         /// </summary>
         /// <remarks>The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
         /// scenarios, protocol desynchronization can occur, which may not be noticed immediately; this option adds additional data

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -105,6 +105,14 @@ namespace StackExchange.Redis.Configuration
         public virtual bool CheckCertificateRevocation => true;
 
         /// <summary>
+        /// A Boolean value that specifies whether to use per-command validation of strict protocol validity
+        /// </summary>
+        /// <remarks>The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
+        /// scenarios, protocol desynchronization can occur, which may not be noticed immediately; this option adds additional data
+        /// to ensure that this cannot occur, at the cost of some (small) additional bandwidth usage.</remarks>
+        public virtual bool HighIntegrity => true;
+
+        /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly.
         /// </summary>
         public virtual int ConnectRetry => 3;

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -285,9 +285,11 @@ namespace StackExchange.Redis
         /// A Boolean value that specifies whether to use per-command validation of strict protocol validity.
         /// This sends an additional command after EVERY command which incurs measurable overhead.
         /// </summary>
-        /// <remarks>The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
+        /// <remarks>
+        /// The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
         /// scenarios, protocol desynchronization can occur, which may not be noticed immediately; this option adds additional data
-        /// to ensure that this cannot occur, at the cost of some (small) additional bandwidth usage.</remarks>
+        /// to ensure that this cannot occur, at the cost of some (small) additional bandwidth usage.
+        /// </remarks>
         public bool HighIntegrity
         {
             get => highIntegrity ?? Defaults.HighIntegrity;

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -282,7 +282,8 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// A Boolean value that specifies whether to use per-command validation of strict protocol validity
+        /// A Boolean value that specifies whether to use per-command validation of strict protocol validity.
+        /// This sends an additional command after EVERY command which incurs measurable overhead.
         /// </summary>
         /// <remarks>The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
         /// scenarios, protocol desynchronization can occur, which may not be noticed immediately; this option adds additional data

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -110,7 +110,8 @@ namespace StackExchange.Redis
                 CheckCertificateRevocation = "checkCertificateRevocation",
                 Tunnel = "tunnel",
                 SetClientLibrary = "setlib",
-                Protocol = "protocol";
+                Protocol = "protocol",
+                HighIntegrity = "highIntegrity";
 
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
@@ -141,6 +142,7 @@ namespace StackExchange.Redis
                 WriteBuffer,
                 CheckCertificateRevocation,
                 Protocol,
+                HighIntegrity,
             }.ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
             public static string TryNormalize(string value)
@@ -156,7 +158,7 @@ namespace StackExchange.Redis
         private DefaultOptionsProvider? defaultOptions;
 
         private bool? allowAdmin, abortOnConnectFail, resolveDns, ssl, checkCertificateRevocation, heartbeatConsistencyChecks,
-                      includeDetailInExceptions, includePerformanceCountersInExceptions, setClientLibrary;
+                      includeDetailInExceptions, includePerformanceCountersInExceptions, setClientLibrary, highIntegrity;
 
         private string? tieBreaker, sslHost, configChannel, user, password;
 
@@ -277,6 +279,18 @@ namespace StackExchange.Redis
         {
             get => checkCertificateRevocation ?? Defaults.CheckCertificateRevocation;
             set => checkCertificateRevocation = value;
+        }
+
+        /// <summary>
+        /// A Boolean value that specifies whether to use per-command validation of strict protocol validity
+        /// </summary>
+        /// <remarks>The regular RESP protocol does not include correlation identifiers between requests and responses; in exceptional
+        /// scenarios, protocol desynchronization can occur, which may not be noticed immediately; this option adds additional data
+        /// to ensure that this cannot occur, at the cost of some (small) additional bandwidth usage.</remarks>
+        public bool HighIntegrity
+        {
+            get => highIntegrity ?? Defaults.HighIntegrity;
+            set => highIntegrity = value;
         }
 
         /// <summary>
@@ -769,6 +783,7 @@ namespace StackExchange.Redis
             Protocol = Protocol,
             heartbeatInterval = heartbeatInterval,
             heartbeatConsistencyChecks = heartbeatConsistencyChecks,
+            highIntegrity = highIntegrity,
         };
 
         /// <summary>
@@ -849,6 +864,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.ResponseTimeout, responseTimeout);
             Append(sb, OptionKeys.DefaultDatabase, DefaultDatabase);
             Append(sb, OptionKeys.SetClientLibrary, setClientLibrary);
+            Append(sb, OptionKeys.HighIntegrity, highIntegrity);
             Append(sb, OptionKeys.Protocol, FormatProtocol(Protocol));
             if (Tunnel is { IsInbuilt: true } tunnel)
             {
@@ -894,7 +910,7 @@ namespace StackExchange.Redis
         {
             ClientName = ServiceName = user = password = tieBreaker = sslHost = configChannel = null;
             keepAlive = syncTimeout = asyncTimeout = connectTimeout = connectRetry = configCheckSeconds = DefaultDatabase = null;
-            allowAdmin = abortOnConnectFail = resolveDns = ssl = setClientLibrary = null;
+            allowAdmin = abortOnConnectFail = resolveDns = ssl = setClientLibrary = highIntegrity = null;
             SslProtocols = null;
             defaultVersion = null;
             EndPoints.Clear();
@@ -1012,6 +1028,9 @@ namespace StackExchange.Redis
                             break;
                         case OptionKeys.SetClientLibrary:
                             SetClientLibrary = OptionKeys.ParseBoolean(key, value);
+                            break;
+                        case OptionKeys.HighIntegrity:
+                            HighIntegrity = OptionKeys.ParseBoolean(key, value);
                             break;
                         case OptionKeys.Tunnel:
                             if (value.IsNullOrWhiteSpace())

--- a/src/StackExchange.Redis/Enums/ConnectionFailureType.cs
+++ b/src/StackExchange.Redis/Enums/ConnectionFailureType.cs
@@ -44,6 +44,10 @@
         /// <summary>
         /// It has not been possible to create an initial connection to the redis server(s).
         /// </summary>
-        UnableToConnect
+        UnableToConnect,
+        /// <summary>
+        /// High-integrity mode was enabled, and a failure was detected
+        /// </summary>
+        ResponseIntegrityFailure,
     }
 }

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -53,7 +53,7 @@ namespace StackExchange.Redis
     {
         public readonly int Db;
 
-        private int _highIntegrityChecksum;
+        private uint _highIntegrityToken;
 
         internal const CommandFlags InternalCallFlag = (CommandFlags)128;
 
@@ -201,17 +201,12 @@ namespace StackExchange.Redis
 
         public bool IsAsking => (Flags & AskingFlag) != 0;
 
-        public bool IsHighIntegrity => _highIntegrityChecksum != 0;
-        public int HighIntegrityChecksum => _highIntegrityChecksum;
+        public bool IsHighIntegrity => _highIntegrityToken != 0;
 
-        internal void WithHighIntegrity(Random rng)
-        {
-            // create a required value if needed; avoid sentinel zero
-            while (_highIntegrityChecksum is 0)
-            {
-                _highIntegrityChecksum = rng.Next();
-            }
-        }
+        public uint HighIntegrityToken => _highIntegrityToken;
+
+        internal void WithHighIntegrity(uint value)
+            => _highIntegrityToken = value;
 
         internal bool IsScriptUnavailable => (Flags & ScriptUnavailableFlag) != 0;
 
@@ -737,7 +732,7 @@ namespace StackExchange.Redis
                 Span<byte> chk = stackalloc byte[10];
                 Debug.Assert(ChecksumTemplate.Length == chk.Length, "checksum template length error");
                 ChecksumTemplate.CopyTo(chk);
-                BinaryPrimitives.WriteInt32LittleEndian(chk.Slice(4, 4), _highIntegrityChecksum);
+                BinaryPrimitives.WriteUInt32LittleEndian(chk.Slice(4, 4), _highIntegrityToken);
                 physical.WriteRaw(chk);
             }
             catch (Exception ex)

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -70,7 +70,7 @@ namespace StackExchange.Redis
 
         internal string? PhysicalName => physical?.ToString();
 
-        private readonly Random? _highIntegrityEntropy = null;
+        private uint _nextHighIntegrityToken; // zero means not enabled
 
         public DateTime? ConnectedAt { get; private set; }
 
@@ -86,7 +86,8 @@ namespace StackExchange.Redis
 #endif
             if (type == ConnectionType.Interactive && Multiplexer.RawConfig.HighIntegrity)
             {
-                _highIntegrityEntropy = new Random();
+                // we just need this to be non-zero to enable tracking
+                _nextHighIntegrityToken = 1;
             }
         }
 
@@ -1552,11 +1553,14 @@ namespace StackExchange.Redis
                         break;
                 }
 
-                if (_highIntegrityEntropy is not null && !connection.TransactionActive)
+                if (_nextHighIntegrityToken is not 0
+                    && !connection.TransactionActive // validated in the UNWATCH/EXEC/DISCARD
+                    && message.Command is not RedisCommand.AUTH or RedisCommand.HELLO // if auth fails, ECHO may also fail; avoid confusion
+                    )
                 {
                     // make sure this value exists early to avoid a race condition
                     // if the response comes back super quickly
-                    message.WithHighIntegrity(_highIntegrityEntropy);
+                    message.WithHighIntegrity(NextHighIntegrityTokenInsideLock());
                     Debug.Assert(message.IsHighIntegrity, "message should be high integrity");
                 }
                 else
@@ -1622,6 +1626,21 @@ namespace StackExchange.Redis
                 // We're not sure *what* happened here - probably an IOException; kill the connection
                 connection?.RecordConnectionFailed(ConnectionFailureType.InternalFailure, ex);
                 return WriteResult.WriteFailure;
+            }
+        }
+
+        private uint NextHighIntegrityTokenInsideLock()
+        {
+            // inside lock: no concurrency concerns here
+            switch (_nextHighIntegrityToken)
+            {
+                case 0: return 0; // disabled
+                case uint.MaxValue:
+                    // avoid leaving the value at zero due to wrap-around
+                    _nextHighIntegrityToken = 1;
+                    return ushort.MaxValue;
+                default:
+                    return _nextHighIntegrityToken++;
             }
         }
 

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1704,7 +1704,7 @@ namespace StackExchange.Redis
             // check whether we're waiting for a high-integrity mode post-response checksum (using cheap null-check first)
             if (_awaitingToken is not null && (msg = Interlocked.Exchange(ref _awaitingToken, null)) is not null)
             {
-                _readStatus = ReadStatus.ResponseChecksum;
+                _readStatus = ReadStatus.ResponseSequenceCheck;
                 ProcessHighIntegrityResponseToken(msg, in result, BridgeCouldBeNull);
                 return;
             }
@@ -2109,7 +2109,7 @@ namespace StackExchange.Redis
             PubSubPMessage,
             Reconfigure,
             InvokePubSub,
-            ResponseChecksum, // high-integrity mode only
+            ResponseSequenceCheck, // high-integrity mode only
             DequeueResult,
             ComputeResult,
             CompletePendingMessageSync,

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using static StackExchange.Redis.Message;
+using System.Buffers.Binary;
 
 namespace StackExchange.Redis
 {
@@ -43,6 +44,8 @@ namespace StackExchange.Redis
 
         // things sent to this physical, but not yet received
         private readonly Queue<Message> _writtenAwaitingResponse = new Queue<Message>();
+
+        private Message? _awaitingChecksum;
 
         private readonly string _physicalName;
 
@@ -388,6 +391,8 @@ namespace StackExchange.Redis
             Exception? outerException = innerException;
             IdentifyFailureType(innerException, ref failureType);
             var bridge = BridgeCouldBeNull;
+            Message? nextMessage;
+
             if (_ioPipe != null || isInitialConnect) // if *we* didn't burn the pipe: flag it
             {
                 if (failureType == ConnectionFailureType.InternalFailure && innerException is not null)
@@ -419,9 +424,9 @@ namespace StackExchange.Redis
                     lock (_writtenAwaitingResponse)
                     {
                         // find oldest message awaiting a response
-                        if (_writtenAwaitingResponse.TryPeek(out var next))
+                        if (_writtenAwaitingResponse.TryPeek(out nextMessage))
                         {
-                            unansweredWriteTime = next.GetWriteTime();
+                            unansweredWriteTime = nextMessage.GetWriteTime();
                         }
                     }
 
@@ -510,23 +515,17 @@ namespace StackExchange.Redis
                 bridge?.Trace(_writtenAwaitingResponse.Count != 0, "Failing outstanding messages: " + _writtenAwaitingResponse.Count);
             }
 
-            while (TryDequeueLocked(_writtenAwaitingResponse, out var next))
+            var ex = innerException is RedisException ? innerException : outerException;
+
+            nextMessage = Interlocked.Exchange(ref _awaitingChecksum, null);
+            if (nextMessage is not null)
             {
-                if (next.Command == RedisCommand.QUIT && next.TrySetResult(true))
-                {
-                    // fine, death of a socket is close enough
-                    next.Complete();
-                }
-                else
-                {
-                    var ex = innerException is RedisException ? innerException : outerException;
-                    if (bridge != null)
-                    {
-                        bridge.Trace("Failing: " + next);
-                        bridge.Multiplexer?.OnMessageFaulted(next, ex, origin);
-                    }
-                    next.SetExceptionAndComplete(ex!, bridge);
-                }
+                RecordMessageFailed(nextMessage, ex, origin, bridge);
+            }
+
+            while (TryDequeueLocked(_writtenAwaitingResponse, out nextMessage))
+            {
+                RecordMessageFailed(nextMessage, ex, origin, bridge);
             }
 
             // burn the socket
@@ -538,6 +537,24 @@ namespace StackExchange.Redis
                 {
                     return queue.TryDequeue(out message);
                 }
+            }
+        }
+
+        private void RecordMessageFailed(Message next, Exception? ex, string? origin, PhysicalBridge? bridge)
+        {
+            if (next.Command == RedisCommand.QUIT && next.TrySetResult(true))
+            {
+                // fine, death of a socket is close enough
+                next.Complete();
+            }
+            else
+            {
+                if (bridge != null)
+                {
+                    bridge.Trace("Failing: " + next);
+                    bridge.Multiplexer?.OnMessageFaulted(next, ex, origin);
+                }
+                next.SetExceptionAndComplete(ex!, bridge);
             }
         }
 
@@ -879,6 +896,8 @@ namespace StackExchange.Redis
 
             writer.Advance(offset);
         }
+
+        internal void WriteRaw(ReadOnlySpan<byte> bytes) => _ioPipe?.Output?.Write(bytes);
 
         internal void RecordQuit() // don't blame redis if we fired the first shot
             => (_ioPipe as SocketConnection)?.TrySetProtocolShutdown(PipeShutdownKind.ProtocolExitClient);
@@ -1680,10 +1699,24 @@ namespace StackExchange.Redis
                 // if it didn't look like "[p]message", then we still need to process the pending queue
             }
             Trace("Matching result...");
-            Message? msg;
+
+            Message? msg = null;
+            // check whether we're waiting for a high-integrity mode post-response checksum (using cheap null-check first)
+            if (_awaitingChecksum is not null && (msg = Interlocked.Exchange(ref _awaitingChecksum, null)) is not null)
+            {
+                _readStatus = ReadStatus.ResponseChecksum;
+                ProcessHighIntegrityResponseChecksum(msg, in result, BridgeCouldBeNull);
+                return;
+            }
+
             _readStatus = ReadStatus.DequeueResult;
             lock (_writtenAwaitingResponse)
             {
+                if (msg is not null)
+                {
+                    _awaitingChecksum = null;
+                }
+
                 if (!_writtenAwaitingResponse.TryDequeue(out msg))
                 {
                     throw new InvalidOperationException("Received response with no message waiting: " + result.ToString());
@@ -1696,10 +1729,54 @@ namespace StackExchange.Redis
             if (msg.ComputeResult(this, result))
             {
                 _readStatus = msg.ResultBoxIsAsync ? ReadStatus.CompletePendingMessageAsync : ReadStatus.CompletePendingMessageSync;
-                msg.Complete();
+                if (!msg.IsHighIntegrity)
+                {
+                    // can't complete yet if needs checksum
+                    msg.Complete();
+                }
             }
+            if (msg.IsHighIntegrity)
+            {
+                // stash this for the next non-OOB response
+                Volatile.Write(ref _awaitingChecksum, msg);
+            }
+
+
             _readStatus = ReadStatus.MatchResultComplete;
             _activeMessage = null;
+
+            static void ProcessHighIntegrityResponseChecksum(Message message, in RawResult result, PhysicalBridge? bridge)
+            {
+                bool isValid = false;
+                if (result.Resp2TypeBulkString == ResultType.BulkString)
+                {
+                    var payload = result.Payload;
+                    if (payload.Length == 4)
+                    {
+                        int interpreted;
+                        if (payload.IsSingleSegment)
+                        {
+                            interpreted = BinaryPrimitives.ReadInt32LittleEndian(payload.First.Span);
+                        }
+                        else
+                        {
+                            Span<byte> span = stackalloc byte[4];
+                            payload.CopyTo(span);
+                            interpreted = BinaryPrimitives.ReadInt32LittleEndian(payload.First.Span);
+                        }
+                        isValid = interpreted == message.HighIntegrityChecksum;
+                    }
+                }
+                if (isValid)
+                {
+                    message.Complete();
+                }
+                else
+                {
+                    message.SetExceptionAndComplete(new InvalidOperationException("High-integrity mode detected possible protocol de-sync"), bridge);
+                }
+                
+            }
 
             static bool TryGetPubSubPayload(in RawResult value, out RedisValue parsed, bool allowArraySingleton = true)
             {
@@ -2032,6 +2109,7 @@ namespace StackExchange.Redis
             PubSubPMessage,
             Reconfigure,
             InvokePubSub,
+            ResponseChecksum, // high-integrity mode only
             DequeueResult,
             ComputeResult,
             CompletePendingMessageSync,

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -236,6 +236,8 @@ StackExchange.Redis.ConfigurationOptions.HeartbeatConsistencyChecks.get -> bool
 StackExchange.Redis.ConfigurationOptions.HeartbeatConsistencyChecks.set -> void
 StackExchange.Redis.ConfigurationOptions.HeartbeatInterval.get -> System.TimeSpan
 StackExchange.Redis.ConfigurationOptions.HeartbeatInterval.set -> void
+StackExchange.Redis.ConfigurationOptions.HighIntegrity.get -> bool
+StackExchange.Redis.ConfigurationOptions.HighIntegrity.set -> void
 StackExchange.Redis.ConfigurationOptions.HighPrioritySocketThreads.get -> bool
 StackExchange.Redis.ConfigurationOptions.HighPrioritySocketThreads.set -> void
 StackExchange.Redis.ConfigurationOptions.IncludeDetailInExceptions.get -> bool
@@ -1801,6 +1803,7 @@ virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.GetDefaultSsl(S
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.GetSslHostFromEndpoints(StackExchange.Redis.EndPointCollection! endPoints) -> string?
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HeartbeatConsistencyChecks.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HeartbeatInterval.get -> System.TimeSpan
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HighIntegrity.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IncludeDetailInExceptions.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IncludePerformanceCountersInExceptions.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IsMatch(System.Net.EndPoint! endpoint) -> bool

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -321,6 +321,7 @@ StackExchange.Redis.ConnectionFailureType.ProtocolFailure = 4 -> StackExchange.R
 StackExchange.Redis.ConnectionFailureType.SocketClosed = 6 -> StackExchange.Redis.ConnectionFailureType
 StackExchange.Redis.ConnectionFailureType.SocketFailure = 2 -> StackExchange.Redis.ConnectionFailureType
 StackExchange.Redis.ConnectionFailureType.UnableToConnect = 9 -> StackExchange.Redis.ConnectionFailureType
+StackExchange.Redis.ConnectionFailureType.ResponseIntegrityFailure = 10 -> StackExchange.Redis.ConnectionFailureType
 StackExchange.Redis.ConnectionFailureType.UnableToResolvePhysicalConnection = 1 -> StackExchange.Redis.ConnectionFailureType
 StackExchange.Redis.ConnectionMultiplexer
 StackExchange.Redis.ConnectionMultiplexer.ClientName.get -> string!

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿#nullable enable

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
-﻿
+﻿StackExchange.Redis.ConfigurationOptions.HighIntegrity.get -> bool
+StackExchange.Redis.ConfigurationOptions.HighIntegrity.set -> void
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HighIntegrity.get -> bool

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
-﻿StackExchange.Redis.ConfigurationOptions.HighIntegrity.get -> bool
-StackExchange.Redis.ConfigurationOptions.HighIntegrity.set -> void
-virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HighIntegrity.get -> bool
+﻿

--- a/tests/BasicTest/BasicTest.csproj
+++ b/tests/BasicTest/BasicTest.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>BasicTest</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BasicTest</PackageId>
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+    <!--<RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BasicTestBaseline/BasicTestBaseline.csproj
+++ b/tests/BasicTestBaseline/BasicTestBaseline.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>BasicTestBaseline</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BasicTestBaseline</PackageId>
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+    <!--<RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>-->
     <DefineConstants>$(DefineConstants);TEST_BASELINE</DefineConstants>
   </PropertyGroup>
 

--- a/tests/ConsoleTest/Program.cs
+++ b/tests/ConsoleTest/Program.cs
@@ -6,13 +6,24 @@ Stopwatch stopwatch = new Stopwatch();
 stopwatch.Start();
 
 var options = ConfigurationOptions.Parse("localhost");
+#if !SEREDIS_BASELINE
+options.HighIntegrity = false; // as needed
+Console.WriteLine($"{nameof(options.HighIntegrity)}: {options.HighIntegrity}");
+#endif
+
 //options.SocketManager = SocketManager.ThreadPool;
 var connection = ConnectionMultiplexer.Connect(options);
+connection.ConnectionFailed += Connection_ConnectionFailed;
+
+void Connection_ConnectionFailed(object? sender, ConnectionFailedEventArgs e)
+{
+    Console.Error.WriteLine($"CONNECTION FAILED: {e.ConnectionType}, {e.FailureType}, {e.Exception}");
+}
 
 var startTime = DateTime.UtcNow;
 var startCpuUsage = Process.GetCurrentProcess().TotalProcessorTime;
 
-var scenario = args?.Length > 0 ? args[0] : "parallel";
+var scenario = args?.Length > 0 ? args[0] : "mass-insert";
 
 switch (scenario)
 {

--- a/tests/ConsoleTestBaseline/ConsoleTestBaseline.csproj
+++ b/tests/ConsoleTestBaseline/ConsoleTestBaseline.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);SEREDIS_BASELINE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Tests/BasicOpTests.cs
+++ b/tests/StackExchange.Redis.Tests/BasicOpTests.cs
@@ -477,4 +477,42 @@ public class BasicOpsTests : TestBase
         int count = (int)conn.GetDatabase().StringGet("abc" + key);
         Assert.Equal(3, count);
     }
+
+    [Fact]
+    public void TransactionSync()
+    {
+        using var conn = Create();
+        var db = conn.GetDatabase();
+
+        RedisKey key = Me();
+
+        var tran = db.CreateTransaction();
+        _ = db.KeyDeleteAsync(key);
+        var x = tran.StringIncrementAsync(Me());
+        var y = tran.StringIncrementAsync(Me());
+        var z = tran.StringIncrementAsync(Me());
+        Assert.True(tran.Execute());
+        Assert.Equal(1, x.Result);
+        Assert.Equal(2, y.Result);
+        Assert.Equal(3, z.Result);
+    }
+
+    [Fact]
+    public async Task TransactionAsync()
+    {
+        await using var conn = Create();
+        var db = conn.GetDatabase();
+
+        RedisKey key = Me();
+
+        var tran = db.CreateTransaction();
+        _ = db.KeyDeleteAsync(key);
+        var x = tran.StringIncrementAsync(Me());
+        var y = tran.StringIncrementAsync(Me());
+        var z = tran.StringIncrementAsync(Me());
+        Assert.True(await tran.ExecuteAsync());
+        Assert.Equal(1, await x);
+        Assert.Equal(2, await y);
+        Assert.Equal(3, await z);
+    }
 }

--- a/tests/StackExchange.Redis.Tests/BasicOpTests.cs
+++ b/tests/StackExchange.Redis.Tests/BasicOpTests.cs
@@ -8,9 +8,17 @@ using Xunit.Abstractions;
 namespace StackExchange.Redis.Tests;
 
 [Collection(SharedConnectionFixture.Key)]
+public class HighIntegrityBasicOpsTests : BasicOpsTests
+{
+    public HighIntegrityBasicOpsTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
+
+    internal override bool HighIntegrity => true;
+}
+
+[Collection(SharedConnectionFixture.Key)]
 public class BasicOpsTests : TestBase
 {
-    public BasicOpsTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base (output, fixture) { }
+    public BasicOpsTests(ITestOutputHelper output, SharedConnectionFixture fixture) : base(output, fixture) { }
 
     [Fact]
     public async Task PingOnce()

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -760,4 +760,25 @@ public class ConfigTests : TestBase
         Assert.Equal(setlib, options.SetClientLibrary);
         Assert.Equal(configurationString, options.ToString());
     }
+
+    [Theory]
+    [InlineData(null, false, "dummy")]
+    [InlineData(false, false, "dummy,highIntegrity=False")]
+    [InlineData(true, true, "dummy,highIntegrity=True")]
+    public void CheckHighIntegrity(bool? assigned, bool expected, string cs)
+    {
+        var options = ConfigurationOptions.Parse("dummy");
+        if (assigned.HasValue) options.HighIntegrity = assigned.Value;
+
+        Assert.Equal(expected, options.HighIntegrity);
+        Assert.Equal(cs, options.ToString());
+
+        var clone = options.Clone();
+        Assert.Equal(expected, clone.HighIntegrity);
+        Assert.Equal(cs, clone.ToString());
+
+        var parsed = ConfigurationOptions.Parse(cs);
+        Assert.Equal(expected, options.HighIntegrity);
+
+    }
 }

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -43,7 +43,7 @@ public class ConfigTests : TestBase
             "configChannel", "configCheckSeconds", "connectRetry",
             "connectTimeout", "DefaultDatabase", "defaultOptions",
             "defaultVersion", "EndPoints", "heartbeatConsistencyChecks",
-            "heartbeatInterval", "includeDetailInExceptions", "includePerformanceCountersInExceptions",
+            "heartbeatInterval", "highIntegrity", "includeDetailInExceptions", "includePerformanceCountersInExceptions",
             "keepAlive", "LibraryName", "loggerFactory",
             "password", "Protocol", "proxy",
             "reconnectRetryPolicy", "resolveDns", "responseTimeout",

--- a/tests/StackExchange.Redis.Tests/ConnectCustomConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectCustomConfigTests.cs
@@ -93,7 +93,7 @@ public class ConnectCustomConfigTests : TestBase
     }
 
     [Theory]
-    [InlineData(true, 5, 15)]
+    [InlineData(true, 4, 15)]
     [InlineData(false, 0, 0)]
     public async Task HeartbeatConsistencyCheckPingsAsync(bool enableConsistencyChecks, int minExpected, int maxExpected)
     {

--- a/tests/StackExchange.Redis.Tests/ResultBoxTests.cs
+++ b/tests/StackExchange.Redis.Tests/ResultBoxTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+public class ResultBoxTests
+{
+    [Fact]
+    public void SyncResultBox()
+    {
+        var msg = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
+        var box = SimpleResultBox<string>.Get();
+        Assert.False(box.IsAsync);
+
+        int activated = 0;
+        lock (box)
+        {
+            Task.Run(() =>
+            {
+                lock (box)
+                {
+                    // release the worker to start work
+                    Monitor.PulseAll(box);
+
+                    // wait for the completion signal
+                    if (Monitor.Wait(box, TimeSpan.FromSeconds(10)))
+                    {
+                        Interlocked.Increment(ref activated);
+                    }
+                }
+            });
+            Assert.True(Monitor.Wait(box, TimeSpan.FromSeconds(10)), "failed to handover lock to worker");
+        }
+
+        // check that continuation was not already signalled
+        Thread.Sleep(100);
+        Assert.Equal(0, Volatile.Read(ref activated));
+
+        msg.SetSource(ResultProcessor.DemandOK, box);
+        Assert.True(msg.TrySetResult("abc"));
+
+        // check that TrySetResult did not signal continuation
+        Thread.Sleep(100);
+        Assert.Equal(0, Volatile.Read(ref activated));
+
+        // check that complete signals continuation
+        msg.Complete();
+        Thread.Sleep(100);
+        Assert.Equal(1, Volatile.Read(ref activated));
+
+        var s = box.GetResult(out var ex);
+        Assert.Null(ex);
+        Assert.NotNull(s);
+        Assert.Equal("abc", s);
+    }
+
+    [Fact]
+    public void TaskResultBox()
+    {
+        // TaskResultBox currently uses a stating field for values before activations are
+        // signalled; High Integrity Mode *demands* this behaviour, so: validate that it
+        // works correctly
+        var msg = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
+        var box = TaskResultBox<string>.Create(out var tcs, null);
+        Assert.True(box.IsAsync);
+
+        msg.SetSource(ResultProcessor.DemandOK, box);
+        Assert.True(msg.TrySetResult("abc"));
+
+        // check that continuation was not already signalled
+        Thread.Sleep(100);
+        Assert.False(tcs.Task.IsCompleted);
+
+        msg.SetSource(ResultProcessor.DemandOK, box);
+        Assert.True(msg.TrySetResult("abc"));
+
+        // check that TrySetResult did not signal continuation
+        Thread.Sleep(100);
+        Assert.False(tcs.Task.IsCompleted);
+
+        // check that complete signals continuation
+        msg.Complete();
+        Thread.Sleep(100);
+        Assert.True(tcs.Task.IsCompleted);
+
+        var s = box.GetResult(out var ex);
+        Assert.Null(ex);
+        Assert.NotNull(s);
+        Assert.Equal("abc", s);
+
+        Assert.Equal("abc", tcs.Task.Result); // we already checked IsCompleted
+    }
+}

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -394,7 +394,8 @@ public abstract class TestBase : IDisposable
         bool logTransactionData = true,
         int? defaultDatabase = null,
         BacklogPolicy? backlogPolicy = null,
-        RedisProtocol? protocol = null, bool highIntegrity = false,
+        RedisProtocol? protocol = null,
+        bool highIntegrity = false,
         [CallerMemberName] string caller = "")
     {
         StringWriter? localLog = null;


### PR DESCRIPTION
Fixes #2706

This adds additional `ECHO` items after every outbound request, and adds validation of that correlation marker before treating responses as valid.

This is initial draft only; needs conversion to sequence and testing of failure modes.

#### Discussion points
- [x] Entropy vs counter - Going with Counter
- [x] Naming
- [ ] Confidence testing (success and failure)
- [x] Performance impact testing
- [x] Depending on performance impact: should this be defaulted for any scenarios? azure?
- [x] Needs checks of sync vs async, F+F, etc