### PR TITLE
AutoConfigure detects protocol failure HeartBeats allow ReplicaReconfig

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -610,19 +610,19 @@ namespace StackExchange.Redis
                                 checkConfigSeconds = ServerEndPoint.ConfigCheckSeconds;
 
                             if (state == (int)State.ConnectedEstablished && ConnectionType == ConnectionType.Interactive
-                                && tmp.BridgeCouldBeNull?.Multiplexer.RawConfig.HeartbeatConsistencyChecks == true)
+                                && checkConfigSeconds > 0 && ServerEndPoint.LastInfoReplicationCheckSecondsAgo >= checkConfigSeconds
+                                && ServerEndPoint.CheckInfoReplication())
+                            {
+                                // that serves as a keep-alive, if it is accepted
+                            }
+                            else if (state == (int)State.ConnectedEstablished && ConnectionType == ConnectionType.Interactive
+                                 && tmp.BridgeCouldBeNull?.Multiplexer.RawConfig.HeartbeatConsistencyChecks == true)
                             {
                                 // If HeartbeatConsistencyChecks are enabled, we're sending a PING (expecting PONG) or ECHO (expecting UniqueID back) every single
                                 // heartbeat as an opt-in measure to react to any network stream drop ASAP to terminate the connection as faulted.
                                 // If we don't get the expected response to that command, then the connection is terminated.
                                 // This is to prevent the case of things like 100% string command usage where a protocol error isn't otherwise encountered.
                                 KeepAlive(forceRun: true);
-                            }
-                            else if (state == (int)State.ConnectedEstablished && ConnectionType == ConnectionType.Interactive
-                                && checkConfigSeconds > 0 && ServerEndPoint.LastInfoReplicationCheckSecondsAgo >= checkConfigSeconds
-                                && ServerEndPoint.CheckInfoReplication())
-                            {
-                                // that serves as a keep-alive, if it is accepted
                             }
                             else if (writeEverySeconds > 0 && tmp.LastWriteSecondsAgo >= writeEverySeconds)
                             {


### PR DESCRIPTION
When connecting to a Redis Cluster and enabling the `HeartbeatConsistencyChecks` this prevents `CheckInfoReplication()` from ever being called and `ConfigCheckSeconds` is no longer respected.

This change will do the replication check but adds the `RecordConnectionFailed` like the `TracerProcessor` was doing for `HeartbeatConsistencyChecks`.

I haven't been able to run all the tests locally so I'm not sure if this change breaks anything, but was able to build the package and use it successfully.

The main thing I would be concerned about is if there are scenarios that AutoConfigureProcessor shouldn't parse anything, this would be recorded as a protocol failure.

This should fix the issue mentioned in #2778.