### PR TITLE
Fix #2785: Support optionally disabling pipelining on AUTH flow

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -100,6 +100,7 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | setlib={bool}          | `SetClientLibrary`     | `true`                       | Whether to attempt to use `CLIENT SETINFO` to set the library name/version on the connection              |
 | protocol={string}      | `Protocol`             | `null`                       | Redis protocol to use; see section below                                                                  |
 | highIntegrity={bool}   | `HighIntegrity`        | `false`                      | High integrity (incurs overhead) sequence checking on every command; see section below                    |
+| waitForAuth={bool}     | `WaitForAuth`          | `false`                      | Wait before the result of the `AUTH` command is returned before trying to send any other commands to the server |
 
 Additional code-only options:
 - LoggerFactory (`ILoggerFactory`) - Default: `null`

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -116,6 +116,17 @@ namespace StackExchange.Redis.Configuration
         public virtual bool HighIntegrity => false;
 
         /// <summary>
+        /// A Boolean value that specifies whether the client should wait for the server to return
+        /// response for the initial AUTH command before trying any further commands.
+        /// </summary>
+        /// <remarks>
+        /// This is especially useful when connecting to Envoy proxies with external authentication
+        /// providers.
+        /// The default and recommended value is false.
+        /// </remarks>
+        public virtual bool WaitForAuth => false;
+
+        /// <summary>
         /// The number of times to repeat the initial connect cycle if no servers respond promptly.
         /// </summary>
         public virtual int ConnectRetry => 3;

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -254,6 +254,8 @@ StackExchange.Redis.ConfigurationOptions.HeartbeatInterval.get -> System.TimeSpa
 StackExchange.Redis.ConfigurationOptions.HeartbeatInterval.set -> void
 StackExchange.Redis.ConfigurationOptions.HighIntegrity.get -> bool
 StackExchange.Redis.ConfigurationOptions.HighIntegrity.set -> void
+StackExchange.Redis.ConfigurationOptions.WaitForAuth.get -> bool
+StackExchange.Redis.ConfigurationOptions.WaitForAuth.set -> void
 StackExchange.Redis.ConfigurationOptions.HighPrioritySocketThreads.get -> bool
 StackExchange.Redis.ConfigurationOptions.HighPrioritySocketThreads.set -> void
 StackExchange.Redis.ConfigurationOptions.IncludeDetailInExceptions.get -> bool
@@ -1846,6 +1848,7 @@ virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.GetSslHostFromE
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HeartbeatConsistencyChecks.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HeartbeatInterval.get -> System.TimeSpan
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.HighIntegrity.get -> bool
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.WaitForAuth.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IncludeDetailInExceptions.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IncludePerformanceCountersInExceptions.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.IsMatch(System.Net.EndPoint! endpoint) -> bool

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -85,6 +85,7 @@ public class ConfigTests : TestBase
                 "tieBreaker",
                 "Tunnel",
                 "user",
+                "waitForAuth",
             },
             fields);
     }
@@ -810,5 +811,25 @@ public class ConfigTests : TestBase
 
         var parsed = ConfigurationOptions.Parse(cs);
         Assert.Equal(expected, options.HighIntegrity);
+    }
+
+    [Theory]
+    [InlineData(null, false, "dummy")]
+    [InlineData(false, false, "dummy,waitForAuth=False")]
+    [InlineData(true, true, "dummy,waitForAuth=True")]
+    public void CheckWaitForAuth(bool? assigned, bool expected, string cs)
+    {
+        var options = ConfigurationOptions.Parse("dummy");
+        if (assigned.HasValue) options.WaitForAuth = assigned.Value;
+
+        Assert.Equal(expected, options.WaitForAuth);
+        Assert.Equal(cs, options.ToString());
+
+        var clone = options.Clone();
+        Assert.Equal(expected, clone.WaitForAuth);
+        Assert.Equal(cs, clone.ToString());
+
+        var parsed = ConfigurationOptions.Parse(cs);
+        Assert.Equal(expected, options.WaitForAuth);
     }
 }

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -262,6 +262,7 @@ public abstract class TestBase : IDisposable
         BacklogPolicy? backlogPolicy = null,
         Version? require = null,
         RedisProtocol? protocol = null,
+        bool? waitForAuth = null,
         [CallerMemberName] string caller = "")
     {
         if (Output == null)
@@ -314,6 +315,7 @@ public abstract class TestBase : IDisposable
             backlogPolicy,
             protocol,
             highIntegrity,
+            waitForAuth,
             caller);
 
         ThrowIfIncorrectProtocol(conn, protocol);
@@ -409,6 +411,7 @@ public abstract class TestBase : IDisposable
         BacklogPolicy? backlogPolicy = null,
         RedisProtocol? protocol = null,
         bool highIntegrity = false,
+        bool? waitForAuth = null,
         [CallerMemberName] string caller = "")
     {
         StringWriter? localLog = null;
@@ -445,6 +448,7 @@ public abstract class TestBase : IDisposable
             if (backlogPolicy is not null) config.BacklogPolicy = backlogPolicy;
             if (protocol is not null) config.Protocol = protocol;
             if (highIntegrity) config.HighIntegrity = highIntegrity;
+            if (waitForAuth is not null) config.WaitForAuth = waitForAuth.Value;
             var watch = Stopwatch.StartNew();
             var task = ConnectionMultiplexer.ConnectAsync(config, log);
             if (!task.Wait(config.ConnectTimeout >= (int.MaxValue / 2) ? int.MaxValue : config.ConnectTimeout * 2))


### PR DESCRIPTION
resolves #2785 

This PR is (for now) an initial proposal for fixing the issue mentioned above.
With the new _external authentication_ feature of _Envoy_, pipelining AUTH with further commands can cause unexpected behavior where we see `+OK` for AUTH, followed by `NOAUTH` for the critical trace.

We fix this by adding an **optional** `ConfigurationOptions` flag that disables this behaviour.