### PR TITLE
Always perform "last read" check in heartbeat when HeartbeatConsistencyChecks is enabled

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,8 @@ Current package versions:
 | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
 ## Unreleased
-No pending unreleased changes.
+
+- Fix: PhysicalBridge: Always perform "last read" check in heartbeat when `HeartbeatConsistencyChecks` is enabled ([#2795 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2795))
 
 ## 2.8.14
 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -652,7 +652,9 @@ namespace StackExchange.Redis
                                 // so if we have an empty unsent queue and a non-empty sent queue, test the socket.
                                 KeepAlive();
                             }
-                            else if (timedOutThisHeartbeat > 0
+
+                            // This is an "always" check - we always want to evaluate a dead connection from a non-responsive sever regardless of the need to heartbeat above
+                            if (timedOutThisHeartbeat > 0
                                 && tmp.LastReadSecondsAgo * 1_000 > (tmp.BridgeCouldBeNull?.Multiplexer.AsyncTimeoutMilliseconds * 4))
                             {
                                 // If we've received *NOTHING* on the pipe in 4 timeouts worth of time and we're timing out commands, issue a connection failure so that we reconnect


### PR DESCRIPTION
When we have slowly adding things to the heartbeat (originally intended just to send data to keep connections alive) like detecting connection health, the if/else has gotten more complicated. With the addition of `HeartbeatConsistencyChecks`, we prevented some fall throughs to later checks which means that if that option is enabled, we were no longer detecting dead sockets as intended.

This is a tactical fix for the combination, but I think overall we should look at refactoring how this entire method works because shoehorning these things into the original structure/purpose has been problematic several times.