### PR TITLE
Automatically detect and tune for Azure Managed Redis caches

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ Current package versions:
 
 - Format IPv6 endpoints correctly when rewriting configration strings ([#2813 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2813))
 - Update default Redis version from 4.0.0 to 6.0.0 for Azure Redis resources ([#2810 by philon-msft](https://github.com/StackExchange/StackExchange.Redis/pull/2810))
+- Detect Azure Managed Redis caches and tune default connection settings for them ([#2818 by philon-msft](https://github.com/StackExchange/StackExchange.Redis/pull/2818))
 
 ## 2.8.16
 

--- a/src/StackExchange.Redis/Configuration/AzureOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/AzureOptionsProvider.cs
@@ -21,7 +21,7 @@ namespace StackExchange.Redis.Configuration
         public override Version DefaultVersion => RedisFeatures.v6_0_0;
 
         /// <summary>
-        /// List of domains known to be Azure Redis, so we can light up some helpful functionality
+        /// Lists of domains known to be Azure Redis, so we can light up some helpful functionality
         /// for minimizing downtime during maintenance events and such.
         /// </summary>
         private static readonly string[] azureRedisDomains = new[]
@@ -29,8 +29,14 @@ namespace StackExchange.Redis.Configuration
             ".redis.cache.windows.net",
             ".redis.cache.chinacloudapi.cn",
             ".redis.cache.usgovcloudapi.net",
-            ".redis.cache.cloudapi.de",
             ".redisenterprise.cache.azure.net",
+        };
+
+        private static readonly string[] azureManagedRedisDomains = new[]
+        {
+            ".redis.azure.net",
+            ".redis.chinacloudapi.cn",
+            ".redis.usgovcloudapi.net",
         };
 
         /// <inheritdoc/>
@@ -38,14 +44,25 @@ namespace StackExchange.Redis.Configuration
         {
             if (endpoint is DnsEndPoint dnsEp)
             {
-                foreach (var host in azureRedisDomains)
+                if (IsHostInDomains(dnsEp.Host, azureRedisDomains) || IsHostInDomains(dnsEp.Host, azureManagedRedisDomains))
                 {
-                    if (dnsEp.Host.EndsWith(host, StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
+
+            return false;
+        }
+
+        private bool IsHostInDomains(string hostName, string[] domains)
+        {
+            foreach (var domain in domains)
+            {
+                if (hostName.EndsWith(domain, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
 
@@ -64,6 +81,10 @@ namespace StackExchange.Redis.Configuration
                         if (dns.Port == 6380)
                         {
                             return true;
+                        }
+                        if (dns.Port == 10000 && IsHostInDomains(dns.Host, azureManagedRedisDomains))
+                        {
+                            return true; // SSL is enabled by default on AMR caches
                         }
                         break;
                     case IPEndPoint ip:

--- a/tests/StackExchange.Redis.Tests/DefaultOptionsTests.cs
+++ b/tests/StackExchange.Redis.Tests/DefaultOptionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -63,6 +64,21 @@ public class DefaultOptionsTests : TestBase
         epc = new EndPointCollection(new List<EndPoint>() { new DnsEndPoint("local.nottestdomain", 0) });
         provider = DefaultOptionsProvider.GetProvider(epc);
         Assert.IsType<DefaultOptionsProvider>(provider);
+    }
+
+    [Theory]
+    [InlineData("contoso.redis.cache.windows.net")]
+    [InlineData("contoso.REDIS.CACHE.chinacloudapi.cn")] // added a few upper case chars to validate comparison
+    [InlineData("contoso.redis.cache.usgovcloudapi.net")]
+    [InlineData("contoso.redisenterprise.cache.azure.net")]
+    [InlineData("contoso.redis.azure.net")]
+    [InlineData("contoso.redis.chinacloudapi.cn")]
+    [InlineData("contoso.redis.usgovcloudapi.net")]
+    public void IsMatchOnAzureDomain(string hostName)
+    {
+        var epc = new EndPointCollection(new List<EndPoint>() { new DnsEndPoint(hostName, 0) });
+        var provider = DefaultOptionsProvider.GetProvider(epc);
+        Assert.IsType<AzureOptionsProvider>(provider);
     }
 
     [Fact]


### PR DESCRIPTION
Detect when connecting to a new Azure Managed Redis cache, and adjust default connection settings to align with their capabilities. 

More about Azure Managed Redis: https://learn.microsoft.com/azure/azure-cache-for-redis/managed-redis/managed-redis-overview