### PR TITLE
update envoy defs to allow `UNWATCH`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,8 @@ Current package versions:
 | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
 ## Unreleased
-No pending unreleased changes.
+
+- Update *envoy* command definitions to [allow `UNWATCH`](https://github.com/envoyproxy/envoy/pull/37620) ([#2824 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2824))
 
 ## 2.8.22
 

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -59,8 +59,6 @@ namespace StackExchange.Redis
 
             RedisCommand.PSUBSCRIBE, RedisCommand.PUNSUBSCRIBE, RedisCommand.SUBSCRIBE, RedisCommand.UNSUBSCRIBE,
 
-            RedisCommand.UNWATCH,
-
             RedisCommand.SCRIPT,
 
             RedisCommand.SELECT,


### PR DESCRIPTION
Fix #2823 in combination with https://github.com/envoyproxy/envoy/pull/37620

Note that in passing it occurs that this is an exclusion list, and these exclusions have not been kept up-to-date with new command additions; consequently, the exclusion lists may be incomplete in a few cases. This isn't a *huge* problem - the command will still fail, but it will fail at the proxy or server instead of at the client.