### PR TITLE
add minId overloads

### DIFF
--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -2780,10 +2780,12 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="key">The key of the stream.</param>
         /// <param name="minId">All entries with an id (timestamp) earlier minId will be removed.</param>
+        /// <param name="useApproximateMaxLength">If true, the "~" argument is used to allow the stream to exceed minId by a small number. This improves performance when removing messages.</param>
+        /// <param name="limit">The maximum number of entries to remove per call when useApproximateMaxLength = true. If 0, the limiting mechanism is disabled entirely.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages removed from the stream.</returns>
         /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
-        long StreamTrim(RedisKey key, RedisValue minId, CommandFlags flags);
+        long StreamTrimByMinId(RedisKey key, RedisValue minId, bool useApproximateMaxLength = false, int? limit = null, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
         /// If key already exists and is a string, this command appends the value at the end of the string.

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -2776,6 +2776,16 @@ namespace StackExchange.Redis
         long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Trim the stream to a specified minimum timestamp.
+        /// </summary>
+        /// <param name="key">The key of the stream.</param>
+        /// <param name="minId">All entries less than minId will be removed.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>The number of messages removed from the stream.</returns>
+        /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>
+        long StreamTrim(RedisKey key, RedisValue minId, CommandFlags flags);
+
+        /// <summary>
         /// If key already exists and is a string, this command appends the value at the end of the string.
         /// If key does not exist it is created and set as an empty string, so APPEND will be similar to SET in this special case.
         /// </summary>

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -2779,7 +2779,7 @@ namespace StackExchange.Redis
         /// Trim the stream to a specified minimum timestamp.
         /// </summary>
         /// <param name="key">The key of the stream.</param>
-        /// <param name="minId">All entries less than minId will be removed.</param>
+        /// <param name="minId">All entries with an id (timestamp) earlier minId will be removed.</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The number of messages removed from the stream.</returns>
         /// <remarks><seealso href="https://redis.io/topics/streams-intro"/></remarks>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -672,6 +672,9 @@ namespace StackExchange.Redis
         /// <inheritdoc cref="IDatabase.StreamTrim(RedisKey, int, bool, CommandFlags)"/>
         Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
+        /// <inheritdoc cref="IDatabase.StreamTrim(RedisKey, RedisValue, CommandFlags)"/>
+        Task<long> StreamTrimAsync(RedisKey key, RedisValue minId, CommandFlags flags);
+
         /// <inheritdoc cref="IDatabase.StringAppend(RedisKey, RedisValue, CommandFlags)"/>
         Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -672,8 +672,8 @@ namespace StackExchange.Redis
         /// <inheritdoc cref="IDatabase.StreamTrim(RedisKey, int, bool, CommandFlags)"/>
         Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None);
 
-        /// <inheritdoc cref="IDatabase.StreamTrim(RedisKey, RedisValue, CommandFlags)"/>
-        Task<long> StreamTrimAsync(RedisKey key, RedisValue minId, CommandFlags flags);
+        /// <inheritdoc cref="IDatabase.StreamTrimByMinId(RedisKey, RedisValue, bool, int?, CommandFlags)"/>
+        Task<long> StreamTrimByMinIdAsync(RedisKey key, RedisValue minId, bool useApproximateMaxLength = false, int? limit = null, CommandFlags flags = CommandFlags.None);
 
         /// <inheritdoc cref="IDatabase.StringAppend(RedisKey, RedisValue, CommandFlags)"/>
         Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None);

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -642,8 +642,8 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None) =>
             Inner.StreamTrimAsync(ToInner(key), maxLength, useApproximateMaxLength, flags);
 
-        public Task<long> StreamTrimAsync(RedisKey key, RedisValue minId, CommandFlags flags) =>
-            Inner.StreamTrimAsync(ToInner(key), minId, flags);
+        public Task<long> StreamTrimByMinIdAsync(RedisKey key, RedisValue minId, bool useApproximateMaxLength = false, int? limit = null, CommandFlags flags = CommandFlags.None) =>
+            Inner.StreamTrimByMinIdAsync(ToInner(key), minId, useApproximateMaxLength, limit, flags);
 
         public Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None) =>
             Inner.StringAppendAsync(ToInner(key), value, flags);

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -642,6 +642,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None) =>
             Inner.StreamTrimAsync(ToInner(key), maxLength, useApproximateMaxLength, flags);
 
+        public Task<long> StreamTrimAsync(RedisKey key, RedisValue minId, CommandFlags flags) =>
+            Inner.StreamTrimAsync(ToInner(key), minId, flags);
+
         public Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None) =>
             Inner.StringAppendAsync(ToInner(key), value, flags);
 

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -624,8 +624,8 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None) =>
             Inner.StreamTrim(ToInner(key), maxLength, useApproximateMaxLength, flags);
 
-        public long StreamTrim(RedisKey key, RedisValue minId, CommandFlags flags) =>
-            Inner.StreamTrim(ToInner(key), minId, flags);
+        public long StreamTrimByMinId(RedisKey key, RedisValue minId, bool useApproximateMaxLength = false, int? limit = null, CommandFlags flags = CommandFlags.None) =>
+            Inner.StreamTrimByMinId(ToInner(key), minId, useApproximateMaxLength, limit, flags);
 
         public long StringAppend(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None) =>
             Inner.StringAppend(ToInner(key), value, flags);

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -624,6 +624,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None) =>
             Inner.StreamTrim(ToInner(key), maxLength, useApproximateMaxLength, flags);
 
+        public long StreamTrim(RedisKey key, RedisValue minId, CommandFlags flags) =>
+            Inner.StreamTrim(ToInner(key), minId, flags);
+
         public long StringAppend(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None) =>
             Inner.StringAppend(ToInner(key), value, flags);
 

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 ﻿#nullable enable
-StackExchange.Redis.IDatabase.StreamTrim(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue minId, StackExchange.Redis.CommandFlags flags) -> long
-StackExchange.Redis.IDatabaseAsync.StreamTrimAsync(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue minId, StackExchange.Redis.CommandFlags flags) -> System.Threading.Tasks.Task<long>!
+StackExchange.Redis.IDatabase.StreamTrimByMinId(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue minId, bool useApproximateMaxLength = false, int? limit = null, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long
+StackExchange.Redis.IDatabaseAsync.StreamTrimByMinIdAsync(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue minId, bool useApproximateMaxLength = false, int? limit = null, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long>!

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+StackExchange.Redis.IDatabase.StreamTrim(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue minId, StackExchange.Redis.CommandFlags flags) -> long
+StackExchange.Redis.IDatabaseAsync.StreamTrimAsync(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue minId, StackExchange.Redis.CommandFlags flags) -> System.Threading.Tasks.Task<long>!

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3007,6 +3007,20 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
+        public long StreamTrim(RedisKey key, RedisValue minId, CommandFlags flags = CommandFlags.None)
+        {
+            var values = new[] { StreamConstants.MinId, minId };
+            var msg = Message.Create(Database, flags, RedisCommand.XTRIM, key, values);
+            return ExecuteSync(msg, ResultProcessor.Int64);
+        }
+
+        public Task<long> StreamTrimAsync(RedisKey key, RedisValue minId, CommandFlags flags = CommandFlags.None)
+        {
+            var values = new[] { StreamConstants.MinId, minId };
+            var msg = Message.Create(Database, flags, RedisCommand.XTRIM, key, values);
+            return ExecuteAsync(msg, ResultProcessor.Int64);
+        }
+
         public long StringAppend(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(Database, flags, RedisCommand.APPEND, key, value);

--- a/src/StackExchange.Redis/StreamConstants.cs
+++ b/src/StackExchange.Redis/StreamConstants.cs
@@ -59,6 +59,7 @@
         internal static readonly RedisValue SetId = "SETID";
 
         internal static readonly RedisValue MaxLen = "MAXLEN";
+        internal static readonly RedisValue MinId = "MINID";
 
         internal static readonly RedisValue MkStream = "MKSTREAM";
 

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
@@ -1203,10 +1203,24 @@ public sealed class KeyPrefixedDatabaseTests
     }
 
     [Fact]
-    public void StreamTrimMinId()
+    public void StreamTrimByMinId()
     {
-        prefixed.StreamTrim("key", 1111111111, CommandFlags.None);
-        mock.Received().StreamTrim("prefix:key", 1111111111, CommandFlags.None);
+        prefixed.StreamTrimByMinId("key", 1111111111);
+        mock.Received().StreamTrimByMinId("prefix:key", 1111111111);
+    }
+
+    [Fact]
+    public void StreamTrimByMinIdWithApproximate()
+    {
+        prefixed.StreamTrimByMinId("key", 1111111111, useApproximateMaxLength: true);
+        mock.Received().StreamTrimByMinId("prefix:key", 1111111111, useApproximateMaxLength: true);
+    }
+
+    [Fact]
+    public void StreamTrimByMinIdWithApproximateAndLimit()
+    {
+        prefixed.StreamTrimByMinId("key", 1111111111, useApproximateMaxLength: true, limit: 100);
+        mock.Received().StreamTrimByMinId("prefix:key", 1111111111, useApproximateMaxLength: true, limit: 100);
     }
 
     [Fact]

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
@@ -1203,6 +1203,13 @@ public sealed class KeyPrefixedDatabaseTests
     }
 
     [Fact]
+    public void StreamTrimMinId()
+    {
+        prefixed.StreamTrim("key", 1111111111, CommandFlags.None);
+        mock.Received().StreamTrim("prefix:key", 1111111111, CommandFlags.None);
+    }
+
+    [Fact]
     public void StringAppend()
     {
         prefixed.StringAppend("key", "value", CommandFlags.None);

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
@@ -1119,10 +1119,24 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
-        public async Task StreamTrimMinIdAsync()
+        public async Task StreamTrimByMinIdAsync()
         {
-            await prefixed.StreamTrimAsync("key", 1111111111, CommandFlags.None);
-            await mock.Received().StreamTrimAsync("prefix:key", 1111111111, CommandFlags.None);
+            await prefixed.StreamTrimByMinIdAsync("key", 1111111111);
+            await mock.Received().StreamTrimByMinIdAsync("prefix:key", 1111111111);
+        }
+
+        [Fact]
+        public async Task StreamTrimByMinIdAsyncWithApproximate()
+        {
+            await prefixed.StreamTrimByMinIdAsync("key", 1111111111, useApproximateMaxLength: true);
+            await mock.Received().StreamTrimByMinIdAsync("prefix:key", 1111111111, useApproximateMaxLength: true);
+        }
+
+        [Fact]
+        public async Task StreamTrimByMinIdAsyncWithApproximateAndLimit()
+        {
+            await prefixed.StreamTrimByMinIdAsync("key", 1111111111, useApproximateMaxLength: true, limit: 100);
+            await mock.Received().StreamTrimByMinIdAsync("prefix:key", 1111111111, useApproximateMaxLength: true, limit: 100);
         }
 
         [Fact]

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
@@ -1119,6 +1119,13 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public async Task StreamTrimMinIdAsync()
+        {
+            await prefixed.StreamTrimAsync("key", 1111111111, CommandFlags.None);
+            await mock.Received().StreamTrimAsync("prefix:key", 1111111111, CommandFlags.None);
+        }
+
+        [Fact]
         public async Task StringAppendAsync()
         {
             await prefixed.StringAppendAsync("key", "value", CommandFlags.None);

--- a/tests/StackExchange.Redis.Tests/StreamTests.cs
+++ b/tests/StackExchange.Redis.Tests/StreamTests.cs
@@ -1933,7 +1933,7 @@ public class StreamTests : TestBase
         var len = db.StreamLength(key);
 
         Assert.Equal(1, numRemoved);
-        Assert.Equal(1, len);
+        Assert.Equal(2, len);
     }
 
     [Fact]

--- a/tests/StackExchange.Redis.Tests/StreamTests.cs
+++ b/tests/StackExchange.Redis.Tests/StreamTests.cs
@@ -1917,6 +1917,26 @@ public class StreamTests : TestBase
     }
 
     [Fact]
+    public void StreamTrimMinId()
+    {
+        using var conn = Create(require: RedisFeatures.v5_0_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+
+        // Add a couple items and check length.
+        db.StreamAdd(key, "field1", "value1", 1111111110);
+        db.StreamAdd(key, "field2", "value2", 1111111111);
+        db.StreamAdd(key, "field3", "value3", 1111111112);
+
+        var numRemoved = db.StreamTrim(key, 1111111111, CommandFlags.None);
+        var len = db.StreamLength(key);
+
+        Assert.Equal(2, numRemoved);
+        Assert.Equal(1, len);
+    }
+
+    [Fact]
     public void StreamVerifyLength()
     {
         using var conn = Create(require: RedisFeatures.v5_0_0);

--- a/tests/StackExchange.Redis.Tests/StreamTests.cs
+++ b/tests/StackExchange.Redis.Tests/StreamTests.cs
@@ -1932,7 +1932,7 @@ public class StreamTests : TestBase
         var numRemoved = db.StreamTrim(key, 1111111111, CommandFlags.None);
         var len = db.StreamLength(key);
 
-        Assert.Equal(2, numRemoved);
+        Assert.Equal(1, numRemoved);
         Assert.Equal(1, len);
     }
 


### PR DESCRIPTION
Fixes #1718

Initial commit. Still orienting on how to contribute.
It's building. Tests pass. 

Before I continue, does the diff look sane?

I think I got the "public api" situated correctly.

The strangest thing I ran into was this error about default parameters. I'm not sure if this is pushing me towards adding a new method rather than an overload, e.g. StreamTrimWithMinId. I took out the default CommandFlags to build successfully.

`error RS0026: Symbol 'StreamTrim' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'`

I'm having trouble running the tests locally. I tried running the tests before making any changes and ~2/3 passed. It might be because I don't have all the versions of .net installed.