### PR TITLE
Fix: Respect IReconnectRetryPolicy in disconnect loops

### DIFF
--- a/src/StackExchange.Redis/ExponentialRetry.cs
+++ b/src/StackExchange.Redis/ExponentialRetry.cs
@@ -8,7 +8,7 @@ namespace StackExchange.Redis
     public class ExponentialRetry : IReconnectRetryPolicy
     {
         private readonly int deltaBackOffMilliseconds;
-        private readonly int maxDeltaBackOffMilliseconds = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+        private readonly int maxDeltaBackOffMilliseconds = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
         [ThreadStatic]
         private static Random? r;
 


### PR DESCRIPTION
Fixes the case where we loop from `Connecting` -> `BeginConnectAsync` -> `OnDisconnected` and the next heartbeat triggers a reconnect again due to the backoff thresholds resetting. This ultimately causes the backoff to not be respected.

Here, we're doing 2 things:
- Upping the max exponential backoff window to 60 seconds which better handlers clients at scale and mass DDoS cases.
- Only resets the reconnect counter on the first disconnect, not doing so again until we've successfully reconnected and heartbeated again, so backoffs are properly respected.