### PR TITLE
Fix: Rexpect backoff in the disconnect -> resurrection case as well

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,7 +7,7 @@ Current package versions:
 | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
 ## Unreleased
-- Fix: Respect `IReconnectRetryPolicy` timing in the case that a node that was present disconnects indefinitely ([#2853 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2853))
+- Fix: Respect `IReconnectRetryPolicy` timing in the case that a node that was present disconnects indefinitely ([#2853](https://github.com/StackExchange/StackExchange.Redis/pull/2853) & [#2856](https://github.com/StackExchange/StackExchange.Redis/pull/2856) by NickCraver)
 - Changes max default retry policy backoff to 60 seconds ([#2853 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2853))
 - Fix [#2652](https://github.com/StackExchange/StackExchange.Redis/issues/2652): Track client-initiated shutdown for any pipe type ([#2814 by bgrainger](https://github.com/StackExchange/StackExchange.Redis/pull/2814))
 

--- a/tests/StackExchange.Redis.Tests/ConnectingFailDetectionTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConnectingFailDetectionTests.cs
@@ -18,6 +18,7 @@ public class ConnectingFailDetectionTests : TestBase
         try
         {
             using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false);
+            conn.RawConfig.ReconnectRetryPolicy = new LinearRetry(200);
 
             var db = conn.GetDatabase();
             db.Ping();
@@ -57,6 +58,7 @@ public class ConnectingFailDetectionTests : TestBase
         try
         {
             using var conn = Create(keepAlive: 1, connectTimeout: 10000, allowAdmin: true, shared: false);
+            conn.RawConfig.ReconnectRetryPolicy = new LinearRetry(200);
 
             var db = conn.GetDatabase();
             db.Ping();


### PR DESCRIPTION
Additional case handling for #2853, respecting backoff in the disconnected -> resurrecting state case. We need to check backoff in that flow as well to prevent a premature `TryConnect`.