### PR TITLE
Subscribe to all primaries (for key-space-notifications)

### DIFF
--- a/src/StackExchange.Redis/Interfaces/ISubscriber.cs
+++ b/src/StackExchange.Redis/Interfaces/ISubscriber.cs
@@ -62,6 +62,39 @@ namespace StackExchange.Redis
         Task SubscribeAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Subscribe to perform some operation when a message to any primary node is broadcast, without any guarantee of ordered handling.
+        /// This is most useful when addressing key space notifications. For user controlled pub/sub channels, it should be used with caution and further it is not advised.
+        /// </summary>
+        /// <param name="channel">The channel to subscribe to.</param>
+        /// <param name="handler">The handler to invoke when a message is received on <paramref name="channel"/>.</param>
+        /// <param name="flags">The command flags to use.</param>
+        /// <remarks>
+        /// See
+        /// <seealso href="https://redis.io/docs/latest/develop/use/keyspace-notifications/"/>,
+        /// <seealso href="https://redis.io/commands/subscribe"/>,
+        /// <seealso href="https://redis.io/commands/psubscribe"/>.
+        /// </remarks>
+        Task SubscribeAllPrimariesAsync(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Unsubscribe from a specified message channel on all primary nodes.
+        /// Note: if no handler is specified, the subscription is canceled regardless of the subscribers.
+        /// If a handler is specified, the subscription is only canceled if this handler is the last handler remaining against the channel.
+        /// This is used in combination with <see cref="SubscribeAllPrimariesAsync"/> and as mentioned there,
+        /// it is intended to use with key space notitications and not advised for user controlled pub/sub channels.
+        /// </summary>
+        /// <param name="channel">The channel that was subscribed to.</param>
+        /// <param name="handler">The handler to no longer invoke when a message is received on <paramref name="channel"/>.</param>
+        /// <param name="flags">The command flags to use.</param>
+        /// <remarks>
+        /// See
+        /// <seealso href="https://redis.io/docs/latest/develop/use/keyspace-notifications/"/>,
+        /// <seealso href="https://redis.io/commands/unsubscribe"/>,
+        /// <seealso href="https://redis.io/commands/punsubscribe"/>.
+        /// </remarks>
+        Task UnsubscribeAllPrimariesAsync(RedisChannel channel, Action<RedisChannel, RedisValue>? handler = null, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Subscribe to perform some operation when a message to the preferred/active node is broadcast, as a queue that guarantees ordered handling.
         /// </summary>
         /// <param name="channel">The redis channel to subscribe to.</param>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -1893,4 +1893,5 @@ virtual StackExchange.Redis.RedisResult.Length.get -> int
 virtual StackExchange.Redis.RedisResult.this[int index].get -> StackExchange.Redis.RedisResult!
 StackExchange.Redis.ConnectionMultiplexer.AddLibraryNameSuffix(string! suffix) -> void
 StackExchange.Redis.IConnectionMultiplexer.AddLibraryNameSuffix(string! suffix) -> void
-
+StackExchange.Redis.ISubscriber.SubscribeAllPrimariesAsync(StackExchange.Redis.RedisChannel channel, System.Action<StackExchange.Redis.RedisChannel, StackExchange.Redis.RedisValue>! handler, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task!
+StackExchange.Redis.ISubscriber.UnsubscribeAllPrimariesAsync(StackExchange.Redis.RedisChannel channel, System.Action<StackExchange.Redis.RedisChannel, StackExchange.Redis.RedisValue>? handler = null, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task!


### PR DESCRIPTION
Closes/Fixes #2846 

This approach essentially uses the same methodology as pub/sub subscriptions but runs on all primary nodes in the cluster, attempting to combine the results into a single output.

While some parts of it align with existing pub/sub functionality, making them reusable compromises readability. Therefore, I'm not sure it's preferable to make them reusable.

Another point is that I went back and forth on API naming, trying to decide whether to reference the keyspace or not. To provide more clarity on what is happening, I chose a name that refers to the primaries, and I’ve kept the keyspace-related explanations in the documentation.