### PR TITLE
Log multiplexer reconfiguration

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -463,7 +463,7 @@ public partial class ConnectionMultiplexer
         if (hasNew)
         {
             // Reconfigure the sentinel multiplexer if we added new endpoints
-            ReconfigureAsync(first: false, reconfigureAll: true, null, EndPoints[0], "Updating Sentinel List", false).Wait();
+            ReconfigureAsync(first: false, reconfigureAll: true, Logger, EndPoints[0], "Updating Sentinel List", false).Wait();
         }
     }
 }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1378,7 +1378,7 @@ namespace StackExchange.Redis
             {
                 bool reconfigureAll = fromBroadcast || publishReconfigure;
                 Trace("Configuration change detected; checking nodes", "Configuration");
-                ReconfigureAsync(first: false, reconfigureAll, null, blame, cause, publishReconfigure, flags).ObserveErrors();
+                ReconfigureAsync(first: false, reconfigureAll, Logger, blame, cause, publishReconfigure, flags).ObserveErrors();
                 return true;
             }
             else
@@ -1393,7 +1393,7 @@ namespace StackExchange.Redis
         /// This re-assessment of all server endpoints to get the current topology and adjust, the same as if we had first connected.
         /// </summary>
         public Task<bool> ReconfigureAsync(string reason) =>
-            ReconfigureAsync(first: false, reconfigureAll: false, log: null, blame: null, cause: reason);
+            ReconfigureAsync(first: false, reconfigureAll: false, log: Logger, blame: null, cause: reason);
 
         internal async Task<bool> ReconfigureAsync(bool first, bool reconfigureAll, ILogger? log, EndPoint? blame, string cause, bool publishReconfigure = false, CommandFlags publishReconfigureFlags = CommandFlags.None)
         {

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -408,9 +408,14 @@ namespace StackExchange.Redis
             return message == null ? command.ToString() : (includeDetail ? message.CommandAndKey : message.CommandString);
         }
 
-        internal static Exception UnableToConnect(ConnectionMultiplexer muxer, string? failureMessage = null)
+        internal static Exception UnableToConnect(ConnectionMultiplexer muxer, string? failureMessage = null, string? connectionName = null)
         {
-            var sb = new StringBuilder("It was not possible to connect to the redis server(s).");
+            var sb = new StringBuilder("It was not possible to connect to the redis server(s)");
+            if (connectionName is not null)
+            {
+                sb.Append(' ').Append(connectionName);
+            }
+            sb.Append('.');
             Exception? inner = null;
             var failureType = ConnectionFailureType.UnableToConnect;
             if (muxer is not null)

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -584,7 +584,7 @@ namespace StackExchange.Redis
                         if (DueForConnectRetry())
                         {
                             Interlocked.Increment(ref connectTimeoutRetryCount);
-                            var ex = ExceptionFactory.UnableToConnect(Multiplexer, "ConnectTimeout");
+                            var ex = ExceptionFactory.UnableToConnect(Multiplexer, "ConnectTimeout", Name);
                             LastException = ex;
                             Multiplexer.Logger?.LogError(ex, ex.Message);
                             Trace("Aborting connect");


### PR DESCRIPTION
Multiplexer reconfiguration (e.g., caused by AzureMaintenance) is an important event and as such should be logged.
Additionally, include connection name in exception when applicable (PhysicalBridge).