### PR TITLE
Make it easier to use user certificate files

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,8 @@ Current package versions:
 ## Unreleased
 No pending unreleased changes
 
+- Add `ConfigurationOptions.SetUserPemCertificate(...)` and `ConfigurationOptions.SetUserPfxCertificate(...)` methods to simplify using client certificates ([#2873 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2873))
+
 ## 2.8.31
 
 - Fix: Respect `IReconnectRetryPolicy` timing in the case that a node that was present disconnects indefinitely ([#2853](https://github.com/StackExchange/StackExchange.Redis/pull/2853) & [#2856](https://github.com/StackExchange/StackExchange.Redis/pull/2856) by NickCraver)

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -301,6 +301,49 @@ namespace StackExchange.Redis
         /// <param name="issuerCertificatePath">The file system path to find the certificate at.</param>
         public void TrustIssuer(string issuerCertificatePath) => CertificateValidationCallback = TrustIssuerCallback(issuerCertificatePath);
 
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// Supply a user certificate from a PEM file pair and enable TLS.
+        /// </summary>
+        /// <param name="userCertificatePath">The path for the the user certificate (commonly a .crt file).</param>
+        /// <param name="userKeyPath">The path for the the user key (commonly a .key file).</param>
+        public void SetUserPemCertificate(string userCertificatePath, string userKeyPath)
+        {
+            CertificateSelectionCallback = CreatePemUserCertificateCallback(userCertificatePath, userKeyPath);
+            Ssl = true;
+        }
+#endif
+
+        /// <summary>
+        /// Supply a user certificate from a PFX file and optional password and enable TLS.
+        /// </summary>
+        /// <param name="userCertificatePath">The path for the the user certificate (commonly a .pfx file).</param>
+        /// <param name="password">The password for the certificate file.</param>
+        public void SetUserPfxCertificate(string userCertificatePath, string? password = null)
+        {
+            CertificateSelectionCallback = CreatePfxUserCertificateCallback(userCertificatePath, password);
+            Ssl = true;
+        }
+
+#if NET5_0_OR_GREATER
+        internal static LocalCertificateSelectionCallback CreatePemUserCertificateCallback(string userCertificatePath, string userKeyPath)
+        {
+            // PEM handshakes not universally supported and causes a runtime error about ephemeral certificates; to avoid, export as PFX
+            using var pem = X509Certificate2.CreateFromPemFile(userCertificatePath, userKeyPath);
+#pragma warning disable SYSLIB0057 // Type or member is obsolete
+            var pfx = new X509Certificate2(pem.Export(X509ContentType.Pfx));
+#pragma warning restore SYSLIB0057 // Type or member is obsolete
+
+            return (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => pfx;
+        }
+#endif
+
+        internal static LocalCertificateSelectionCallback CreatePfxUserCertificateCallback(string userCertificatePath, string? password, X509KeyStorageFlags storageFlags = X509KeyStorageFlags.DefaultKeySet)
+        {
+            var pfx = new X509Certificate2(userCertificatePath, password ?? "", storageFlags);
+            return (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => pfx;
+        }
+
         /// <summary>
         /// Create a certificate validation check that checks against the supplied issuer even when not known by the machine.
         /// </summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -307,7 +307,7 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="userCertificatePath">The path for the the user certificate (commonly a .crt file).</param>
         /// <param name="userKeyPath">The path for the the user key (commonly a .key file).</param>
-        public void SetUserPemCertificate(string userCertificatePath, string userKeyPath)
+        public void SetUserPemCertificate(string userCertificatePath, string? userKeyPath = null)
         {
             CertificateSelectionCallback = CreatePemUserCertificateCallback(userCertificatePath, userKeyPath);
             Ssl = true;
@@ -326,7 +326,7 @@ namespace StackExchange.Redis
         }
 
 #if NET5_0_OR_GREATER
-        internal static LocalCertificateSelectionCallback CreatePemUserCertificateCallback(string userCertificatePath, string userKeyPath)
+        internal static LocalCertificateSelectionCallback CreatePemUserCertificateCallback(string userCertificatePath, string? userKeyPath)
         {
             // PEM handshakes not universally supported and causes a runtime error about ephemeral certificates; to avoid, export as PFX
             using var pem = X509Certificate2.CreateFromPemFile(userCertificatePath, userKeyPath);

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1524,10 +1524,7 @@ namespace StackExchange.Redis
                 if (!string.IsNullOrEmpty(certificatePath) && File.Exists(certificatePath))
                 {
                     var passwordPath = Environment.GetEnvironmentVariable("SERedis_ClientCertPasswordPath");
-                    if (!string.IsNullOrEmpty(passwordPath) && File.Exists(passwordPath))
-                    {
-                        return ConfigurationOptions.CreatePemUserCertificateCallback(certificatePath, passwordPath);
-                    }
+                    return ConfigurationOptions.CreatePemUserCertificateCallback(certificatePath, passwordPath);
                 }
 #endif
             }

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1504,21 +1504,32 @@ namespace StackExchange.Redis
         {
             try
             {
-                var pfxPath = Environment.GetEnvironmentVariable("SERedis_ClientCertPfxPath");
-                var pfxPassword = Environment.GetEnvironmentVariable("SERedis_ClientCertPassword");
-                var pfxStorageFlags = Environment.GetEnvironmentVariable("SERedis_ClientCertStorageFlags");
-
-                X509KeyStorageFlags? flags = null;
-                if (!string.IsNullOrEmpty(pfxStorageFlags))
+                var certificatePath = Environment.GetEnvironmentVariable("SERedis_ClientCertPfxPath");
+                if (!string.IsNullOrEmpty(certificatePath) && File.Exists(certificatePath))
                 {
-                    flags = Enum.Parse(typeof(X509KeyStorageFlags), pfxStorageFlags) as X509KeyStorageFlags?;
+                    var password = Environment.GetEnvironmentVariable("SERedis_ClientCertPassword");
+                    var pfxStorageFlags = Environment.GetEnvironmentVariable("SERedis_ClientCertStorageFlags");
+                    X509KeyStorageFlags storageFlags = X509KeyStorageFlags.DefaultKeySet;
+                    if (!string.IsNullOrEmpty(pfxStorageFlags))
+                    {
+                        var tmp = Enum.Parse(typeof(X509KeyStorageFlags), pfxStorageFlags) as X509KeyStorageFlags?;
+                        if (tmp is not null) storageFlags = tmp.GetValueOrDefault();
+                    }
+
+                    return ConfigurationOptions.CreatePfxUserCertificateCallback(certificatePath, password, storageFlags);
                 }
 
-                if (!string.IsNullOrEmpty(pfxPath) && File.Exists(pfxPath))
+#if NET5_0_OR_GREATER
+                certificatePath = Environment.GetEnvironmentVariable("SERedis_ClientCertPemPath");
+                if (!string.IsNullOrEmpty(certificatePath) && File.Exists(certificatePath))
                 {
-                    return (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) =>
-                        new X509Certificate2(pfxPath, pfxPassword ?? "", flags ?? X509KeyStorageFlags.DefaultKeySet);
+                    var passwordPath = Environment.GetEnvironmentVariable("SERedis_ClientCertPasswordPath");
+                    if (!string.IsNullOrEmpty(passwordPath) && File.Exists(passwordPath))
+                    {
+                        return ConfigurationOptions.CreatePemUserCertificateCallback(certificatePath, passwordPath);
+                    }
                 }
+#endif
             }
             catch (Exception ex)
             {

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1510,10 +1510,9 @@ namespace StackExchange.Redis
                     var password = Environment.GetEnvironmentVariable("SERedis_ClientCertPassword");
                     var pfxStorageFlags = Environment.GetEnvironmentVariable("SERedis_ClientCertStorageFlags");
                     X509KeyStorageFlags storageFlags = X509KeyStorageFlags.DefaultKeySet;
-                    if (!string.IsNullOrEmpty(pfxStorageFlags))
+                    if (!string.IsNullOrEmpty(pfxStorageFlags) && Enum.TryParse<X509KeyStorageFlags>(pfxStorageFlags, true, out var typedFlags))
                     {
-                        var tmp = Enum.Parse(typeof(X509KeyStorageFlags), pfxStorageFlags) as X509KeyStorageFlags?;
-                        if (tmp is not null) storageFlags = tmp.GetValueOrDefault();
+                        storageFlags = typedFlags;
                     }
 
                     return ConfigurationOptions.CreatePfxUserCertificateCallback(certificatePath, password, storageFlags);

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -1893,4 +1893,4 @@ virtual StackExchange.Redis.RedisResult.Length.get -> int
 virtual StackExchange.Redis.RedisResult.this[int index].get -> StackExchange.Redis.RedisResult!
 StackExchange.Redis.ConnectionMultiplexer.AddLibraryNameSuffix(string! suffix) -> void
 StackExchange.Redis.IConnectionMultiplexer.AddLibraryNameSuffix(string! suffix) -> void
-
+StackExchange.Redis.ConfigurationOptions.SetUserPfxCertificate(string! userCertificatePath, string? password = null) -> void

--- a/src/StackExchange.Redis/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,3 +1,4 @@
 ﻿StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.get -> System.Func<string!, System.Net.Security.SslClientAuthenticationOptions!>?
 StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.set -> void
 System.Runtime.CompilerServices.IsExternalInit (forwarded, contained in System.Runtime)
+StackExchange.Redis.ConfigurationOptions.SetUserPemCertificate(string! userCertificatePath, string! userKeyPath) -> void

--- a/src/StackExchange.Redis/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
 ﻿StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.get -> System.Func<string!, System.Net.Security.SslClientAuthenticationOptions!>?
 StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.set -> void
 System.Runtime.CompilerServices.IsExternalInit (forwarded, contained in System.Runtime)
-StackExchange.Redis.ConfigurationOptions.SetUserPemCertificate(string! userCertificatePath, string! userKeyPath) -> void
+StackExchange.Redis.ConfigurationOptions.SetUserPemCertificate(string! userCertificatePath, string? userKeyPath = null) -> void

--- a/src/StackExchange.Redis/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,3 +1,4 @@
 ﻿StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.get -> System.Func<string!, System.Net.Security.SslClientAuthenticationOptions!>?
 StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.set -> void
 System.Runtime.CompilerServices.IsExternalInit (forwarded, contained in System.Runtime)
+StackExchange.Redis.ConfigurationOptions.SetUserPemCertificate(string! userCertificatePath, string! userKeyPath) -> void

--- a/src/StackExchange.Redis/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
 ﻿StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.get -> System.Func<string!, System.Net.Security.SslClientAuthenticationOptions!>?
 StackExchange.Redis.ConfigurationOptions.SslClientAuthenticationOptions.set -> void
 System.Runtime.CompilerServices.IsExternalInit (forwarded, contained in System.Runtime)
-StackExchange.Redis.ConfigurationOptions.SetUserPemCertificate(string! userCertificatePath, string! userKeyPath) -> void
+StackExchange.Redis.ConfigurationOptions.SetUserPemCertificate(string! userCertificatePath, string? userKeyPath = null) -> void


### PR DESCRIPTION
Historically, certs only worked with PFX files, which made it a pain to work with the cert pairs typically downloaded from hosts like Redis Ltd; however, on more recent .NET versions PEM is fully available. Here, we:

- add new methods on `ConfigurationOptions` (akin to the existing `TrustIssuer` method) to configure certificates from files
- support PEM in the ambient setup

There are no tests added here, due to the inherent problems of CI talking to such servers; however:

``` c#
 var options = ConfigurationOptions.Parse("redis-redacted.redislabs.com:4242"); // port also redacted
 options.TrustIssuer(@"C:\Code\RedisKeys\redis_ca.pem");
 options.SetUserPemCertificate(@"C:\Code\RedisKeys\redis-redacted.crt", @"C:\Code\RedisKeys\redis-redacted.key");
 using var conn = await ConnectionMultiplexer.ConnectAsync(options);
 for (int i = 0; i < 10; i++)
 {
     var ttl = await conn.GetDatabase().PingAsync();
     Console.WriteLine(ttl);
 }
```

works with the files downloaded from my hosted Redis Ltd endpoint:

![image](https://github.com/user-attachments/assets/ddaceb06-bc6b-4dd9-b306-c7cac104d235)

To @philon-msft : open question: can we check Azure Redis with similar?

^^^ update: Philo assures me that Azure Redis doesn't have any relevant client-cert scenarios to consider