### PR TITLE
Connections: Move all AuthenticateAsClient to async

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ Current package versions:
 No pending unreleased changes
 
 - Add `ConfigurationOptions.SetUserPemCertificate(...)` and `ConfigurationOptions.SetUserPfxCertificate(...)` methods to simplify using client certificates ([#2873 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2873))
+- Fix: Move `AuthenticateAsClient` to fully async after dropping older framework support, to help client thread starvation in cases TLS negotiation stalls server-side ([#2878 by NickCraver](https://github.com/StackExchange/StackExchange.Redis/pull/2878))
 
 ## 2.8.31
 

--- a/src/StackExchange.Redis/Configuration/LoggingTunnel.cs
+++ b/src/StackExchange.Redis/Configuration/LoggingTunnel.cs
@@ -367,10 +367,10 @@ public abstract class LoggingTunnel : Tunnel
         }
         else
         {
-            ssl.AuthenticateAsClient(host, _options.SslProtocols, _options.CheckCertificateRevocation);
+            await ssl.AuthenticateAsClientAsync(host, _options.SslProtocols, _options.CheckCertificateRevocation).ForAwait();
         }
 #else
-        ssl.AuthenticateAsClient(host, _options.SslProtocols, _options.CheckCertificateRevocation);
+        await ssl.AuthenticateAsClientAsync(host, _options.SslProtocols, _options.CheckCertificateRevocation).ForAwait();
 #endif
         return ssl;
     }

--- a/src/StackExchange.Redis/ExtensionMethods.cs
+++ b/src/StackExchange.Redis/ExtensionMethods.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading.Tasks;
 using Pipelines.Sockets.Unofficial.Arenas;
 
 namespace StackExchange.Redis
@@ -188,22 +189,16 @@ namespace StackExchange.Redis
             return Array.ConvertAll(values, x => (string?)x);
         }
 
-        internal static void AuthenticateAsClient(this SslStream ssl, string host, SslProtocols? allowedProtocols, bool checkCertificateRevocation)
+        internal static Task AuthenticateAsClientAsync(this SslStream ssl, string host, SslProtocols? allowedProtocols, bool checkCertificateRevocation)
         {
             if (!allowedProtocols.HasValue)
             {
                 // Default to the sslProtocols defined by the .NET Framework
-                AuthenticateAsClientUsingDefaultProtocols(ssl, host);
-                return;
+                return ssl.AuthenticateAsClientAsync(host);
             }
 
             var certificateCollection = new X509CertificateCollection();
-            ssl.AuthenticateAsClient(host, certificateCollection, allowedProtocols.Value, checkCertificateRevocation);
-        }
-
-        private static void AuthenticateAsClientUsingDefaultProtocols(SslStream ssl, string host)
-        {
-            ssl.AuthenticateAsClient(host);
+            return ssl.AuthenticateAsClientAsync(host, certificateCollection, allowedProtocols.Value, checkCertificateRevocation);
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1585,10 +1585,10 @@ namespace StackExchange.Redis
                             }
                             else
                             {
-                                ssl.AuthenticateAsClient(host, config.SslProtocols, config.CheckCertificateRevocation);
+                                await ssl.AuthenticateAsClientAsync(host, config.SslProtocols, config.CheckCertificateRevocation).ForAwait();
                             }
 #else
-                            ssl.AuthenticateAsClient(host, config.SslProtocols, config.CheckCertificateRevocation);
+                            await ssl.AuthenticateAsClientAsync(host, config.SslProtocols, config.CheckCertificateRevocation).ForAwait();
 #endif
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Previously when supporting earlier versions of .NET Framework, we did not have an async version of `AuthenticateAsClient` due to socket itself not having async handlers in earlier versions of `netstandard`. These days though with the supported target framework matrix, this can be fully async to prevent thread starvation specifically in the case where we're able to connect a socket but the server is overwhelmed and unable to finish TLS negotiations.

Example:
![image](https://github.com/user-attachments/assets/4b82c2b0-7f54-4720-ae4e-d540b5584d49)

This is a case we've never seen stall before, where the server is able to accept connections but unable to complete TLS negotiation, so there's never been a reported stall raising this potential issue. Last night we saw it live on a major instance though. It's still TBD how this was manifesting server-side (could be a proxy stall in front of nodes, etc.) but we saw this against Redis Enterprise which we know a lot of folks use, so let's definitely improve anything we can as always.

Note that none of these methods take a cancellation token, so while we can avoid thread growth on the client side as a primary symptom of the case here, the server-side impact of backlogged but unconnected things may continue to grow. It's net better overall, though, and should help a bit on mass connection cases for some applications as well, in the cases TLS negotiation isn't instant.