### PR TITLE
StreamGroupInfo.Lag can be null

### DIFF
--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -2286,6 +2286,19 @@ The coordinates as a two items x,y array (longitude,latitude).
                 }
                 return false;
             }
+            internal static bool TryRead(Sequence<RawResult> pairs, in CommandBytes key, ref long? value)
+            {
+                var len = pairs.Length / 2;
+                for (int i = 0; i < len; i++)
+                {
+                    if (pairs[i * 2].IsEqual(key) && pairs[(i * 2) + 1].TryGetInt64(out var tmp))
+                    {
+                        value = tmp;
+                        return true;
+                    }
+                }
+                return false;
+            }
 
             internal static bool TryRead(Sequence<RawResult> pairs, in CommandBytes key, ref int value)
             {
@@ -2348,7 +2361,8 @@ The coordinates as a two items x,y array (longitude,latitude).
                 var arr = result.GetItems();
                 string? name = default, lastDeliveredId = default;
                 int consumerCount = default, pendingMessageCount = default;
-                long entriesRead = default, lag = default;
+                long entriesRead = default;
+                long? lag = default;
 
                 KeyValuePairParser.TryRead(arr, KeyValuePairParser.Name, ref name);
                 KeyValuePairParser.TryRead(arr, KeyValuePairParser.Consumers, ref consumerCount);


### PR DESCRIPTION
In the special case where consumer group lag is unavailable [XINFO GROUPS](https://redis.io/docs/latest/commands/xinfo-groups/) lag is reported as null from redis.
The Lag property on StreamGroupInfo is long?, so the type is correct.

StreamGroupInfoProcessor.ParseItem parses the value as a long and defaults to 0 not null

This is a bug-fix on that issue, it does contain some code duplication, but that is probably just my skill level.

Make some tests for this, probably not in the right place but that is how it is.