### PR TITLE
Fix CLIENT ID error during handshake

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ Current package versions:
 
 - Add support for new `BITOP` operations in CE 8.2 ([#2900 by atakavci](https://github.com/StackExchange/StackExchange.Redis/pull/2900))
 - Package updates ([#2906 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2906))
+- Fix handshake error connecting to RESP2 servers
 
 ## 2.8.41
 

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -831,6 +831,9 @@ namespace StackExchange.Redis
                             {
                                 connection.ConnectionId = clientId;
                                 Log?.LogInformation($"{Format.ToString(server)}: Auto-configured (CLIENT) connection-id: {clientId}");
+
+                                SetResult(message, true);
+                                return true;
                             }
                         }
                         break;

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -472,6 +472,7 @@ public class ConfigTests : TestBase
         if (server.Features.ClientId)
         {
             var id = conn.GetConnectionId(server.EndPoint, ConnectionType.Interactive);
+            Log("client id: " + id);
             Assert.NotNull(id);
             Assert.True(clients.Any(x => x.Id == id), "expected: " + id);
             id = conn.GetConnectionId(server.EndPoint, ConnectionType.Subscription);


### PR DESCRIPTION
This is odd; no idea how this hasn't already flagged, but: the `CLIENT ID` issued in handshake *breaks connections* - the auto-config handler didn't report success correctly, leading it to manifest as a protocol failure.

This is probably urgent.