### PR TITLE
Workaround Mono test failures

### DIFF
--- a/StackExchange.Redis.sln.DotSettings
+++ b/StackExchange.Redis.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OK/@EntryIndexedValue">OK</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PONG/@EntryIndexedValue">PONG</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PONG/@EntryIndexedValue">PONG</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pubsub/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/StackExchange.Redis/Runtime.cs
+++ b/src/StackExchange.Redis/Runtime.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace StackExchange.Redis;
+
+internal static class Runtime
+{
+    public static readonly bool IsMono = RuntimeInformation.FrameworkDescription.StartsWith("Mono ", StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/StackExchange.Redis.Tests/Certificates/CertValidationTests.cs
+++ b/tests/StackExchange.Redis.Tests/Certificates/CertValidationTests.cs
@@ -16,30 +16,39 @@ public class CertValidationTests(ITestOutputHelper output) : TestBase(output)
 
         // Trusting CA explicitly
         var callback = ConfigurationOptions.TrustIssuerCallback(Path.Combine("Certificates", "ca.foo.com.pem"));
-        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.None));
-        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNameMismatch));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNotAvailable));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNotAvailable));
+        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.None), "subtest 1a");
+        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors), "subtest 1b");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNameMismatch), "subtest 1c");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNotAvailable), "subtest 1d");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch), "subtest 1e");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNotAvailable), "subtest 1f");
 
         // Trusting the remote endpoint cert directly
         callback = ConfigurationOptions.TrustIssuerCallback(Path.Combine("Certificates", "device01.foo.com.pem"));
-        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.None));
-        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNameMismatch));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNotAvailable));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNotAvailable));
+        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.None), "subtest 2a");
+        if (Runtime.IsMono)
+        {
+            // Mono doesn't support this cert usage, reports as rejection (happy for someone to work around this, but isn't high priority)
+            Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors), "subtest 2b");
+        }
+        else
+        {
+            Assert.True(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors), "subtest 2b");
+        }
+
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNameMismatch), "subtest 2c");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNotAvailable), "subtest 2d");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch), "subtest 2e");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNotAvailable), "subtest 2f");
 
         // Attempting to trust another CA (mismatch)
         callback = ConfigurationOptions.TrustIssuerCallback(Path.Combine("Certificates", "ca2.foo.com.pem"));
-        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.None));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNameMismatch));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNotAvailable));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch));
-        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNotAvailable));
+        Assert.True(callback(this, endpointCert, null, SslPolicyErrors.None), "subtest 3a");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors), "subtest 3b");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNameMismatch), "subtest 3c");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateNotAvailable), "subtest 3d");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch), "subtest 3e");
+        Assert.False(callback(this, endpointCert, null, SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNotAvailable), "subtest 3f");
     }
 
     private static X509Certificate2 LoadCert(string certificatePath) => new X509Certificate2(File.ReadAllBytes(certificatePath));

--- a/tests/StackExchange.Redis.Tests/FormatTests.cs
+++ b/tests/StackExchange.Redis.Tests/FormatTests.cs
@@ -68,7 +68,10 @@ public class FormatTests(ITestOutputHelper output) : TestBase(output)
     [InlineData(CommandFlags.DemandReplica | CommandFlags.FireAndForget, "PreferMaster, FireAndForget, DemandReplica")] // 2-bit flag is hit-and-miss
 #endif
     public void CommandFlagsFormatting(CommandFlags value, string expected)
-        => Assert.Equal(expected, value.ToString());
+    {
+        Assert.SkipWhen(Runtime.IsMono, "Mono has different enum flag behavior");
+        Assert.Equal(expected, value.ToString());
+    }
 
     [Theory]
     [InlineData(ClientType.Normal, "Normal")]


### PR DESCRIPTION
- acknowledge enum tostring delta (skip check)
- acknowledge limitation in cert handling (avoid fault, report as rejection)

Context: this is primarily so that the tests behave reasonably when developing on linux and running the netfx tests via Mono. This is strictly a nice-to-have:

- the recommended approach for running on linux is modern .NET (.NET 9, etc)
- for *actual* validation of netfx behaviour, the CI servers running Windows should be considered the oracle

Mono itself is basically EOL, so the fact that it works at all is mostly a development convenience rather than a hard focus.