### PR TITLE
Make ConfigurationOptions IDisposable

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-- nothing yet
+- Make ConfigurationOptions IDisposable ([#2922 by philon-msft](https://github.com/StackExchange/StackExchange.Redis/pull/2922))
 
 ## 2.8.58
 

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -246,6 +246,7 @@ StackExchange.Redis.ConfigurationOptions.Defaults.get -> StackExchange.Redis.Con
 StackExchange.Redis.ConfigurationOptions.Defaults.set -> void
 StackExchange.Redis.ConfigurationOptions.DefaultVersion.get -> System.Version!
 StackExchange.Redis.ConfigurationOptions.DefaultVersion.set -> void
+StackExchange.Redis.ConfigurationOptions.Dispose() -> void
 StackExchange.Redis.ConfigurationOptions.EndPoints.get -> StackExchange.Redis.EndPointCollection!
 StackExchange.Redis.ConfigurationOptions.EndPoints.init -> void
 StackExchange.Redis.ConfigurationOptions.HeartbeatConsistencyChecks.get -> bool

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -34,6 +34,7 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
         Assert.Equal(
             new[]
             {
+                "_isDisposed",
                 "abortOnConnectFail",
                 "allowAdmin",
                 "asyncTimeout",
@@ -760,5 +761,21 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
 
         var parsed = ConfigurationOptions.Parse(cs);
         Assert.Equal(expected, parsed.HighIntegrity);
+    }
+
+    [Fact]
+    public void DisposedThrows()
+    {
+        var options = ConfigurationOptions.Parse("myhost");
+        Assert.IsType<DefaultOptionsProvider>(options.Defaults);
+
+        options.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => options.Defaults);
+        Assert.Throws<ObjectDisposedException>(() => options.BacklogPolicy);
+        Assert.Throws<ObjectDisposedException>(() => options.CommandMap);
+        Assert.Throws<ObjectDisposedException>(() => options.LoggerFactory);
+        Assert.Throws<ObjectDisposedException>(() => options.ReconnectRetryPolicy);
+        Assert.Throws<ObjectDisposedException>(() => options.Clone());
     }
 }


### PR DESCRIPTION
Creating this PR for discussion. 

The main advantage of IDisposable ConfigurationOptions is it enables graceful shutdown of IDisposable default options providers like AzureCacheOptionsProviderWithToken, which has a token refresh Timer that should be stopped. 