### PR TITLE
chore: Replaces string interpolation with structured logging - ServerEndPoint

### DIFF
--- a/src/StackExchange.Redis/LoggerExtensions.cs
+++ b/src/StackExchange.Redis/LoggerExtensions.cs
@@ -403,4 +403,89 @@ internal static partial class LoggerExtensions
         EventId = 56,
         Message = "...but we did find instead: {DeDottedEndpoint}")]
     internal static partial void LogInformationFoundAlternativeEndpoint(this ILogger logger, string deDottedEndpoint);
+
+    // ServerEndPoint logging methods
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 57,
+        Message = "{Server}: OnConnectedAsync already connected start")]
+    internal static partial void LogInformationOnConnectedAsyncAlreadyConnectedStart(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 58,
+        Message = "{Server}: OnConnectedAsync already connected end")]
+    internal static partial void LogInformationOnConnectedAsyncAlreadyConnectedEnd(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 59,
+        Message = "{Server}: OnConnectedAsync init (State={ConnectionState})")]
+    internal static partial void LogInformationOnConnectedAsyncInit(this ILogger logger, ServerEndPointLogValue server, PhysicalBridge.State? connectionState);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 60,
+        Message = "{Server}: OnConnectedAsync completed ({Result})")]
+    internal static partial void LogInformationOnConnectedAsyncCompleted(this ILogger logger, ServerEndPointLogValue server, string result);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 61,
+        Message = "{Server}: Auto-configuring...")]
+    internal static partial void LogInformationAutoConfiguring(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 62,
+        Message = "{EndPoint}: Requesting tie-break (Key=\"{TieBreakerKey}\")...")]
+    internal static partial void LogInformationRequestingTieBreak(this ILogger logger, EndPointLogValue endPoint, string tieBreakerKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 63,
+        Message = "{Server}: Server handshake")]
+    internal static partial void LogInformationServerHandshake(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 64,
+        Message = "{Server}: Authenticating via HELLO")]
+    internal static partial void LogInformationAuthenticatingViaHello(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 65,
+        Message = "{Server}: Authenticating (user/password)")]
+    internal static partial void LogInformationAuthenticatingUserPassword(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 66,
+        Message = "{Server}: Authenticating (password)")]
+    internal static partial void LogInformationAuthenticatingPassword(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 67,
+        Message = "{Server}: Setting client name: {ClientName}")]
+    internal static partial void LogInformationSettingClientName(this ILogger logger, ServerEndPointLogValue server, string clientName);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 68,
+        Message = "{Server}: Setting client lib/ver")]
+    internal static partial void LogInformationSettingClientLibVer(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 69,
+        Message = "{Server}: Sending critical tracer (handshake): {CommandAndKey}")]
+    internal static partial void LogInformationSendingCriticalTracer(this ILogger logger, ServerEndPointLogValue server, string commandAndKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 70,
+        Message = "{Server}: Flushing outbound buffer")]
+    internal static partial void LogInformationFlushingOutboundBuffer(this ILogger logger, ServerEndPointLogValue server);
 }

--- a/src/StackExchange.Redis/LoggerExtensions.cs
+++ b/src/StackExchange.Redis/LoggerExtensions.cs
@@ -439,7 +439,7 @@ internal static partial class LoggerExtensions
         Level = LogLevel.Information,
         EventId = 62,
         Message = "{EndPoint}: Requesting tie-break (Key=\"{TieBreakerKey}\")...")]
-    internal static partial void LogInformationRequestingTieBreak(this ILogger logger, EndPointLogValue endPoint, string tieBreakerKey);
+    internal static partial void LogInformationRequestingTieBreak(this ILogger logger, EndPointLogValue endPoint, RedisKey tieBreakerKey);
 
     [LoggerMessage(
         Level = LogLevel.Information,

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -458,7 +458,7 @@ namespace StackExchange.Redis
             // But if GETs are disabled on this, do not fail the connection - we just don't get tiebreaker benefits
             if (Multiplexer.RawConfig.TryGetTieBreaker(out var tieBreakerKey) && Multiplexer.CommandMap.IsAvailable(RedisCommand.GET))
             {
-                log?.LogInformationRequestingTieBreak(new LoggerExtensions.EndPointLogValue(EndPoint), tieBreakerKey.ToString());
+                log?.LogInformationRequestingTieBreak(new(EndPoint), tieBreakerKey);
                 msg = Message.Create(0, flags, RedisCommand.GET, tieBreakerKey);
                 msg.SetInternalCall();
                 msg = LoggingMessage.Create(log, msg);


### PR DESCRIPTION
related #2899 

Migrates Redis server endpoint logging from string interpolation to LoggerMessage attributes for better performance and structured logging support.

Adds 14 new LoggerMessage methods for server connection lifecycle events including handshake, authentication, configuration, and buffer operations.

Uses ServerEndPointLogValue wrapper to ensure consistent server representation in logs while maintaining type safety.

github-copilot prompt used:
<img width="502" height="163" alt="image" src="https://github.com/user-attachments/assets/675b061d-bba4-4bbf-a2cd-d0003016ab1a" />
