### PR TITLE
chore: Adds macOS CI pipeline to GitHub Actions workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,3 +143,41 @@ jobs:
         name: Tests Results - Windows Server 2022
         path: 'test-results/*.trx'
         reporter: dotnet-trx
+
+  macos:
+    name: StackExchange.Redis (macOS)
+    runs-on: macos-latest
+    env:
+      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Enable color output, even though the console output is redirected in Actions
+      TERM: xterm # Enable color output in GitHub Actions
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch the full history
+    - name: Install Redis
+      run: |
+        brew install redis
+        brew services start redis
+        # Wait for Redis to start
+        sleep 3
+        # Verify Redis is running
+        redis-cli ping
+    - name: Install .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: | 
+          6.0.x
+          8.0.x
+          9.0.x
+    - name: .NET Build
+      run: dotnet build Build.csproj -c Release /p:CI=true
+    - name: StackExchange.Redis.Tests
+      run: dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj -c Release --logger trx --logger GitHubActions --results-directory ./test-results/ /p:CI=true
+    - uses: dorny/test-reporter@v1
+      continue-on-error: true
+      if: success() || failure()
+      with:
+        name: Test Results - macOS
+        path: 'test-results/*.trx'
+        reporter: dotnet-trx

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,14 +155,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch the full history
-    - name: Install Redis
-      run: |
-        brew install redis
-        brew services start redis
-        # Wait for Redis to start
-        sleep 3
-        # Verify Redis is running
-        redis-cli ping
+    - name: Start Redis Services (docker-compose)
+      working-directory: ./tests/RedisConfigs
+      run: docker compose -f docker-compose.yml up -d --wait  
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v3
       with:


### PR DESCRIPTION
Extends continuous integration coverage by adding a dedicated macOS job that mirrors the existing Windows and Linux test environments.

Installs Redis via Homebrew and configures multiple .NET versions (6.0, 8.0, 9.0) to ensure cross-platform compatibility and comprehensive test coverage across different operating systems.

<img width="965" height="865" alt="image" src="https://github.com/user-attachments/assets/07b0b07d-2cad-4f00-b327-757072c084c0" />
