### PR TITLE
Improve `double` formatting performance on net8+ and fix equality incorrectness re special doubles

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,7 +12,8 @@ Current package versions:
 - Fix key-prefix omission in `SetIntersectionLength` and `SortedSet{Combine[WithScores]|IntersectionLength}` ([#2863 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2863))
 - Add `Condition.SortedSet[Not]ContainsStarting` condition for transactions ([#2638 by ArnoKoll](https://github.com/StackExchange/StackExchange.Redis/pull/2638))
 - Add support for XPENDING Idle time filter ([#2822 by david-brink-talogy](https://github.com/StackExchange/StackExchange.Redis/pull/2822))
-- 
+- Improve `double` formatting performance on net8+ ([#xxxx by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/xxxx))
+
 ## 2.8.58
 
 - Fix [#2679](https://github.com/StackExchange/StackExchange.Redis/issues/2679) - blocking call in long-running connects ([#2680 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2680))

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,7 +12,7 @@ Current package versions:
 - Fix key-prefix omission in `SetIntersectionLength` and `SortedSet{Combine[WithScores]|IntersectionLength}` ([#2863 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2863))
 - Add `Condition.SortedSet[Not]ContainsStarting` condition for transactions ([#2638 by ArnoKoll](https://github.com/StackExchange/StackExchange.Redis/pull/2638))
 - Add support for XPENDING Idle time filter ([#2822 by david-brink-talogy](https://github.com/StackExchange/StackExchange.Redis/pull/2822))
-- Improve `double` formatting performance on net8+ ([#xxxx by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/xxxx))
+- Improve `double` formatting performance on net8+ ([#2928 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2928))
 
 ## 2.8.58
 

--- a/src/StackExchange.Redis/Format.cs
+++ b/src/StackExchange.Redis/Format.cs
@@ -399,14 +399,15 @@ namespace StackExchange.Redis
 
         internal const int
             MaxInt32TextLen = 11, // -2,147,483,648 (not including the commas)
-            MaxInt64TextLen = 20; // -9,223,372,036,854,775,808 (not including the commas)
+            MaxInt64TextLen = 20, // -9,223,372,036,854,775,808 (not including the commas),
+            MaxDoubleTextLen = 40; // we use G17, allow for sign/E/and allow plenty of panic room
 
         internal static int MeasureDouble(double value)
         {
             if (double.IsInfinity(value)) return 4; // +inf / -inf
 
 #if NET8_0_OR_GREATER // can use IUtf8Formattable
-            Span<byte> buffer = stackalloc byte[64];
+            Span<byte> buffer = stackalloc byte[MaxDoubleTextLen];
             if (value.TryFormat(buffer, out int len, "G17", NumberFormatInfo.InvariantInfo))
             {
                 return len;

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -1381,6 +1381,7 @@ namespace StackExchange.Redis
             var span = writer.GetSpan(7 + len);
             span[0] = (byte)'$';
             int offset = WriteRaw(span, len, withLengthPrefix: false, offset: 1);
+            valueSpan.Slice(0, len).CopyTo(span.Slice(offset));
             offset += len;
             offset = WriteCrlf(span, offset);
             writer.Advance(offset);

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -986,7 +986,8 @@ namespace StackExchange.Redis
                         if (Format.TryParseInt64(s, out i64)) return i64;
                         if (Format.TryParseUInt64(s, out u64)) return u64;
                     }
-                    if (Format.TryParseDouble(s, out var f64)) return f64;
+                    // note: don't simplify inf/nan, as that causes equality semantic problems
+                    if (Format.TryParseDouble(s, out var f64) && !IsSpecialDouble(f64)) return f64;
                     break;
                 case StorageType.Raw:
                     var b = _memory.Span;
@@ -995,7 +996,8 @@ namespace StackExchange.Redis
                         if (Format.TryParseInt64(b, out i64)) return i64;
                         if (Format.TryParseUInt64(b, out u64)) return u64;
                     }
-                    if (TryParseDouble(b, out f64)) return f64;
+                    // note: don't simplify inf/nan, as that causes equality semantic problems
+                    if (TryParseDouble(b, out f64) && !IsSpecialDouble(f64)) return f64;
                     break;
                 case StorageType.Double:
                     // is the double actually an integer?
@@ -1005,6 +1007,8 @@ namespace StackExchange.Redis
             }
             return this;
         }
+
+        private static bool IsSpecialDouble(double d) => double.IsNaN(d) || double.IsInfinity(d);
 
         /// <summary>
         /// Convert to a signed <see cref="long"/> if possible.

--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -149,7 +149,7 @@ namespace StackExchange.Redis
         /// <param name="y">The second <see cref="RedisValue"/> to compare.</param>
         public static bool operator !=(RedisValue x, RedisValue y) => !(x == y);
 
-        private double OverlappedValueDouble
+        internal double OverlappedValueDouble
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => BitConverter.Int64BitsToDouble(_overlappedBits64);
@@ -849,7 +849,7 @@ namespace StackExchange.Redis
                     len = Format.FormatUInt64(value.OverlappedValueUInt64, span);
                     return span.Slice(0, len).ToArray();
                 case StorageType.Double:
-                    span = stackalloc byte[128];
+                    span = stackalloc byte[Format.MaxDoubleTextLen];
                     len = Format.FormatDouble(value.OverlappedValueDouble, span);
                     return span.Slice(0, len).ToArray();
                 case StorageType.String:

--- a/tests/StackExchange.Redis.Tests/KeyAndValueTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyAndValueTests.cs
@@ -64,6 +64,12 @@ public class KeyAndValueTests
 
     internal static void CheckSame(RedisValue x, RedisValue y)
     {
+        if (x.TryParse(out double value) && double.IsNaN(value))
+        {
+            // NaN has atypical equality rules
+            Assert.True(y.TryParse(out value) && double.IsNaN(value));
+            return;
+        }
         Assert.True(Equals(x, y), "Equals(x, y)");
         Assert.True(Equals(y, x), "Equals(y, x)");
         Assert.True(EqualityComparer<RedisValue>.Default.Equals(x, y), "EQ(x,y)");

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
@@ -136,24 +136,12 @@ public class RedisValueEquivalency
         CheckString(-1099511627848.6001, "-1099511627848.6001");
 
         Check(double.NegativeInfinity, double.NegativeInfinity);
-        Check(double.NegativeInfinity, "-inf");
-        Check(double.NegativeInfinity, Bytes("-inf"));
         CheckString(double.NegativeInfinity, "-inf");
 
         Check(double.PositiveInfinity, double.PositiveInfinity);
-        Check(double.PositiveInfinity, "+inf");
-        Check(double.PositiveInfinity, "inf");
-        Check(double.PositiveInfinity, Bytes("+inf"));
-        Check(double.PositiveInfinity, Bytes("inf"));
         CheckString(double.PositiveInfinity, "+inf");
 
         Check(double.NaN, double.NaN);
-        Check(double.NaN, "+nan");
-        Check(double.NaN, "-nan");
-        Check(double.NaN, "nan");
-        Check(double.NaN, Bytes("+nan"));
-        Check(double.NaN, Bytes("-nan"));
-        Check(double.NaN, Bytes("nan"));
         CheckString(double.NaN, "NaN");
     }
 

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
@@ -157,6 +157,125 @@ public class RedisValueEquivalency
         CheckString(double.NaN, "NaN");
     }
 
+    [Theory]
+    [InlineData("na")]
+    [InlineData("nan")]
+    [InlineData("nans")]
+    [InlineData("in")]
+    [InlineData("inf")]
+    [InlineData("info")]
+    public void SpecialCaseEqualityRules_String(string value)
+    {
+        RedisValue x = value, y = value;
+        Assert.Equal(x, y);
+
+        Assert.True(x.Equals(y));
+        Assert.True(y.Equals(x));
+        Assert.True(x == y);
+        Assert.True(y == x);
+        Assert.False(x != y);
+        Assert.False(y != x);
+        Assert.Equal(x.GetHashCode(), y.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("na")]
+    [InlineData("nan")]
+    [InlineData("nans")]
+    [InlineData("in")]
+    [InlineData("inf")]
+    [InlineData("info")]
+    public void SpecialCaseEqualityRules_Bytes(string value)
+    {
+        byte[] bytes0 = Encoding.UTF8.GetBytes(value),
+               bytes1 = Encoding.UTF8.GetBytes(value);
+        Assert.NotSame(bytes0, bytes1);
+        RedisValue x = bytes0, y = bytes1;
+
+        Assert.True(x.Equals(y));
+        Assert.True(y.Equals(x));
+        Assert.True(x == y);
+        Assert.True(y == x);
+        Assert.False(x != y);
+        Assert.False(y != x);
+        Assert.Equal(x.GetHashCode(), y.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("na")]
+    [InlineData("nan")]
+    [InlineData("nans")]
+    [InlineData("in")]
+    [InlineData("inf")]
+    [InlineData("info")]
+    public void SpecialCaseEqualityRules_Hybrid(string value)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(value);
+        RedisValue x = bytes, y = value;
+
+        Assert.True(x.Equals(y));
+        Assert.True(y.Equals(x));
+        Assert.True(x == y);
+        Assert.True(y == x);
+        Assert.False(x != y);
+        Assert.False(y != x);
+        Assert.Equal(x.GetHashCode(), y.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("na", "NA")]
+    [InlineData("nan", "NAN")]
+    [InlineData("nans", "NANS")]
+    [InlineData("in", "IN")]
+    [InlineData("inf", "INF")]
+    [InlineData("info", "INFO")]
+    public void SpecialCaseNonEqualityRules_String(string s, string t)
+    {
+        RedisValue x = s, y = t;
+        Assert.False(x.Equals(y));
+        Assert.False(y.Equals(x));
+        Assert.False(x == y);
+        Assert.False(y == x);
+        Assert.True(x != y);
+        Assert.True(y != x);
+    }
+
+    [Theory]
+    [InlineData("na", "NA")]
+    [InlineData("nan", "NAN")]
+    [InlineData("nans", "NANS")]
+    [InlineData("in", "IN")]
+    [InlineData("inf", "INF")]
+    [InlineData("info", "INFO")]
+    public void SpecialCaseNonEqualityRules_Bytes(string s, string t)
+    {
+        RedisValue x = Encoding.UTF8.GetBytes(s), y = Encoding.UTF8.GetBytes(t);
+        Assert.False(x.Equals(y));
+        Assert.False(y.Equals(x));
+        Assert.False(x == y);
+        Assert.False(y == x);
+        Assert.True(x != y);
+        Assert.True(y != x);
+    }
+
+    [Theory]
+    [InlineData("na", "NA")]
+    [InlineData("nan", "NAN")]
+    [InlineData("nans", "NANS")]
+    [InlineData("in", "IN")]
+    [InlineData("inf", "INF")]
+    [InlineData("info", "INFO")]
+    public void SpecialCaseNonEqualityRules_Hybrid(string s, string t)
+    {
+        RedisValue x = s, y = Encoding.UTF8.GetBytes(t);
+        Assert.False(x.Equals(y));
+        Assert.False(y.Equals(x));
+        Assert.False(x == y);
+        Assert.False(y == x);
+        Assert.True(x != y);
+        Assert.True(y != x);
+    }
+
     private static void CheckString(RedisValue value, string expected)
     {
         var s = value.ToString();

--- a/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
+++ b/tests/StackExchange.Redis.Tests/RedisValueEquivalencyTests.cs
@@ -137,11 +137,24 @@ public class RedisValueEquivalency
 
         Check(double.NegativeInfinity, double.NegativeInfinity);
         Check(double.NegativeInfinity, "-inf");
+        Check(double.NegativeInfinity, Bytes("-inf"));
         CheckString(double.NegativeInfinity, "-inf");
 
         Check(double.PositiveInfinity, double.PositiveInfinity);
         Check(double.PositiveInfinity, "+inf");
+        Check(double.PositiveInfinity, "inf");
+        Check(double.PositiveInfinity, Bytes("+inf"));
+        Check(double.PositiveInfinity, Bytes("inf"));
         CheckString(double.PositiveInfinity, "+inf");
+
+        Check(double.NaN, double.NaN);
+        Check(double.NaN, "+nan");
+        Check(double.NaN, "-nan");
+        Check(double.NaN, "nan");
+        Check(double.NaN, Bytes("+nan"));
+        Check(double.NaN, Bytes("-nan"));
+        Check(double.NaN, Bytes("nan"));
+        CheckString(double.NaN, "NaN");
     }
 
     private static void CheckString(RedisValue value, string expected)


### PR DESCRIPTION
by using `double : IUtf8Formattable`

open question: this is net8+; however, for anything netcoreapp2.1+ we could actually use the `Span<char>` overload to a scratch buffer, which would avoid a `string` alloc (and copy down if needed, like we do today from `string`). However, this would only really impact net6 which is EOL, so I do *not* propose to introduce extra code for that.

This PR also fixes a pre-existing oddity where, (as `RedisValue`):

- `"na" != "NA"`
- `"nan" == "NAN"`
- `"nand" != "NAND"`

(and similar for `inf`)
