### PR TITLE
chore: Replaces string interpolation with structured logging - left overs

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -396,7 +396,7 @@ public partial class ConnectionMultiplexer
         var logger = Logger.With(writer);
         if (connection.RawConfig.ServiceName is not string serviceName)
         {
-            logger?.LogInformation("Service name not defined.");
+            logger?.LogInformationServiceNameNotDefined();
             return;
         }
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1335,14 +1335,16 @@ namespace StackExchange.Redis
             if (log == null) return;
 
             var tmp = GetServerSnapshot();
-            log?.LogInformation("Endpoint Summary:");
+            log.LogInformationEndpointSummaryHeader();
             foreach (var server in tmp)
             {
-                log?.LogInformation("  " + server.Summary());
-                log?.LogInformation("  " + server.GetCounters().ToString());
-                log?.LogInformation("  " + server.GetProfile());
+                log.LogInformationServerSummary(server.Summary(), server.GetCounters(), server.GetProfile());
             }
-            log?.LogInformation($"Sync timeouts: {Interlocked.Read(ref syncTimeouts)}; async timeouts: {Interlocked.Read(ref asyncTimeouts)}; fire and forget: {Interlocked.Read(ref fireAndForgets)}; last heartbeat: {LastHeartbeatSecondsAgo}s ago");
+            log.LogInformationTimeoutsSummary(
+                Interlocked.Read(ref syncTimeouts),
+                Interlocked.Read(ref asyncTimeouts),
+                Interlocked.Read(ref fireAndForgets),
+                LastHeartbeatSecondsAgo);
         }
 
         private void ActivateAllServers(ILogger? log)

--- a/src/StackExchange.Redis/EndPointCollection.cs
+++ b/src/StackExchange.Redis/EndPointCollection.cs
@@ -209,12 +209,12 @@ namespace StackExchange.Redis
                         }
                         else
                         {
-                            log?.LogInformation($"Using DNS to resolve '{dns.Host}'...");
+                            log?.LogInformationUsingDnsToResolve(dns.Host);
                             var ips = await Dns.GetHostAddressesAsync(dns.Host).ObserveErrors().ForAwait();
                             if (ips.Length == 1)
                             {
                                 ip = ips[0];
-                                log?.LogInformation($"'{dns.Host}' => {ip}");
+                                log?.LogInformationDnsResolutionResult(dns.Host, ip);
                                 cache[dns.Host] = ip;
                                 this[i] = new IPEndPoint(ip, dns.Port);
                             }
@@ -223,7 +223,7 @@ namespace StackExchange.Redis
                     catch (Exception ex)
                     {
                         multiplexer.OnInternalError(ex);
-                        log?.LogError(ex, ex.Message);
+                        log?.LogErrorDnsResolution(ex, ex.Message);
                     }
                 }
             }

--- a/src/StackExchange.Redis/LoggerExtensions.cs
+++ b/src/StackExchange.Redis/LoggerExtensions.cs
@@ -665,4 +665,48 @@ internal static partial class LoggerExtensions
         EventId = 100,
         Message = "{BridgeName}: Connected")]
     internal static partial void LogInformationConnected(this ILogger logger, string bridgeName);
+
+    // ConnectionMultiplexer GetStatus logging methods
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 101,
+        Message = "Endpoint Summary:")]
+    internal static partial void LogInformationEndpointSummaryHeader(this ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 102,
+        Message = "Server summary: {ServerSummary}, counters: {ServerCounters}, profile: {ServerProfile}")]
+    internal static partial void LogInformationServerSummary(this ILogger logger, string serverSummary, ServerCounters serverCounters, string serverProfile);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 105,
+        Message = "Sync timeouts: {SyncTimeouts}; async timeouts: {AsyncTimeouts}; fire and forget: {FireAndForgets}; last heartbeat: {LastHeartbeatSecondsAgo}s ago")]
+    internal static partial void LogInformationTimeoutsSummary(this ILogger logger, long syncTimeouts, long asyncTimeouts, long fireAndForgets, long lastHeartbeatSecondsAgo);
+
+    // EndPointCollection logging methods
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 106,
+        Message = "Using DNS to resolve '{DnsHost}'...")]
+    internal static partial void LogInformationUsingDnsToResolve(this ILogger logger, string dnsHost);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 107,
+        Message = "'{DnsHost}' => {IpAddress}")]
+    internal static partial void LogInformationDnsResolutionResult(this ILogger logger, string dnsHost, IPAddress ipAddress);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        EventId = 108,
+        Message = "{ErrorMessage}")]
+    internal static partial void LogErrorDnsResolution(this ILogger logger, Exception exception, string errorMessage);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 109,
+        Message = "Service name not defined.")]
+    internal static partial void LogInformationServiceNameNotDefined(this ILogger logger);
 }


### PR DESCRIPTION
closes #2899

Converts manual log message formatting to LoggerMessage source generator methods for better performance and structured logging support.

Improves logging efficiency by eliminating string allocations when logging is disabled and provides consistent structured data for log analysis tools.