### PR TITLE
Flush & write concurrently in LoggingTunnel and avoid double lookups in dictionaries

### DIFF
--- a/src/StackExchange.Redis/ClusterConfiguration.cs
+++ b/src/StackExchange.Redis/ClusterConfiguration.cs
@@ -180,7 +180,7 @@ namespace StackExchange.Redis
                     if (node.IsMyself)
                         Origin = node.EndPoint;
 
-                    if (nodeLookup.ContainsKey(node.EndPoint))
+                    if (nodeLookup.TryGetValue(node.EndPoint, out var lookedUpNode))
                     {
                         // Deal with conflicting node entries for the same endpoint
                         // This can happen in dynamic environments when a node goes down and a new one is created
@@ -190,7 +190,7 @@ namespace StackExchange.Redis
                             // The node we're trying to add is probably about to become stale. Ignore it.
                             continue;
                         }
-                        else if (!nodeLookup[node.EndPoint].IsConnected)
+                        else if (!lookedUpNode.IsConnected)
                         {
                             // The node we registered previously is probably stale. Replace it with a known good node.
                             nodeLookup[node.EndPoint] = node;

--- a/src/StackExchange.Redis/Configuration/LoggingTunnel.cs
+++ b/src/StackExchange.Redis/Configuration/LoggingTunnel.cs
@@ -504,8 +504,9 @@ public abstract class LoggingTunnel : Tunnel
 
         public override async Task FlushAsync(CancellationToken cancellationToken)
         {
-            await _writes.FlushAsync().ForAwait();
+            var writesTask = _writes.FlushAsync().ForAwait();
             await _inner.FlushAsync().ForAwait();
+            await writesTask;
         }
 
         protected override void Dispose(bool disposing)
@@ -608,8 +609,9 @@ public abstract class LoggingTunnel : Tunnel
         }
         public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            await _writes.WriteAsync(buffer, offset, count, cancellationToken).ForAwait();
+            var writesTask = _writes.WriteAsync(buffer, offset, count, cancellationToken).ForAwait();
             await _inner.WriteAsync(buffer, offset, count, cancellationToken).ForAwait();
+            await writesTask;
         }
 #if NETCOREAPP3_0_OR_GREATER
         public override void Write(ReadOnlySpan<byte> buffer)
@@ -619,8 +621,9 @@ public abstract class LoggingTunnel : Tunnel
         }
         public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            await _writes.WriteAsync(buffer, cancellationToken).ForAwait();
+            var writesTask = _writes.WriteAsync(buffer, cancellationToken).ForAwait();
             await _inner.WriteAsync(buffer, cancellationToken).ForAwait();
+            await writesTask;
         }
 #endif
     }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -14,7 +14,7 @@ public partial class ConnectionMultiplexer
 {
     internal EndPoint? currentSentinelPrimaryEndPoint;
     internal Timer? sentinelPrimaryReconnectTimer;
-    internal Dictionary<string, ConnectionMultiplexer> sentinelConnectionChildren = new Dictionary<string, ConnectionMultiplexer>();
+    internal readonly Dictionary<string, ConnectionMultiplexer> sentinelConnectionChildren = new();
     internal ConnectionMultiplexer? sentinelConnection;
 
     /// <summary>
@@ -44,10 +44,8 @@ public partial class ConnectionMultiplexer
                     lock (sentinelConnectionChildren)
                     {
                         // Switch the primary if we have connections for that service
-                        if (sentinelConnectionChildren.ContainsKey(messageParts[0]))
+                        if (sentinelConnectionChildren.TryGetValue(messageParts[0], out ConnectionMultiplexer? child))
                         {
-                            ConnectionMultiplexer child = sentinelConnectionChildren[messageParts[0]];
-
                             // Is the connection still valid?
                             if (child.IsDisposed)
                             {
@@ -57,7 +55,7 @@ public partial class ConnectionMultiplexer
                             }
                             else
                             {
-                                SwitchPrimary(switchBlame, sentinelConnectionChildren[messageParts[0]]);
+                                SwitchPrimary(switchBlame, child);
                             }
                         }
                     }


### PR DESCRIPTION
Code is not in hot paths, it is mainly for correctness.