### PR TITLE
Add overridable DefaultOptionsProvider.AfterDisconnectAsync() callback

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,7 +8,7 @@ Current package versions:
 
 ## Unreleased
 
-- (none)
+- Add overrideable `AfterDisconnectAsync()` callback on `DefaultOptionsProvider` ([#2952 by philon-msft](https://github.com/StackExchange/StackExchange.Redis/pull/2952))
 
 ## 2.9.17
 

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -308,6 +308,12 @@ namespace StackExchange.Redis.Configuration
         public virtual Task AfterConnectAsync(ConnectionMultiplexer multiplexer, Action<string> log) => Task.CompletedTask;
 
         /// <summary>
+        /// The action to perform, if any, immediately after a connection is closed.
+        /// </summary>
+        /// <param name="multiplexer">The multiplexer that just disconnected.</param>
+        public virtual Task AfterDisconnectAsync(ConnectionMultiplexer multiplexer) => Task.CompletedTask;
+
+        /// <summary>
         /// Gets the default SSL "enabled or not" based on a set of endpoints.
         /// Note: this setting then applies for *all* endpoints.
         /// </summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -210,6 +210,8 @@ namespace StackExchange.Redis
 
         internal Func<ConnectionMultiplexer, Action<string>, Task> AfterConnectAsync => Defaults.AfterConnectAsync;
 
+        internal Func<ConnectionMultiplexer, Task> AfterDisconnectAsync => Defaults.AfterDisconnectAsync;
+
         /// <summary>
         /// Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException.
         /// </summary>
@@ -305,8 +307,8 @@ namespace StackExchange.Redis
         /// <summary>
         /// Supply a user certificate from a PEM file pair and enable TLS.
         /// </summary>
-        /// <param name="userCertificatePath">The path for the the user certificate (commonly a .crt file).</param>
-        /// <param name="userKeyPath">The path for the the user key (commonly a .key file).</param>
+        /// <param name="userCertificatePath">The path for the user certificate (commonly a .crt file).</param>
+        /// <param name="userKeyPath">The path for the user key (commonly a .key file).</param>
         public void SetUserPemCertificate(string userCertificatePath, string? userKeyPath = null)
         {
             CertificateSelectionCallback = CreatePemUserCertificateCallback(userCertificatePath, userKeyPath);
@@ -317,7 +319,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Supply a user certificate from a PFX file and optional password and enable TLS.
         /// </summary>
-        /// <param name="userCertificatePath">The path for the the user certificate (commonly a .pfx file).</param>
+        /// <param name="userCertificatePath">The path for the user certificate (commonly a .pfx file).</param>
         /// <param name="password">The password for the certificate file.</param>
         public void SetUserPfxCertificate(string userCertificatePath, string? password = null)
         {
@@ -383,7 +385,7 @@ namespace StackExchange.Redis
             chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
             chain.ChainPolicy.VerificationTime = chainToValidate?.ChainPolicy?.VerificationTime ?? DateTime.Now;
             chain.ChainPolicy.UrlRetrievalTimeout = new TimeSpan(0, 0, 0);
-            // Ensure entended key usage checks are run and that we're observing a server TLS certificate
+            // Ensure intended key usage checks are run and that we're observing a server TLS certificate
             chain.ChainPolicy.ApplicationPolicy.Add(_serverAuthOid);
 
             chain.ChainPolicy.ExtraStore.Add(authority);

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -1848,6 +1848,7 @@ static StackExchange.Redis.StreamPosition.Beginning.get -> StackExchange.Redis.R
 static StackExchange.Redis.StreamPosition.NewMessages.get -> StackExchange.Redis.RedisValue
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.AbortOnConnectFail.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.AfterConnectAsync(StackExchange.Redis.ConnectionMultiplexer! multiplexer, System.Action<string!>! log) -> System.Threading.Tasks.Task!
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.AfterDisconnectAsync(StackExchange.Redis.ConnectionMultiplexer! multiplexer) -> System.Threading.Tasks.Task!
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.AllowAdmin.get -> bool
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.BacklogPolicy.get -> StackExchange.Redis.BacklogPolicy!
 virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.CheckCertificateRevocation.get -> bool


### PR DESCRIPTION
Enables graceful release and shutdown in custom DefaultOptionsProviders. For example, Microsoft.Azure.StackExchangeRedis uses a token refresh Timer that should be stopped when the connection is closed. 

This approach using a callback was suggested as an alternative to previous PR #2922 