### PR TITLE
Convert to Hex only on Encoding.UTF8.GetString possible exceptions

### DIFF
--- a/src/StackExchange.Redis/RedisValue.cs
+++ b/src/StackExchange.Redis/RedisValue.cs
@@ -784,7 +784,10 @@ namespace StackExchange.Redis
                     {
                         return Format.GetString(span);
                     }
-                    catch
+                    catch (Exception e) when // Only catch exception throwed by Encoding.UTF8.GetString
+                        (e is DecoderFallbackException
+                        || e is ArgumentException
+                        || e is ArgumentNullException)
                     {
                         return ToHex(span);
                     }


### PR DESCRIPTION
Under high memory pressure, OutOfMemory exceptions can occure randomly on every line of cade that allocate memory like in native **`Encoding.UTF8.GetString`** used by the tryed call to **`Format.GetString(span);`**

Redis value conversion to string should not convert string in hex value on all possible exception but only when value is not a valid UTF8 byte array.... 

For this the catch will now catch only possible exceptions throwed by **`Encoding.UTF8.GetString`**, this should not change the conversion behavior but will fix bad results in case of **`OutOfMemory`** exceptions or other not expected exceptions.

- Exception throwed by **`Encoding.UTF8.GetString`** from Microsoft documentation:

[ArgumentException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentexception?view=net-9.0)
The byte array contains invalid Unicode code points.
[ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-9.0)
bytes is null.

[DecoderFallbackException](https://learn.microsoft.com/en-us/dotnet/api/system.text.decoderfallbackexception?view=net-9.0)
A fallback occurred (for more information, see [Character Encoding in .NET](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding))
