### PR TITLE
Remove supported Envoyproxy commands from exclusions.

### DIFF
--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -59,8 +59,6 @@ namespace StackExchange.Redis
 
             RedisCommand.PSUBSCRIBE, RedisCommand.PUBLISH, RedisCommand.PUNSUBSCRIBE, RedisCommand.SUBSCRIBE, RedisCommand.UNSUBSCRIBE, RedisCommand.SPUBLISH, RedisCommand.SSUBSCRIBE, RedisCommand.SUNSUBSCRIBE,
 
-            RedisCommand.DISCARD, RedisCommand.EXEC, RedisCommand.MULTI, RedisCommand.UNWATCH, RedisCommand.WATCH,
-
             RedisCommand.SCRIPT,
 
             RedisCommand.SELECT,


### PR DESCRIPTION
Starting this conversation, to understand if this change is intentional.

Context: since version **2.9.17**, multiple Envoy commands [were added](https://github.com/StackExchange/StackExchange.Redis/pull/2887/files#diff-d76e63e6d287770f768927dfdc3b25d17fc14d4413e0562140a86a6426cac7b4) to the list of excluded commands. Previously, in versions **2.8.16** and **2.8.37**, the intent seems to be, to remove these commands from the exclusion list. See [#2794](https://github.com/StackExchange/StackExchange.Redis/pull/2794
) and [#2824](https://github.com/StackExchange/StackExchange.Redis/pull/2824)

@mgravell - let me know if I am missing anything or if there is another way to initialize CommandMap for Envoyproxy.