### PR TITLE
Channel routing: revert non-S routing to random, with new API to opt into routed

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ Current package versions:
 ## Unreleased
 
 - Fix [#2951](https://github.com/StackExchange/StackExchange.Redis/issues/2951) - sentinel reconnection failure ([#2956 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2956))
+- Mitigate [#2955](https://github.com/StackExchange/StackExchange.Redis/issues/2955) (unbalanced pub/sub routing) ([#XXXX by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/XXXX))
 
 ## 2.9.17
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,7 +9,7 @@ Current package versions:
 ## Unreleased
 
 - Fix [#2951](https://github.com/StackExchange/StackExchange.Redis/issues/2951) - sentinel reconnection failure ([#2956 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2956))
-- Mitigate [#2955](https://github.com/StackExchange/StackExchange.Redis/issues/2955) (unbalanced pub/sub routing) ([#XXXX by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/XXXX))
+- Mitigate [#2955](https://github.com/StackExchange/StackExchange.Redis/issues/2955) (unbalanced pub/sub routing) ([#2958 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2958))
 
 ## 2.9.17
 

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -867,7 +867,7 @@ namespace StackExchange.Redis
             public override string CommandAndKey => Command + " " + Channel;
 
             public override int GetHashSlot(ServerSelectionStrategy serverSelectionStrategy)
-                => Channel.UseClusterRouting ? serverSelectionStrategy.HashSlot(Channel) : ServerSelectionStrategy.NoSlot;
+                => Channel.IsKeyRouted ? serverSelectionStrategy.HashSlot(Channel) : ServerSelectionStrategy.NoSlot;
         }
 
         internal abstract class CommandKeyBase : Message

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -866,7 +866,8 @@ namespace StackExchange.Redis
 
             public override string CommandAndKey => Command + " " + Channel;
 
-            public override int GetHashSlot(ServerSelectionStrategy serverSelectionStrategy) => serverSelectionStrategy.HashSlot(Channel);
+            public override int GetHashSlot(ServerSelectionStrategy serverSelectionStrategy)
+                => Channel.UseClusterRouting ? serverSelectionStrategy.HashSlot(Channel) : ServerSelectionStrategy.NoSlot;
         }
 
         internal abstract class CommandKeyBase : Message

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -2051,3 +2051,4 @@ StackExchange.Redis.IServer.ExecuteAsync(int? database, string! command, System.
 [SER001]static StackExchange.Redis.VectorSetAddRequest.Member(StackExchange.Redis.RedisValue element, System.ReadOnlyMemory<float> values, string? attributesJson = null) -> StackExchange.Redis.VectorSetAddRequest!
 [SER001]static StackExchange.Redis.VectorSetSimilaritySearchRequest.ByMember(StackExchange.Redis.RedisValue member) -> StackExchange.Redis.VectorSetSimilaritySearchRequest!
 [SER001]static StackExchange.Redis.VectorSetSimilaritySearchRequest.ByVector(System.ReadOnlyMemory<float> vector) -> StackExchange.Redis.VectorSetSimilaritySearchRequest!
+StackExchange.Redis.RedisChannel.WithKeyRouting() -> StackExchange.Redis.RedisChannel

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 ﻿#nullable enable
-static StackExchange.Redis.RedisChannel.LiteralRouted(byte[]! value) -> StackExchange.Redis.RedisChannel
-static StackExchange.Redis.RedisChannel.LiteralRouted(string! value) -> StackExchange.Redis.RedisChannel
-static StackExchange.Redis.RedisChannel.PatternRouted(byte[]! value) -> StackExchange.Redis.RedisChannel
-static StackExchange.Redis.RedisChannel.PatternRouted(string! value) -> StackExchange.Redis.RedisChannel

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 ﻿#nullable enable
+static StackExchange.Redis.RedisChannel.LiteralRouted(byte[]! value) -> StackExchange.Redis.RedisChannel
+static StackExchange.Redis.RedisChannel.LiteralRouted(string! value) -> StackExchange.Redis.RedisChannel
+static StackExchange.Redis.RedisChannel.PatternRouted(byte[]! value) -> StackExchange.Redis.RedisChannel
+static StackExchange.Redis.RedisChannel.PatternRouted(string! value) -> StackExchange.Redis.RedisChannel

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -1871,14 +1871,16 @@ namespace StackExchange.Redis
         {
             if (channel.IsNullOrEmpty) throw new ArgumentNullException(nameof(channel));
             var msg = Message.Create(-1, flags, channel.PublishCommand, channel, message);
-            return ExecuteSync(msg, ResultProcessor.Int64);
+            // if we're actively subscribed: send via that connection (otherwise, follow normal rules)
+            return ExecuteSync(msg, ResultProcessor.Int64, server: multiplexer.GetSubscribedServer(channel));
         }
 
         public Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None)
         {
             if (channel.IsNullOrEmpty) throw new ArgumentNullException(nameof(channel));
             var msg = Message.Create(-1, flags, channel.PublishCommand, channel, message);
-            return ExecuteAsync(msg, ResultProcessor.Int64);
+            // if we're actively subscribed: send via that connection (otherwise, follow normal rules)
+            return ExecuteAsync(msg, ResultProcessor.Int64, server: multiplexer.GetSubscribedServer(channel));
         }
 
         public RedisResult Execute(string command, params object[] args)

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -182,18 +182,16 @@ namespace StackExchange.Redis
             /// </summary>
             internal Message GetMessage(RedisChannel channel, SubscriptionAction action, CommandFlags flags, bool internalCall)
             {
-                var isPattern = channel.IsPattern;
-                var isSharded = channel.IsSharded;
-                var command = action switch
+                var command = action switch // note that the Routed flag doesn't impact the message here - just the routing
                 {
-                    SubscriptionAction.Subscribe => channel.Options switch
+                    SubscriptionAction.Subscribe => (channel.Options & ~RedisChannel.RedisChannelOptions.Routed) switch
                     {
                         RedisChannel.RedisChannelOptions.None => RedisCommand.SUBSCRIBE,
                         RedisChannel.RedisChannelOptions.Pattern => RedisCommand.PSUBSCRIBE,
                         RedisChannel.RedisChannelOptions.Sharded => RedisCommand.SSUBSCRIBE,
                         _ => Unknown(action, channel.Options),
                     },
-                    SubscriptionAction.Unsubscribe => channel.Options switch
+                    SubscriptionAction.Unsubscribe => (channel.Options & ~RedisChannel.RedisChannelOptions.Routed) switch
                     {
                         RedisChannel.RedisChannelOptions.None => RedisCommand.UNSUBSCRIBE,
                         RedisChannel.RedisChannelOptions.Pattern => RedisCommand.PUNSUBSCRIBE,
@@ -384,14 +382,16 @@ namespace StackExchange.Redis
         {
             ThrowIfNull(channel);
             var msg = Message.Create(-1, flags, channel.PublishCommand, channel, message);
-            return ExecuteSync(msg, ResultProcessor.Int64);
+            // if we're actively subscribed: send via that connection (otherwise, follow normal rules)
+            return ExecuteSync(msg, ResultProcessor.Int64, server: multiplexer.GetSubscribedServer(channel));
         }
 
         public Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None)
         {
             ThrowIfNull(channel);
             var msg = Message.Create(-1, flags, channel.PublishCommand, channel, message);
-            return ExecuteAsync(msg, ResultProcessor.Int64);
+            // if we're actively subscribed: send via that connection (otherwise, follow normal rules)
+            return ExecuteAsync(msg, ResultProcessor.Int64, server: multiplexer.GetSubscribedServer(channel));
         }
 
         void ISubscriber.Subscribe(RedisChannel channel, Action<RedisChannel, RedisValue> handler, CommandFlags flags)

--- a/src/StackExchange.Redis/RedisSubscriber.cs
+++ b/src/StackExchange.Redis/RedisSubscriber.cs
@@ -184,14 +184,14 @@ namespace StackExchange.Redis
             {
                 var command = action switch // note that the Routed flag doesn't impact the message here - just the routing
                 {
-                    SubscriptionAction.Subscribe => (channel.Options & ~RedisChannel.RedisChannelOptions.Routed) switch
+                    SubscriptionAction.Subscribe => (channel.Options & ~RedisChannel.RedisChannelOptions.KeyRouted) switch
                     {
                         RedisChannel.RedisChannelOptions.None => RedisCommand.SUBSCRIBE,
                         RedisChannel.RedisChannelOptions.Pattern => RedisCommand.PSUBSCRIBE,
                         RedisChannel.RedisChannelOptions.Sharded => RedisCommand.SSUBSCRIBE,
                         _ => Unknown(action, channel.Options),
                     },
-                    SubscriptionAction.Unsubscribe => (channel.Options & ~RedisChannel.RedisChannelOptions.Routed) switch
+                    SubscriptionAction.Unsubscribe => (channel.Options & ~RedisChannel.RedisChannelOptions.KeyRouted) switch
                     {
                         RedisChannel.RedisChannelOptions.None => RedisCommand.UNSUBSCRIBE,
                         RedisChannel.RedisChannelOptions.Pattern => RedisCommand.PUNSUBSCRIBE,

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -47,7 +47,13 @@ namespace StackExchange.Redis
         };
 
         private readonly ConnectionMultiplexer multiplexer;
-        private int anyStartOffset;
+        private int anyStartOffset = SharedRandom.Next(); // initialize to a random value so routing isn't uniform
+
+        #if NET6_0_OR_GREATER
+        private static Random SharedRandom => Random.Shared;
+        #else
+        private static Random SharedRandom { get; } = new();
+        #endif
 
         private ServerEndPoint[]? map;
 

--- a/tests/StackExchange.Redis.Tests/ClusterTests.cs
+++ b/tests/StackExchange.Redis.Tests/ClusterTests.cs
@@ -744,15 +744,34 @@ public class ClusterTests(ITestOutputHelper output, SharedConnectionFixture fixt
 
     [Theory]
     [InlineData(true)]
-    [InlineData(false)]
-    public async Task ClusterPubSub(bool sharded)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    public async Task ClusterPubSub(bool sharded, bool routed = false)
     {
         var guid = Guid.NewGuid().ToString();
-        var channel = sharded ? RedisChannel.Sharded(guid) : RedisChannel.Literal(guid);
+        var channel = sharded ? RedisChannel.Sharded(guid) : routed ? RedisChannel.LiteralRouted(guid) : RedisChannel.Literal(guid);
         await using var conn = Create(keepAlive: 1, connectTimeout: 3000, shared: false, require: sharded ? RedisFeatures.v7_0_0_rc1 : RedisFeatures.v2_0_0);
         Assert.True(conn.IsConnected);
 
         var pubsub = conn.GetSubscriber();
+        HashSet<string> eps = [];
+        for (int i = 0; i < 10; i++)
+        {
+            var ep = Format.ToString(await pubsub.IdentifyEndpointAsync(channel));
+            Log($"Channel {channel} => {ep}");
+            eps.Add(ep);
+        }
+
+        if (sharded | routed)
+        {
+            Assert.Single(eps);
+        }
+        else
+        {
+            // if not routed: we should have at least two different endpoints
+            Assert.True(eps.Count > 1);
+        }
+
         List<(RedisChannel, RedisValue)> received = [];
         var queue = await pubsub.SubscribeAsync(channel);
         _ = Task.Run(async () =>
@@ -766,16 +785,28 @@ public class ClusterTests(ITestOutputHelper output, SharedConnectionFixture fixt
                 }
             }
         });
-
+        var subscribedEp = Format.ToString(pubsub.SubscribedEndpoint(channel));
+        Log($"Subscribed to {subscribedEp}");
+        Assert.NotNull(subscribedEp);
+        if (sharded | routed)
+        {
+            Assert.Equal(eps.Single(), subscribedEp);
+        }
         var db = conn.GetDatabase();
         await Task.Delay(50); // let the sub settle (this isn't needed on RESP3, note)
         await db.PingAsync();
         for (int i = 0; i < 10; i++)
         {
-            // check we get a hit
-            Assert.Equal(1, await db.PublishAsync(channel, i.ToString()));
+            // publish
+            var receivers = await db.PublishAsync(channel, i.ToString());
+
+            // check we get a hit (we are the only subscriber, and because we prefer to
+            // use our own subscribed connection: we can reliably expect to see this hit)
+            Log($"Published {i} to {receivers} receiver(s) against the receiving server.");
+            Assert.Equal(1, receivers);
         }
-        await Task.Delay(50); // let the sub settle (this isn't needed on RESP3, note)
+
+        await Task.Delay(250); // let the sub settle (this isn't needed on RESP3, note)
         await db.PingAsync();
         await pubsub.UnsubscribeAsync(channel);
 
@@ -792,6 +823,8 @@ public class ClusterTests(ITestOutputHelper output, SharedConnectionFixture fixt
             var pair = snap[i];
             Log("element {0}: {1}/{2}", i, pair.Channel, pair.Value);
         }
+        // even if not routed: we can expect the *order* to be correct, since there's
+        // only one publisher (us), and we prefer to publish via our own subscription
         for (int i = 0; i < 10; i++)
         {
             var pair = snap[i];


### PR DESCRIPTION
mitigate #2955

Reason for revert: many environments use very few channels, which can lead to a massively skewed subscriber distribution in cluster scenarios, rather than making good use of the horizontal broadcast feature

- by default: use round-robin (not channel-routing) for "non-sharded" pub/sub
- add new API for channel-routed literals/wildcards
- when publishing, if we're also subscribed: use that connection
- randomize where the round-robin starts, to better randomize startup behaviour