### PR TITLE
eng: remove PublicSign windows-only restriction

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,8 @@ Current package versions:
 
 ## Unreleased
 
+- (build) Fix SNK on non-Windows builds ([#2963 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2963))
+
 ## 2.9.24
 
 - Fix [#2951](https://github.com/StackExchange/StackExchange.Redis/issues/2951) - sentinel reconnection failure ([#2956 by mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/2956))

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -9,7 +9,6 @@
     <PackageId>StackExchange.Redis</PackageId>
     <PackageTags>Async;Redis;Cache;PubSub;Messaging</PackageTags>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);VECTOR_SAFE</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0'">$(DefineConstants);UNIX_SOCKET</DefineConstants>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
+++ b/toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj
@@ -9,7 +9,6 @@
     <PackageTags>Server;Async;Redis;Cache;PubSub;Messaging</PackageTags>
     <OutputTypeEx>Library</OutputTypeEx>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
fix #2961

problem: linux build does not strong-sign (or rather: it public-signs, which is like delay-sign but: looser)

The cause is explicit in the csproj; this was [added 7 years ago](https://github.com/StackExchange/StackExchange.Redis/commit/f1003b471d82adf527aa7736834e4425b02f8394#diff-15df3c28997ba29023c38391cdb263eab4c5e7c50efc5f2591ac985aeaea5bc2R12); I *assume* this was due to a glitch in .NET Core 2.x (as-was at the time), on non-Windows, but: checking locally: it works fine now

``` txt
> sn -v bin/Release/net8.0/StackExchange.Redis.dll
Mono StrongName - version 6.12.0.199
StrongName utility for signing assemblies
Copyright 2002, 2003 Motus Technologies. Copyright 2004-2008 Novell. BSD licensed.

Assembly bin/Release/net8.0/StackExchange.Redis.dll is strongnamed.
```

