### PR TITLE
Actions: support publishing to MyGet off main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,3 +143,8 @@ jobs:
         name: Tests Results - Windows Server 2022
         path: 'test-results/*.trx'
         reporter: dotnet-trx
+    - name: .NET Pack
+      run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=${env:GITHUB_WORKSPACE}\.nupkgs /p:CI=true
+    - name: Upload to MyGet
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: dotnet nuget push ${env:GITHUB_WORKSPACE}\.nupkgs\*.nupkg -s https://www.myget.org/F/stackoverflow/api/v2/package -k ${{ secrets.MYGET_API_KEY }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,7 +143,9 @@ jobs:
         name: Tests Results - Windows Server 2022
         path: 'test-results/*.trx'
         reporter: dotnet-trx
+    # Package and upload to MyGet only on pushes to main, not on PRs
     - name: .NET Pack
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=${env:GITHUB_WORKSPACE}\.nupkgs /p:CI=true
     - name: Upload to MyGet
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
This is on the way to removing AppVeyor (currently broken) from our environment. Publishes to MyGet when building from a push to main, _not_ on pull requests.