### PR TITLE
Make PhysicalBridge? physical member threadSafe

### DIFF
--- a/src/StackExchange.Redis/ThreadSafePhysicalConnectionAccessor.cs
+++ b/src/StackExchange.Redis/ThreadSafePhysicalConnectionAccessor.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace StackExchange.Redis
+{
+    internal sealed class ThreadSafePhysicalConnectionAccessor
+    {
+        private PhysicalConnection? physical;
+        private readonly ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+        internal ThreadSafePhysicalConnectionAccessor()
+        {
+        }
+
+        public bool HasOutputPipe
+        {
+            get
+            {
+                try
+                {
+                    rwLock.EnterReadLock();
+                    return physical?.HasOutputPipe ?? false;
+                }
+                finally
+                {
+                    rwLock.ExitReadLock();
+                }
+            }
+        }
+
+        public bool HasPendingCallerFacingItems
+        {
+            get
+            {
+                try
+                {
+                    rwLock.EnterReadLock();
+                    return physical?.HasPendingCallerFacingItems() ?? false;
+                }
+                finally
+                {
+                    rwLock.ExitReadLock();
+                }
+            }
+        }
+
+        internal void CreateConnection(PhysicalBridge bridge, ILogger? log)
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                physical = new PhysicalConnection(bridge);
+                physical.BeginConnectAsync(log).RedisFireAndForget();
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        internal long? GetConnectionId()
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                return physical?.ConnectionId;
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal string? GetPhysicalName()
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                return physical?.ToString();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal long GetSubscriptionCount()
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                return physical?.SubscriptionCount ?? 0;
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal void DisposePhysicalConnection()
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                if (physical != null)
+                {
+                    physical.Dispose();
+                    physical = null;
+                }
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        internal void Shutdown()
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                try
+                {
+                    physical?.Shutdown();
+                }
+                catch { }
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        internal bool WorkOnPhysicalWithLock(Action<PhysicalConnection> callBack)
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                if (physical != null)
+                {
+                    callBack(physical);
+                    return true;
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        internal void SimulateConnectionFailure(SimulatedFailureType failureType)
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                physical?.SimulateConnectionFailure(failureType);
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        internal void SetIdle()
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                physical?.SetIdle();
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        internal void GetCounters(ConnectionCounters counters)
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                physical?.GetCounters(counters);
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal PhysicalConnection.ConnectionStatus GetStatus()
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                return physical?.GetStatus() ?? PhysicalConnection.ConnectionStatus.Default;
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal void GetStormLog(StringBuilder sb)
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                physical?.GetStormLog(sb);
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal bool IsIdle()
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                return physical?.IsIdle() ?? false;
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal bool ConnectionMatch(PhysicalConnection connection)
+        {
+            try
+            {
+                rwLock.EnterReadLock();
+                return physical == connection;
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        internal bool ClearPhysicalIfMatch(PhysicalConnection? connection, out bool isNull)
+        {
+            try
+            {
+                rwLock.EnterWriteLock();
+                isNull = physical == null;
+                if (physical == connection)
+                {
+                    physical = null;
+                    return true;
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+    }
+}

--- a/src/StackExchange.Redis/ThreadSafePhysicalConnectionAccessor.cs
+++ b/src/StackExchange.Redis/ThreadSafePhysicalConnectionAccessor.cs
@@ -13,7 +13,7 @@ namespace StackExchange.Redis
         {
         }
 
-        public bool HasOutputPipe
+        internal bool HasOutputPipe
         {
             get
             {
@@ -29,7 +29,7 @@ namespace StackExchange.Redis
             }
         }
 
-        public bool HasPendingCallerFacingItems
+        internal bool HasPendingCallerFacingItems
         {
             get
             {


### PR DESCRIPTION
By reading PhysicalBridge code i see that the phycical connexion is hosted by a volatile class member to be "protected".
This have been done to securize concurrent accesses to the physical connection because of volatile keyword i think.. but iot's not really safe.
This PR try to move physical connection in a threadSafe accessor class so no conflicts can happen.

Some details:

Seeing this kind of unsafe codes:
<img width="290" height="95" alt="image" src="https://github.com/user-attachments/assets/86c3881d-3f1b-437d-b752-66346d081f59" />
or another example
<img width="442" height="163" alt="image" src="https://github.com/user-attachments/assets/33c6de44-136c-4dc1-8c60-38a36023f5b1" />
and more example where we only test the nullity of the memeber and then work on it... but can be set to null, and /or shutdown / disposed at any time by an other thread

And reading the microsoft documentation for the volatile keyword here: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/volatile?devlangs=csharp
<img width="894" height="409" alt="image" src="https://github.com/user-attachments/assets/4362983e-37e4-43a1-b133-d970a42959a5" />

This code protection + HighIntegrity mode seem to fix the two issue: #2919 and #2920



