### PR TITLE
Upgrade version of some packages needing system.memory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
     <!-- Packages we depend on for StackExchange.Redis, upgrades can create binding redirect pain! -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.16" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="5.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/StackExchange.Redis/TextWriterLogger.cs
+++ b/src/StackExchange.Redis/TextWriterLogger.cs
@@ -17,11 +17,7 @@ internal sealed class TextWriterLogger : ILogger
         _wrapped = wrapped;
     }
 
-#if NET8_0_OR_GREATER
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NothingDisposable.Instance;
-#else
-    public IDisposable BeginScope<TState>(TState state) => NothingDisposable.Instance;
-#endif
 
     public bool IsEnabled(LogLevel logLevel) => _writer is not null || _wrapped is not null;
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/tests/StackExchange.Redis.Tests/LoggerTests.cs
+++ b/tests/StackExchange.Redis.Tests/LoggerTests.cs
@@ -62,11 +62,7 @@ public class LoggerTests(ITestOutputHelper output) : TestBase(output)
         public int LogCount = 0;
         private ILogger Inner { get; } = toWrap;
 
-#if NET8_0_OR_GREATER
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => Inner.BeginScope(state);
-#else
-        public IDisposable BeginScope<TState>(TState state) => Inner.BeginScope(state);
-#endif
         public bool IsEnabled(LogLevel logLevel) => Inner.IsEnabled(logLevel);
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
@@ -80,11 +76,7 @@ public class LoggerTests(ITestOutputHelper output) : TestBase(output)
     /// </summary>
     private sealed class TestMultiLogger(params ILogger[] loggers) : ILogger
     {
-#if NET8_0_OR_GREATER
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-#else
-        public IDisposable BeginScope<TState>(TState state) => null!;
-#endif
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
@@ -104,11 +96,7 @@ public class LoggerTests(ITestOutputHelper output) : TestBase(output)
         public TestLogger(LogLevel logLevel, TextWriter output) =>
             (_logLevel, _output) = (logLevel, output);
 
-#if NET8_0_OR_GREATER
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-#else
-        public IDisposable BeginScope<TState>(TState state) => null!;
-#endif
         public bool IsEnabled(LogLevel logLevel) => logLevel >= _logLevel;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {


### PR DESCRIPTION
so they use the same version (4:0:1:2) than System.Hashing.IO

System.Hashing.IO can not be downgraded for old .net because first version with XxHash3 use system.memory 4:0:1:2

see issue https://github.com/StackExchange/StackExchange.Redis/issues/3055 for more informations

My tests from a simple .net 4.8 cmmandline thant include Stackexchange.redis seem to be OK without needing to add ugly runtime assemblyBinding in .config file