### PR TITLE
Fix #2173: Honor AbortOnConnectFail on sentinel path

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -206,7 +206,7 @@ public partial class ConnectionMultiplexer
             {
                 if (!config.AbortOnConnectFail)
                 {
-                    connection = ConnectImpl(config, log, endpoints: config.EndPoints);
+                    connection = ConnectImpl(config, log, endpoints: config.EndPoints.Clone());
                     connection.ConnectionRestored += OnManagedConnectionRestored;
                     connection.ConnectionFailed += OnManagedConnectionFailed;
                     lock (sentinelConnectionChildren)

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Sentinel.cs
@@ -166,7 +166,8 @@ public partial class ConnectionMultiplexer
     /// <param name="log">The writer to log to, if any.</param>
     public ConnectionMultiplexer GetSentinelMasterConnection(ConfigurationOptions config, TextWriter? log = null)
     {
-        if (ServerSelectionStrategy.ServerType != ServerType.Sentinel)
+        if (ServerSelectionStrategy.ServerType != ServerType.Sentinel
+            && (RawConfig.AbortOnConnectFail || IsConnected))
         {
             throw new RedisConnectionException(
                 ConnectionFailureType.UnableToConnect,
@@ -203,6 +204,18 @@ public partial class ConnectionMultiplexer
 
             if (newPrimaryEndPoint is null)
             {
+                if (!config.AbortOnConnectFail)
+                {
+                    connection = ConnectImpl(config, log, endpoints: config.EndPoints);
+                    connection.ConnectionRestored += OnManagedConnectionRestored;
+                    connection.ConnectionFailed += OnManagedConnectionFailed;
+                    lock (sentinelConnectionChildren)
+                    {
+                        sentinelConnectionChildren[serviceName] = connection;
+                    }
+                    return connection;
+                }
+
                 throw new RedisConnectionException(
                     ConnectionFailureType.UnableToConnect,
                     $"Sentinel: Failed connecting to configured primary for service: {config.ServiceName}");

--- a/tests/StackExchange.Redis.Tests/SentinelAbortOnConnectTests.cs
+++ b/tests/StackExchange.Redis.Tests/SentinelAbortOnConnectTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+public class SentinelAbortOnConnectTests(ITestOutputHelper output) : TestBase(output)
+{
+    [Fact]
+    public void ConnectToUnreachableSentinelReturnsDisconnectedMultiplexer()
+    {
+        var config = ConfigurationOptions.Parse("nonexistent:26379,serviceName=mymaster");
+        config.AbortOnConnectFail = false;
+        config.ConnectTimeout = 1000;
+
+        using var mux = ConnectionMultiplexer.Connect(config);
+        Assert.NotNull(mux);
+        Assert.False(mux.IsConnected);
+    }
+
+    [Fact]
+    public async Task ConnectAsyncToUnreachableSentinelReturnsDisconnectedMultiplexer()
+    {
+        var config = ConfigurationOptions.Parse("nonexistent:26379,serviceName=mymaster");
+        config.AbortOnConnectFail = false;
+        config.ConnectTimeout = 1000;
+
+        await using var mux = await ConnectionMultiplexer.ConnectAsync(config);
+        Assert.NotNull(mux);
+        Assert.False(mux.IsConnected);
+    }
+
+    [Fact]
+    public void ConnectToUnreachableSentinelThrowsWhenAbortOnConnectFailIsTrue()
+    {
+        var config = ConfigurationOptions.Parse("nonexistent:26379,serviceName=mymaster");
+        config.AbortOnConnectFail = true;
+        config.ConnectTimeout = 1000;
+
+        Assert.Throws<RedisConnectionException>(() => ConnectionMultiplexer.Connect(config));
+    }
+}


### PR DESCRIPTION
When `Connect` is called with `ServiceName` and `AbortOnConnectFail=false`,
the non-sentinel path returns a disconnected multiplexer that reconnects in
the background. The sentinel path ignores this flag and throws unconditionally
with "Sentinel: The ConnectionMultiplexer is not a Sentinel connection.
Detected as: Standalone".

This is because `SentinelConnect` returns a disconnected multiplexer
(ServerType defaults to Standalone when the handshake hasn't completed),
and `GetSentinelMasterConnection` throws when it sees the wrong ServerType
— without checking AbortOnConnectFail.

Changes in `GetSentinelMasterConnection`:

- Skip the ServerType check when AbortOnConnectFail is false and the
  connection hasn't completed handshake.
- When primary discovery returns null and AbortOnConnectFail is false,
  return a disconnected multiplexer with OnManagedConnectionFailed /
  OnManagedConnectionRestored wired up instead of throwing. Self-healing
  works via the existing SwitchPrimary retry timer.

While Sentinel isn't the future direction for Redis HA, it's still widely
used — especially with Valkey, AWS ElastiCache, and Kubernetes deployments
that haven't moved to cluster mode.

Tests in `SentinelAbortOnConnectTests.cs` — no running Redis/Sentinel
instance required. Self-healing reuses the existing SwitchPrimary mechanism
tested by `ManagedPrimaryConnectionEndToEndWithFailoverTest`.