### PR TITLE
Support ZADD INCR

### DIFF
--- a/StackExchange.Redis.slnx
+++ b/StackExchange.Redis.slnx
@@ -1,0 +1,99 @@
+<Solution>
+  <Folder Name="/eng/">
+    <Project Path="eng/StackExchange.Redis.Build/StackExchange.Redis.Build.csproj" />
+  </Folder>
+  <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path=".github/workflows/CI.yml" />
+    <File Path=".github/workflows/codeql.yml" />
+    <File Path="appveyor.yml" />
+    <File Path="build.cmd" />
+    <File Path="Build.csproj" />
+    <File Path="build.ps1" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
+    <File Path="Directory.Packages.props" />
+    <File Path="docs/ReleaseNotes.md" />
+    <File Path="global.json" />
+    <File Path="NuGet.Config" />
+    <File Path="README.md" />
+    <File Path="Shared.ruleset" />
+    <File Path="tests/RedisConfigs/.docker/Redis/Dockerfile" />
+    <File Path="tests/RedisConfigs/docker-compose.yml" />
+    <File Path="version.json" />
+  </Folder>
+  <Folder Name="/src/">
+    <File Path="src/Directory.Build.props" />
+    <Project Path="src/RESPite/RESPite.csproj" />
+    <Project Path="src/StackExchange.Redis/StackExchange.Redis.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <File Path="tests/.editorconfig" />
+    <File Path="tests/Directory.Build.targets" />
+    <Project Path="tests/BasicTest/BasicTest.csproj" />
+    <Project Path="tests/BasicTestBaseline/BasicTestBaseline.csproj" />
+    <Project Path="tests/ConsoleTest/ConsoleTest.csproj" />
+    <Project Path="tests/ConsoleTestBaseline/ConsoleTestBaseline.csproj" />
+    <Project Path="tests/RESPite.Tests/RESPite.Tests.csproj" />
+    <Project Path="tests/StackExchange.Redis.Benchmarks/StackExchange.Redis.Benchmarks.csproj" />
+    <Project Path="tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj" />
+  </Folder>
+  <Folder Name="/tests/RedisConfigs/">
+    <File Path="tests/RedisConfigs/cli-master.cmd" />
+    <File Path="tests/RedisConfigs/cli-secure.cmd" />
+    <File Path="tests/RedisConfigs/cli-slave.cmd" />
+    <File Path="tests/RedisConfigs/docker-compose.yml" />
+    <File Path="tests/RedisConfigs/Dockerfile" />
+    <File Path="tests/RedisConfigs/start-all.cmd" />
+    <File Path="tests/RedisConfigs/start-all.sh" />
+    <File Path="tests/RedisConfigs/start-basic.cmd" />
+    <File Path="tests/RedisConfigs/start-basic.sh" />
+    <File Path="tests/RedisConfigs/start-cluster.cmd" />
+    <File Path="tests/RedisConfigs/start-sentinel.cmd" />
+    <File Path="tests/RedisConfigs/wsl2.md" />
+  </Folder>
+  <Folder Name="/tests/RedisConfigs/Basic/">
+    <File Path="tests/RedisConfigs/Basic/primary-6379.conf" />
+    <File Path="tests/RedisConfigs/Basic/replica-6380.conf" />
+    <File Path="tests/RedisConfigs/Basic/secure-6381.conf" />
+    <File Path="tests/RedisConfigs/Basic/tls-ciphers-6384.conf" />
+  </Folder>
+  <Folder Name="/tests/RedisConfigs/Cluster/">
+    <File Path="tests/RedisConfigs/Cluster/cluster-7000.conf" />
+    <File Path="tests/RedisConfigs/Cluster/cluster-7001.conf" />
+    <File Path="tests/RedisConfigs/Cluster/cluster-7002.conf" />
+    <File Path="tests/RedisConfigs/Cluster/cluster-7003.conf" />
+    <File Path="tests/RedisConfigs/Cluster/cluster-7004.conf" />
+    <File Path="tests/RedisConfigs/Cluster/cluster-7005.conf" />
+    <File Path="tests/RedisConfigs/Cluster/nodes-7000.conf" />
+    <File Path="tests/RedisConfigs/Cluster/nodes-7001.conf" />
+    <File Path="tests/RedisConfigs/Cluster/nodes-7002.conf" />
+    <File Path="tests/RedisConfigs/Cluster/nodes-7003.conf" />
+    <File Path="tests/RedisConfigs/Cluster/nodes-7004.conf" />
+    <File Path="tests/RedisConfigs/Cluster/nodes-7005.conf" />
+  </Folder>
+  <Folder Name="/tests/RedisConfigs/Docker/">
+    <File Path="tests/RedisConfigs/Docker/docker-entrypoint.sh" />
+    <File Path="tests/RedisConfigs/Docker/supervisord.conf" />
+  </Folder>
+  <Folder Name="/tests/RedisConfigs/Failover/">
+    <File Path="tests/RedisConfigs/Failover/primary-6382.conf" />
+    <File Path="tests/RedisConfigs/Failover/replica-6383.conf" />
+  </Folder>
+  <Folder Name="/tests/RedisConfigs/Sentinel/">
+    <File Path="tests/RedisConfigs/Sentinel/redis-7010.conf" />
+    <File Path="tests/RedisConfigs/Sentinel/redis-7011.conf" />
+    <File Path="tests/RedisConfigs/Sentinel/sentinel-26379.conf" />
+    <File Path="tests/RedisConfigs/Sentinel/sentinel-26380.conf" />
+    <File Path="tests/RedisConfigs/Sentinel/sentinel-26381.conf" />
+  </Folder>
+  <Folder Name="/toys/">
+    <Project Path="toys/KestrelRedisServer/KestrelRedisServer.csproj" />
+    <Project Path="toys/OpBench/OpBench.csproj" />
+    <Project Path="toys/StackExchange.Redis.Server/StackExchange.Redis.Server.csproj" />
+    <Project Path="toys/TestConsole/TestConsole.csproj" />
+    <Project Path="toys/TestConsoleBaseline/TestConsoleBaseline.csproj" />
+  </Folder>
+  <Project Path=".github/.github.csproj" />
+  <Project Path="docs/docs.csproj" />
+</Solution>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,7 @@ Current package versions:
 - Add Redis 8.8 stream negative acknowledgements (`XNACK`) ([#3058 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3058))
 - Update experimental `GCRA` APIs and wire protocol terminology from "requests" to "tokens", to match server change ([#3051 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3051))
 - Add experimental `Aggregate.Count` support for sorted-set combination operations against Redis 8.8 ([#3059 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3059))
+- Add `ValueCondition` overloads for `SortedSetIncrement`/`SortedSetIncrementAsync`, supporting `ZADD INCR` with existence conditions
 
 ## 2.12.14
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,7 +12,7 @@ Current package versions:
 - Add Redis 8.8 stream negative acknowledgements (`XNACK`) ([#3058 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3058))
 - Update experimental `GCRA` APIs and wire protocol terminology from "requests" to "tokens", to match server change ([#3051 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3051))
 - Add experimental `Aggregate.Count` support for sorted-set combination operations against Redis 8.8 ([#3059 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3059))
-- Add `ValueCondition` overloads for `SortedSetIncrement`/`SortedSetIncrementAsync`, supporting `ZADD INCR` with existence conditions
+- Add `ValueCondition` overloads for `SortedSetIncrement`/`SortedSetIncrementAsync`, supporting `ZADD INCR` with existence conditions ([#3071 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3071))
 
 ## 2.12.14
 

--- a/src/StackExchange.Redis/Enums/SortedSetWhen.cs
+++ b/src/StackExchange.Redis/Enums/SortedSetWhen.cs
@@ -36,15 +36,6 @@ namespace StackExchange.Redis
 
     internal static class SortedSetWhenExtensions
     {
-        internal static uint CountBits(this SortedSetWhen when)
-        {
-            uint v = (uint)when;
-            v -= (v >> 1) & 0x55555555; // reuse input as temporary
-            v = (v & 0x33333333) + ((v >> 2) & 0x33333333); // temp
-            uint c = ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24; // count
-            return c;
-        }
-
         internal static SortedSetWhen Parse(When when) => when switch
         {
             When.Always => SortedSetWhen.Always,

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -2101,7 +2101,25 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>The new score of member.</returns>
         /// <remarks><seealso href="https://redis.io/commands/zincrby"/></remarks>
+#pragma warning disable RS0027 // conditional overload needs an additional required ValueCondition parameter
         double SortedSetIncrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
+#pragma warning restore RS0027
+
+        /// <summary>
+        /// Increments the score of member in the sorted set stored at key by increment, when the specified condition is met.
+        /// If member does not exist in the sorted set and the condition permits it, it is added with increment as its score (as if its previous score was 0.0).
+        /// </summary>
+        /// <param name="key">The key of the sorted set.</param>
+        /// <param name="member">The member to increment.</param>
+        /// <param name="value">The amount to increment by.</param>
+        /// <param name="when">The condition to increment the element under; only existence conditions are currently supported.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>The new score of member, or <see langword="null"/> when the condition was not met.</returns>
+        /// <remarks>
+        /// <para>Uses <c>ZINCRBY</c> when <paramref name="when"/> is <see cref="ValueCondition.Always"/>, and <c>ZADD INCR</c> for <see cref="ValueCondition.Exists"/> and <see cref="ValueCondition.NotExists"/>.</para>
+        /// <para><seealso href="https://redis.io/commands/zadd"/></para>
+        /// </remarks>
+        double? SortedSetIncrement(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags);
 
         /// <summary>
         /// Returns the cardinality of the intersection of the sorted sets at <paramref name="keys"/>.

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -500,7 +500,12 @@ namespace StackExchange.Redis
         Task<double> SortedSetDecrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
 
         /// <inheritdoc cref="IDatabase.SortedSetIncrement(RedisKey, RedisValue, double, CommandFlags)"/>
+#pragma warning disable RS0027 // conditional overload needs an additional required ValueCondition parameter
         Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None);
+#pragma warning restore RS0027
+
+        /// <inheritdoc cref="IDatabase.SortedSetIncrement(RedisKey, RedisValue, double, ValueCondition, CommandFlags)"/>
+        Task<double?> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags);
 
         /// <inheritdoc cref="IDatabase.SortedSetIntersectionLength(RedisKey[], long, CommandFlags)"/>
         Task<long> SortedSetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None);

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -506,6 +506,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None) =>
             Inner.SortedSetIncrementAsync(ToInner(key), member, value, flags);
 
+        public Task<double?> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags) =>
+            Inner.SortedSetIncrementAsync(ToInner(key), member, value, when, flags);
+
         public Task<long> SortedSetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None) =>
             Inner.SortedSetIntersectionLengthAsync(ToInner(keys), limit, flags);
 

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -491,6 +491,9 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public double SortedSetIncrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None) =>
             Inner.SortedSetIncrement(ToInner(key), member, value, flags);
 
+        public double? SortedSetIncrement(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags) =>
+            Inner.SortedSetIncrement(ToInner(key), member, value, when, flags);
+
         public long SortedSetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None) =>
             Inner.SortedSetIntersectionLength(ToInner(keys), limit, flags);
 

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+StackExchange.Redis.IDatabase.SortedSetIncrement(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue member, double value, StackExchange.Redis.ValueCondition when, StackExchange.Redis.CommandFlags flags) -> double?
+StackExchange.Redis.IDatabaseAsync.SortedSetIncrementAsync(StackExchange.Redis.RedisKey key, StackExchange.Redis.RedisValue member, double value, StackExchange.Redis.ValueCondition when, StackExchange.Redis.CommandFlags flags) -> System.Threading.Tasks.Task<double?>!

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -2435,10 +2435,22 @@ namespace StackExchange.Redis
             return ExecuteSync(msg, ResultProcessor.Double);
         }
 
+        public double? SortedSetIncrement(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags)
+        {
+            var msg = GetSortedSetIncrementMessage(key, member, value, when, flags);
+            return ExecuteSync(msg, ResultProcessor.NullableDouble);
+        }
+
         public Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(Database, flags, RedisCommand.ZINCRBY, key, value, member);
             return ExecuteAsync(msg, ResultProcessor.Double);
+        }
+
+        public Task<double?> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags)
+        {
+            var msg = GetSortedSetIncrementMessage(key, member, value, when, flags);
+            return ExecuteAsync(msg, ResultProcessor.NullableDouble);
         }
 
         public long SortedSetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
@@ -4399,33 +4411,7 @@ namespace StackExchange.Redis
         }
 
         private Message GetSortedSetAddMessage(RedisKey key, RedisValue member, double score, SortedSetWhen when, bool change, CommandFlags flags)
-        {
-            RedisValue[] arr = new RedisValue[2 + when.CountBits() + (change ? 1 : 0)];
-            int index = 0;
-            if ((when & SortedSetWhen.NotExists) != 0)
-            {
-                arr[index++] = RedisLiterals.NX;
-            }
-            if ((when & SortedSetWhen.Exists) != 0)
-            {
-                arr[index++] = RedisLiterals.XX;
-            }
-            if ((when & SortedSetWhen.GreaterThan) != 0)
-            {
-                arr[index++] = RedisLiterals.GT;
-            }
-            if ((when & SortedSetWhen.LessThan) != 0)
-            {
-                arr[index++] = RedisLiterals.LT;
-            }
-            if (change)
-            {
-                arr[index++] = RedisLiterals.CH;
-            }
-            arr[index++] = score;
-            arr[index++] = member;
-            return Message.Create(Database, flags, RedisCommand.ZADD, key, arr);
-        }
+            => new SingleSortedSetAddMessage(Database, flags, key, member, score, when, change, increment: false);
 
         private Message? GetSortedSetAddMessage(RedisKey key, SortedSetEntry[] values, SortedSetWhen when, bool change, CommandFlags flags)
         {
@@ -4436,35 +4422,23 @@ namespace StackExchange.Redis
                 case 1:
                     return GetSortedSetAddMessage(key, values[0].element, values[0].score, when, change, flags);
                 default:
-                    RedisValue[] arr = new RedisValue[(values.Length * 2) + when.CountBits() + (change ? 1 : 0)];
-                    int index = 0;
-                    if ((when & SortedSetWhen.NotExists) != 0)
-                    {
-                        arr[index++] = RedisLiterals.NX;
-                    }
-                    if ((when & SortedSetWhen.Exists) != 0)
-                    {
-                        arr[index++] = RedisLiterals.XX;
-                    }
-                    if ((when & SortedSetWhen.GreaterThan) != 0)
-                    {
-                        arr[index++] = RedisLiterals.GT;
-                    }
-                    if ((when & SortedSetWhen.LessThan) != 0)
-                    {
-                        arr[index++] = RedisLiterals.LT;
-                    }
-                    if (change)
-                    {
-                        arr[index++] = RedisLiterals.CH;
-                    }
+                    return new MultipleSortedSetAddMessage(Database, flags, key, values, when, change);
+            }
+        }
 
-                    for (int i = 0; i < values.Length; i++)
-                    {
-                        arr[index++] = values[i].score;
-                        arr[index++] = values[i].element;
-                    }
-                    return Message.Create(Database, flags, RedisCommand.ZADD, key, arr);
+        private Message GetSortedSetIncrementMessage(RedisKey key, RedisValue member, double value, ValueCondition when, CommandFlags flags)
+        {
+            switch (when.Kind)
+            {
+                case ValueCondition.ConditionKind.Always:
+                    return Message.Create(Database, flags, RedisCommand.ZINCRBY, key, value, member);
+                case ValueCondition.ConditionKind.Exists:
+                    return new SingleSortedSetAddMessage(Database, flags, key, member, value, SortedSetWhen.Exists, change: false, increment: true);
+                case ValueCondition.ConditionKind.NotExists:
+                    return new SingleSortedSetAddMessage(Database, flags, key, member, value, SortedSetWhen.NotExists, change: false, increment: true);
+                default:
+                    when.ThrowInvalidOperation(nameof(SortedSetIncrement));
+                    goto case ValueCondition.ConditionKind.Always; // not reached
             }
         }
 

--- a/src/StackExchange.Redis/SortedSetAddMessage.cs
+++ b/src/StackExchange.Redis/SortedSetAddMessage.cs
@@ -1,0 +1,144 @@
+using System;
+
+namespace StackExchange.Redis;
+
+internal partial class RedisDatabase
+{
+    private abstract class SortedSetAddMessage(
+        int db,
+        CommandFlags flags,
+        in RedisKey key,
+        SortedSetWhen when,
+        bool change,
+        bool increment) : Message.CommandKeyBase(db, flags, RedisCommand.ZADD, key)
+    {
+        private const SortedSetWhen KnownWhen =
+            SortedSetWhen.Exists | SortedSetWhen.GreaterThan | SortedSetWhen.LessThan | SortedSetWhen.NotExists;
+
+        private readonly SortedSetWhen _when = ValidateWhen(when);
+        private readonly bool _change = change;
+        private readonly bool _increment = increment;
+
+        public override int ArgCount => 1 + GetOptionCount() + (2 * EntryCount);
+
+        protected abstract int EntryCount { get; }
+
+        protected override void WriteImpl(PhysicalConnection physical)
+        {
+            physical.WriteHeader(Command, ArgCount);
+            physical.Write(Key);
+            WriteOptions(physical);
+            WriteEntries(physical);
+        }
+
+        protected abstract void WriteEntries(PhysicalConnection physical);
+
+        private int GetOptionCount()
+        {
+            int count = 0;
+            if ((_when & SortedSetWhen.NotExists) != 0) count++;
+            if ((_when & SortedSetWhen.Exists) != 0) count++;
+            if ((_when & SortedSetWhen.GreaterThan) != 0) count++;
+            if ((_when & SortedSetWhen.LessThan) != 0) count++;
+            if (_change) count++;
+            if (_increment) count++;
+            return count;
+        }
+
+        private static SortedSetWhen ValidateWhen(SortedSetWhen when)
+        {
+            if ((when & ~KnownWhen) != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(when));
+            }
+            return when;
+        }
+
+        private void WriteOptions(PhysicalConnection physical)
+        {
+            if ((_when & SortedSetWhen.NotExists) != 0)
+            {
+                physical.WriteBulkString("NX"u8);
+            }
+            if ((_when & SortedSetWhen.Exists) != 0)
+            {
+                physical.WriteBulkString("XX"u8);
+            }
+            if ((_when & SortedSetWhen.GreaterThan) != 0)
+            {
+                physical.WriteBulkString("GT"u8);
+            }
+            if ((_when & SortedSetWhen.LessThan) != 0)
+            {
+                physical.WriteBulkString("LT"u8);
+            }
+            if (_change)
+            {
+                physical.WriteBulkString("CH"u8);
+            }
+            if (_increment)
+            {
+                physical.WriteBulkString("INCR"u8);
+            }
+        }
+    }
+
+    private sealed class SingleSortedSetAddMessage(
+        int db,
+        CommandFlags flags,
+        in RedisKey key,
+        in RedisValue member,
+        double score,
+        SortedSetWhen when,
+        bool change,
+        bool increment) : SortedSetAddMessage(db, flags, key, when, change, increment)
+    {
+        private readonly RedisValue _member = AssertMember(member);
+        private readonly double _score = score;
+
+        protected override int EntryCount => 1;
+
+        protected override void WriteEntries(PhysicalConnection physical)
+        {
+            physical.WriteBulkString(_score);
+            physical.WriteBulkString(_member);
+        }
+
+        private static RedisValue AssertMember(in RedisValue member)
+        {
+            member.AssertNotNull();
+            return member;
+        }
+    }
+
+    private sealed class MultipleSortedSetAddMessage(
+        int db,
+        CommandFlags flags,
+        in RedisKey key,
+        SortedSetEntry[] values,
+        SortedSetWhen when,
+        bool change) : SortedSetAddMessage(db, flags, key, when, change, increment: false)
+    {
+        private readonly SortedSetEntry[] _values = AssertValues(values);
+
+        protected override int EntryCount => _values.Length;
+
+        protected override void WriteEntries(PhysicalConnection physical)
+        {
+            for (int i = 0; i < _values.Length; i++)
+            {
+                physical.WriteBulkString(_values[i].score);
+                physical.WriteBulkString(_values[i].element);
+            }
+        }
+
+        private static SortedSetEntry[] AssertValues(SortedSetEntry[] values)
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i].element.AssertNotNull();
+            }
+            return values;
+        }
+    }
+}

--- a/src/StackExchange.Redis/SortedSetAddMessage.cs
+++ b/src/StackExchange.Redis/SortedSetAddMessage.cs
@@ -14,10 +14,10 @@ internal partial class RedisDatabase
     {
         private const SortedSetWhen KnownWhen =
             SortedSetWhen.Exists | SortedSetWhen.GreaterThan | SortedSetWhen.LessThan | SortedSetWhen.NotExists;
+        private const SortedSetWhen Change = (SortedSetWhen)(1 << 30);
+        private const SortedSetWhen Increment = (SortedSetWhen)(1 << 29);
 
-        private readonly SortedSetWhen _when = ValidateWhen(when);
-        private readonly bool _change = change;
-        private readonly bool _increment = increment;
+        private readonly SortedSetWhen _when = GetWhen(when, change, increment);
 
         public override int ArgCount => 1 + GetOptionCount() + (2 * EntryCount);
 
@@ -40,17 +40,19 @@ internal partial class RedisDatabase
             if ((_when & SortedSetWhen.Exists) != 0) count++;
             if ((_when & SortedSetWhen.GreaterThan) != 0) count++;
             if ((_when & SortedSetWhen.LessThan) != 0) count++;
-            if (_change) count++;
-            if (_increment) count++;
+            if ((_when & Change) != 0) count++;
+            if ((_when & Increment) != 0) count++;
             return count;
         }
 
-        private static SortedSetWhen ValidateWhen(SortedSetWhen when)
+        private static SortedSetWhen GetWhen(SortedSetWhen when, bool change, bool increment)
         {
             if ((when & ~KnownWhen) != 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(when));
             }
+            if (change) when |= Change;
+            if (increment) when |= Increment;
             return when;
         }
 
@@ -72,11 +74,11 @@ internal partial class RedisDatabase
             {
                 physical.WriteBulkString("LT"u8);
             }
-            if (_change)
+            if ((_when & Change) != 0)
             {
                 physical.WriteBulkString("CH"u8);
             }
-            if (_increment)
+            if ((_when & Increment) != 0)
             {
                 physical.WriteBulkString("INCR"u8);
             }

--- a/src/StackExchange.Redis/VectorSetAddMessage.cs
+++ b/src/StackExchange.Redis/VectorSetAddMessage.cs
@@ -12,13 +12,14 @@ internal abstract class VectorSetAddMessage(
     VectorSetQuantization quantization,
     int? buildExplorationFactor,
     int? maxConnections,
-    bool useCheckAndSet) : Message(db, flags, RedisCommand.VADD)
+    bool useCheckAndSet,
+    bool useFp32) : Message(db, flags, RedisCommand.VADD)
 {
-    public override int ArgCount => GetArgCount(UseFp32);
+    public override int ArgCount => GetArgCount();
 
-    private int GetArgCount(bool packed)
+    private int GetArgCount()
     {
-        var count = 2 + GetElementArgCount(packed); // key, element and either "FP32 {vector}" or VALUES {num}"
+        var count = 2 + GetElementArgCount(); // key, element and either "FP32 {vector}" or VALUES {num}"
         if (reducedDimensions.HasValue) count += 2; // [REDUCE {dim}]
 
         if (useCheckAndSet) count++; // [CAS]
@@ -35,13 +36,14 @@ internal abstract class VectorSetAddMessage(
         return count;
     }
 
-    public abstract int GetElementArgCount(bool packed);
+    public abstract int GetElementArgCount();
     public abstract int GetAttributeArgCount();
 
     public override int GetHashSlot(ServerSelectionStrategy serverSelectionStrategy)
         => serverSelectionStrategy.HashSlot(key);
 
-    private static readonly bool CanUseFp32 = BitConverter.IsLittleEndian && CheckFp32();
+    internal static readonly bool CanUseFp32 = BitConverter.IsLittleEndian && CheckFp32();
+    internal bool UseFp32 { get; } = useFp32 & CanUseFp32; // evaluated during .ctor
 
     private static bool CheckFp32() // check endianness with a known value
     {
@@ -49,23 +51,11 @@ internal abstract class VectorSetAddMessage(
         return MemoryMarshal.Cast<byte, float>("\0\0(B"u8)[0] == 42;
     }
 
-#if DEBUG
-    private static int _fp32Disabled;
-    internal static bool UseFp32 => CanUseFp32 & Volatile.Read(ref _fp32Disabled) == 0;
-    internal static void SuppressFp32() => Interlocked.Increment(ref _fp32Disabled);
-    internal static void RestoreFp32() => Interlocked.Decrement(ref _fp32Disabled);
-#else
-    internal static bool UseFp32 => CanUseFp32;
-    internal static void SuppressFp32() { }
-    internal static void RestoreFp32() { }
-#endif
-
-    protected abstract void WriteElement(bool packed, PhysicalConnection physical);
+    protected abstract void WriteElement(PhysicalConnection physical);
 
     protected override void WriteImpl(PhysicalConnection physical)
     {
-        bool packed = UseFp32; // snapshot to avoid race in debug scenarios
-        physical.WriteHeader(Command, GetArgCount(packed));
+        physical.WriteHeader(Command, GetArgCount());
         physical.Write(key);
         if (reducedDimensions.HasValue)
         {
@@ -73,7 +63,7 @@ internal abstract class VectorSetAddMessage(
             physical.WriteBulkString(reducedDimensions.GetValueOrDefault());
         }
 
-        WriteElement(packed, physical);
+        WriteElement(physical);
         if (useCheckAndSet) physical.WriteBulkString("CAS"u8);
 
         switch (quantization)
@@ -118,7 +108,8 @@ internal abstract class VectorSetAddMessage(
         bool useCheckAndSet,
         RedisValue element,
         ReadOnlyMemory<float> values,
-        string? attributesJson) : VectorSetAddMessage(
+        string? attributesJson,
+        bool useFp32) : VectorSetAddMessage(
         db,
         flags,
         key,
@@ -126,19 +117,20 @@ internal abstract class VectorSetAddMessage(
         quantization,
         buildExplorationFactor,
         maxConnections,
-        useCheckAndSet)
+        useCheckAndSet,
+        useFp32)
     {
         private readonly string? _attributesJson = string.IsNullOrWhiteSpace(attributesJson) ? null : attributesJson;
-        public override int GetElementArgCount(bool packed)
+        public override int GetElementArgCount()
             => 2 // "FP32 {vector}" or "VALUES {num}"
-               + (packed ? 0 : values.Length); // {vector...}"
+               + (UseFp32 ? 0 : values.Length); // {vector...}"
 
         public override int GetAttributeArgCount()
             => _attributesJson is null ? 0 : 2; // [SETATTR {attributes}]
 
-        protected override void WriteElement(bool packed, PhysicalConnection physical)
+        protected override void WriteElement(PhysicalConnection physical)
         {
-            if (packed)
+            if (UseFp32)
             {
                 physical.WriteBulkString("FP32"u8);
                 physical.WriteBulkString(MemoryMarshal.AsBytes(values.Span));

--- a/src/StackExchange.Redis/VectorSetAddRequest.cs
+++ b/src/StackExchange.Redis/VectorSetAddRequest.cs
@@ -38,6 +38,8 @@ public abstract class VectorSetAddRequest
     /// </summary>
     public int? ReducedDimensions { get; set; }
 
+    internal bool UseFp32 { get; set; } = true; // for testing
+
     /// <summary>
     /// Quantization type - Int8 (Q8), None (NOQUANT), or Binary (BIN). Default: Int8.
     /// </summary>
@@ -74,6 +76,7 @@ public abstract class VectorSetAddRequest
                 UseCheckAndSet,
                 element,
                 values,
-                attributesJson);
+                attributesJson,
+                UseFp32);
     }
 }

--- a/src/StackExchange.Redis/VectorSetSimilaritySearchMessage.cs
+++ b/src/StackExchange.Redis/VectorSetSimilaritySearchMessage.cs
@@ -11,7 +11,8 @@ internal abstract class VectorSetSimilaritySearchMessage(
     double epsilon,
     int searchExplorationFactor,
     string? filterExpression,
-    int maxFilteringEffort) : Message(db, flags, RedisCommand.VSIM)
+    int maxFilteringEffort,
+    bool useFp32) : Message(db, flags, RedisCommand.VSIM)
 {
     // For "FP32" and "VALUES" scenarios; in the future we might want other vector sizes / encodings - for
     // example, there could be some "FP16" or "FP8" transport that requires a ROM-short or ROM-sbyte from
@@ -27,15 +28,16 @@ internal abstract class VectorSetSimilaritySearchMessage(
         double epsilon,
         int searchExplorationFactor,
         string? filterExpression,
-        int maxFilteringEffort) : VectorSetSimilaritySearchMessage(db, flags, vsimFlags, key, count, epsilon,
-        searchExplorationFactor, filterExpression, maxFilteringEffort)
+        int maxFilteringEffort,
+        bool useFp32) : VectorSetSimilaritySearchMessage(db, flags, vsimFlags, key, count, epsilon,
+        searchExplorationFactor, filterExpression, maxFilteringEffort, useFp32)
     {
-        internal override int GetSearchTargetArgCount(bool packed) =>
-            packed ? 2 : 2 + vector.Length; // FP32 {vector} or VALUES {num} {vector}
+        internal override int GetSearchTargetArgCount() =>
+            UseFp32 ? 2 : (2 + vector.Length); // FP32 {vector} or VALUES {num} {vector}
 
-        internal override void WriteSearchTarget(bool packed, PhysicalConnection physical)
+        internal override void WriteSearchTarget(PhysicalConnection physical)
         {
-            if (packed)
+            if (UseFp32)
             {
                 physical.WriteBulkString("FP32"u8);
                 physical.WriteBulkString(System.Runtime.InteropServices.MemoryMarshal.AsBytes(vector.Span));
@@ -63,20 +65,21 @@ internal abstract class VectorSetSimilaritySearchMessage(
         double epsilon,
         int searchExplorationFactor,
         string? filterExpression,
-        int maxFilteringEffort) : VectorSetSimilaritySearchMessage(db, flags, vsimFlags, key, count, epsilon,
-        searchExplorationFactor, filterExpression, maxFilteringEffort)
+        int maxFilteringEffort,
+        bool useFp32) : VectorSetSimilaritySearchMessage(db, flags, vsimFlags, key, count, epsilon,
+        searchExplorationFactor, filterExpression, maxFilteringEffort, useFp32)
     {
-        internal override int GetSearchTargetArgCount(bool packed) => 2; // ELE {member}
+        internal override int GetSearchTargetArgCount() => 2; // ELE {member}
 
-        internal override void WriteSearchTarget(bool packed, PhysicalConnection physical)
+        internal override void WriteSearchTarget(PhysicalConnection physical)
         {
             physical.WriteBulkString("ELE"u8);
             physical.WriteBulkString(member);
         }
     }
 
-    internal abstract int GetSearchTargetArgCount(bool packed);
-    internal abstract void WriteSearchTarget(bool packed, PhysicalConnection physical);
+    internal abstract int GetSearchTargetArgCount();
+    internal abstract void WriteSearchTarget(PhysicalConnection physical);
 
     public ResultProcessor<Lease<VectorSetSimilaritySearchResult>?> GetResultProcessor() =>
         VectorSetSimilaritySearchProcessor.Instance;
@@ -177,11 +180,11 @@ internal abstract class VectorSetSimilaritySearchMessage(
 
     private bool HasFlag(VsimFlags flag) => (vsimFlags & flag) != 0;
 
-    public override int ArgCount => GetArgCount(VectorSetAddMessage.UseFp32);
+    public override int ArgCount => GetArgCount();
 
-    private int GetArgCount(bool packed)
+    private int GetArgCount()
     {
-        int argCount = 1 + GetSearchTargetArgCount(packed); // {key} and whatever we need for the vector/element portion
+        int argCount = 1 + GetSearchTargetArgCount(); // {key} and whatever we need for the vector/element portion
         if (HasFlag(VsimFlags.WithScores)) argCount++; // [WITHSCORES]
         if (HasFlag(VsimFlags.WithAttributes)) argCount++; // [WITHATTRIBS]
         if (HasFlag(VsimFlags.Count)) argCount += 2; // [COUNT {count}]
@@ -194,17 +197,18 @@ internal abstract class VectorSetSimilaritySearchMessage(
         return argCount;
     }
 
+    internal bool UseFp32 { get; } = useFp32 & VectorSetAddMessage.CanUseFp32; // evaluated during .ctor
+
     protected override void WriteImpl(PhysicalConnection physical)
     {
         // snapshot to avoid race in debug scenarios
-        bool packed = VectorSetAddMessage.UseFp32;
-        physical.WriteHeader(Command, GetArgCount(packed));
+        physical.WriteHeader(Command, GetArgCount());
 
         // Write key
         physical.Write(key);
 
         // Write search target: either "ELE {member}" or vector data
-        WriteSearchTarget(packed, physical);
+        WriteSearchTarget(physical);
 
         if (HasFlag(VsimFlags.WithScores))
         {

--- a/src/StackExchange.Redis/VectorSetSimilaritySearchRequest.cs
+++ b/src/StackExchange.Redis/VectorSetSimilaritySearchRequest.cs
@@ -26,7 +26,8 @@ public abstract class VectorSetSimilaritySearchRequest
                 _epsilon,
                 _searchExplorationFactor,
                 _filterExpression,
-                _maxFilteringEffort);
+                _maxFilteringEffort,
+                UseFp32);
     }
 
     private sealed class VectorSetSimilarityVectorSingleSearchRequest(ReadOnlyMemory<float> vector)
@@ -43,8 +44,11 @@ public abstract class VectorSetSimilaritySearchRequest
                 _epsilon,
                 _searchExplorationFactor,
                 _filterExpression,
-                _maxFilteringEffort);
+                _maxFilteringEffort,
+                UseFp32);
     }
+
+    internal bool UseFp32 { get; set; } = true; // for testing
 
     // snapshot the values; I don't trust people not to mutate the object behind my back
     internal abstract VectorSetSimilaritySearchMessage ToMessage(RedisKey key, int db, CommandFlags flags);

--- a/tests/RedisConfigs/.docker/Redis/Dockerfile
+++ b/tests/RedisConfigs/.docker/Redis/Dockerfile
@@ -1,4 +1,4 @@
-ARG CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.8-m02
+ARG CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:unstable-24805570909-debian
 FROM ${CLIENT_LIBS_TEST_IMAGE}
 
 COPY --from=configs ./Basic /data/Basic/

--- a/tests/RedisConfigs/docker-compose.yml
+++ b/tests/RedisConfigs/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .docker/Redis
       args:
-        CLIENT_LIBS_TEST_IMAGE: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-m02}
+        CLIENT_LIBS_TEST_IMAGE: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:unstable-24805570909-debian}
       additional_contexts:
          configs: .
     platform: linux

--- a/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
+++ b/tests/StackExchange.Redis.Tests/GarbageCollectionTests.cs
@@ -38,12 +38,17 @@ public class GarbageCollectionTests(ITestOutputHelper helper) : TestBase(helper)
         var wr = new WeakReference(conn);
         conn = null;
 
-        ForceGC();
-        await Task.Delay(2000).ForAwait(); // GC is twitchy
-        ForceGC();
+        for (int i = 0; i < 5 && wr.IsAlive; i++)
+        {
+            ForceGC();
+            await Task.Delay(2000).ForAwait(); // GC is twitchy
+            ForceGC();
+        }
 
         // should be collectable
         Assert.Null(wr.Target);
+        // just to ensure we wrote conn, and to suppress a warning
+        Assert.Null(conn);
 
 // #if DEBUG // this counter only exists in debug
 //            int after = ConnectionMultiplexer.CollectedWithoutDispose;

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedDatabaseTests.cs
@@ -852,6 +852,13 @@ public sealed class KeyPrefixedDatabaseTests
     }
 
     [Fact]
+    public void SortedSetIncrement_When()
+    {
+        prefixed.SortedSetIncrement("key", "member", 1.23, ValueCondition.Exists, CommandFlags.None);
+        mock.Received().SortedSetIncrement("prefix:key", "member", 1.23, ValueCondition.Exists, CommandFlags.None);
+    }
+
+    [Fact]
     public void SortedSetIntersectionLength()
     {
         prefixed.SortedSetIntersectionLength(["a", "b"], 1, CommandFlags.None);

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedTests.cs
@@ -776,6 +776,13 @@ namespace StackExchange.Redis.Tests
         }
 
         [Fact]
+        public async Task SortedSetIncrementAsync_When()
+        {
+            await prefixed.SortedSetIncrementAsync("key", "member", 1.23, ValueCondition.Exists, CommandFlags.None);
+            await mock.Received().SortedSetIncrementAsync("prefix:key", "member", 1.23, ValueCondition.Exists, CommandFlags.None);
+        }
+
+        [Fact]
         public async Task SortedSetIntersectionLengthAsync()
         {
             await prefixed.SortedSetIntersectionLengthAsync(["a", "b"], 1, CommandFlags.None);

--- a/tests/StackExchange.Redis.Tests/KeyPrefixedVectorSetTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyPrefixedVectorSetTests.cs
@@ -22,17 +22,11 @@ namespace StackExchange.Redis.Tests
         {
             if (BitConverter.IsLittleEndian)
             {
-                Assert.True(VectorSetAddMessage.UseFp32);
-#if DEBUG // can be suppressed
-                VectorSetAddMessage.SuppressFp32();
-                Assert.False(VectorSetAddMessage.UseFp32);
-                VectorSetAddMessage.RestoreFp32();
-                Assert.True(VectorSetAddMessage.UseFp32);
-#endif
+                Assert.True(VectorSetAddMessage.CanUseFp32);
             }
             else
             {
-                Assert.False(VectorSetAddMessage.UseFp32);
+                Assert.False(VectorSetAddMessage.CanUseFp32);
             }
         }
 

--- a/tests/StackExchange.Redis.Tests/LoggerTests.cs
+++ b/tests/StackExchange.Redis.Tests/LoggerTests.cs
@@ -119,11 +119,21 @@ public class LoggerTests(ITestOutputHelper output) : TestBase(output)
 
             Interlocked.Increment(ref _callCount);
             var logLine = $"{_logLevel}> [LogLevel: {logLevel}, EventId: {eventId}]: {formatter?.Invoke(state, exception)}";
-            sb.AppendLine(logLine);
+            lock (sb)
+            {
+                sb.AppendLine(logLine);
+            }
+
             _output.WriteLine(logLine);
         }
 
         public long CallCount => Interlocked.Read(ref _callCount);
-        public override string ToString() => sb.ToString();
+        public override string ToString()
+        {
+            lock (sb)
+            {
+                return sb.ToString();
+            }
+        }
     }
 }

--- a/tests/StackExchange.Redis.Tests/SortedSetIncrementUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/SortedSetIncrementUnitTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+public class SortedSetIncrementUnitTests
+{
+    [Theory]
+    [MemberData(nameof(InvalidValueConditions))]
+    public void InvalidValueConditionModesThrow(ValueCondition condition)
+    {
+        var db = new RedisDatabase(null!, 0, null);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            db.SortedSetIncrement("key", "member", 1, condition, CommandFlags.None));
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = db.SortedSetIncrementAsync("key", "member", 1, condition, CommandFlags.None);
+        });
+    }
+
+    public static IEnumerable<object[]> InvalidValueConditions()
+    {
+        yield return [ValueCondition.Equal("value")];
+        yield return [ValueCondition.NotEqual("value")];
+        yield return [ValueCondition.DigestEqual("value")];
+        yield return [ValueCondition.DigestNotEqual("value")];
+    }
+}

--- a/tests/StackExchange.Redis.Tests/SortedSetWhenTests.cs
+++ b/tests/StackExchange.Redis.Tests/SortedSetWhenTests.cs
@@ -23,6 +23,26 @@ public class SortedSetWhenTest(ITestOutputHelper output, SharedConnectionFixture
     }
 
     [Fact]
+    public async Task Increment()
+    {
+        await using var conn = Create(require: RedisFeatures.v6_2_0);
+
+        var db = conn.GetDatabase();
+        var key = Me();
+        var member = "a";
+        var missingMember = "b";
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        db.SortedSetAdd(key, member, 2);
+
+        Assert.Equal(5, db.SortedSetIncrement(key, member, 3, ValueCondition.Always, CommandFlags.None));
+        Assert.Equal(6, db.SortedSetIncrement(key, member, 1, ValueCondition.Exists, CommandFlags.None));
+        Assert.Null(db.SortedSetIncrement(key, missingMember, 1, ValueCondition.Exists, CommandFlags.None));
+        Assert.Equal(1, db.SortedSetIncrement(key, missingMember, 1, ValueCondition.NotExists, CommandFlags.None));
+        Assert.Null(db.SortedSetIncrement(key, member, 1, ValueCondition.NotExists, CommandFlags.None));
+        Assert.Equal(8, await db.SortedSetIncrementAsync(key, member, 2, ValueCondition.Exists, CommandFlags.None));
+    }
+
+    [Fact]
     public async Task IllegalCombinations()
     {
         await using var conn = Create(require: RedisFeatures.v6_2_0);

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -8,14 +8,13 @@ using Xunit;
 
 namespace StackExchange.Redis.Tests;
 
-[Collection(NonParallelCollection.Name)] // because of the FP32 suppression
 [RunPerProtocol]
 public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBase(output)
 {
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task VectorSetAdd_BasicOperation(bool suppressFp32)
+    public async Task VectorSetAdd_BasicOperation(bool useFp32)
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
@@ -26,18 +25,11 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
 
         var vector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
 
-        if (suppressFp32) VectorSetAddMessage.SuppressFp32();
-        try
-        {
-            var request = VectorSetAddRequest.Member("element1", vector.AsMemory(), null);
-            var result = await db.VectorSetAddAsync(key, request);
+        var request = VectorSetAddRequest.Member("element1", vector.AsMemory(), null);
+        request.UseFp32 = useFp32;
+        var result = await db.VectorSetAddAsync(key, request);
 
-            Assert.True(result);
-        }
-        finally
-        {
-            if (suppressFp32) VectorSetAddMessage.RestoreFp32();
-        }
+        Assert.True(result);
     }
 
     [Fact]
@@ -69,7 +61,7 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     [InlineData(VectorSetQuantization.Int8, true)]
     [InlineData(VectorSetQuantization.None, true)]
     [InlineData(VectorSetQuantization.Binary, true)]
-    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool disableFp32)
+    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool useFp32)
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
@@ -80,30 +72,22 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
         var vector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
         var attributes = """{"category":"test","id":123}""";
 
-        try
-        {
-            if (disableFp32) VectorSetAddMessage.SuppressFp32();
-            Assert.Equal(!disableFp32, VectorSetAddMessage.UseFp32);
-            var request = VectorSetAddRequest.Member(
-                "element1",
-                vector.AsMemory(),
-                attributes);
-            request.Quantization = quantization;
-            request.ReducedDimensions = 64;
-            request.BuildExplorationFactor = 300;
-            request.MaxConnections = 32;
-            request.UseCheckAndSet = true;
-            Log("Storing...");
-            var result = await db.VectorSetAddAsync(
-                key,
-                request);
+        var request = VectorSetAddRequest.Member(
+            "element1",
+            vector.AsMemory(),
+            attributes);
+        request.UseFp32 = useFp32;
+        request.Quantization = quantization;
+        request.ReducedDimensions = 64;
+        request.BuildExplorationFactor = 300;
+        request.MaxConnections = 32;
+        request.UseCheckAndSet = true;
+        Log("Storing...");
+        var result = await db.VectorSetAddAsync(
+            key,
+            request);
 
-            Assert.True(result);
-        }
-        finally
-        {
-            if (disableFp32) VectorSetAddMessage.RestoreFp32();
-        }
+        Assert.True(result);
 
         Log("Stored successfully; fetching attributes...");
         // Verify attributes were stored
@@ -165,7 +149,7 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task VectorSetContains(bool suppressFp32)
+    public async Task VectorSetContains(bool useFp32)
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
@@ -174,28 +158,21 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
         await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
 
         var vector = new[] { 1.0f, 2.0f, 3.0f };
-        if (suppressFp32) VectorSetAddMessage.SuppressFp32();
-        try
-        {
-            var request = VectorSetAddRequest.Member("element1", vector.AsMemory());
-            await db.VectorSetAddAsync(key, request);
+        var request = VectorSetAddRequest.Member("element1", vector.AsMemory());
+        request.UseFp32 = useFp32;
+        await db.VectorSetAddAsync(key, request);
 
-            var exists = await db.VectorSetContainsAsync(key, "element1");
-            var notExists = await db.VectorSetContainsAsync(key, "element2");
+        var exists = await db.VectorSetContainsAsync(key, "element1");
+        var notExists = await db.VectorSetContainsAsync(key, "element2");
 
-            Assert.True(exists);
-            Assert.False(notExists);
-        }
-        finally
-        {
-            if (suppressFp32) VectorSetAddMessage.RestoreFp32();
-        }
+        Assert.True(exists);
+        Assert.False(notExists);
     }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task VectorSetGetApproximateVector(bool suppressFp32)
+    public async Task VectorSetGetApproximateVector(bool useFp32)
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
@@ -204,29 +181,22 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
         await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
 
         var originalVector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
-        if (suppressFp32) VectorSetAddMessage.SuppressFp32();
-        try
+        var request = VectorSetAddRequest.Member("element1", originalVector.AsMemory());
+        request.UseFp32 = useFp32;
+        await db.VectorSetAddAsync(key, request);
+
+        using var retrievedLease = await db.VectorSetGetApproximateVectorAsync(key, "element1");
+
+        Assert.NotNull(retrievedLease);
+        var retrievedVector = retrievedLease.Span;
+
+        Assert.Equal(originalVector.Length, retrievedVector.Length);
+        // Note: Due to quantization, values might not be exactly equal
+        for (int i = 0; i < originalVector.Length; i++)
         {
-            var request = VectorSetAddRequest.Member("element1", originalVector.AsMemory());
-            await db.VectorSetAddAsync(key, request);
-
-            using var retrievedLease = await db.VectorSetGetApproximateVectorAsync(key, "element1");
-
-            Assert.NotNull(retrievedLease);
-            var retrievedVector = retrievedLease.Span;
-
-            Assert.Equal(originalVector.Length, retrievedVector.Length);
-            // Note: Due to quantization, values might not be exactly equal
-            for (int i = 0; i < originalVector.Length; i++)
-            {
-                Assert.True(
-                    Math.Abs(originalVector[i] - retrievedVector[i]) < 0.1f,
-                    $"Vector component {i} differs too much: expected {originalVector[i]}, got {retrievedVector[i]}");
-            }
-        }
-        finally
-        {
-            if (suppressFp32) VectorSetAddMessage.RestoreFp32();
+            Assert.True(
+                Math.Abs(originalVector[i] - retrievedVector[i]) < 0.1f,
+                $"Vector component {i} differs too much: expected {originalVector[i]}, got {retrievedVector[i]}");
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace StackExchange.Redis.Tests;
 
+[Collection(NonParallelCollection.Name)] // because of the FP32 suppression
 [RunPerProtocol]
 public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBase(output)
 {
@@ -62,10 +63,13 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     }
 
     [Theory]
-    [InlineData(VectorSetQuantization.Int8)]
-    [InlineData(VectorSetQuantization.None)]
-    [InlineData(VectorSetQuantization.Binary)]
-    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization)
+    [InlineData(VectorSetQuantization.Int8, false)]
+    [InlineData(VectorSetQuantization.None, false)]
+    [InlineData(VectorSetQuantization.Binary, false)]
+    [InlineData(VectorSetQuantization.Int8, true)]
+    [InlineData(VectorSetQuantization.None, true)]
+    [InlineData(VectorSetQuantization.Binary, true)]
+    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool disableFp32)
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
@@ -76,21 +80,31 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
         var vector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
         var attributes = """{"category":"test","id":123}""";
 
-        var request = VectorSetAddRequest.Member(
-            "element1",
-            vector.AsMemory(),
-            attributes);
-        request.Quantization = quantization;
-        request.ReducedDimensions = 64;
-        request.BuildExplorationFactor = 300;
-        request.MaxConnections = 32;
-        request.UseCheckAndSet = true;
-        Log("Storing...");
-        var result = await db.VectorSetAddAsync(
-            key,
-            request);
+        try
+        {
+            if (disableFp32) VectorSetAddMessage.SuppressFp32();
+            Assert.Equal(!disableFp32, VectorSetAddMessage.UseFp32);
+            var request = VectorSetAddRequest.Member(
+                "element1",
+                vector.AsMemory(),
+                attributes);
+            request.Quantization = quantization;
+            request.ReducedDimensions = 64;
+            request.BuildExplorationFactor = 300;
+            request.MaxConnections = 32;
+            request.UseCheckAndSet = true;
+            Log("Storing...");
+            var result = await db.VectorSetAddAsync(
+                key,
+                request);
 
-        Assert.True(result);
+            Assert.True(result);
+        }
+        finally
+        {
+            if (disableFp32) VectorSetAddMessage.RestoreFp32();
+        }
+
         Log("Stored successfully; fetching attributes...");
         // Verify attributes were stored
         var retrievedAttributes = await db.VectorSetGetAttributesJsonAsync(key, "element1");

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -69,7 +69,7 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
-        var key = Me();
+        var key = Me() + "/" + quantization;
 
         await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
 

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -85,12 +85,13 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
         request.BuildExplorationFactor = 300;
         request.MaxConnections = 32;
         request.UseCheckAndSet = true;
+        Log("Storing...");
         var result = await db.VectorSetAddAsync(
             key,
             request);
 
         Assert.True(result);
-
+        Log("Stored successfully; fetching attributes...");
         // Verify attributes were stored
         var retrievedAttributes = await db.VectorSetGetAttributesJsonAsync(key, "element1");
         Assert.Equal(attributes, retrievedAttributes);

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -64,7 +64,9 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     [InlineData(VectorSetQuantization.Binary, true)]
     public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool useFp32)
     {
-        Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "CI oddness on Windows; needs attention");
+#if RELEASE // CI runs as Release
+        Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "CI oddness on Windows; needs attention - logged #3072");
+#endif
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
         var key = Me() + "/" + quantization;

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -63,6 +64,7 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     [InlineData(VectorSetQuantization.Binary, true)]
     public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool useFp32)
     {
+        Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "CI oddness on Windows; needs attention");
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
         var key = Me() + "/" + quantization;

--- a/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
@@ -5,15 +5,18 @@ using Xunit;
 
 namespace StackExchange.Redis.Tests;
 
-[RunPerProtocol]
+[Collection(NonParallelCollection.Name)] // because of the FP32 suppression
 public sealed class VectorSetUnitTests(ITestOutputHelper output)
 {
     // the aim of this test is to validate that we're sending the right thing - VADD is complex
     [Theory]
-    [InlineData(VectorSetQuantization.Int8)]
-    [InlineData(VectorSetQuantization.None)]
-    [InlineData(VectorSetQuantization.Binary)]
-    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization)
+    [InlineData(VectorSetQuantization.Int8, false)]
+    [InlineData(VectorSetQuantization.None, false)]
+    [InlineData(VectorSetQuantization.Binary, false)]
+    [InlineData(VectorSetQuantization.Int8, true)]
+    [InlineData(VectorSetQuantization.None, true)]
+    [InlineData(VectorSetQuantization.Binary, true)]
+    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool disableFp32)
     {
         using var server = new VectorServer(output);
         await using var conn = await server.ConnectAsync();
@@ -25,20 +28,29 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
         var vector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
         var attributes = """{"category":"test","id":123}""";
 
-        var request = VectorSetAddRequest.Member(
-            "element1",
-            vector.AsMemory(),
-            attributes);
-        request.Quantization = quantization;
-        request.ReducedDimensions = 64;
-        request.BuildExplorationFactor = 300;
-        request.MaxConnections = 32;
-        request.UseCheckAndSet = true;
-        output.WriteLine("Storing...");
-        var result = await db.VectorSetAddAsync(
-            key,
-            request);
-        Assert.True(result);
+        try
+        {
+            if (disableFp32) VectorSetAddMessage.SuppressFp32();
+            Assert.Equal(!disableFp32, VectorSetAddMessage.UseFp32);
+            var request = VectorSetAddRequest.Member(
+                "element1",
+                vector.AsMemory(),
+                attributes);
+            request.Quantization = quantization;
+            request.ReducedDimensions = 64;
+            request.BuildExplorationFactor = 300;
+            request.MaxConnections = 32;
+            request.UseCheckAndSet = true;
+            output.WriteLine("Storing...");
+            var result = await db.VectorSetAddAsync(
+                key,
+                request);
+            Assert.True(result);
+        }
+        finally
+        {
+            if (disableFp32) VectorSetAddMessage.RestoreFp32();
+        }
 
         // now: what did we send?
         var req = server.LastRequest.ReadRequest().AsSpan();
@@ -48,17 +60,34 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
         {
             output.WriteLine($"  $ '{item}'");
         }
-        Assert.Equal(quantization is VectorSetQuantization.Int8 ? 14 : 15, req.Length);
+
         Assert.Equal("VADD", req[0]);
         Assert.Equal("mykey", req[1]);
         Assert.Equal("REDUCE", req[2]);
         Assert.Equal(64, req[3]);
-        Assert.Equal("FP32", req[4]);
-        Assert.Equal("00-00-80-3F-00-00-00-40-00-00-40-40-00-00-80-40", BitConverter.ToString(req[5]!));
-        Assert.Equal("element1", req[6]);
-        Assert.Equal("CAS", req[7]);
+        req = req.Slice(4);
 
-        req = req.Slice(8);
+        if (disableFp32)
+        {
+            Assert.Equal("VALUES", req[0]);
+            Assert.Equal(4, req[1]);
+            Assert.Equal(1.0f, (float)req[2], precision: 3);
+            Assert.Equal(2.0f, (float)req[3], precision: 3);
+            Assert.Equal(3.0f, (float)req[4], precision: 3);
+            Assert.Equal(4.0f, (float)req[5], precision: 3);
+            req = req.Slice(6);
+        }
+        else
+        {
+            Assert.Equal("FP32", req[0]);
+            Assert.Equal("00-00-80-3F-00-00-00-40-00-00-40-40-00-00-80-40", BitConverter.ToString(req[1]!));
+            req = req.Slice(2);
+        }
+
+        Assert.Equal("element1", req[0]);
+        Assert.Equal("CAS", req[1]);
+        req = req.Slice(2);
+
         switch (quantization)
         {
             case VectorSetQuantization.None:
@@ -70,12 +99,16 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
                 req = req.Slice(1);
                 break;
         }
+
         Assert.Equal("EF", req[0]);
         Assert.Equal(300, req[1]);
         Assert.Equal("SETATTR", req[2]);
         Assert.Equal("""{"category":"test","id":123}""", req[3]);
         Assert.Equal("M", req[4]);
         Assert.Equal(32, req[5]);
+        req = req.Slice(6);
+
+        Assert.True(req.IsEmpty);
     }
 
     private sealed class VectorServer(ITestOutputHelper log) : InProcessTestServer(log)

--- a/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
@@ -1,4 +1,3 @@
-extern alias respite;
 using System;
 using System.Threading.Tasks;
 using StackExchange.Redis.Server;

--- a/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
@@ -1,7 +1,6 @@
 extern alias respite;
 using System;
 using System.Threading.Tasks;
-using respite::RESPite.Messages;
 using StackExchange.Redis.Server;
 using Xunit;
 

--- a/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
@@ -1,0 +1,94 @@
+extern alias respite;
+using System;
+using System.Threading.Tasks;
+using respite::RESPite.Messages;
+using StackExchange.Redis.Server;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+[RunPerProtocol]
+public sealed class VectorSetUnitTests(ITestOutputHelper output)
+{
+    // the aim of this test is to validate that we're sending the right thing - VADD is complex
+    [Theory]
+    [InlineData(VectorSetQuantization.Int8)]
+    [InlineData(VectorSetQuantization.None)]
+    [InlineData(VectorSetQuantization.Binary)]
+    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization)
+    {
+        using var server = new VectorServer(output);
+        await using var conn = await server.ConnectAsync();
+        var db = conn.GetDatabase();
+        var key = "mykey";
+
+        await db.KeyDeleteAsync(key, CommandFlags.FireAndForget);
+
+        var vector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
+        var attributes = """{"category":"test","id":123}""";
+
+        var request = VectorSetAddRequest.Member(
+            "element1",
+            vector.AsMemory(),
+            attributes);
+        request.Quantization = quantization;
+        request.ReducedDimensions = 64;
+        request.BuildExplorationFactor = 300;
+        request.MaxConnections = 32;
+        request.UseCheckAndSet = true;
+        output.WriteLine("Storing...");
+        var result = await db.VectorSetAddAsync(
+            key,
+            request);
+        Assert.True(result);
+
+        // now: what did we send?
+        var req = server.LastRequest.ReadRequest().AsSpan();
+
+        output.WriteLine($"Request: * {req.Length}");
+        foreach (var item in req)
+        {
+            output.WriteLine($"  $ '{item}'");
+        }
+        Assert.Equal(quantization is VectorSetQuantization.Int8 ? 14 : 15, req.Length);
+        Assert.Equal("VADD", req[0]);
+        Assert.Equal("mykey", req[1]);
+        Assert.Equal("REDUCE", req[2]);
+        Assert.Equal(64, req[3]);
+        Assert.Equal("FP32", req[4]);
+        Assert.Equal("00-00-80-3F-00-00-00-40-00-00-40-40-00-00-80-40", BitConverter.ToString(req[5]!));
+        Assert.Equal("element1", req[6]);
+        Assert.Equal("CAS", req[7]);
+
+        req = req.Slice(8);
+        switch (quantization)
+        {
+            case VectorSetQuantization.None:
+                Assert.Equal("NOQUANT", req[0]);
+                req = req.Slice(1);
+                break;
+            case VectorSetQuantization.Binary:
+                Assert.Equal("BIN", req[0]);
+                req = req.Slice(1);
+                break;
+        }
+        Assert.Equal("EF", req[0]);
+        Assert.Equal(300, req[1]);
+        Assert.Equal("SETATTR", req[2]);
+        Assert.Equal("""{"category":"test","id":123}""", req[3]);
+        Assert.Equal("M", req[4]);
+        Assert.Equal(32, req[5]);
+    }
+
+    private sealed class VectorServer(ITestOutputHelper log) : InProcessTestServer(log)
+    {
+        public TypedRedisValue LastRequest { get; private set; } = TypedRedisValue.Nil;
+
+        [RedisCommand(-1)]
+        private TypedRedisValue Vadd(RedisClient client, in RedisRequest request)
+        {
+            LastRequest = request.AsResponse();
+            return TypedRedisValue.Integer(1); // spoof success
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
@@ -16,7 +16,7 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
     [InlineData(VectorSetQuantization.Int8, true)]
     [InlineData(VectorSetQuantization.None, true)]
     [InlineData(VectorSetQuantization.Binary, true)]
-    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool disableFp32)
+    public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool useFp32)
     {
         using var server = new VectorServer(output);
         await using var conn = await server.ConnectAsync();
@@ -28,29 +28,21 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
         var vector = new[] { 1.0f, 2.0f, 3.0f, 4.0f };
         var attributes = """{"category":"test","id":123}""";
 
-        try
-        {
-            if (disableFp32) VectorSetAddMessage.SuppressFp32();
-            Assert.Equal(!disableFp32, VectorSetAddMessage.UseFp32);
-            var request = VectorSetAddRequest.Member(
-                "element1",
-                vector.AsMemory(),
-                attributes);
-            request.Quantization = quantization;
-            request.ReducedDimensions = 64;
-            request.BuildExplorationFactor = 300;
-            request.MaxConnections = 32;
-            request.UseCheckAndSet = true;
-            output.WriteLine("Storing...");
-            var result = await db.VectorSetAddAsync(
-                key,
-                request);
-            Assert.True(result);
-        }
-        finally
-        {
-            if (disableFp32) VectorSetAddMessage.RestoreFp32();
-        }
+        var request = VectorSetAddRequest.Member(
+            "element1",
+            vector.AsMemory(),
+            attributes);
+        request.UseFp32 = useFp32;
+        request.Quantization = quantization;
+        request.ReducedDimensions = 64;
+        request.BuildExplorationFactor = 300;
+        request.MaxConnections = 32;
+        request.UseCheckAndSet = true;
+        output.WriteLine("Storing...");
+        var result = await db.VectorSetAddAsync(
+            key,
+            request);
+        Assert.True(result);
 
         // now: what did we send?
         var req = server.LastRequest.ReadRequest().AsSpan();
@@ -67,7 +59,13 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
         Assert.Equal(64, req[3]);
         req = req.Slice(4);
 
-        if (disableFp32)
+        if (useFp32)
+        {
+            Assert.Equal("FP32", req[0]);
+            Assert.Equal("00-00-80-3F-00-00-00-40-00-00-40-40-00-00-80-40", BitConverter.ToString(req[1]!));
+            req = req.Slice(2);
+        }
+        else
         {
             Assert.Equal("VALUES", req[0]);
             Assert.Equal(4, req[1]);
@@ -76,12 +74,6 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
             Assert.Equal(3.0f, (float)req[4], precision: 3);
             Assert.Equal(4.0f, (float)req[5], precision: 3);
             req = req.Slice(6);
-        }
-        else
-        {
-            Assert.Equal("FP32", req[0]);
-            Assert.Equal("00-00-80-3F-00-00-00-40-00-00-40-40-00-00-80-40", BitConverter.ToString(req[1]!));
-            req = req.Slice(2);
         }
 
         Assert.Equal("element1", req[0]);

--- a/toys/StackExchange.Redis.Server/RedisRequest.cs
+++ b/toys/StackExchange.Redis.Server/RedisRequest.cs
@@ -137,6 +137,17 @@ namespace StackExchange.Redis.Server
         internal RedisRequest(in ReadOnlySequence<byte> payload, ref byte[] commandLease) : this(new RespReader(payload), ref commandLease) { }
 
         public byte[] Serialize() => _rootReader.Serialize();
+
+        public TypedRedisValue AsResponse(bool rent = false)
+        {
+            var response = rent ? TypedRedisValue.Rent(Count, out var span, RespPrefix.Array) : TypedRedisValue.Standalone(Count, out span, RespPrefix.Array);
+
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] = TypedRedisValue.BulkString(GetReader(i).ReadRedisValue());
+            }
+            return response;
+        }
     }
 
     [Flags]

--- a/toys/StackExchange.Redis.Server/TypedRedisValue.cs
+++ b/toys/StackExchange.Redis.Server/TypedRedisValue.cs
@@ -33,6 +33,23 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// Like <see cref="Rent(int, out Span{TypedRedisValue}, RespPrefix)"/>, but allocates a new array,
+        /// and should **not** be recycled.
+        /// </summary>
+        public static TypedRedisValue Standalone(int count, out Span<TypedRedisValue> span, RespPrefix type)
+        {
+            if (count == 0)
+            {
+                span = default;
+                return EmptyArray(type);
+            }
+
+            var arr = new TypedRedisValue[count];
+            span = new Span<TypedRedisValue>(arr, 0, count);
+            return new TypedRedisValue(arr, count, type);
+        }
+
+        /// <summary>
         /// An invalid empty value that has no type.
         /// </summary>
         public static TypedRedisValue Nil => default;
@@ -228,5 +245,18 @@ namespace StackExchange.Redis
         /// </summary>
         /// <param name="obj">The object to compare to.</param>
         public override bool Equals(object obj) => throw new NotSupportedException();
+
+        public RedisValue[] ReadRequest()
+        {
+            if (Type is not RespPrefix.Array) throw new InvalidOperationException("Expected array (root)");
+            var span = Span;
+            var result = new RedisValue[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                if (span[i].Type is not RespPrefix.BulkString) throw new InvalidOperationException($"Expected bulk string ({i})");
+                result[i] = span[i].AsRedisValue();
+            }
+            return result;
+        }
     }
 }


### PR DESCRIPTION
API uses `ValueCondition`, in anticipation of new server APIs

The decision not to add a matching Decrement API is intentional and considered

Side fixes:

- LoggerTests.TestLogger threw in CI in race scenario; fixed
- VADD CI test wobbling, lots of investigation - very odd
- GC CI test wobbling, fixing by allowing a small loop

Fix #3069 

There's some noise in this PR which was me trying to get the `VADD` CI green; this was very odd, and I had to split that off in the end; see https://github.com/StackExchange/StackExchange.Redis/issues/3072 for status