### PR TITLE
Investigate (and fix) VADD CI failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ StackExchange.Redis.*.zip
 .idea/
 .vs/
 .vscode/
+.codex
 *.lock.json
 test-results*.xml
 packages/

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -64,9 +64,6 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     [InlineData(VectorSetQuantization.Binary, true)]
     public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool useFp32)
     {
-#if RELEASE // CI runs as Release
-        Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "CI oddness on Windows; needs attention - logged #3072");
-#endif
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
         var db = conn.GetDatabase();
         var key = Me() + "/" + quantization;

--- a/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetIntegrationTests.cs
@@ -65,6 +65,8 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
     public async Task VectorSetAdd_WithEverything(VectorSetQuantization quantization, bool useFp32)
     {
         await using var conn = Create(require: RedisFeatures.v8_0_0_M04);
+        var server = conn.GetServer(RedisKey.Null);
+        Log($"Server version: {server.Version}");
         var db = conn.GetDatabase();
         var key = Me() + "/" + quantization;
 
@@ -79,7 +81,7 @@ public sealed class VectorSetIntegrationTests(ITestOutputHelper output) : TestBa
             attributes);
         request.UseFp32 = useFp32;
         request.Quantization = quantization;
-        request.ReducedDimensions = 64;
+        request.ReducedDimensions = 4;
         request.BuildExplorationFactor = 300;
         request.MaxConnections = 32;
         request.UseCheckAndSet = true;

--- a/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/VectorSetUnitTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace StackExchange.Redis.Tests;
 
-[Collection(NonParallelCollection.Name)] // because of the FP32 suppression
 public sealed class VectorSetUnitTests(ITestOutputHelper output)
 {
     // the aim of this test is to validate that we're sending the right thing - VADD is complex
@@ -34,7 +33,7 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
             attributes);
         request.UseFp32 = useFp32;
         request.Quantization = quantization;
-        request.ReducedDimensions = 64;
+        request.ReducedDimensions = 4;
         request.BuildExplorationFactor = 300;
         request.MaxConnections = 32;
         request.UseCheckAndSet = true;
@@ -56,7 +55,7 @@ public sealed class VectorSetUnitTests(ITestOutputHelper output)
         Assert.Equal("VADD", req[0]);
         Assert.Equal("mykey", req[1]);
         Assert.Equal("REDUCE", req[2]);
-        Assert.Equal(64, req[3]);
+        Assert.Equal(4, req[3]);
         req = req.Slice(4);
 
         if (useFp32)


### PR DESCRIPTION
fix https://github.com/StackExchange/StackExchange.Redis/issues/3072

The real issue here was that the Windows CI uses apt-get, which means it pulls down GA; 8.6.3 went GA, and includes a change to `VADD`, where-by if you attempt to `REDUCE`  vector to a size larger than the actual data (i.e. actually an expansion), it fails. That's exactly what we were doing!