### PR TITLE
Don't serialize (ToString() or clone Protocol if it comes from the defaults-provider

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,7 +9,8 @@ Current package versions:
 ## Unreleased
 
 - Add experimental Redis 8.8 array support, including array APIs on `IDatabase`/`IDatabaseAsync`,
-  array helper types, `RedisType.Array`, and array delete keyspace notification event types.
+  array helper types, `RedisType.Array`, and array delete keyspace notification event types. ([#3076 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3076))
+- `ConfigurationOptions` : don't persist `Protocol` when it comes from the defaults-provider. ([#3082 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3082))
 
 ## 2.13.1
 

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -843,7 +843,7 @@ namespace StackExchange.Redis
             Tunnel = Tunnel,
             setClientLibrary = setClientLibrary,
             LibraryName = LibraryName,
-            Protocol = Protocol,
+            _protocol = _protocol,
             heartbeatInterval = heartbeatInterval,
             heartbeatConsistencyChecks = heartbeatConsistencyChecks,
             highIntegrity = highIntegrity,
@@ -928,7 +928,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.DefaultDatabase, DefaultDatabase);
             Append(sb, OptionKeys.SetClientLibrary, setClientLibrary);
             Append(sb, OptionKeys.HighIntegrity, highIntegrity);
-            Append(sb, OptionKeys.Protocol, FormatProtocol(Protocol));
+            Append(sb, OptionKeys.Protocol, FormatProtocol(_protocol));
             if (Tunnel is { IsInbuilt: true } tunnel)
             {
                 Append(sb, OptionKeys.Tunnel, tunnel.ToString());
@@ -1121,7 +1121,7 @@ namespace StackExchange.Redis
                             }
                             break;
                         case OptionKeys.Protocol:
-                            Protocol = OptionKeys.ParseRedisProtocol(key, value);
+                            _protocol = OptionKeys.ParseRedisProtocol(key, value);
                             break;
                         // Deprecated options we ignore...
                         case OptionKeys.HighPrioritySocketThreads:
@@ -1171,9 +1171,11 @@ namespace StackExchange.Redis
         /// </summary>
         public RedisProtocol? Protocol
         {
-            get => field ?? Defaults.Protocol;
-            set;
+            get => _protocol ?? Defaults.Protocol;
+            set => _protocol = value;
         }
+
+        private RedisProtocol? _protocol;
 
         internal bool TryResp3()
         {

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -827,4 +827,18 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
         var parsed = ConfigurationOptions.Parse(cs);
         Assert.Equal(expected, parsed.HighIntegrity);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DefaultsProviderProtocolNotSerialized(bool clone)
+    {
+        var options = new ConfigurationOptions();
+        var provider = new AzureManagedRedisOptionsProvider();
+        options.Defaults = provider;
+        if (clone) options = options.Clone();
+        Assert.Equal(RedisProtocol.Resp3, options.Protocol);
+        Assert.Same(provider, options.Defaults);
+        Assert.Equal("", options.ToString());
+    }
 }

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -36,6 +36,7 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
         Assert.Equal(
             new[]
             {
+                "_protocol",
                 "abortOnConnectFail",
                 "allowAdmin",
                 "asyncTimeout",
@@ -64,7 +65,6 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
                 "LibraryName",
                 "loggerFactory",
                 "password",
-                "Protocol",
                 "proxy",
                 "reconnectRetryPolicy",
                 "resolveDns",


### PR DESCRIPTION
The AMR default RESP3 change is accidentally manifesting in `options.ToString()` and `options.Clone()`; fix that.