### PR TITLE
Fix platform-specific TCP keep-alive issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
     <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'StackExchange.Redis.Build' and '$(MSBuildProjectName)' != 'docker' and '$(MSBuildProjectName)' != 'docs' and '$(MSBuildProjectName)' != '.github'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,5 +39,6 @@
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.v3.runner.console" Version="3.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -83,6 +83,7 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | configCheckSeconds={int} | `ConfigCheckSeconds` | `60`                         | Time (seconds) to check configuration. This serves as a keep-alive for interactive sockets, if it is supported.     |
 | defaultDatabase={int}  | `DefaultDatabase`      | `null`                       | Default database index, from `0` to `databases - 1`                                                       |
 | keepAlive={int}        | `KeepAlive`            | `-1`                         | Time (seconds) at which to send a message to help keep sockets alive (60 sec default)                     |
+| tcpKeepAlive={bool}    | `TcpKeepAlive`         | `true`                       | Enables TCP keep-alive when appropriate (endpoint- and platform-dependent)                                |
 | name={string}          | `ClientName`           | `null`                       | Identification for the connection within redis                                                            |
 | password={string}      | `Password`             | `null`                       | Password for the redis server                                                                             |
 | user={string}          | `User`                 | `null`                       | User for the redis server (for use with ACLs on redis 6 and above)                                        |

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@ Current package versions:
 ## Unreleased
 
 - Fix logic inversion with `ARGREP NOCASE`, add `IsReversed` to simplify ordering, and support `ARINFO FULL`. ([#3087 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3087))
+- Fix TCP platform-dependent TCP keep-alive problems, and make an explicit option. ([#3090 by @mgravell](https://github.com/StackExchange/StackExchange.Redis/pull/3090))
 
 ## 2.13.10
 

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -265,6 +265,11 @@ namespace StackExchange.Redis.Configuration
         public virtual RedisProtocol? Protocol => null;
 
         /// <summary>
+        /// Gets whether to enable TCP keep-alive when appropriate (endpoint- and platform-dependent).
+        /// </summary>
+        public virtual bool TcpKeepAlive => true;
+
+        /// <summary>
         /// Tries to get the RoleInstance Id if Microsoft.WindowsAzure.ServiceRuntime is loaded.
         /// In case of any failure, swallows the exception and returns null.
         /// </summary>

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -111,7 +111,8 @@ namespace StackExchange.Redis
                 Tunnel = "tunnel",
                 SetClientLibrary = "setlib",
                 Protocol = "protocol",
-                HighIntegrity = "highIntegrity";
+                HighIntegrity = "highIntegrity",
+                TcpKeepAlive = "tcpkeepalive";
 
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
@@ -169,6 +170,7 @@ namespace StackExchange.Redis
         private Version? defaultVersion;
 
         private int? keepAlive, asyncTimeout, syncTimeout, connectTimeout, responseTimeout, connectRetry, configCheckSeconds;
+        private bool? tcpKeepAlive;
 
         private Proxy? proxy;
 
@@ -597,6 +599,15 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// Gets or sets whether to enable TCP keep-alive when appropriate (endpoint- and platform-dependent).
+        /// </summary>
+        public bool TcpKeepAlive
+        {
+            get => tcpKeepAlive ?? Defaults.TcpKeepAlive;
+            set => tcpKeepAlive = value;
+        }
+
+        /// <summary>
         /// The <see cref="ILoggerFactory"/> to get loggers for connection events.
         /// Note: changes here only affect <see cref="ConnectionMultiplexer"/>s created after.
         /// </summary>
@@ -847,6 +858,7 @@ namespace StackExchange.Redis
             heartbeatInterval = heartbeatInterval,
             heartbeatConsistencyChecks = heartbeatConsistencyChecks,
             highIntegrity = highIntegrity,
+            tcpKeepAlive = tcpKeepAlive,
         };
 
         /// <summary>
@@ -929,6 +941,7 @@ namespace StackExchange.Redis
             Append(sb, OptionKeys.SetClientLibrary, setClientLibrary);
             Append(sb, OptionKeys.HighIntegrity, highIntegrity);
             Append(sb, OptionKeys.Protocol, FormatProtocol(_protocol));
+            Append(sb, OptionKeys.TcpKeepAlive, tcpKeepAlive);
             if (Tunnel is { IsInbuilt: true } tunnel)
             {
                 Append(sb, OptionKeys.Tunnel, tunnel.ToString());
@@ -1094,6 +1107,9 @@ namespace StackExchange.Redis
                             break;
                         case OptionKeys.HighIntegrity:
                             HighIntegrity = OptionKeys.ParseBoolean(key, value);
+                            break;
+                        case OptionKeys.TcpKeepAlive:
+                            TcpKeepAlive = OptionKeys.ParseBoolean(key, value);
                             break;
                         case OptionKeys.Tunnel:
                             if (value.IsNullOrWhiteSpace())

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -112,7 +112,7 @@ namespace StackExchange.Redis
                 SetClientLibrary = "setlib",
                 Protocol = "protocol",
                 HighIntegrity = "highIntegrity",
-                TcpKeepAlive = "tcpkeepalive";
+                TcpKeepAlive = "tcpKeepAlive";
 
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
@@ -133,6 +133,7 @@ namespace StackExchange.Redis
                 PreserveAsyncOrder,
                 Proxy,
                 ResolveDns,
+                ResponseTimeout,
                 ServiceName,
                 Ssl,
                 SslHost,
@@ -142,8 +143,11 @@ namespace StackExchange.Redis
                 Version,
                 WriteBuffer,
                 CheckCertificateRevocation,
+                Tunnel,
+                SetClientLibrary,
                 Protocol,
                 HighIntegrity,
+                TcpKeepAlive,
             }.ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
             public static string TryNormalize(string value)

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -113,7 +113,8 @@ namespace StackExchange.Redis
             }
 
             Trace("Connecting...");
-            var tunnel = bridge.Multiplexer.RawConfig.Tunnel;
+            var rawConfig = bridge.Multiplexer.RawConfig;
+            var tunnel = rawConfig.Tunnel;
             var connectTo = endpoint;
             if (tunnel is not null)
             {
@@ -121,7 +122,7 @@ namespace StackExchange.Redis
             }
             if (connectTo is not null)
             {
-                _socket = SocketManager.CreateSocket(connectTo);
+                _socket = SocketManager.CreateSocket(connectTo, rawConfig.TcpKeepAlive);
             }
 
             if (_socket is not null)

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+StackExchange.Redis.ConfigurationOptions.TcpKeepAlive.get -> bool
+StackExchange.Redis.ConfigurationOptions.TcpKeepAlive.set -> void
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.TcpKeepAlive.get -> bool
 [SER006]StackExchange.Redis.ArrayGrepRequest.IsCaseInsensitive.get -> bool
 [SER006]StackExchange.Redis.ArrayGrepRequest.IsCaseInsensitive.set -> void
 [SER006]StackExchange.Redis.ArrayGrepRequest.IsReversed.get -> bool

--- a/src/StackExchange.Redis/SocketManager.cs
+++ b/src/StackExchange.Redis/SocketManager.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Pipelines.Sockets.Unofficial;
 
@@ -215,7 +216,7 @@ namespace StackExchange.Redis
         /// </summary>
         ~SocketManager() => DisposeRefs();
 
-        internal static Socket CreateSocket(EndPoint endpoint)
+        internal static Socket CreateSocket(EndPoint endpoint, bool tcpKeepAlive)
         {
             var addressFamily = endpoint.AddressFamily;
             var protocolType = addressFamily == AddressFamily.Unix ? ProtocolType.Unspecified : ProtocolType.Tcp;
@@ -224,18 +225,7 @@ namespace StackExchange.Redis
                 ? new Socket(SocketType.Stream, protocolType)
                 : new Socket(addressFamily, SocketType.Stream, protocolType);
             SocketConnection.SetRecommendedClientOptions(socket);
-            if (protocolType is ProtocolType.Tcp)
-            {
-                try
-                {
-                    // enable TCP keep-alive (best effort only)
-                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine(ex.Message);
-                }
-            }
+            if (tcpKeepAlive) TryEnableTcpKeepAlive(socket, endpoint);
             return socket;
         }
 
@@ -245,6 +235,40 @@ namespace StackExchange.Redis
         {
             var s = SchedulerPool;
             return s == null ? null : $"{s.AvailableCount} of {s.WorkerCount} available";
+        }
+
+        internal static bool TryEnableTcpKeepAlive(Socket socket, EndPoint endPoint)
+        {
+            // TCP keep-alive; there's a clue in the name
+            if (socket.ProtocolType is not ProtocolType.Tcp) return false;
+
+            switch (endPoint)
+            {
+#if !NET10_0_OR_GREATER
+                // Prior to .NET 10, enabling TCP keep-alive on host-based endpoints fails outside of Windows.
+                // see https://github.com/StackExchange/StackExchange.Redis/issues/3086
+                case DnsEndPoint when !RuntimeInformation.IsOSPlatform(OSPlatform.Windows): return false;
+#endif
+                case DnsEndPoint:
+                case IPEndPoint:
+                    // fine
+                    break;
+                default:
+                    // don't enable on unexpected endpoint types (unix domain sockets, for example)
+                    return false;
+            }
+
+            try
+            {
+                // enable TCP keep-alive (best effort only)
+                socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                return false;
+            }
         }
     }
 }

--- a/tests/RedisConfigs/.docker/Redis/Dockerfile
+++ b/tests/RedisConfigs/.docker/Redis/Dockerfile
@@ -1,4 +1,4 @@
-ARG CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.8-rc1
+ARG CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.8.0
 FROM ${CLIENT_LIBS_TEST_IMAGE}
 
 COPY --from=configs ./Basic /data/Basic/

--- a/tests/RedisConfigs/docker-compose.yml
+++ b/tests/RedisConfigs/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .docker/Redis
       args:
-        CLIENT_LIBS_TEST_IMAGE: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-rc1}
+        CLIENT_LIBS_TEST_IMAGE: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8.0}
       additional_contexts:
          configs: .
     platform: linux

--- a/tests/StackExchange.Redis.Tests/ArrayTests.cs
+++ b/tests/StackExchange.Redis.Tests/ArrayTests.cs
@@ -126,6 +126,9 @@ public class ArrayTests(SharedConnectionFixture fixture, ITestOutputHelper log)
     [Fact(Timeout = 10000)]
     public async Task DeleteLastElementPublishesArrayDeleteBeforeKeyDeleteNotifications()
     {
+        #if !DEBUG
+        Assert.Skip("Debug only due to parallelism overhead");
+        #endif
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v8_8_0);
         var db = conn.GetDatabase();
         await AssertArrayKeyspaceNotificationsEnabledAsync(conn);
@@ -631,9 +634,12 @@ public class ArrayTests(SharedConnectionFixture fixture, ITestOutputHelper log)
 
     private async Task<(KeyNotificationKind Kind, KeyNotificationType Type)> ReadNotificationAsync(ChannelMessageQueue queue, RedisKey key)
     {
-        for (int i = 0; i < 64; i++)
+        // there might be a lot of parallel notifications happening from parallel tests; as such, we might need to skip a lot of unrelated
+        // stuff - allow for the timeout
+        var ct = TestContext.Current.CancellationToken;
+        while (!ct.IsCancellationRequested)
         {
-            var message = await queue.ReadAsync(TestContext.Current.CancellationToken);
+            var message = await queue.ReadAsync(ct);
             if (message.TryParseKeyNotification(out var notification))
             {
                 Log($"{notification.Kind}, {notification.Type} {message}");

--- a/tests/StackExchange.Redis.Tests/ArrayTests.cs
+++ b/tests/StackExchange.Redis.Tests/ArrayTests.cs
@@ -136,6 +136,8 @@ public class ArrayTests(SharedConnectionFixture fixture, ITestOutputHelper log)
         var sub = conn.GetSubscriber();
         var channel = RedisChannel.Pattern($"__key*@{db.Database}__:*");
         var queue = await sub.SubscribeAsync(channel);
+        await Task.Delay(100);
+        await sub.PingAsync();
         try
         {
             Assert.True(await db.ArraySetAsync(key, 0, "a"));

--- a/tests/StackExchange.Redis.Tests/ClusterTests.cs
+++ b/tests/StackExchange.Redis.Tests/ClusterTests.cs
@@ -521,6 +521,8 @@ public class ClusterTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [InlineData("abc", 100)]
     public async Task Keys(string? pattern, int pageSize)
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true);
 
         var dbId = TestConfig.GetDedicatedDB(conn);
@@ -621,6 +623,8 @@ public class ClusterTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [Fact(Skip = "FlushAllDatabases")]
     public async Task AccessRandomKeys()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true);
 
         var cluster = conn.GetDatabase();

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -79,6 +79,7 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
                 "sslHost",
                 "SslProtocols",
                 "syncTimeout",
+                "tcpKeepAlive",
                 "tieBreaker",
                 "Tunnel",
                 "user",

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -88,6 +88,25 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
     }
 
     [Fact]
+    public void OptionKeysAreAllNormalized()
+    {
+        var optionKeys = typeof(ConfigurationOptions).GetNestedType("OptionKeys", BindingFlags.NonPublic)!;
+        var constants = (
+            from field in optionKeys.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            where field.IsLiteral && !field.IsInitOnly && field.FieldType == typeof(string)
+            orderby field.Name
+            select (string)field.GetRawConstantValue()!).ToArray();
+
+        var normalizedOptions = (System.Collections.Generic.IReadOnlyDictionary<string, string>)optionKeys
+            .GetField("normalizedOptions", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+        Assert.Equal(
+            constants.OrderBy(x => x, StringComparer.Ordinal),
+            normalizedOptions.Keys.OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
     public void SslProtocols_SingleValue()
     {
         var options = ConfigurationOptions.Parse("myhost,sslProtocols=Tls12");

--- a/tests/StackExchange.Redis.Tests/DatabaseTests.cs
+++ b/tests/StackExchange.Redis.Tests/DatabaseTests.cs
@@ -67,6 +67,8 @@ public class DatabaseTests(ITestOutputHelper output, SharedConnectionFixture fix
     [Fact]
     public async Task CountKeys()
     {
+        NoConcurrentRuntime();
+
         var db1Id = TestConfig.GetDedicatedDB();
         var db2Id = TestConfig.GetDedicatedDB();
         await using (var conn = Create(allowAdmin: true))

--- a/tests/StackExchange.Redis.Tests/HotKeysTests.cs
+++ b/tests/StackExchange.Redis.Tests/HotKeysTests.cs
@@ -15,6 +15,8 @@ public class HotKeysClusterTests(ITestOutputHelper output, SharedConnectionFixtu
     [InlineData(false)]
     public void CanUseClusterFilter(bool sample)
     {
+        NoConcurrentRuntime();
+
         var key = Me();
         using var muxer = GetServer(key, out var server);
         Log($"server: {Format.ToString(server.EndPoint)}, key: '{key}'");
@@ -129,6 +131,8 @@ public class HotKeysTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [Fact]
     public void CanStartStopReset()
     {
+        NoConcurrentRuntime();
+
         RedisKey key = Me();
         using var muxer = GetServer(key, out var server);
         server.HotKeysStart(duration: Duration);
@@ -215,6 +219,8 @@ public class HotKeysTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [Fact]
     public async Task CanStartStopResetAsync()
     {
+        NoConcurrentRuntime();
+
         RedisKey key = Me();
         await using var muxer = GetServer(key, out var server);
         await server.HotKeysStartAsync(duration: Duration);
@@ -244,6 +250,8 @@ public class HotKeysTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [Fact]
     public async Task DurationFilterAsync()
     {
+        NoConcurrentRuntime();
+
         Skip.UnlessLongRunning(); // time-based tests are horrible
 
         RedisKey key = Me();
@@ -276,6 +284,8 @@ public class HotKeysTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [InlineData(HotKeysMetrics.Network | HotKeysMetrics.Cpu)]
     public async Task MetricsChoiceAsync(HotKeysMetrics metrics)
     {
+        NoConcurrentRuntime();
+
         RedisKey key = Me();
         await using var muxer = GetServer(key, out var server);
         await server.HotKeysStartAsync(metrics, duration: Duration);
@@ -305,6 +315,8 @@ public class HotKeysTests(ITestOutputHelper output, SharedConnectionFixture fixt
     [Fact]
     public async Task SampleRatioUsageAsync()
     {
+        NoConcurrentRuntime();
+
         RedisKey key = Me();
         await using var muxer = GetServer(key, out var server);
         await server.HotKeysStartAsync(sampleRatio: 3, duration: Duration);

--- a/tests/StackExchange.Redis.Tests/InProcessDatabaseUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/InProcessDatabaseUnitTests.cs
@@ -5,12 +5,14 @@ using Xunit;
 namespace StackExchange.Redis.Tests;
 
 [RunPerProtocol]
-public class InProcessDatabaseUnitTests(ITestOutputHelper output)
+public class InProcessDatabaseUnitTests(ITestOutputHelper output) : TestBase(output)
 {
     [Fact]
     public async Task DatabasesAreIsolatedAndCanBeFlushed()
     {
-        using var server = new InProcessTestServer(output);
+        NoConcurrentRuntime();
+
+        using var server = new InProcessTestServer(Output);
         await using var conn = await server.ConnectAsync();
 
         var admin = conn.GetServer(conn.GetEndPoints()[0]);

--- a/tests/StackExchange.Redis.Tests/InProcessDatabaseUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/InProcessDatabaseUnitTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 namespace StackExchange.Redis.Tests;
 
 [RunPerProtocol]
-public class InProcessDatabaseUnitTests(ITestOutputHelper output) : TestBase(output)
+public class InProcessDatabaseUnitTests(ITestOutputHelper output)
 {
     [Fact]
     public async Task DatabasesAreIsolatedAndCanBeFlushed()
     {
-        NoConcurrentRuntime();
+        TestBase.NoConcurrentRuntime();
 
-        using var server = new InProcessTestServer(Output);
+        using var server = new InProcessTestServer(output);
         await using var conn = await server.ConnectAsync();
 
         var admin = conn.GetServer(conn.GetEndPoints()[0]);

--- a/tests/StackExchange.Redis.Tests/Issues/MassiveDeleteTests.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/MassiveDeleteTests.cs
@@ -10,6 +10,8 @@ public class MassiveDeleteTests(ITestOutputHelper output) : TestBase(output)
 {
     private async Task Prep(int dbId, string key)
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true);
 
         var prefix = Me();
@@ -29,6 +31,8 @@ public class MassiveDeleteTests(ITestOutputHelper output) : TestBase(output)
     [Fact]
     public async Task ExecuteMassiveDelete()
     {
+        NoConcurrentRuntime();
+
         Skip.UnlessLongRunning();
         var dbId = TestConfig.GetDedicatedDB();
         var key = Me();

--- a/tests/StackExchange.Redis.Tests/KeyTests.cs
+++ b/tests/StackExchange.Redis.Tests/KeyTests.cs
@@ -14,6 +14,8 @@ public class KeyTests(ITestOutputHelper output, SharedConnectionFixture fixture)
     [Fact]
     public async Task TestScan()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true);
 
         var dbId = TestConfig.GetDedicatedDB(conn);
@@ -33,6 +35,8 @@ public class KeyTests(ITestOutputHelper output, SharedConnectionFixture fixture)
     [Fact]
     public async Task FlushFetchRandomKey()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true);
 
         var dbId = TestConfig.GetDedicatedDB(conn);

--- a/tests/StackExchange.Redis.Tests/MultiPrimaryTests.cs
+++ b/tests/StackExchange.Redis.Tests/MultiPrimaryTests.cs
@@ -14,6 +14,8 @@ public class MultiPrimaryTests(ITestOutputHelper output) : TestBase(output)
     [Fact]
     public async Task CannotFlushReplica()
     {
+        NoConcurrentRuntime();
+
         var ex = await Assert.ThrowsAsync<RedisCommandException>(async () =>
         {
             await using var conn = await ConnectionMultiplexer.ConnectAsync(TestConfig.Current.ReplicaServerAndPort + ",allowAdmin=true");

--- a/tests/StackExchange.Redis.Tests/ScanTests.cs
+++ b/tests/StackExchange.Redis.Tests/ScanTests.cs
@@ -14,6 +14,8 @@ public class ScanTests(ITestOutputHelper output, SharedConnectionFixture fixture
     [InlineData(false)]
     public async Task KeysScan(bool supported)
     {
+        NoConcurrentRuntime();
+
         string[]? disabledCommands = supported ? null : ["scan"];
         await using var conn = Create(disabledCommands: disabledCommands, allowAdmin: true);
 
@@ -51,6 +53,8 @@ public class ScanTests(ITestOutputHelper output, SharedConnectionFixture fixture
     [Fact]
     public async Task ScansIScanning()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true);
 
         var prefix = Me() + Guid.NewGuid();
@@ -98,6 +102,8 @@ public class ScanTests(ITestOutputHelper output, SharedConnectionFixture fixture
     [Fact]
     public async Task ScanResume()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_8_0);
 
         var dbId = TestConfig.GetDedicatedDB(conn);

--- a/tests/StackExchange.Redis.Tests/ScriptingTests.cs
+++ b/tests/StackExchange.Redis.Tests/ScriptingTests.cs
@@ -184,6 +184,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task FlushDetection()
     {
+        NoConcurrentRuntime();
+
         // we don't expect this to handle everything; we just expect it to be predictable
         await using var conn = GetScriptConn(allowAdmin: true);
 
@@ -206,6 +208,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task PrepareScript()
     {
+        NoConcurrentRuntime();
+
         string[] scripts = ["return redis.call('get', KEYS[1])", "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}"];
         await using (var conn = GetScriptConn(allowAdmin: true))
         {
@@ -389,6 +393,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [InlineData(false)]
     public async Task CheckLoads(bool async)
     {
+        NoConcurrentRuntime();
+
         await using var conn0 = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
         await using var conn1 = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
@@ -437,6 +443,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task CompareScriptToDirect()
     {
+        NoConcurrentRuntime();
+
         Skip.UnlessLongRunning();
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
@@ -484,6 +492,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task TestCallByHash()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "return redis.call('incr', KEYS[1])";
@@ -501,16 +511,18 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
         string hexHash = string.Concat(hash.Select(x => x.ToString("X2")));
         Assert.Equal("2BAB3B661081DB58BD2341920E0BA7CF5DC77B25", hexHash);
 
-        db.ScriptEvaluate(script: hexHash, keys: keys, flags: CommandFlags.FireAndForget);
-        db.ScriptEvaluate(hash, keys, flags: CommandFlags.FireAndForget);
+        await db.ScriptEvaluateAsync(script: hexHash, keys: keys);
+        await db.ScriptEvaluateAsync(hash, keys);
 
-        var count = (int)db.StringGet(keys)[0];
+        var count = (int)db.StringGet(key);
         Assert.Equal(2, count);
     }
 
     [Fact]
     public async Task SimpleLuaScript()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "return @ident";
@@ -565,6 +577,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task SimpleRawScriptEvaluate()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "return ARGV[1]";
@@ -617,6 +631,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task LuaScriptWithKeys()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "redis.call('set', @key, @value)";
@@ -645,6 +661,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task NoInlineReplacement()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "redis.call('set', @key, 'hello@example')";
@@ -678,6 +696,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task SimpleLoadedLuaScript()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "return @ident";
@@ -733,6 +753,8 @@ public class ScriptingTests(ITestOutputHelper output, SharedConnectionFixture fi
     [Fact]
     public async Task LoadedLuaScriptWithKeys()
     {
+        NoConcurrentRuntime();
+
         await using var conn = Create(allowAdmin: true, require: RedisFeatures.v2_6_0);
 
         const string Script = "redis.call('set', @key, @value)";

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- can also run fine in net8.0, but: don't want triplicate by default, and don't want competition between runs --> 
-    <TargetFrameworks>net481;net10.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyName>StackExchange.Redis.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -33,5 +33,7 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="System.IO.Compression" />
     <PackageReference Include="System.IO.Pipelines" />
+    <!-- to deal with package security warning -->
+    <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
 </Project>

--- a/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
+++ b/tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj
@@ -9,6 +9,9 @@
     <DebugType>full</DebugType>
     <Nullable>enable</Nullable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+    <!-- avoid parallelism on some brittle things like script-flush that *really* don't work well vs concurrent runtimes --> 
+    <DefineConstants Condition="'$(TargetFramework)'=='net10.0'">$(DefineConstants);BUILD_CURRENT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.Tests/TcpKeepAliveTests.cs
+++ b/tests/StackExchange.Redis.Tests/TcpKeepAliveTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+public class TcpKeepAliveTests(ITestOutputHelper log, TcpTestFixture fixture) : IClassFixture<TcpTestFixture>
+{
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task Roundtrip(bool ip, bool keepAlive)
+    {
+        using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        EndPoint ep = ip ? fixture.IP : fixture.Dns;
+        log.WriteLine($"Connecting to {Format.ToString(ep)}, keepAlive: {keepAlive}");
+        if (keepAlive)
+        {
+            client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+        }
+        await client.ConnectAsync(ep);
+
+        byte[] buffer = new byte[4];
+        int i = random.Next(int.MinValue, int.MaxValue);
+        BinaryPrimitives.WriteInt32LittleEndian(buffer, i);
+        client.Send(buffer, 0, 4, SocketFlags.None);
+        Array.Clear(buffer, 0, buffer.Length);
+        Assert.Equal(0, BinaryPrimitives.ReadInt32LittleEndian(buffer));
+        int bytesRead, count = 0;
+        while (count < buffer.Length &&
+               (bytesRead = client.Receive(buffer, count, buffer.Length - count, SocketFlags.None)) > 0)
+        {
+            count += bytesRead;
+        }
+        if (count != buffer.Length) throw new EndOfStreamException();
+        Assert.Equal(i, BinaryPrimitives.ReadInt32LittleEndian(buffer));
+    }
+    private static readonly Random random = new();
+}
+
+public class TcpTestFixture : IDisposable
+{
+    private TcpListener server;
+    private CancellationTokenSource cts = new();
+    public IPEndPoint IP { get; }
+    public DnsEndPoint Dns { get; }
+
+    public TcpTestFixture()
+    {
+        int port = 18000;
+#if NET10_OR_GREATER
+        port += 1;
+#elif NET8_0_OR_GREATER
+        port += 2;
+#elif NET6_0_OR_GREATER
+        port += 3;
+#endif
+        var ip = IPAddress.Parse("172.24.32.1");
+        IP = new(ip, port);
+        Dns = new("marc-z13", port);
+        server = new TcpListener(ip, port);
+        server.Start();
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    #if NET
+                    var client = await server.AcceptTcpClientAsync(cts.Token);
+                    #else
+                    var client = await server.AcceptTcpClientAsync();
+                    #endif
+                    _ = Task.Run(() => RunClient(client, cts.Token));
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+            }
+        });
+    }
+
+    private static async Task? RunClient(TcpClient client, CancellationToken cancel)
+    {
+        // echo up to 4 bytes
+        try
+        {
+            using var stream = client.GetStream();
+            byte[] buffer = new byte[4];
+            int bytesRead, count = 0;
+            while (count < buffer.Length &&
+                   (bytesRead = await stream.ReadAsync(buffer, count, buffer.Length - count, cancel)) > 0)
+            {
+                await stream.WriteAsync(buffer, count, bytesRead, cancel);
+                count += bytesRead;
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.Message);
+        }
+        finally
+        {
+            client.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        cts.Cancel();
+        server.Stop();
+        #if NET
+        server.Dispose();
+        #endif
+    }
+}

--- a/tests/StackExchange.Redis.Tests/TcpKeepAliveTests.cs
+++ b/tests/StackExchange.Redis.Tests/TcpKeepAliveTests.cs
@@ -64,7 +64,7 @@ public class TcpTestFixture : IDisposable
     public TcpTestFixture()
     {
         int port = 18000;
-#if NET10_OR_GREATER
+#if NET10_0_OR_GREATER
         port += 1;
 #elif NET8_0_OR_GREATER
         port += 2;

--- a/tests/StackExchange.Redis.Tests/TcpKeepAliveTests.cs
+++ b/tests/StackExchange.Redis.Tests/TcpKeepAliveTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -20,13 +21,19 @@ public class TcpKeepAliveTests(ITestOutputHelper log, TcpTestFixture fixture) : 
     [InlineData(false, false)]
     public async Task Roundtrip(bool ip, bool keepAlive)
     {
+        #if NETFRAMEWORK
+        Assert.SkipWhen(
+            !ip && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Mono has glitches with DNS endpoints");
+        #endif
         using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
         EndPoint ep = ip ? fixture.IP : fixture.Dns;
-        log.WriteLine($"Connecting to {Format.ToString(ep)}, keepAlive: {keepAlive}");
+        log.WriteLine($"Connecting to {Format.ToString(ep)}, {ep.AddressFamily}, keepAlive: {keepAlive}");
         if (keepAlive)
         {
-            client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+            Assert.SkipUnless(SocketManager.TryEnableTcpKeepAlive(client, ep), "keep-alive not supported");
         }
+
         await client.ConnectAsync(ep);
 
         byte[] buffer = new byte[4];
@@ -64,9 +71,11 @@ public class TcpTestFixture : IDisposable
 #elif NET6_0_OR_GREATER
         port += 3;
 #endif
-        var ip = IPAddress.Parse("172.24.32.1");
+        var host = Environment.MachineName;
+        var ip = System.Net.Dns.GetHostEntry(host).AddressList.First(x => x.AddressFamily is AddressFamily.InterNetwork);
+
         IP = new(ip, port);
-        Dns = new("marc-z13", port);
+        Dns = new(host, port, AddressFamily.InterNetwork);
         server = new TcpListener(ip, port);
         server.Start();
         _ = Task.Run(async () =>

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -66,6 +66,16 @@ public abstract class TestBase : IDisposable
         }
     }
 
+    protected void NoConcurrentRuntime()
+    {
+        // Some tests are not amenable to running concurrently in different runtimes - for
+        // example they might do a script-flush or a flush-db; ensure it only runs against
+        // our primary build target (or debug, which is local).
+        #if !(DEBUG || BUILD_CURRENT)
+        Assert.Skip("Avoiding concurrent runtime; this is not the primary build");
+        #endif
+    }
+
     protected void Log(string? message, params object[] args)
     {
         if (args is { Length: > 0 })

--- a/tests/StackExchange.Redis.Tests/TestBase.cs
+++ b/tests/StackExchange.Redis.Tests/TestBase.cs
@@ -66,7 +66,7 @@ public abstract class TestBase : IDisposable
         }
     }
 
-    protected void NoConcurrentRuntime()
+    internal static void NoConcurrentRuntime()
     {
         // Some tests are not amenable to running concurrently in different runtimes - for
         // example they might do a script-flush or a flush-db; ensure it only runs against


### PR DESCRIPTION
Fix https://github.com/StackExchange/StackExchange.Redis/issues/3086

before .NET 10, there are problems with TCP keep-alive on DNS endpoint on non-Windows; here we compensate:

1. make TCP keep-alive an explicit option (defaults to enabled, usual setup i.e. defaults-provider etc)
2. restrict TCP keep-alives to IP and DNS endpoints
3. if not .NET10+, disable for DNS endpoints if not on Windows

(also updates CI image to Redis 8.8)