### PR TITLE
Tear down connection on write failure to prevent queue desync

### DIFF
--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -797,6 +797,11 @@ namespace StackExchange.Redis
             {
                 physical?.OnInternalError(ex);
                 Fail(ConnectionFailureType.InternalFailure, ex, null, physical?.BridgeCouldBeNull?.Multiplexer);
+                // Re-throw so the outer write path (PhysicalBridge.HandleWriteException) can tear down the
+                // connection. A partial write would otherwise leave bytes on the wire while the response
+                // queue still considers the slot healthy, allowing a subsequent reply to match the wrong
+                // in-flight message.
+                throw;
             }
         }
 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -865,7 +865,7 @@ namespace StackExchange.Redis
                 physical.SetIdle();
                 return result;
             }
-            catch (Exception ex) { return HandleWriteException(message, ex); }
+            catch (Exception ex) { return HandleWriteException(physical, message, ex); }
             finally
             {
                 UnmarkActiveMessage(message);
@@ -1215,13 +1215,13 @@ namespace StackExchange.Redis
                         {
                             _backlogStatus = BacklogStatus.RecordingWriteFailure;
                             var ex = Multiplexer.GetException(result, message, ServerEndPoint);
-                            HandleWriteException(message, ex);
+                            HandleWriteException(physical, message, ex);
                         }
                     }
                     catch (Exception ex)
                     {
                         _backlogStatus = BacklogStatus.RecordingFault;
-                        HandleWriteException(message, ex);
+                        HandleWriteException(physical, message, ex);
                     }
                     finally
                     {
@@ -1333,9 +1333,9 @@ namespace StackExchange.Redis
                     {
                         releaseLock = false; // so we don't release prematurely
 #if NET
-                        return CompleteWriteAndReleaseLockAsync(flush, message);
+                        return CompleteWriteAndReleaseLockAsync(physical, flush, message);
 #else
-                        return CompleteWriteAndReleaseLockAsync(token, flush, message);
+                        return CompleteWriteAndReleaseLockAsync(token, physical, flush, message);
 #endif
                     }
 
@@ -1348,7 +1348,7 @@ namespace StackExchange.Redis
             }
             catch (Exception ex)
             {
-                return new ValueTask<WriteResult>(HandleWriteException(message, ex));
+                return new ValueTask<WriteResult>(HandleWriteException(physical, message, ex));
             }
             finally
             {
@@ -1406,7 +1406,7 @@ namespace StackExchange.Redis
             }
             catch (Exception ex)
             {
-                return HandleWriteException(message, ex);
+                return HandleWriteException(physical, message, ex);
             }
             finally
             {
@@ -1425,6 +1425,7 @@ namespace StackExchange.Redis
 #if !NETCOREAPP
             LockToken lockToken,
 #endif
+            PhysicalConnection physical,
             ValueTask<WriteResult> flush,
             Message message)
         {
@@ -1439,7 +1440,7 @@ namespace StackExchange.Redis
             }
             catch (Exception ex)
             {
-                return HandleWriteException(message, ex);
+                return HandleWriteException(physical, message, ex);
             }
             finally
             {
@@ -1449,10 +1450,15 @@ namespace StackExchange.Redis
             }
         }
 
-        private WriteResult HandleWriteException(Message message, Exception ex)
+        private WriteResult HandleWriteException(PhysicalConnection? physical, Message message, Exception ex)
         {
             var inner = new RedisConnectionException(ConnectionFailureType.InternalFailure, "Failed to write", ex);
             message.SetExceptionAndComplete(inner, this);
+            // Tear down the physical connection. A write that throws may have left a partial frame on the
+            // wire, and continuing to use the same socket would let the next reply match the wrong message
+            // in the response queue. Forcing a reconnect drains the in-flight queue with failures and
+            // restores wire-level synchronization.
+            physical?.RecordConnectionFailed(ConnectionFailureType.InternalFailure, inner);
             return WriteResult.WriteFailure;
         }
 

--- a/tests/StackExchange.Redis.Tests/WriteFailureTeardownTests.cs
+++ b/tests/StackExchange.Redis.Tests/WriteFailureTeardownTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+public class WriteFailureTeardownTests(ITestOutputHelper output) : TestBase(output)
+{
+    private sealed class ThrowingMessage : Message
+    {
+        private readonly Exception _toThrow;
+        public ThrowingMessage(int db, CommandFlags flags, RedisCommand command, Exception toThrow)
+            : base(db, flags, command)
+        {
+            _toThrow = toThrow;
+        }
+
+        public override int ArgCount => 0;
+
+        protected override void WriteImpl(PhysicalConnection physical) => throw _toThrow;
+    }
+
+    [Fact]
+    public void WriteTo_PropagatesWriteImplException()
+    {
+        var inner = new InvalidOperationException("simulated write failure");
+        var msg = new ThrowingMessage(-1, CommandFlags.None, RedisCommand.PING, inner);
+
+        // The new behavior: WriteTo must rethrow so the bridge's outer catch can record a connection
+        // failure. Passing null for physical is safe because WriteTo null-conditionals every member
+        // access on it.
+        var thrown = Assert.Throws<InvalidOperationException>(() => msg.WriteTo(null!));
+        Assert.Same(inner, thrown);
+    }
+
+    [Fact]
+    public void WriteTo_DoesNotWrapRedisCommandException()
+    {
+        // RedisCommandException is excluded from the catch filter (it carries its own meaning),
+        // so it must surface unchanged from WriteImpl through WriteTo.
+        var inner = new RedisCommandException("intentional");
+        var msg = new ThrowingMessage(-1, CommandFlags.None, RedisCommand.PING, inner);
+
+        var thrown = Assert.Throws<RedisCommandException>(() => msg.WriteTo(null!));
+        Assert.Same(inner, thrown);
+    }
+
+    [Fact]
+    public async Task WriteFailure_TearsDownPhysicalConnection()
+    {
+        // We deliberately raise InternalError + ConnectionFailed events here, so don't fail
+        // the test on ambient failures.
+        SetExpectedAmbientFailureCount(-1);
+
+        await using var conn = Create(shared: false, allowAdmin: true);
+
+        int failedCount = 0;
+        ConnectionFailureType? observedFailure = null;
+        conn.ConnectionFailed += (_, e) =>
+        {
+            Interlocked.Increment(ref failedCount);
+            observedFailure ??= e.FailureType;
+        };
+
+        await conn.GetDatabase().PingAsync();
+
+        var muxer = conn.UnderlyingMultiplexer;
+        var server = muxer.GetServerSnapshot()[0];
+
+        var boom = new InvalidOperationException("simulated WriteImpl failure");
+        var throwingMsg = new ThrowingMessage(-1, CommandFlags.None, RedisCommand.PING, boom);
+        muxer.CheckMessage(throwingMsg);
+
+        var sendTask = muxer.ExecuteAsyncImpl(throwingMsg, ResultProcessor.ResponseTimer, state: null, server);
+
+        // The throwing message should fault the awaiter (HandleWriteException calls SetExceptionAndComplete),
+        // wrapping the inner exception in a RedisConnectionException with InternalFailure.
+        var redisEx = await Assert.ThrowsAsync<RedisConnectionException>(async () => await sendTask);
+        Assert.Equal(ConnectionFailureType.InternalFailure, redisEx.FailureType);
+
+        // The new behavior: HandleWriteException calls RecordConnectionFailed on the physical
+        // connection, which raises ConnectionFailed. Before this fix, no failure was raised
+        // and the connection was left corrupt — the next response could match the wrong
+        // in-flight message.
+        await UntilConditionAsync(TimeSpan.FromSeconds(3), () => Volatile.Read(ref failedCount) > 0);
+        Assert.True(Volatile.Read(ref failedCount) > 0, "ConnectionFailed event did not fire after write failure");
+        Assert.Equal(ConnectionFailureType.InternalFailure, observedFailure);
+    }
+}


### PR DESCRIPTION
## Summary

- `Message.WriteTo` now re-throws after calling `Fail()`, so `PhysicalBridge`'s outer write path can act on the failure instead of seeing a phantom success.
- `PhysicalBridge.HandleWriteException` takes the `PhysicalConnection` and calls `RecordConnectionFailed(ConnectionFailureType.InternalFailure, ...)`, tearing the connection down and draining the response queue with failures.
- All callers of `HandleWriteException` (sync, async, backlog, post-flush completion) thread the connection through.

Fixes the underlying cause behind the symptoms reported in #2883, #2804, #2919, #2913 — without depending on `HighIntegrity` mode (which catches the desync after the fact rather than preventing it).

See accompanying issue for the full root-cause writeup.

## Why

If `WriteImpl` throws partway through a frame (OOM during serialization is the most-reported trigger, but any exception out of `WriteImpl` does it), the old `WriteTo` swallowed the exception. The bridge then saw `WriteResult.Success`, kept the message at the head of the in-flight queue, and left the socket connected. Any subsequent reply from the server matched against the wrong message.

`Fail()` signals the broken message's awaiter, but it does nothing about the wire state or the sibling messages whose ordering has now been corrupted. Tearing down the physical connection completes all in-flight awaiters with `RedisConnectionException(InternalFailure)` and forces a clean reconnect.

## Test plan

- [x] New `WriteTo_PropagatesWriteImplException` — fails on `main`, passes here. Asserts `WriteTo` rethrows non-`RedisCommandException` from `WriteImpl`.
- [x] New `WriteTo_DoesNotWrapRedisCommandException` — `RedisCommandException` continues to surface unwrapped (it's excluded from the catch filter).
- [x] New `WriteFailure_TearsDownPhysicalConnection` — end-to-end: a `Message` whose `WriteImpl` throws faults the awaiter with `RedisConnectionException(InternalFailure)` *and* raises a `ConnectionFailed` event with `InternalFailure`.
- [x] Verified the new tests fail on the unfixed source and pass with the fix applied (stash/unstash cycle).
- [x] `dotnet build` clean for `src/StackExchange.Redis/StackExchange.Redis.csproj` and `tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj` on `net10.0`.

## Risk

The change widens the conditions under which a connection is torn down — specifically, an in-process exception out of `WriteImpl` now triggers a reconnect where it previously left the connection up. That's the intended behavior (the connection was already in an undefined state), but it may surface as additional `ConnectionFailed` events for users who were silently hitting `Fail()` paths. In every case observed in the issues above, that reconnect is what users *wanted* to happen.

## Related

- Issue: #3091
- Existing reports: #2883, #2804, #2919, #2913
- Adjacent: #2992, #2993 (rough edges around `HighIntegrity` itself, which is the current workaround)