### PR TITLE
Support overriding library version

### DIFF
--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -237,9 +237,9 @@ namespace StackExchange.Redis.Configuration
         /// Gets the default client name for a connection.
         /// </summary>
         protected virtual string GetDefaultClientName() =>
-            (TryGetAzureRoleInstanceIdNoThrow()
+            $"{TryGetAzureRoleInstanceIdNoThrow()
              ?? ComputerName
-             ?? "StackExchange.Redis") + "(SE.Redis-v" + LibraryVersion + ")";
+             ?? "StackExchange.Redis"}({LibraryName}-v{LibraryVersion})";
 
         /// <summary>
         /// Gets the library name to use for CLIENT SETINFO lib-name calls to Redis during handshake.
@@ -248,9 +248,9 @@ namespace StackExchange.Redis.Configuration
         public virtual string LibraryName => "SE.Redis";
 
         /// <summary>
-        /// String version of the StackExchange.Redis library, for use in any options.
+        /// String version of the StackExchange.Redis library, for use in other options and in CLIENT SETINFO lib-ver.
         /// </summary>
-        protected static string LibraryVersion => Utils.GetLibVersion();
+        public virtual string LibraryVersion => Utils.GetLibVersion();
 
         /// <summary>
         /// Name of the machine we're running on, for use in any options.

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -116,7 +116,9 @@ namespace StackExchange.Redis
                 SetClientLibrary = "setlib",
                 Protocol = "protocol",
                 HighIntegrity = "highIntegrity",
-                TcpKeepAlive = "tcpKeepAlive";
+                TcpKeepAlive = "tcpKeepAlive",
+                LibraryName = "libraryName",
+                LibraryVersion = "libraryVersion";
 
             private static readonly Dictionary<string, string> normalizedOptions = new[]
             {
@@ -152,6 +154,8 @@ namespace StackExchange.Redis
                 Protocol,
                 HighIntegrity,
                 TcpKeepAlive,
+                LibraryName,
+                LibraryVersion,
             }.ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
             public static string TryNormalize(string value)
@@ -209,7 +213,7 @@ namespace StackExchange.Redis
 
         private OptionFlags optionFlags;
 
-        private string? tieBreaker, sslHost, configChannel, user, password;
+        private string? tieBreaker, sslHost, configChannel, user, password, libraryName, libraryVersion;
 
         private TimeSpan heartbeatInterval;
 
@@ -368,7 +372,22 @@ namespace StackExchange.Redis
         /// </summary>
         /// <remarks>If the value is null, empty or whitespace, then the value from the options-provider is used;
         /// to disable the library name feature, use <see cref="SetClientLibrary"/> instead.</remarks>
-        public string? LibraryName { get; set; }
+        public string? LibraryName
+        {
+            get => libraryName ?? Defaults.LibraryName;
+            set => libraryName = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the library version to use for CLIENT SETINFO lib-ver calls to Redis during handshake.
+        /// Defaults to the StackExchange.Redis version, but can be overridden by extensions or for other purposes.
+        /// </summary>
+        /// <remarks>To disable the library version feature, use <see cref="SetClientLibrary"/> instead.</remarks>
+        public string? LibraryVersion
+        {
+            get => libraryVersion ?? Defaults.LibraryVersion;
+            set => libraryVersion = value;
+        }
 
         /// <summary>
         /// Automatically encodes and decodes channels.
@@ -967,7 +986,8 @@ namespace StackExchange.Redis
             SslClientAuthenticationOptions = SslClientAuthenticationOptions,
 #endif
             Tunnel = Tunnel,
-            LibraryName = LibraryName,
+            libraryName = libraryName,
+            libraryVersion = libraryVersion,
             _protocol = _protocol,
             heartbeatInterval = heartbeatInterval,
             WriteMode = WriteMode,
@@ -1063,6 +1083,8 @@ namespace StackExchange.Redis
             {
                 Append(sb, OptionKeys.Tunnel, tunnel.ToString());
             }
+            Append(sb, OptionKeys.LibraryName, libraryName);
+            Append(sb, OptionKeys.LibraryVersion, libraryVersion);
             commandMap?.AppendDeltas(sb);
             return sb.ToString();
 
@@ -1164,7 +1186,8 @@ namespace StackExchange.Redis
             CertificateValidation = null;
             BeforeSocketConnect = null;
             ChannelPrefix = default;
-            LibraryName = null;
+            libraryName = null;
+            libraryVersion = null;
 #pragma warning disable CS0618 // Type or member is obsolete
             SocketManager = null;
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/StackExchange.Redis/ConnectionMultiplexer.LibraryName.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.LibraryName.cs
@@ -14,6 +14,8 @@ public partial class ConnectionMultiplexer
     /// <inheritdoc cref="IConnectionMultiplexer.AddLibraryNameSuffix(string)" />
     public void AddLibraryNameSuffix(string suffix)
     {
+        if (!RawConfig.SetClientLibrary) return; // disabled
+
         if (string.IsNullOrWhiteSpace(suffix)) return; // trivial
 
         // sanitize and re-check
@@ -28,7 +30,7 @@ public partial class ConnectionMultiplexer
         }
 
         // if we get here, we *actually changed something*; we can retroactively fixup the connections
-        var libName = GetFullLibraryName(); // note this also checks SetClientLibrary
+        var libName = GetFullLibraryName();
         if (string.IsNullOrWhiteSpace(libName) || !CommandMap.IsAvailable(RedisCommand.CLIENT)) return; // disabled on no lib name
 
         // note that during initial handshake we use raw Message; this is low frequency - no
@@ -56,18 +58,9 @@ public partial class ConnectionMultiplexer
 
     internal string GetFullLibraryName()
     {
-        var config = RawConfig;
-        if (!config.SetClientLibrary) return ""; // disabled
-
-        var libName = config.LibraryName;
-        if (string.IsNullOrWhiteSpace(libName))
-        {
-            // defer to provider if missing (note re null vs blank; if caller wants to disable
-            // it, they should set SetClientLibrary to false, not set the name to empty string)
-            libName = config.Defaults.LibraryName;
-        }
-
+        var libName = RawConfig.LibraryName;
         libName = ServerEndPoint.ClientInfoSanitize(libName);
+
         // if no primary name, return nothing, even if suffixes exist
         if (string.IsNullOrWhiteSpace(libName)) return "";
 

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Shipped.txt
@@ -1693,7 +1693,6 @@ static StackExchange.Redis.Configuration.DefaultOptionsProvider.AddProvider(Stac
 static StackExchange.Redis.Configuration.DefaultOptionsProvider.ComputerName.get -> string!
 static StackExchange.Redis.Configuration.DefaultOptionsProvider.GetProvider(StackExchange.Redis.EndPointCollection! endpoints) -> StackExchange.Redis.Configuration.DefaultOptionsProvider!
 static StackExchange.Redis.Configuration.DefaultOptionsProvider.GetProvider(System.Net.EndPoint! endpoint) -> StackExchange.Redis.Configuration.DefaultOptionsProvider!
-static StackExchange.Redis.Configuration.DefaultOptionsProvider.LibraryVersion.get -> string!
 static StackExchange.Redis.ConfigurationOptions.Parse(string! configuration) -> StackExchange.Redis.ConfigurationOptions!
 static StackExchange.Redis.ConfigurationOptions.Parse(string! configuration, bool ignoreUnknown) -> StackExchange.Redis.ConfigurationOptions!
 static StackExchange.Redis.ConnectionMultiplexer.Connect(StackExchange.Redis.ConfigurationOptions! configuration, System.IO.TextWriter? log = null) -> StackExchange.Redis.ConnectionMultiplexer!

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+StackExchange.Redis.ConfigurationOptions.LibraryVersion.get -> string?
+StackExchange.Redis.ConfigurationOptions.LibraryVersion.set -> void
+virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.LibraryVersion.get -> string!

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -1056,7 +1056,7 @@ namespace StackExchange.Redis
                         await WriteDirectOrQueueFireAndForgetAsync(connection, msg, ResultProcessor.DemandOK).ForAwait();
                     }
 
-                    var version = ClientInfoSanitize(Utils.GetLibVersion());
+                    var version = ClientInfoSanitize(config.LibraryVersion);
                     if (!string.IsNullOrWhiteSpace(version))
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget | Message.NoFlushFlag, RedisCommand.CLIENT, RedisLiterals.SETINFO, RedisLiterals.lib_ver, version);

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -81,7 +81,8 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
                 "EndPoints",
                 "heartbeatInterval",
                 "keepAlive",
-                "LibraryName",
+                "libraryName",
+                "libraryVersion",
                 "loggerFactory",
                 "optionFlags",
 #if DEBUG


### PR DESCRIPTION
Allow customizing the reported library version via a DefaultOptionsProvider. Intended for use by the Microsoft.Azure.StackExchangeRedis extension package because knowing the extension's version is usually more helpful than the SE.Redis version when diagnosing issues customers are having. 

This PR also aligns behavior of LibraryName with other ConfigurationOptions properties in terms of defaulting to a value from the current DefaultOptionsProvider. 