### PR TITLE
fix: Queue batch commands to backlog during MOVED reconnection

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -730,13 +730,39 @@ namespace StackExchange.Redis
 
             if (isDisposed) throw new ObjectDisposedException(Name);
 
-            if (!IsConnected)
+            if (!IsConnected || NeedsReconnect)
             {
+                // During reconnection (e.g. MOVED-to-same-endpoint), queue messages to the backlog
+                // so they can be sent once the connection is re-established.
+                // This matches the behavior of TryWriteAsync/TryWriteSync for individual commands.
+                if (Multiplexer.RawConfig.BacklogPolicy.QueueWhileDisconnected)
+                {
+                    foreach (var message in messages)
+                    {
+                        message.SetEnqueued(null);
+                        BacklogEnqueue(message);
+                    }
+                    StartBacklogProcessor();
+                    return true;
+                }
                 return false;
             }
 
             var physical = this.physical;
-            if (physical == null) return false;
+            if (physical == null)
+            {
+                if (Multiplexer.RawConfig.BacklogPolicy.QueueWhileDisconnected)
+                {
+                    foreach (var message in messages)
+                    {
+                        message.SetEnqueued(null);
+                        BacklogEnqueue(message);
+                    }
+                    StartBacklogProcessor();
+                    return true;
+                }
+                return false;
+            }
             foreach (var message in messages)
             {
                 // deliberately not taking a single lock here; we don't care if

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -25,6 +25,13 @@ namespace StackExchange.Redis
             foreach (var message in snapshot)
             {
                 var server = multiplexer.SelectServer(message);
+                // If no server found and we're allowed to queue while disconnected (e.g. during
+                // MOVED-triggered reconnection), retry with allowDisconnected to find the server
+                // so we can queue batch messages to its backlog.
+                if (server == null && multiplexer.RawConfig.BacklogPolicy.QueueWhileDisconnected)
+                {
+                    server = multiplexer.ServerSelectionStrategy.Select(message, allowDisconnected: true);
+                }
                 if (server == null)
                 {
                     FailNoServer(multiplexer, snapshot);


### PR DESCRIPTION
## Problem

When a MOVED-to-same-endpoint triggers reconnection (as implemented in PR #3003), batch commands (`IBatch`) issued during the ~50-100ms reconnection window fail immediately with `RedisConnectionException: NoConnectionAvailable`. This is because:

1. `RedisBatch.Execute()` calls `SelectServer()` which returns null for disconnected/reconnecting servers.
2. `PhysicalBridge.TryEnqueue()` returns false when `!IsConnected`, unlike `TryWriteAsync`/`TryWriteSync` which queue to the backlog via `QueueOrFailMessage()` → `BacklogEnqueue()`.

This creates an inconsistency: individual async commands (e.g. `db.StringSetAsync()`) are queued and succeed after reconnection, but batch commands throw immediately during the same reconnection window.

## Impact

- Applications using `IBatch` see 1-3 `RedisConnectionException` errors per MOVED redirect, while individual commands see zero errors in the same scenario

## Fix

**`RedisBatch.Execute()`**: When `SelectServer()` returns null and `BacklogPolicy.QueueWhileDisconnected` is enabled, retry with `allowDisconnected: true` to locate the server endpoint. This mirrors the pattern already used in `PrepareToPushMessageToBridge()`.

**`PhysicalBridge.TryEnqueue()`**: When `!IsConnected || NeedsReconnect` and `BacklogPolicy.QueueWhileDisconnected` is enabled, queue messages to the backlog instead of returning false. This matches the existing behavior of `TryWriteSync()` and `TryWriteAsync()` for individual commands.

## Testing

- **Before fix**: 1-3 `NoConnectionAvailable` errors per redirect event (batch.Execute throws during ~50-100ms reconnection window)
- **After fix**: 0 errors — batch commands are queued to backlog and sent after reconnection completes

The fix was also validated against plain disconnect scenario, where batch commands are similarly queued rather than failing immediately.

## Related

- #3003: Handle MOVED error pointing to same endpoint (the original MOVED reconnect fix)
- valkey-io/valkey-glide#5893: Same fix for valkey-glide (queues commands during reconnection)
- #2990: Original issue report for MOVED-to-same-endpoint