### PR TITLE
fix: Queue batch commands to backlog during MOVED reconnection

### DIFF
--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -730,13 +730,39 @@ namespace StackExchange.Redis
 
             if (isDisposed) throw new ObjectDisposedException(Name);
 
-            if (!IsConnected)
+            if (!IsConnected || NeedsReconnect)
             {
+                // During reconnection (e.g. MOVED-to-same-endpoint), queue messages to the backlog
+                // so they can be sent once the connection is re-established.
+                // This matches the behavior of TryWriteAsync/TryWriteSync for individual commands.
+                if (Multiplexer.RawConfig.BacklogPolicy.QueueWhileDisconnected)
+                {
+                    foreach (var message in messages)
+                    {
+                        message.SetEnqueued(null);
+                        BacklogEnqueue(message);
+                    }
+                    StartBacklogProcessor();
+                    return true;
+                }
                 return false;
             }
 
             var physical = this.physical;
-            if (physical == null) return false;
+            if (physical == null)
+            {
+                if (Multiplexer.RawConfig.BacklogPolicy.QueueWhileDisconnected)
+                {
+                    foreach (var message in messages)
+                    {
+                        message.SetEnqueued(null);
+                        BacklogEnqueue(message);
+                    }
+                    StartBacklogProcessor();
+                    return true;
+                }
+                return false;
+            }
             foreach (var message in messages)
             {
                 // deliberately not taking a single lock here; we don't care if

--- a/src/StackExchange.Redis/RedisBatch.cs
+++ b/src/StackExchange.Redis/RedisBatch.cs
@@ -25,6 +25,13 @@ namespace StackExchange.Redis
             foreach (var message in snapshot)
             {
                 var server = multiplexer.SelectServer(message);
+                // If no server found and we're allowed to queue while disconnected (e.g. during
+                // MOVED-triggered reconnection), retry with allowDisconnected to find the server
+                // so we can queue batch messages to its backlog.
+                if (server == null && multiplexer.RawConfig.BacklogPolicy.QueueWhileDisconnected)
+                {
+                    server = multiplexer.ServerSelectionStrategy.Select(message, allowDisconnected: true);
+                }
                 if (server == null)
                 {
                     FailNoServer(multiplexer, snapshot);

--- a/tests/StackExchange.Redis.Tests/MovedUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/MovedUnitTests.cs
@@ -158,4 +158,68 @@ public class MovedUnitTests(ITestOutputHelper log)
         id = await server.ExecuteAsync("client", "id");
         log?.WriteLine($"Client id after: {id}");
     }
+
+    /// <summary>
+    /// Integration test: Verifies that batch commands issued during a MOVED-triggered
+    /// reconnection are queued to the backlog and succeed after reconnection completes,
+    /// rather than throwing NoConnectionAvailable immediately.
+    ///
+    /// Test scenario:
+    /// 1. Client connects to test server
+    /// 2. Client sends a batch containing SET commands, with the trigger key as the last command
+    /// 3. Server returns MOVED error for the trigger key pointing to same endpoint
+    /// 4. Client triggers reconnection and queues the MOVED command's retry in the backlog
+    /// 5. All batch commands complete successfully after reconnection
+    ///
+    /// Expected behavior:
+    /// - All batch tasks should complete successfully (no exceptions)
+    /// - MOVED response count should be 1
+    /// - Connection count should increase by 1 (reconnection after MOVED)
+    /// - Values should be stored correctly
+    /// </summary>
+    [Theory]
+    [InlineData(ServerType.Cluster)]
+    [InlineData(ServerType.Standalone)]
+    public async Task MovedToSameEndpoint_BatchCommands_QueuedDuringReconnect(ServerType serverType)
+    {
+        RedisKey key = Me();
+
+        using var testServer = new MovedTestServer(
+            triggerKey: key,
+            log: log) { ServerType = serverType, };
+
+        await using var conn = await testServer.ConnectAsync(withPubSub: false);
+        var server = conn.GetServer(testServer.DefaultEndPoint);
+        await server.PingAsync(); // init everything
+        Assert.Equal(serverType, server.ServerType);
+        var db = conn.GetDatabase();
+
+        // Record baseline counters
+        Assert.Equal(0, testServer.SetCmdCount);
+        Assert.Equal(0, testServer.MovedResponseCount);
+        var initialConnectionCount = testServer.TotalClientCount;
+
+        // Create a batch: normal commands + trigger key as last command
+        var batch = db.CreateBatch();
+        var setTask1 = batch.StringSetAsync("normalkey1", "value1");
+        var setTask2 = batch.StringSetAsync("normalkey2", "value2");
+        var triggerTask = batch.StringSetAsync(key, "triggervalue"); // this will get MOVED
+        batch.Execute();
+
+        // All tasks should complete successfully (trigger command retried after reconnect)
+        Assert.True(await setTask1, "First SET should succeed");
+        Assert.True(await setTask2, "Second SET should succeed");
+        Assert.True(await triggerTask, "Trigger SET should succeed after reconnect+retry");
+
+        // Verify values were stored
+        Assert.Equal("value1", (string?)await db.StringGetAsync("normalkey1"));
+        Assert.Equal("value2", (string?)await db.StringGetAsync("normalkey2"));
+        Assert.Equal("triggervalue", (string?)await db.StringGetAsync(key));
+
+        // Verify MOVED was returned exactly once
+        Assert.Equal(1, testServer.MovedResponseCount);
+
+        // Verify reconnection occurred
+        Assert.Equal(initialConnectionCount + 1, testServer.TotalClientCount);
+    }
 }


### PR DESCRIPTION
## Problem

When a MOVED-to-same-endpoint triggers reconnection (as implemented in PR #3003), batch commands (`IBatch`) issued during the ~50-100ms reconnection window fail immediately with `RedisConnectionException: NoConnectionAvailable`. This is because:

1. `RedisBatch.Execute()` calls `SelectServer()` which returns null for disconnected/reconnecting servers.
2. `PhysicalBridge.TryEnqueue()` returns false when `!IsConnected`, unlike `TryWriteAsync`/`TryWriteSync` which queue to the backlog via `QueueOrFailMessage()` → `BacklogEnqueue()`.

This creates an inconsistency: individual async commands (e.g. `db.StringSetAsync()`) are queued and succeed after reconnection, but batch commands throw immediately during the same reconnection window.

## Impact

- Applications using `IBatch` see 1-3 `RedisConnectionException` errors per MOVED redirect, while individual async commands see zero errors in the same scenario.
- This affects deployments where Redis is behind DNS records, load balancers, or proxies that use MOVED-to-same-endpoint.

## Fix

**`RedisBatch.Execute()`**: When `SelectServer()` returns null and `BacklogPolicy.QueueWhileDisconnected` is enabled, retry with `allowDisconnected: true` to locate the server endpoint. This mirrors the pattern already used in `PrepareToPushMessageToBridge()`.

**`PhysicalBridge.TryEnqueue()`**: When `!IsConnected || NeedsReconnect` and `BacklogPolicy.QueueWhileDisconnected` is enabled, queue messages to the backlog instead of returning false. This matches the existing behavior of `TryWriteSync()` and `TryWriteAsync()` for individual commands.

## Testing

Tested with a proxy that sends MOVED-to-same-endpoint followed by connection close:
- **Before fix**: 1-3 `NoConnectionAvailable` errors per redirect event (batch.Execute throws during ~50-100ms reconnection window)
- **After fix**: 0 errors — batch commands are queued to backlog and sent after reconnection completes

The fix only activates when `BacklogPolicy.QueueWhileDisconnected` is true (the default), preserving existing behavior for users who have disabled backlog queuing.

## Related

- #3003: Handle MOVED error pointing to same endpoint (the original MOVED reconnect fix)
- #2990: Original issue report for MOVED-to-same-endpoint