### PR TITLE
update CI image; 2022 being super flakey

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,11 @@ jobs:
           client-libs-test-image-tag: "${{ github.event.inputs.client-libs-test-image-tag }}"
 
   windows:
-    name: StackExchange.Redis (Windows Server 2022)
+    name: StackExchange.Redis (Windows Server 2025)
     if: github.event.inputs.client-libs-test-image-tag == ''
-    runs-on: windows-2022
+    # Note: must not be windows-2022; setup-wsl runs `wsl --update` only on that image
+    # (ImageOS == win22), and that download intermittently 403s from Microsoft, failing the job.
+    runs-on: windows-2025
     env:
       NUGET_CERT_REVOCATION_MODE: offline # Disabling signing because of massive perf hit, see https://github.com/NuGet/Home/issues/11548
       DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1" # Note this doesn't work yet for Windows - see https://github.com/dotnet/runtime/issues/68340
@@ -42,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch the full history
-      - uses: Vampire/setup-wsl@v6
+      - uses: Vampire/setup-wsl@v7 # v7 is the first version running on Node 24
         with:
           distribution: Ubuntu-22.04
       - name: Install Redis
@@ -132,7 +134,7 @@ jobs:
         continue-on-error: true
         if: success() || failure()
         with:
-          name: Tests Results - Windows Server 2022
+          name: Tests Results - Windows Server 2025
           path: 'test-results/*.trx'
           reporter: dotnet-trx
       # Package and upload to MyGet only on pushes to main/v3, not on PRs


### PR DESCRIPTION
Changes base CI Windows image to Server 2025, and bumps the WSL setup version

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
