### PR TITLE
CI: stop dpkg starting redis-server (Windows/WSL install hang on 8.10)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,16 @@ jobs:
           chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list
           apt-get update
+          # Don't let dpkg start the packaged redis-server service: we start our own
+          # instances below, and the packaged unit would otherwise race them for
+          # 127.0.0.1:6379 on any run where WSL came up with systemd.
+          # This also sidesteps an install hang we hit with the 8.10.0 package, whose
+          # redis.conf lost "supervised auto" - redis then never sd_notify()s, so the
+          # Type=notify unit never leaves "activating" and the postinst's
+          # "systemctl start" blocks. That one's an upstream packaging slip being
+          # fixed there, but the guard above is worth keeping either way.
+          printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+          chmod +x /usr/sbin/policy-rc.d
           apt-get install -y redis
           mkdir redis
       - name: Run redis-server


### PR DESCRIPTION
The Windows job's "Install Redis" step began stalling indefinitely once server 8.10.0 hit packages.redis.io. Reproduced locally in a systemd-running jammy container: 8.8.1 installs in ~4s, 8.10.0 never returns.

The 8.10.0 redis-server deb ships the upstream redis.conf rather than the Debian-patched one (control scripts and the systemd unit are unchanged, so this doesn't show up in a package diff). It drops "supervised auto" and changes "dir /var/lib/redis" to "dir ./", which deadlocks the postinst: redis never sd_notify()s, so the Type=notify unit never leaves "activating" and "systemctl start" blocks; at TimeoutStartSec systemd SIGTERMs it, the final RDB save fails against the unit's read-only root so redis refuses to exit; and the unit's TimeoutStopSec=0 means systemd never SIGKILLs it.

We hand-start every server instance we need, so drop a policy-rc.d that tells invoke-rc.d/deb-systemd-invoke not to start services at all. This also stops the packaged unit racing us for 127.0.0.1:6379, which it would win or lose non-deterministically on runs where WSL came up with systemd.

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
