### PR TITLE
Experimental tunnel API for out-of-package network transports

### DIFF
--- a/docs/exp/SER009.md
+++ b/docs/exp/SER009.md
@@ -1,0 +1,11 @@
+`RESPite.Transports.DuplexTransport` (and `TransportReceiver`) are an experimental transport
+abstraction: staged-and-flushed outbound, push inbound with transport-owned memory, and an explicit
+batch-end notification. They exist to let alternative IO engines plug in beneath the library (see
+`Tunnel.ConnectTransportAsync`) without being constrained to `Stream` or pipe semantics.
+
+While experimental:
+
+1. The shape may gain members (the abstract-class form exists so additions can default safely) or
+   change semantics between minor versions.
+2. Implementations and consumers should expect to track such changes without the usual
+   breaking-change ceremony.

--- a/docs/exp/SER009.md
+++ b/docs/exp/SER009.md
@@ -1,11 +1,22 @@
 `RESPite.Transports.DuplexTransport` (and `TransportReceiver`) are an experimental transport
-abstraction: staged-and-flushed outbound, push inbound with transport-owned memory, and an explicit
-batch-end notification. They exist to let alternative IO engines plug in beneath the library (see
-`Tunnel.ConnectTransportAsync`) without being constrained to `Stream` or pipe semantics.
+abstraction: staged-and-flushed outbound (the transport itself is the `IBufferWriter<byte>`), push
+inbound with transport-owned memory, and an explicit batch-end notification. They exist to let
+alternative IO engines plug in beneath the library (see `Tunnel.ConnectTransportAsync`) without being
+constrained to `Stream` or pipe semantics.
 
-While experimental:
+**This API is not intended for external use at this time.** It exists to support internal
+experimentation with alternative transports, and is public only because a seam has to be public to be
+implemented. Specifically:
 
-1. The shape may gain members (the abstract-class form exists so additions can default safely) or
-   change semantics between minor versions.
-2. Implementations and consumers should expect to track such changes without the usual
-   breaking-change ceremony.
+1. **No stability whatsoever is implied.** The shape may gain members, change semantics, be renamed,
+   move assembly or namespace, or be removed outright — between *any* two versions, including
+   patches, with no breaking-change ceremony, no deprecation period, and no migration notes.
+2. **Do not implement or consume it in code you ship.** If you build on it anyway, you are accepting
+   that any update may break you without warning, and issues asking for compatibility or support for
+   it will be closed.
+3. The `[Experimental]` diagnostic (`SER009`) is the enforcement mechanism: suppressing it is you
+   signing up to the above.
+
+If a transport seam useful beyond this experiment emerges, it will be stabilised deliberately — with
+its own announcement and a removed `[Experimental]` marker — rather than by this surface quietly
+hardening into a contract.

--- a/src/RESPite/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/RESPite/PublicAPI/PublicAPI.Unshipped.txt
@@ -5,7 +5,7 @@
 [SER009]abstract RESPite.Transports.DuplexTransport.DisposeAsync() -> System.Threading.Tasks.ValueTask
 [SER009]abstract RESPite.Transports.DuplexTransport.Flush() -> bool
 [SER009]abstract RESPite.Transports.DuplexTransport.GetMemory(int sizeHint = 0) -> System.Memory<byte>
-[SER009]abstract RESPite.Transports.DuplexTransport.GetSpan(int sizeHint = 0) -> System.Span<byte>
+[SER009]virtual RESPite.Transports.DuplexTransport.GetSpan(int sizeHint = 0) -> System.Span<byte>
 [SER009]abstract RESPite.Transports.DuplexTransport.Start(RESPite.Transports.TransportReceiver! receiver) -> void
 [SER009]RESPite.Transports.TransportReceiver
 [SER009]RESPite.Transports.TransportReceiver.TransportReceiver() -> void

--- a/src/RESPite/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/RESPite/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,9 +1,11 @@
 #nullable enable
 [SER009]RESPite.Transports.DuplexTransport
 [SER009]RESPite.Transports.DuplexTransport.DuplexTransport() -> void
+[SER009]abstract RESPite.Transports.DuplexTransport.Advance(int count) -> void
 [SER009]abstract RESPite.Transports.DuplexTransport.DisposeAsync() -> System.Threading.Tasks.ValueTask
 [SER009]abstract RESPite.Transports.DuplexTransport.Flush() -> bool
-[SER009]abstract RESPite.Transports.DuplexTransport.Output.get -> System.Buffers.IBufferWriter<byte>!
+[SER009]abstract RESPite.Transports.DuplexTransport.GetMemory(int sizeHint = 0) -> System.Memory<byte>
+[SER009]abstract RESPite.Transports.DuplexTransport.GetSpan(int sizeHint = 0) -> System.Span<byte>
 [SER009]abstract RESPite.Transports.DuplexTransport.Start(RESPite.Transports.TransportReceiver! receiver) -> void
 [SER009]RESPite.Transports.TransportReceiver
 [SER009]RESPite.Transports.TransportReceiver.TransportReceiver() -> void

--- a/src/RESPite/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/RESPite/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+[SER009]RESPite.Transports.DuplexTransport
+[SER009]RESPite.Transports.DuplexTransport.DuplexTransport() -> void
+[SER009]abstract RESPite.Transports.DuplexTransport.DisposeAsync() -> System.Threading.Tasks.ValueTask
+[SER009]abstract RESPite.Transports.DuplexTransport.Flush() -> bool
+[SER009]abstract RESPite.Transports.DuplexTransport.Output.get -> System.Buffers.IBufferWriter<byte>!
+[SER009]abstract RESPite.Transports.DuplexTransport.Start(RESPite.Transports.TransportReceiver! receiver) -> void
+[SER009]RESPite.Transports.TransportReceiver
+[SER009]RESPite.Transports.TransportReceiver.TransportReceiver() -> void
+[SER009]abstract RESPite.Transports.TransportReceiver.OnReceived(System.ReadOnlySpan<byte> payload) -> bool
+[SER009]virtual RESPite.Transports.TransportReceiver.OnBatchEnd() -> void
+[SER009]virtual RESPite.Transports.TransportReceiver.OnClosed(System.Exception? fault) -> void

--- a/src/RESPite/Shared/Experiments.cs
+++ b/src/RESPite/Shared/Experiments.cs
@@ -20,6 +20,7 @@
         public const string UnitTesting = "SER005";
         public const string GeoRedundantFailover = "SER007";
         public const string Server_8_10 = "SER008";
+        public const string Transport = "SER009";
 
         // ReSharper restore InconsistentNaming
 

--- a/src/RESPite/Transports/DuplexTransport.cs
+++ b/src/RESPite/Transports/DuplexTransport.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace RESPite.Transports;
+
+/// <summary>
+/// A duplex byte transport, deliberately NOT a <see cref="System.IO.Stream"/> and NOT a pipe: outbound
+/// is staged-and-flushed (batching is an explicit contract point, not an implementation accident), and
+/// inbound is PUSH — the transport delivers bytes to a <see cref="TransportReceiver"/> on the
+/// transport's own schedule, in transport-owned memory.
+///
+/// The shape is derived from measured transport work rather than taste: any-thread copying writes with
+/// an explicit flush (batching at the caller's natural boundaries was the largest single lever
+/// measured), push delivery (pull adapters over a push transport measured 24-40% overhead), and a
+/// batch-end notification (coalescing responses produced during a delivery burst into one flush
+/// eliminated a measured 3x send amplification).
+/// </summary>
+[Experimental(Experiments.Transport, UrlFormat = Experiments.UrlFormat)]
+public abstract class DuplexTransport : IAsyncDisposable
+{
+    /// <summary>Stage outbound bytes. Callable from any thread; bytes are copied during the call, so
+    /// caller buffers need not survive it.</summary>
+    public abstract IBufferWriter<byte> Output { get; }
+
+    /// <summary>Hand everything staged since the last flush to the wire, as one send where the
+    /// transport allows. Returns false if the transport is closed (staged bytes are dropped).</summary>
+    public abstract bool Flush();
+
+    /// <summary>Begin inbound delivery. Exactly one receiver, set once, before any data is expected;
+    /// delivery runs on the transport's schedule and threads.</summary>
+    public abstract void Start(TransportReceiver receiver);
+
+    public abstract ValueTask DisposeAsync();
+}
+
+/// <summary>
+/// The consumer half of <see cref="DuplexTransport"/>. Callbacks run on the transport's threads and
+/// must be bounded and non-blocking; anything long-running belongs on the consumer's own scheduler.
+/// </summary>
+[Experimental(Experiments.Transport, UrlFormat = Experiments.UrlFormat)]
+public abstract class TransportReceiver
+{
+    /// <summary>Bytes arrived. <paramref name="payload"/> is TRANSPORT-OWNED and valid only for the
+    /// duration of the call — copy anything retained. Return false to request the transport close.</summary>
+    public abstract bool OnReceived(ReadOnlySpan<byte> payload);
+
+    /// <summary>A delivery burst has ended (for loop transports: the event batch is drained). Flush
+    /// anything staged in response to the burst HERE, once, rather than per <see cref="OnReceived"/> —
+    /// per-callback flushing measurably amplifies peer segmentation.</summary>
+    public virtual void OnBatchEnd() { }
+
+    /// <summary>The transport closed; fires exactly once. <paramref name="fault"/> is the failure when
+    /// the transport can attribute one, else null (a clean or unattributed close).</summary>
+    public virtual void OnClosed(Exception? fault) { }
+}

--- a/src/RESPite/Transports/DuplexTransport.cs
+++ b/src/RESPite/Transports/DuplexTransport.cs
@@ -30,7 +30,9 @@ public abstract class DuplexTransport : IBufferWriter<byte>, IAsyncDisposable
     public abstract Memory<byte> GetMemory(int sizeHint = 0);
 
     /// <inheritdoc cref="GetMemory"/>
-    public abstract Span<byte> GetSpan(int sizeHint = 0);
+    /// <remarks>Defaults to <c>GetMemory(sizeHint).Span</c>; override when the transport has a cheaper
+    /// span path than a <see cref="Memory{T}"/> round-trip.</remarks>
+    public virtual Span<byte> GetSpan(int sizeHint = 0) => GetMemory(sizeHint).Span;
 
     /// <summary>Commit <paramref name="count"/> bytes obtained via <see cref="GetMemory"/> or
     /// <see cref="GetSpan"/>; the transport owns them when this returns, so caller state need not

--- a/src/RESPite/Transports/DuplexTransport.cs
+++ b/src/RESPite/Transports/DuplexTransport.cs
@@ -16,13 +16,26 @@ namespace RESPite.Transports;
 /// measured), push delivery (pull adapters over a push transport measured 24-40% overhead), and a
 /// batch-end notification (coalescing responses produced during a delivery burst into one flush
 /// eliminated a measured 3x send amplification).
+///
+/// The transport IS the outbound <see cref="IBufferWriter{T}"/> — there is no separate output object.
+/// Staging is callable from any thread (single logical writer at a time); bytes are owned by the
+/// transport once <see cref="Advance"/> returns; <see cref="Flush"/> hands the staged bytes to the
+/// wire. Passing the transport AS <see cref="IBufferWriter{T}"/> deliberately grants stage-only
+/// access: the holder composes, the owner flushes at its batch boundary.
 /// </summary>
 [Experimental(Experiments.Transport, UrlFormat = Experiments.UrlFormat)]
-public abstract class DuplexTransport : IAsyncDisposable
+public abstract class DuplexTransport : IBufferWriter<byte>, IAsyncDisposable
 {
-    /// <summary>Stage outbound bytes. Callable from any thread; bytes are copied during the call, so
-    /// caller buffers need not survive it.</summary>
-    public abstract IBufferWriter<byte> Output { get; }
+    /// <summary>Request writable space to stage outbound bytes (see <see cref="IBufferWriter{T}"/>).</summary>
+    public abstract Memory<byte> GetMemory(int sizeHint = 0);
+
+    /// <inheritdoc cref="GetMemory"/>
+    public abstract Span<byte> GetSpan(int sizeHint = 0);
+
+    /// <summary>Commit <paramref name="count"/> bytes obtained via <see cref="GetMemory"/> or
+    /// <see cref="GetSpan"/>; the transport owns them when this returns, so caller state need not
+    /// survive it.</summary>
+    public abstract void Advance(int count);
 
     /// <summary>Hand everything staged since the last flush to the wire, as one send where the
     /// transport allows. Returns false if the transport is closed (staged bytes are dropped).</summary>

--- a/src/StackExchange.Redis/Configuration/Tunnel.cs
+++ b/src/StackExchange.Redis/Configuration/Tunnel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -34,6 +35,16 @@ namespace StackExchange.Redis.Configuration
         /// the entire data flow can be intercepted, providing entire custom transports.
         /// </summary>
         public virtual ValueTask<Stream?> BeforeAuthenticateAsync(EndPoint endpoint, ConnectionType connectionType, Socket? socket, CancellationToken cancellationToken) => default;
+
+        /// <summary>
+        /// Optionally supply the ENTIRE transport for this connection — the same hijack as
+        /// <see cref="BeforeAuthenticateAsync"/> one level deeper: instead of yielding a
+        /// <see cref="Stream"/> over a socket the library owns, yield a
+        /// <see cref="RESPite.Transports.DuplexTransport"/> the tunnel owns, and no socket is created at
+        /// all. Return null (the default for every existing tunnel) for the standard socket path.
+        /// </summary>
+        [Experimental(RESPite.Experiments.Transport, UrlFormat = RESPite.Experiments.UrlFormat)]
+        public virtual ValueTask<RESPite.Transports.DuplexTransport?> ConnectTransportAsync(EndPoint endpoint, ConnectionType connectionType, CancellationToken cancellationToken) => default;
 
         private sealed class HttpProxyTunnel : Tunnel
         {

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+[SER009]virtual StackExchange.Redis.Configuration.Tunnel.ConnectTransportAsync(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<RESPite.Transports.DuplexTransport?>


### PR DESCRIPTION
This is purely experimental work looking at SocketSet as a mechanism to potentially support io_uring, kTLS, and friends - without burying them in the core package for now.

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
