### PR TITLE
Move BufferedStreamWriter (+Switchable, +Pipe) to RESPite.Streams as the single copy

### DIFF
--- a/src/RESPite/RESPite.csproj
+++ b/src/RESPite/RESPite.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- in-box from net10.0; needed by Streams/BufferedStreamWriter.Pipe.cs elsewhere -->
+    <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" Include="System.IO.Pipelines"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="RESPite.Tests"/>
     <None Include="readme.md" Pack="true" PackagePath="/"/>
   </ItemGroup>

--- a/src/RESPite/Streams/BufferedStreamWriter.Pipe.cs
+++ b/src/RESPite/Streams/BufferedStreamWriter.Pipe.cs
@@ -4,7 +4,7 @@ using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace StackExchange.Redis;
+namespace RESPite.Streams;
 
 internal sealed class PipeStreamWriter : BufferedStreamWriter
 {

--- a/src/RESPite/Streams/BufferedStreamWriter.Switchable.cs
+++ b/src/RESPite/Streams/BufferedStreamWriter.Switchable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 using RESPite.Buffers;
 
-namespace StackExchange.Redis;
+namespace RESPite.Streams;
 
 internal sealed class SwitchableBufferedStreamWriter : CycleBufferStreamWriter, IValueTaskSource
 {

--- a/src/RESPite/Streams/BufferedStreamWriter.cs
+++ b/src/RESPite/Streams/BufferedStreamWriter.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using RESPite.Buffers;
 
-namespace StackExchange.Redis;
+namespace RESPite.Streams;
 
 internal abstract class BufferedStreamWriter(Stream target, CancellationToken cancellationToken)
     : IBufferWriter<byte>, IDisposable, IAsyncDisposable
@@ -57,22 +57,15 @@ internal abstract class BufferedStreamWriter(Stream target, CancellationToken ca
 
     public virtual bool IsSync => false;
 
-    public static BufferedStreamWriter Create(WriteMode mode, ConnectionType connectionType, Stream target, ConfigurationOptions? options, CancellationToken cancellationToken)
-    {
-        if (connectionType is ConnectionType.Subscription | mode is WriteMode.Default)
+    public static BufferedStreamWriter Create(WriteMode mode, Stream target, MemoryPool<byte>? bufferPool, CancellationToken cancellationToken)
+        => mode switch
         {
-            // sync-mode targets latency; pub/sub never needs that;
-            // default write-mode should use async
-            mode = WriteMode.Async;
-        }
-        return mode switch
-        {
-            WriteMode.Sync => new SwitchableBufferedStreamWriter(options?.RequestBufferPool, target, cancellationToken, initiallySync: true),
-            WriteMode.Async => new SwitchableBufferedStreamWriter(options?.RequestBufferPool, target, cancellationToken, initiallySync: false),
+            WriteMode.Sync => new SwitchableBufferedStreamWriter(bufferPool, target, cancellationToken, initiallySync: true),
+            // sync-mode targets latency; the safe default is async
+            WriteMode.Default or WriteMode.Async => new SwitchableBufferedStreamWriter(bufferPool, target, cancellationToken, initiallySync: false),
             WriteMode.Pipe => new PipeStreamWriter(target, cancellationToken),
             _ => throw new ArgumentOutOfRangeException(nameof(mode)),
         };
-    }
 
     // ReSharper disable once ReplaceWithFieldKeyword
     private readonly CancellationToken _cancellationToken = cancellationToken;

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using RESPite;
 using RESPite.Buffers;
+using RESPite.Streams;
 using StackExchange.Redis.Availability;
 using StackExchange.Redis.Configuration;
 

--- a/src/StackExchange.Redis/PhysicalConnection.Read.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Read.cs
@@ -11,6 +11,7 @@ using RESPite;
 using RESPite.Buffers;
 using RESPite.Internal;
 using RESPite.Messages;
+using RESPite.Streams;
 
 namespace StackExchange.Redis;
 

--- a/src/StackExchange.Redis/PhysicalConnection.Write.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Write.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
+using RESPite.Streams;
 
 namespace StackExchange.Redis;
 
@@ -23,7 +24,10 @@ internal partial class PhysicalConnection
         if (stream is null) return;
         _ioStream = stream;
         var config = BridgeCouldBeNull?.Multiplexer?.RawConfig;
-        _output = BufferedStreamWriter.Create(WriteMode, connectionType, stream, config, OutputCancel);
+
+        // Redis policy over the generic writer: sync-mode targets latency, which pub/sub never needs.
+        var mode = connectionType is ConnectionType.Subscription ? BufferedStreamWriter.WriteMode.Async : WriteMode;
+        _output = BufferedStreamWriter.Create(mode, stream, config?.RequestBufferPool, OutputCancel);
 
         // Nothing awaits WriteComplete in production (it is mostly a test affordance); observe it so a
         // teardown-time (or any other) write fault never becomes an UnobservedTaskException. Applies to

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using RESPite.Streams;
 using StackExchange.Redis.Availability;
 using static StackExchange.Redis.Message;
 

--- a/tests/StackExchange.Redis.Tests/BufferedStreamWriterTests.cs
+++ b/tests/StackExchange.Redis.Tests/BufferedStreamWriterTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using RESPite.Streams;
 using Xunit;
 
 namespace StackExchange.Redis.Tests;
@@ -17,7 +18,7 @@ public class BufferedStreamWriterTests
     public async Task FlushStateDoesNotLeakIntoNextPageActivation(WriteMode mode)
     {
         var stream = new ObservedStream();
-        var writer = BufferedStreamWriter.Create((BufferedStreamWriter.WriteMode)mode, ConnectionType.Interactive, stream, null, CancellationToken.None);
+        var writer = BufferedStreamWriter.Create((BufferedStreamWriter.WriteMode)mode, stream, null, CancellationToken.None);
         try
         {
             Write(writer, 1, 1);
@@ -50,7 +51,7 @@ public class BufferedStreamWriterTests
     public async Task WriterDoesNotLoseFlushRequestedDuringDrainFlush(WriteMode mode)
     {
         var stream = new ObservedStream();
-        var writer = BufferedStreamWriter.Create((BufferedStreamWriter.WriteMode)mode, ConnectionType.Interactive, stream, null, CancellationToken.None);
+        var writer = BufferedStreamWriter.Create((BufferedStreamWriter.WriteMode)mode, stream, null, CancellationToken.None);
         try
         {
             stream.BlockNextFlush();
@@ -81,7 +82,7 @@ public class BufferedStreamWriterTests
     {
         var failure = new IOException("simulated target write failure");
         var stream = new ObservedStream { WriteException = failure };
-        var writer = BufferedStreamWriter.Create((BufferedStreamWriter.WriteMode)mode, ConnectionType.Interactive, stream, null, CancellationToken.None);
+        var writer = BufferedStreamWriter.Create((BufferedStreamWriter.WriteMode)mode, stream, null, CancellationToken.None);
 
         Write(writer, 1, 1);
         writer.Flush();
@@ -101,7 +102,7 @@ public class BufferedStreamWriterTests
     public async Task SyncWriterTransitionsToAsyncWhileIdleAndPreservesBufferedData()
     {
         var stream = new ObservedStream();
-        var writer = BufferedStreamWriter.Create(BufferedStreamWriter.WriteMode.Sync, ConnectionType.Interactive, stream, null, CancellationToken.None);
+        var writer = BufferedStreamWriter.Create(BufferedStreamWriter.WriteMode.Sync, stream, null, CancellationToken.None);
         try
         {
             Assert.True(writer.IsSync);
@@ -135,7 +136,7 @@ public class BufferedStreamWriterTests
     public async Task SyncWriterTransitionsToAsyncAfterActiveSyncDrain()
     {
         var stream = new ObservedStream();
-        var writer = BufferedStreamWriter.Create(BufferedStreamWriter.WriteMode.Sync, ConnectionType.Interactive, stream, null, CancellationToken.None);
+        var writer = BufferedStreamWriter.Create(BufferedStreamWriter.WriteMode.Sync, stream, null, CancellationToken.None);
         try
         {
             stream.BlockNextWrite();

--- a/tests/StackExchange.Redis.Tests/InProcessTestServer.cs
+++ b/tests/StackExchange.Redis.Tests/InProcessTestServer.cs
@@ -12,6 +12,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using RESPite.Streams;
 using StackExchange.Redis.Configuration;
 using StackExchange.Redis.Server;
 using Xunit;

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/TestConnection.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/TestConnection.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using RESPite.Streams;
 using RESPite.Tests;
 using Xunit;
 

--- a/tests/StackExchange.Redis.Tests/WriteMode.cs
+++ b/tests/StackExchange.Redis.Tests/WriteMode.cs
@@ -1,4 +1,6 @@
-﻿namespace StackExchange.Redis.Tests;
+﻿using RESPite.Streams;
+
+namespace StackExchange.Redis.Tests;
 
 public enum WriteMode
 {


### PR DESCRIPTION
The trio existed twice: here (redis-coupled factory) and drifted lib-generic copies on the proxy spike branch. Duplicated code is asking for trouble, so this is the unification, replace/move not duplicate: the SE.Redis files are GONE, the one copy lives in RESPite.Streams (it already leaned on RESPite.Buffers -- the move is with the grain), and the proxy branch deletes its copies on next rebase.

What decoupled: the factory loses ConnectionType/ConfigurationOptions and takes (WriteMode, Stream, MemoryPool<byte>?, CancellationToken); WriteMode.Default maps to Async as the lib-safe default. The redis POLICY (pub/sub never wants sync latency mode) moves to the one call site in PhysicalConnection.InitOutput, where it reads as policy instead of hiding in a lib factory.

RESPite gains the same conditional System.IO.Pipelines reference SE.Redis already carries (in-box from net10.0) so PipeStreamWriter -- the comparison/troubleshooting implementation -- stays with its family rather than being split back out via cross-assembly inheritance. Everything stays internal; RESPite already grants IVT to StackExchange.Redis and the test projects.

Solution builds 0 errors on all TFMs; BufferedStreamWriter + RoundTrip + InProcess/WriteMode test batteries all pass (129 tests).

<!-- Describe what this PR changes and why. Link any related issues. -->

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
