### PR TITLE
Config strings: '!@name' is a Linux abstract Unix socket

### DIFF
--- a/src/StackExchange.Redis/Format.cs
+++ b/src/StackExchange.Redis/Format.cs
@@ -321,7 +321,18 @@ namespace StackExchange.Redis
                 }
 
 #if UNIX_SOCKET
-                endpoint = new UnixDomainSocketEndPoint(addressWithPort.Substring(1));
+                var path = addressWithPort.Substring(1);
+                if (path[0] == '@' && OperatingSystem.IsLinux())
+                {
+                    // "!@name" is the Linux ABSTRACT namespace, using the same '@' convention as
+                    // socat/systemd (and redis-cli/redis-benchmark where supported): the kernel
+                    // spelling is a leading NUL, which cannot appear in a config string. Linux-gated
+                    // because no other platform has the namespace — elsewhere '@' stays a literal
+                    // (strange) filename, matching what the other tools do. Note ToString() round-trips
+                    // for free: UnixDomainSocketEndPoint renders abstract names back as "@name".
+                    path = "\0" + path.Substring(1);
+                }
+                endpoint = new UnixDomainSocketEndPoint(path);
                 return true;
 #else
                 throw new PlatformNotSupportedException("Unix domain sockets require .NET Core 3 or above");

--- a/tests/StackExchange.Redis.Tests/FormatTests.cs
+++ b/tests/StackExchange.Redis.Tests/FormatTests.cs
@@ -50,6 +50,33 @@ public class FormatTests(ITestOutputHelper output) : TestBase(output)
         Assert.Equal(expectedFormat, s);
     }
 
+    // UDS endpoints live outside EndpointData because UnixDomainSocketEndPoint does not implement
+    // value equality — these compare via ToString instead.
+#if NET
+    [Fact]
+    public void ParseUnixDomainSocketEndPoint()
+    {
+        Assert.True(Format.TryParseEndPoint("!/tmp/redis.sock", out var ep));
+        var uds = Assert.IsType<System.Net.Sockets.UnixDomainSocketEndPoint>(ep);
+        Assert.Equal("/tmp/redis.sock", uds.ToString());
+        Assert.Equal("!/tmp/redis.sock", Format.ToString(ep));
+    }
+
+    [Fact]
+    public void ParseAbstractUnixDomainSocketEndPoint()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "the abstract socket namespace is Linux-only");
+
+        // "!@name": socat/systemd '@' convention for the Linux abstract namespace. The parse maps it
+        // to the kernel's leading-NUL spelling; UnixDomainSocketEndPoint.ToString renders that back
+        // as '@name', so the config string round-trips exactly.
+        Assert.True(Format.TryParseEndPoint("!@redis-abstract", out var ep));
+        var uds = Assert.IsType<System.Net.Sockets.UnixDomainSocketEndPoint>(ep);
+        Assert.Equal("@redis-abstract", uds.ToString());
+        Assert.Equal("!@redis-abstract", Format.ToString(ep));
+    }
+#endif
+
     [Theory]
     [InlineData(CommandFlags.None, "None")]
 #if NETFRAMEWORK


### PR DESCRIPTION
Support the socat/systemd '@' convention.

'!name' has always meant a Unix domain socket, but '!@foo' silently produced a PATHNAME socket literally named '@foo' -- the wrong socket, found by nothing. The parse now maps '@' after '!' to the kernel's leading-NUL spelling, Linux-gated (no other platform has the namespace; elsewhere '@' stays a literal filename, matching redis-cli). ToString round-trips for free: UnixDomainSocketEndPoint renders abstract names back as '@name'.

Tests: FormatTests gains UDS parse/round-trip coverage (there was NONE, even for pathnames) -- pathname and abstract cells, the latter Linux-gated. Verified live end-to-end besides: a ConnectionMultiplexer built from ConfigurationOptions.Parse("!@se-abs-test,abortConnect=true") against a Garnet listening on the same abstract name, SET/GET round-trip clean, no filesystem footprint.

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
