### PR TITLE
docs: fix dead Pub/Sub Message Order links

### DIFF
--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -107,7 +107,7 @@ sub.Publish("messages", "hello");
 
 This will (virtually instantaneously) write `"hello"` to the console of the subscribed process. As before, both channel-names and messages can be binary.
 
-Please also see [Pub / Sub Message Order](PubSubOrder) for guidance on sequential versus concurrent message processing.
+Please also see [Pub / Sub Message Order](PubSubOrder.md) for guidance on sequential versus concurrent message processing.
 
 Accessing individual servers
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Documentation
 - [Transactions](Transactions) - how atomic transactions work in redis
 - [Compare-And-Swap / Compare-And-Delete (CAS/CAD)](CompareAndSwap) - atomic conditional operations using value comparison
 - [Events](Events) - the events available for logging / information purposes
-- [Pub/Sub Message Order](PubSubOrder) - advice on sequential and concurrent processing
+- [Pub/Sub Message Order](PubSubOrder.md) - advice on sequential and concurrent processing
 - [Pub/Sub Key Notifications](KeyspaceNotifications) - how to use keyspace and keyevent notifications
 - [Hot Keys](HotKeys) - how to use `HOTKEYS` profiling
 - [Using RESP3](Resp3) - information on using RESP3


### PR DESCRIPTION
The "Pub / Sub Message Order" cross-links in `docs/Basics.md` and `docs/index.md` point to `PubSubOrder` (no extension), but the page is `docs/PubSubOrder.md` and there is no extensionless file, so both links 404 on GitHub. Every other cross-link in these docs uses the `.md` suffix (e.g. `Transactions.md`, `Timeouts.md`).

Added the `.md` suffix so both links resolve.
