### PR TITLE
Always issue HELLO when the server should understand it, not just for RESP3

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -299,13 +299,17 @@ config.ReconnectRetryPolicy = new LinearRetry(5000);
 
 ## Redis protocol
 
-Without specific configuration, StackExchange.Redis will use the RESP2 protocol; this means that pub/sub requires a separate connection to the server. RESP3 is a newer protocol
-(usually, but not always, available on v6 servers and above) which allows (among other changes) pub/sub messages to be communicated on the *same* connection - which can be very
-desirable in servers with a large number of clients. The protocol handshake needs to happen very early in the connection, so *by default* the library does not attempt a RESP3 connection
-unless it has reason to expect it to work. 
+RESP3 is a newer protocol (available on v6 servers and above) which allows (among other changes) pub/sub messages to be communicated on the *same* connection - which can be very
+desirable in servers with a large number of clients; under RESP2, pub/sub requires a separate connection to the server. The protocol handshake needs to happen very early in the
+connection, so the library only attempts RESP3 when it has reason to expect it to work.
 
 The library determines whether to use RESP3 by:
 - The `HELLO` command has been disabled: RESP2 is used
 - A protocol *other than* `resp3` or `3` is specified: RESP2 is used
 - A protocol of `resp3` or `3` is specified: RESP3 is attempted (with fallback if it fails)
-- In all other scenarios: RESP2 is used
+- Otherwise: RESP3 is attempted if `defaultVersion` (6.0 unless overridden) is v6 or above
+
+Note that `HELLO` is issued either way: `HELLO 2` when staying on RESP2. The reply tells us the server version, replication role, mode (standalone/sentinel/cluster) and connection
+identifier, none of which we would otherwise know without `INFO` or `CONFIG GET` - both of which are in the `@dangerous` ACL category, and are commonly restricted. `HELLO` itself is
+in the `@connection` category. If you need to prevent it (for example when talking to a proxy that does not understand it), disable it at the command-map level with `$hello=` in the
+configuration string - or specify a `defaultVersion` below 6.0, since `HELLO` did not exist before then.

--- a/src/StackExchange.Redis/CommandMap.cs
+++ b/src/StackExchange.Redis/CommandMap.cs
@@ -46,6 +46,9 @@ namespace StackExchange.Redis
 
             RedisCommand.ECHO, RedisCommand.SELECT,
 
+            // twemproxy *closes the connection* on an unsupported command, so HELLO is fatal, not just useless
+            RedisCommand.HELLO,
+
             RedisCommand.BGREWRITEAOF, RedisCommand.BGSAVE, RedisCommand.CLIENT, RedisCommand.CLUSTER, RedisCommand.CONFIG, RedisCommand.DBSIZE,
             RedisCommand.DEBUG, RedisCommand.FLUSHALL, RedisCommand.FLUSHDB, RedisCommand.INFO, RedisCommand.LASTSAVE, RedisCommand.MONITOR, RedisCommand.REPLICAOF,
             RedisCommand.SAVE, RedisCommand.SHUTDOWN, RedisCommand.SLAVEOF, RedisCommand.SLOWLOG, RedisCommand.SYNC, RedisCommand.TIME, RedisCommand.HOTKEYS,
@@ -69,6 +72,11 @@ namespace StackExchange.Redis
             RedisCommand.SCRIPT,
 
             RedisCommand.SELECT,
+
+            // envoy either rejects HELLO ("unsupported command", up to ~1.31) or proxies it to an arbitrary
+            // backend node (1.39+), so the version/role/mode it reports describe *some* server, not the endpoint
+            // we're talking to; either way we don't want it
+            RedisCommand.HELLO,
 
             RedisCommand.BGREWRITEAOF, RedisCommand.BGSAVE, RedisCommand.CLIENT, RedisCommand.CLUSTER, RedisCommand.CONFIG, RedisCommand.DBSIZE,
             RedisCommand.DEBUG, RedisCommand.FLUSHALL, RedisCommand.FLUSHDB, RedisCommand.INFO, RedisCommand.LASTSAVE, RedisCommand.MONITOR, RedisCommand.REPLICAOF,

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -1463,6 +1463,25 @@ namespace StackExchange.Redis
             return use3 && CommandMap.IsAvailable(RedisCommand.HELLO);
         }
 
+        /// <summary>
+        /// Determines whether to issue <c>HELLO</c> as part of the handshake, and at which protocol level.
+        /// </summary>
+        /// <remarks>We want HELLO even when staying on RESP2, because the reply tells us the server version,
+        /// role, mode and connection identifier - none of which we would otherwise know without <c>INFO</c>
+        /// or <c>CONFIG</c>, which are commonly restricted by ACLs (both are <c>@dangerous</c>).</remarks>
+        internal bool TryHello(out int protocolVersion)
+        {
+            // HELLO arrived in 6.0, at the same time as RESP3; the command-map and the assumed server
+            // version are therefore both ways of opting out (`$hello=` and `defaultVersion=5.0`, say)
+            if (CommandMap.IsAvailable(RedisCommand.HELLO) && new RedisFeatures(DefaultVersion).Hello)
+            {
+                protocolVersion = TryResp3() ? 3 : 2;
+                return true;
+            }
+            protocolVersion = 0;
+            return false;
+        }
+
         internal static bool TryParseRedisProtocol(string? value, out RedisProtocol protocol)
         {
             // accept raw integers too, but only trust them if we recognize them

--- a/src/StackExchange.Redis/Enums/ServerType.cs
+++ b/src/StackExchange.Redis/Enums/ServerType.cs
@@ -70,7 +70,7 @@ namespace StackExchange.Redis
         };
 
         /// <summary>
-        /// Whether a server type supports <see cref="ServerEndPoint.AutoConfigureAsync(PhysicalConnection?, Microsoft.Extensions.Logging.ILogger?, CommandFlags)"/>.
+        /// Whether a server type supports <see cref="ServerEndPoint.AutoConfigureAsync(PhysicalConnection?, Microsoft.Extensions.Logging.ILogger?, CommandFlags, bool)"/>.
         /// </summary>
         internal static bool SupportsAutoConfigure(this ServerType type) => type switch
         {

--- a/src/StackExchange.Redis/LoggerExtensions.cs
+++ b/src/StackExchange.Redis/LoggerExtensions.cs
@@ -709,4 +709,10 @@ internal static partial class LoggerExtensions
         EventId = 109,
         Message = "Service name not defined.")]
     internal static partial void LogInformationServiceNameNotDefined(this ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 110,
+        Message = "{Server}: Requesting server details via HELLO")]
+    internal static partial void LogInformationDiscoveryViaHello(this ILogger logger, ServerEndPointLogValue server);
 }

--- a/src/StackExchange.Redis/LoggerExtensions.cs
+++ b/src/StackExchange.Redis/LoggerExtensions.cs
@@ -709,10 +709,4 @@ internal static partial class LoggerExtensions
         EventId = 109,
         Message = "Service name not defined.")]
     internal static partial void LogInformationServiceNameNotDefined(this ILogger logger);
-
-    [LoggerMessage(
-        Level = LogLevel.Information,
-        EventId = 110,
-        Message = "{Server}: Requesting server details via HELLO")]
-    internal static partial void LogInformationDiscoveryViaHello(this ILogger logger, ServerEndPointLogValue server);
 }

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
-#nullable enable
+﻿#nullable enable
 StackExchange.Redis.ConfigurationOptions.SentinelPassword.get -> string?
 StackExchange.Redis.ConfigurationOptions.SentinelPassword.set -> void
 StackExchange.Redis.ConfigurationOptions.SentinelUser.get -> string?
 StackExchange.Redis.ConfigurationOptions.SentinelUser.set -> void
+StackExchange.Redis.RedisFeatures.Hello.get -> bool
 [SER009]virtual StackExchange.Redis.Configuration.Tunnel.ConnectTransportAsync(System.Net.EndPoint! endpoint, StackExchange.Redis.ConnectionType connectionType, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<RESPite.Transports.DuplexTransport?>

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -290,6 +290,13 @@ namespace StackExchange.Redis
         public bool Resp3 => Version.IsAtLeast(v6_0_0);
 
         /// <summary>
+        /// Is the <see href="https://redis.io/commands/hello/">HELLO</see> handshake available?
+        /// </summary>
+        /// <remarks>This is useful even when staying on RESP2; <c>HELLO 2</c> reports the server
+        /// version, role, mode and connection identifier without needing <c>INFO</c> or <c>CONFIG</c>.</remarks>
+        public bool Hello => Version.IsAtLeast(v6_0_0);
+
+        /// <summary>
         /// Are the <c>IF*</c> modifiers on <see href="https://redis.io/commands/set/">SET</see> available?
         /// </summary>
         public bool SetWithValueCheck => Version.IsAtLeast(v8_4_0_rc1);

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -1103,14 +1103,21 @@ namespace StackExchange.Redis
                                     connection.ConnectionId = i64;
                                     Log?.LogInformationAutoConfiguredHelloConnectionId(new(server), i64);
                                     break;
+                                // note: "mode" and "role" describe a *server*, so we only trust them when we're
+                                // talking to one directly; a proxy may answer HELLO from an arbitrary backend node
+                                // (envoy 1.39 does), and taking that at face value would flip us into cluster mode
+                                // or mark the proxy as a replica
                                 case HelloField.Mode
-                                    when iter.Value.TryParseScalar(&ServerTypeMetadata.TryParse, out ServerType serverType):
+                                    when server.ServerType.SupportsAutoConfigure()
+                                        && iter.Value.TryParseScalar(&ServerTypeMetadata.TryParse, out ServerType serverType):
                                     server.ServerType = serverType;
                                     Log?.LogInformationAutoConfiguredHelloServerType(new(server), serverType);
                                     break;
                                 case HelloField.Role
-                                    when iter.Value.TryParseScalar(&KnownRoleMetadata.TryParse, out bool isReplica):
+                                    when server.ServerType.SupportsAutoConfigure()
+                                        && iter.Value.TryParseScalar(&KnownRoleMetadata.TryParse, out bool isReplica):
                                     server.IsReplica = isReplica;
+                                    server.RoleKnownFromHello = true; // so we don't need the key-based fallback probe
                                     Log?.LogInformationAutoConfiguredHelloRole(
                                         new(server),
                                         isReplica ? "replica" : "primary");

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -1120,7 +1120,6 @@ namespace StackExchange.Redis
                     // folding the credentials in here would change how credential failures surface. We only want
                     // the reply, which reports version/role/mode/connection-id without INFO or CONFIG (both
                     // @dangerous, hence often ACL-restricted); see #2968
-                    log?.LogInformationDiscoveryViaHello(new(this));
                     var hello = Message.CreateHello(helloProtocol, null, null, null, CommandFlags.FireAndForget | Message.NoFlushFlag);
                     hello.SetInternalCall();
                     await WriteDirectOrQueueFireAndForgetAsync(connection, hello, autoConfig ??= ResultProcessor.AutoConfigureProcessor.Create(log)).ForAwait();

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -388,7 +388,23 @@ namespace StackExchange.Redis
             }
         }
 
-        internal async Task AutoConfigureAsync(PhysicalConnection? connection, ILogger? log = null, CommandFlags extraFlags = CommandFlags.None)
+        /// <summary>
+        /// Whether <c>HELLO</c> has told us our replication role (and server mode) on the current connection.
+        /// </summary>
+        /// <remarks>Reset at the start of each handshake, and set when the <c>HELLO</c> reply is processed.</remarks>
+        internal bool RoleKnownFromHello { get; set; }
+
+        /// <summary>
+        /// Issues the topology/configuration discovery commands for this server.
+        /// </summary>
+        /// <param name="connection">The connection to write to; <c>null</c> for an already-established connection.</param>
+        /// <param name="log">The log to write handshake details to.</param>
+        /// <param name="extraFlags">Additional flags to apply to the messages issued.</param>
+        /// <param name="helloPending">
+        /// Whether a <c>HELLO</c> has been written to this same batch, but not yet answered; in that case
+        /// we expect to learn our role from it, so we can skip the key-based fallback probe.
+        /// </param>
+        internal async Task AutoConfigureAsync(PhysicalConnection? connection, ILogger? log = null, CommandFlags extraFlags = CommandFlags.None, bool helloPending = false)
         {
             if (!serverType.SupportsAutoConfigure())
             {
@@ -452,9 +468,11 @@ namespace StackExchange.Redis
                     await WriteDirectOrQueueFireAndForgetAsync(connection, msg, autoConfigProcessor).ForAwait();
                 }
             }
-            else if (commandMap.IsAvailable(RedisCommand.SET))
+            else if (commandMap.IsAvailable(RedisCommand.SET) && !(helloPending || RoleKnownFromHello))
             {
                 // This is a nasty way to find if we are a replica, and it will only work on up-level servers, but...
+                // (note we only get here when HELLO isn't going to tell us: the HELLO reply carries "role", and
+                // unlike this probe it doesn't need a key - which matters when ACLs restrict key patterns; see #2968)
                 RedisKey key = Multiplexer.UniqueId;
                 // The actual value here doesn't matter (we detect the error code if it fails).
                 // The value here is to at least give some indication to anyone watching via "monitor",
@@ -1002,10 +1020,24 @@ namespace StackExchange.Redis
             // the various tasks and just `return connection.FlushAsync();` - however, since handshake is low
             // volume, we can afford to optimize for a good stack-trace rather than avoiding state machines.
             ResultProcessor<bool>? autoConfig = null;
-            if (Multiplexer.RawConfig.TryResp3()) // note this includes an availability check on HELLO
+            bool isInteractive = connection.BridgeCouldBeNull?.ConnectionType == ConnectionType.Interactive;
+            if (isInteractive)
+            {
+                // forget what the previous connection's HELLO told us; re-established below, if this one repeats it
+                // (the subscription handshake is deliberately left out of this: it doesn't do the discovery step)
+                RoleKnownFromHello = false;
+            }
+
+            // HELLO comes in two flavours: as the RESP3 negotiation (which has to be the *first* command, and has to
+            // carry the credentials), or - when we're staying on RESP2 - purely for discovery, in which case it is
+            // issued *after* AUTH, below; see #2968 for why we want it even on RESP2
+            bool helloAvailable = Multiplexer.RawConfig.TryHello(out int helloProtocol); // includes an availability check on HELLO
+            bool negotiateResp3 = helloAvailable && helloProtocol >= 3;
+            bool discoveryHello = helloAvailable && !negotiateResp3 && isInteractive;
+            if (negotiateResp3)
             {
                 log?.LogInformationAuthenticatingViaHello(new(this));
-                var hello = Message.CreateHello(3, user, password, clientName, CommandFlags.FireAndForget | Message.NoFlushFlag);
+                var hello = Message.CreateHello(helloProtocol, user, password, clientName, CommandFlags.FireAndForget | Message.NoFlushFlag);
                 hello.SetInternalCall();
                 await WriteDirectOrQueueFireAndForgetAsync(connection, hello, autoConfig ??= ResultProcessor.AutoConfigureProcessor.Create(log)).ForAwait();
 
@@ -1014,7 +1046,7 @@ namespace StackExchange.Redis
             }
             else
             {
-                // if we're not even issuing HELLO, we're RESP2
+                // whether or not we issue HELLO for discovery below, we're RESP2
                 connection.SetProtocol(RedisProtocol.Resp2);
             }
 
@@ -1082,7 +1114,19 @@ namespace StackExchange.Redis
             var connType = bridge.ConnectionType;
             if (connType == ConnectionType.Interactive)
             {
-                await AutoConfigureAsync(connection, log, extraFlags: Message.NoFlushFlag).ForAwait();
+                if (discoveryHello)
+                {
+                    // a bare HELLO (no AUTH clause of its own): we're already authenticated by this point, and
+                    // folding the credentials in here would change how credential failures surface. We only want
+                    // the reply, which reports version/role/mode/connection-id without INFO or CONFIG (both
+                    // @dangerous, hence often ACL-restricted); see #2968
+                    log?.LogInformationDiscoveryViaHello(new(this));
+                    var hello = Message.CreateHello(helloProtocol, null, null, null, CommandFlags.FireAndForget | Message.NoFlushFlag);
+                    hello.SetInternalCall();
+                    await WriteDirectOrQueueFireAndForgetAsync(connection, hello, autoConfig ??= ResultProcessor.AutoConfigureProcessor.Create(log)).ForAwait();
+                }
+
+                await AutoConfigureAsync(connection, log, extraFlags: Message.NoFlushFlag, helloPending: negotiateResp3 || discoveryHello).ForAwait();
             }
 
             // note that the final messages *are* flushed (no Message.NoFlushFlag)

--- a/tests/RedisConfigs/.docker/Envoy/Dockerfile
+++ b/tests/RedisConfigs/.docker/Envoy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.31-latest
+FROM envoyproxy/envoy:v1.39-latest
 
 COPY envoy.yaml /etc/envoy/envoy.yaml
 RUN chmod go+r /etc/envoy/envoy.yaml

--- a/tests/StackExchange.Redis.Tests/CommandMapUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/CommandMapUnitTests.cs
@@ -63,4 +63,17 @@ public class CommandMapUnitTests
         ReadOnlySpan<byte> bytes = Encoding.ASCII.GetBytes(name);
         Assert.False(RedisCommandMetadata.TryParseCI(bytes, out _), $"byte parse unexpectedly succeeded for '{name}'");
     }
+
+    /// <summary>
+    /// We now issue <c>HELLO</c> whenever it is available (RESP2 included), so the proxy maps must exclude it:
+    /// twemproxy 0.5.0 *closes the connection* on an unsupported command, and envoy (1.39, at least) forwards
+    /// HELLO to an arbitrary backend node, so its version/role/mode describe the wrong server.
+    /// </summary>
+    [Fact]
+    public void ProxyCommandMapsExcludeHello()
+    {
+        Assert.False(CommandMap.Twemproxy.IsAvailable(RedisCommand.HELLO), "twemproxy");
+        Assert.False(CommandMap.Envoyproxy.IsAvailable(RedisCommand.HELLO), "envoyproxy");
+        Assert.True(CommandMap.Default.IsAvailable(RedisCommand.HELLO), "default");
+    }
 }

--- a/tests/StackExchange.Redis.Tests/HelloHandshakeTests.cs
+++ b/tests/StackExchange.Redis.Tests/HelloHandshakeTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis.Server;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// We issue <c>HELLO</c> whenever we expect the server to understand it, even when staying on RESP2:
+/// the reply tells us the version/role/mode without needing <c>INFO</c> or <c>CONFIG</c>, both of
+/// which are <c>@dangerous</c> and commonly restricted by ACLs; see issue #2968.
+/// </summary>
+public class HelloHandshakeTests(ITestOutputHelper log)
+{
+    [Theory]
+    [InlineData(RedisProtocol.Resp2, "2")]
+    [InlineData(RedisProtocol.Resp3, "3")]
+    public async Task HelloIsIssuedForBothProtocols(RedisProtocol protocol, string expectedProtover)
+    {
+        using var server = new RecordingServer(log);
+        var config = server.GetClientConfig();
+        config.Protocol = protocol;
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+
+        var hellos = server.Recorded("HELLO");
+        Assert.NotEmpty(hellos);
+        Assert.All(hellos, args => Assert.Equal(expectedProtover, args.FirstOrDefault()));
+        Assert.Equal(protocol, conn.GetServerSnapshot()[0].Protocol);
+    }
+
+    [Fact]
+    public async Task NoHelloWhenDisabledViaCommandMap()
+    {
+        using var server = new RecordingServer(log);
+        var config = server.GetClientConfig();
+        config.Protocol = RedisProtocol.Resp2;
+        config.CommandMap = server.CreateCommandMap(except: "HELLO");
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+
+        Assert.Empty(server.Recorded("HELLO"));
+        Assert.Equal(RedisProtocol.Resp2, conn.GetServerSnapshot()[0].Protocol);
+    }
+
+    [Fact]
+    public async Task NoHelloWhenServerIsAssumedDownLevel()
+    {
+        using var server = new RecordingServer(log);
+        var config = server.GetClientConfig();
+        config.Protocol = RedisProtocol.Resp2;
+        config.DefaultVersion = new Version(5, 0, 0); // HELLO arrived in 6.0
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+
+        Assert.Empty(server.Recorded("HELLO"));
+        Assert.Equal(RedisProtocol.Resp2, conn.GetServerSnapshot()[0].Protocol);
+    }
+
+    /// <summary>
+    /// The point of issue #2968: with <c>INFO</c> and <c>CONFIG</c> unavailable we used to fall back to
+    /// <c>SET {random-guid} replica-read-only PX 1 NX</c> to detect a read-only replica - a key write that
+    /// cannot be allow-listed in an ACL. <c>HELLO</c> reports the role, so the probe isn't needed.
+    /// </summary>
+    [Theory]
+    [InlineData(RedisProtocol.Resp2)]
+    [InlineData(RedisProtocol.Resp3)]
+    public async Task NoReplicaProbeWhenHelloTellsUsTheRole(RedisProtocol protocol)
+    {
+        using var server = new RecordingServer(log);
+        var config = server.GetClientConfig();
+        config.Protocol = protocol;
+        config.CommandMap = server.CreateCommandMap(except: ["INFO", "CONFIG"]);
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+
+        Assert.NotEmpty(server.Recorded("HELLO"));
+        Assert.Empty(server.Recorded("SET"));
+        Assert.False(conn.GetServerSnapshot()[0].IsReplica); // from HELLO's "role"
+    }
+
+    /// <summary>
+    /// The converse of <see cref="NoReplicaProbeWhenHelloTellsUsTheRole"/>: when HELLO isn't available
+    /// either, the key-based probe is still the only signal we have, so it must still be issued.
+    /// </summary>
+    [Fact]
+    public async Task ReplicaProbeStillUsedWhenHelloUnavailable()
+    {
+        using var server = new RecordingServer(log);
+        var config = server.GetClientConfig();
+        config.Protocol = RedisProtocol.Resp2;
+        config.CommandMap = server.CreateCommandMap(except: ["INFO", "CONFIG", "HELLO"]);
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+
+        Assert.Empty(server.Recorded("HELLO"));
+        var sets = server.Recorded("SET");
+        Assert.NotEmpty(sets);
+        Assert.All(sets, args => Assert.Equal("replica-read-only", args.Skip(1).FirstOrDefault()));
+    }
+
+    private sealed class RecordingServer(ITestOutputHelper log) : InProcessTestServer(log)
+    {
+        private readonly ConcurrentQueue<(string Command, string[] Args)> _commands = new();
+
+        public override TypedRedisValue Execute(RedisClient client, in RedisRequest request)
+        {
+            var args = new string[Math.Max(request.Count - 1, 0)];
+            for (int i = 0; i < args.Length; i++)
+            {
+                args[i] = request.GetString(i + 1);
+            }
+            _commands.Enqueue((request.GetString(0).ToUpperInvariant(), args));
+            return base.Execute(client, in request);
+        }
+
+        public List<string[]> Recorded(string command)
+            => _commands.Where(x => x.Command == command).Select(x => x.Args).ToList();
+
+        public CommandMap CreateCommandMap(params string[] except)
+        {
+            var commands = GetCommands();
+            foreach (var command in except)
+            {
+                commands.Remove(command);
+            }
+            return CommandMap.Create(commands);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/Resp3HandshakeTests.cs
+++ b/tests/StackExchange.Redis.Tests/Resp3HandshakeTests.cs
@@ -38,17 +38,12 @@ public class Resp3HandshakeTests(ITestOutputHelper log)
         {
             foreach (var server in servers)
             {
-                if (client is RedisProtocol.Resp2 & server is not ServerResponse.Resp2)
+                // note that every combination is meaningful: we issue HELLO even for RESP2 clients
+                // (as HELLO 2), so "server doesn't understand HELLO" etc still needs exercising
+                int count = 1 << HandshakeFlagsCount;
+                for (int i = 0; i < count; i++)
                 {
-                    // we don't issue HELLO for this, nothing to test
-                }
-                else
-                {
-                    int count = 1 << HandshakeFlagsCount;
-                    for (int i = 0; i < count; i++)
-                    {
-                        yield return [client, server, (HandshakeFlags)i];
-                    }
+                    yield return [client, server, (HandshakeFlags)i];
                 }
             }
         }
@@ -66,6 +61,11 @@ public class Resp3HandshakeTests(ITestOutputHelper log)
         config.ConfigurationChannel = (flags & HandshakeFlags.ConfigChannel) == 0 ? "" : "broadcast_channel";
 
         await using var clientObj = await ConnectionMultiplexer.ConnectAsync(config);
+
+        // RESP3 requires both sides to want it; anything else lands on RESP2
+        var expectedProtocol = client is RedisProtocol.Resp3 && server is ServerResponse.Resp3
+            ? RedisProtocol.Resp3 : RedisProtocol.Resp2;
+        Assert.Equal(expectedProtocol, clientObj.GetServerSnapshot()[0].Protocol);
 
         var sub = clientObj.GetSubscriber();
         var db = clientObj.GetDatabase();


### PR DESCRIPTION
Fixes #2968 (the remaining concern), and fixes a v3 regression against twemproxy found on the way.

## The #2968 problem

With `INFO` unavailable, discovery fell back to `SET {guid} replica-read-only PX 1 NX` to detect a read-only replica. That probe writes a random, unprefixable key, so it can never be allow-listed by an ACL key pattern - which is precisely the situation that made `INFO` unavailable in the first place (`INFO` and `CONFIG` are both `@dangerous`). The reporter was left with permanent ACL-log noise they had no way to silence.

`HELLO`'s reply carries `role`, needs no key, and is in the `@connection` category. It also reports the version, mode (standalone/sentinel/cluster) and connection id. We were only issuing it when negotiating RESP3.

## The change

- `ConfigurationOptions.TryHello(out int protocolVersion)` alongside `TryResp3()`, plus `RedisFeatures.Hello` (6.0). `HELLO` is issued whenever it is available and the assumed server version is 6.0+. Two independent opt-outs: `$hello=` in the command map, and a sub-6.0 `defaultVersion`.
- The key-based replica probe is skipped when `HELLO` is going to report the role (same handshake batch) or has already reported it (sticky per-endpoint flag, for later reconfigure sweeps).
- Since ACLs are themselves 6.0+, the probe is now unreachable for anyone who can express key restrictions at all. Pre-6.0 servers keep the old fallback, where there are no key ACLs to upset.

The RESP2 `HELLO` is deliberately **not** the same message as the RESP3 one:

- `HELLO 3` stays first-in-pipeline and carries the credentials, as it must for RESP3 negotiation to work on a secured server.
- `HELLO 2` is a **bare** `HELLO` issued *after* `AUTH`, on the interactive connection only. It negotiates nothing, and folding credentials in would change how credential failures surface - there is a pre-existing difference between `AUTH` failing on its own and `AUTH` failing inside `HELLO`, which is a separate bug and not one to inherit here.

## Proxies (measured against live proxies, not assumed)

| Target | Version | `HELLO` behaviour |
|---|---|---|
| twemproxy | 0.5.0 (newest release; 2021) | `parsed unsupported command 'hello'`, then **closes the connection** |
| envoy | v1.31 (previous test pin) | `-unsupported command 'hello'` |
| envoy | v1.39 (current) | `HELLO 2` **proxied to an arbitrary backend node**; `HELLO 3` -> `-NOPROTO` |

Consequences, both fixed here by excluding `HELLO` from `CommandMap.Twemproxy` and `CommandMap.Envoyproxy`:

- **v3 already broke twemproxy on default settings** - a regression against v2. v2 assumed version 3.0, so `TryResp3()` was false and no `HELLO` was sent; v3 raised the assumed default to 6.0, and the twemproxy map did not exclude `HELLO`. Verified with a real twemproxy: `SocketClosed (0-read)`, connection never usable.
- Envoy 1.39's forwarded `HELLO 2` reported `version=8.9.241, mode=cluster, role=replica` - i.e. some backend node, not the endpoint. `mode`/`role` from `HELLO` are therefore only applied to server types that support auto-configure, so proxies are excluded even if a hand-rolled command map re-enables the command.

Also bumps the test-topology envoy pin from v1.31 to v1.39 (8 minors stale, and the two behave differently here).

## Tests

`HelloHandshakeTests` uses a recording in-process server (captures every command and its args) to pin exactly what the handshake issues:

- `HELLO` at the right protocol level for both RESP2 and RESP3
- no `HELLO` when disabled via the command map, or when `defaultVersion` is below 6.0
- **no** replica probe when `INFO`/`CONFIG` are unavailable but `HELLO` is, with `IsReplica` coming from `HELLO`'s `role`
- the converse: `HELLO` unavailable too -> the probe **is** issued

`Resp3HandshakeTests` no longer skips the RESP2-client half of its matrix (128 -> 192 cases), so the "server does not understand HELLO" and "server insists on RESP2" spoofs now cover RESP2 clients too, and it asserts the negotiated protocol. Plus a `CommandMapUnitTests` case pinning the proxy exclusions.

Full suite green; `EnvoyTests` verified against a rebuilt v1.39 container.

## Follow-ups (not in this PR)

- A pre-existing bug in the RESP3 connect path: when `HELLO` fails (bad credentials, timeout, down-level server), the protocol downgrade mid-handshake leaves queued `SUBSCRIBE` traffic on the interactive connection. Looks like the same mechanism as #3154, and plausibly related to #3172.
- #2970's remaining items: the `EXISTS {guid}` tracer fallback ignoring hash slots, and skipping the tie-breaker on cluster.