### PR TITLE
Add a Jekyll config for the docs site, and switch to Cayman

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ MyGet Pre-release feed: https://www.myget.org/gallery/stackoverflow
 | ------- | ------------ | ----------------- | --------- | ----- |
 | [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/v/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis](https://img.shields.io/nuget/vpre/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/absoluteLatest) | [![StackExchange.Redis](https://img.shields.io/nuget/dt/StackExchange.Redis.svg)](https://www.nuget.org/packages/StackExchange.Redis/) | [![StackExchange.Redis MyGet](https://img.shields.io/myget/stackoverflow/vpre/StackExchange.Redis.svg)](https://www.myget.org/feed/stackoverflow/package/nuget/StackExchange.Redis) |
 
-Release notes at: https://seredis.dev/ReleaseNotes
+Release notes at: https://github.com/StackExchange/StackExchange.Redis/releases (3.0 onwards; earlier releases at https://seredis.dev/ReleaseNotes)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,22 @@
+# Jekyll config for the published docs site (https://seredis.dev).
+# Without this file the site runs on GitHub's defaults: the Primer theme, and site
+# title/description silently taken from the repo's name and description fields.
+
+title: StackExchange.Redis
+description: The Redis client for .NET
+url: https://seredis.dev
+
+theme: jekyll-theme-cayman
+
+# Cayman renders "Download .zip/.tar.gz" buttons in its header when this is on, and
+# GitHub's default config turns it on; the package comes from NuGet, not a tarball.
+show_downloads: false
+
+# Not in the always-on GitHub Pages plugin set, so it has to be asked for; generates
+# sitemap.xml and robots.txt, neither of which the site had.
+plugins:
+  - jekyll-sitemap
+
+# Present only so the docs show up in the solution; not site content.
+exclude:
+  - docs.csproj

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ﻿StackExchange.Redis
 ===================
 
-- [Release Notes](ReleaseNotes)
+- [Release Notes](https://github.com/StackExchange/StackExchange.Redis/releases) (3.0 onwards; [earlier releases](ReleaseNotes))
 
 ## Overview
 

--- a/src/StackExchange.Redis/README.md
+++ b/src/StackExchange.Redis/README.md
@@ -1,6 +1,6 @@
 StackExchange.Redis is a high-performance RESP (Redis, etc) client for .NET, available under the MIT license.
 
-- Release notes: [https://seredis.dev/ReleaseNotes](https://seredis.dev/ReleaseNotes)
+- Release notes: [https://github.com/StackExchange/StackExchange.Redis/releases](https://github.com/StackExchange/StackExchange.Redis/releases) (3.0 onwards; [earlier](https://seredis.dev/ReleaseNotes))
 - NuGet package: [https://www.nuget.org/packages/StackExchange.Redis/](https://www.nuget.org/packages/StackExchange.Redis/)
 - General docs: [https://seredis.dev/](https://seredis.dev/)
 - Code: [https://github.com/StackExchange/StackExchange.Redis/](https://github.com/StackExchange/StackExchange.Redis/)


### PR DESCRIPTION
The docs site has never had a `_config.yml`, so it has been running entirely on GitHub's defaults. That mostly works - the always-on plugin set is doing real work for us (`jekyll-optional-front-matter` is why our front-matter-less markdown renders at all, `jekyll-relative-links` is why inter-doc links resolve, `jekyll-titles-from-headings` is where page titles come from) - but three things fall out of it that are worth fixing.

**Site metadata was coming from the repo settings UI.** `jekyll-github-metadata` fills `site.title` from the repo name and `site.description` from the repo description field, so editing the description on the repo page silently changed the site's `<meta name="description">` and its Open Graph tags. Now pinned in the config, along with `url`, which is what `jekyll-seo-tag` uses to build canonical and `og:url`.

**No sitemap.** `jekyll-sitemap` is not in the always-on set and has to be asked for; `sitemap.xml` and `robots.txt` both 404 today. Opting in generates both.

**`docs.csproj` was being published**, and is currently readable at `/docs.csproj`. It exists so the docs show up in the solution, so it is excluded from site content.

**Theme.** Primer was never chosen, it is just the default. This picks `jekyll-theme-cayman` explicitly - the same one Dapper uses. `show_downloads: false` goes with it: Cayman puts "Download .zip"/"Download .tar.gz" buttons in its header when that is set, GitHub's default config sets it, and the package comes from NuGet.

The config parses cleanly, but there is no Ruby toolchain here so the theme could not be rendered locally - the Cayman switch is worth a look on the deployed site once this lands. In particular Cayman puts the page title in a banner above the content, and our titles are derived from each page's first heading, so headings may read twice near the top. Easy to revert to `jekyll-theme-primer` (one line) if it does not sit well across ~45 pages.

---

**Also here:** the index linked release notes to `ReleaseNotes`, which is frozen at 3.0 - its own first entry says notes live in GitHub Releases from then on - so the link sent people to a page telling them to go elsewhere. Releases is now the primary link, with the old page kept in parentheses for the historical record.


The same stale link was in two more places, both now pointing at Releases as well: the repo README, and the README embedded in the NuGet package - which is the one most people actually read, and which now agrees with `PackageReleaseNotes`, already pointing at Releases. `docs/ReleaseNotes.md` itself is untouched and stays as the historical record.
