### PR TITLE
Make fallback discovery and keep-alive probes cluster-slot aware

### DIFF
--- a/src/StackExchange.Redis/ClusterConfiguration.cs
+++ b/src/StackExchange.Redis/ClusterConfiguration.cs
@@ -467,7 +467,7 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets the parent node of the current node.
         /// </summary>
-        public ClusterNode? Parent => (parent is not null) ? parent = configuration[ParentNodeId!] : null;
+        public ClusterNode? Parent => ParentNodeId is null ? null : (parent ??= configuration[ParentNodeId]);
 
         /// <summary>
         /// Gets the unique node-id of the parent of the current node.

--- a/src/StackExchange.Redis/RedisServer.cs
+++ b/src/StackExchange.Redis/RedisServer.cs
@@ -65,9 +65,9 @@ namespace StackExchange.Redis
             var guid = Guid.NewGuid();
             if (server.ServerType is ServerType.Cluster)
             {
-                var hashTag = multiplexer.ServerSelectionStrategy.GetHashTag(server);
-                if (string.IsNullOrEmpty(hashTag)) return RedisKey.Null;
-                return prefix.Append($"{guid}:{{{hashTag}}}");
+                var slot = server.GetServableSlot();
+                if (slot is null) return RedisKey.Null;
+                return ServerSelectionStrategy.CreateKeyForSlot(slot.Value, guid.ToString()).Prepend(prefix);
             }
             return prefix.Append(guid.ToString());
         }

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -37,6 +36,8 @@ namespace StackExchange.Redis
         private bool isDisposed, replicaReadOnly, isReplica, allowReplicaWrites;
         private bool? supportsDatabases, supportsPrimaryWrites;
         private ServerType serverType;
+        private RedisKey tracerKey;
+        private int? tracerKeySlot = ServerSelectionStrategy.MultipleSlots;
         private volatile UnselectableFlags unselectableReasons;
         private Version version;
 
@@ -380,7 +381,14 @@ namespace StackExchange.Redis
         }
 
         private ClusterNode? GetClusterNode(ClusterConfiguration? configuration) =>
-            configuration?.Nodes.FirstOrDefault(x => x.EndPoint?.Equals(EndPoint) == true);
+            configuration?[EndPoint];
+
+        internal int? GetServableSlot()
+        {
+            if (ServerType != ServerType.Cluster || GetClusterNode(ClusterConfiguration) is not { } node) return null;
+            if (node.Slots.Count == 0 && node.Parent is { } parent) node = parent;
+            return node.Slots.Count == 0 ? null : node.Slots[0].From;
+        }
 
         public void SetUnselectable(UnselectableFlags flags)
         {
@@ -695,14 +703,15 @@ namespace StackExchange.Redis
 
         internal RedisKey GetTracerKey()
         {
-            RedisKey key = Multiplexer.UniqueId;
-            if (ServerType == ServerType.Cluster
-                && GetClusterNode(ClusterConfiguration) is { } node
-                && node.Slots.Count > 0)
+            var slot = GetServableSlot();
+            if (tracerKeySlot != slot)
             {
-                key = key.Prepend(ServerSelectionStrategy.GetHashTagPrefix(node.Slots[0].From));
+                tracerKey = slot is int value
+                    ? ServerSelectionStrategy.CreateKeyForSlot(value, Multiplexer.UniqueId)
+                    : Multiplexer.UniqueId;
+                tracerKeySlot = slot;
             }
-            return key;
+            return tracerKey;
         }
 
         internal UnselectableFlags GetUnselectableFlags() => unselectableReasons;

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -355,7 +355,7 @@ namespace StackExchange.Redis
 
         public void UpdateNodeRelations(ClusterConfiguration configuration)
         {
-            var thisNode = configuration.Nodes.FirstOrDefault(x => x.EndPoint?.Equals(EndPoint) == true);
+            var thisNode = GetClusterNode(configuration);
             if (thisNode != null)
             {
                 Multiplexer.Trace($"Updating node relations for {Format.ToString(thisNode.EndPoint)}...");
@@ -378,6 +378,9 @@ namespace StackExchange.Redis
                 Replicas = replicas?.ToArray() ?? Array.Empty<ServerEndPoint>();
             }
         }
+
+        private ClusterNode? GetClusterNode(ClusterConfiguration? configuration) =>
+            configuration?.Nodes.FirstOrDefault(x => x.EndPoint?.Equals(EndPoint) == true);
 
         public void SetUnselectable(UnselectableFlags flags)
         {
@@ -502,7 +505,9 @@ namespace StackExchange.Redis
                     await WriteDirectOrQueueFireAndForgetAsync(connection, msg, autoConfigProcessor).ForAwait();
                 }
             }
-            else if (commandMap.IsAvailable(RedisCommand.SET) && !(helloPending || RoleKnownFromHello))
+            else if (commandMap.IsAvailable(RedisCommand.SET)
+                && !(helloPending || RoleKnownFromHello)
+                && !(ServerType == ServerType.Cluster && GetClusterNode(ClusterConfiguration) is not null))
             {
                 // This is a nasty way to find if we are a replica, and it will only work on up-level servers, but...
                 // (note we only get here when HELLO isn't going to tell us: the HELLO reply carries "role", and
@@ -535,7 +540,9 @@ namespace StackExchange.Redis
             }
             // If we are going to fetch a tie breaker, do so last and we'll get it in before the tracer fires completing the connection
             // But if GETs are disabled on this, do not fail the connection - we just don't get tiebreaker benefits
-            if (Multiplexer.RawConfig.TryGetTieBreaker(out var tieBreakerKey) && Multiplexer.CommandMap.IsAvailable(RedisCommand.GET))
+            if (ServerType != ServerType.Cluster
+                && Multiplexer.RawConfig.TryGetTieBreaker(out var tieBreakerKey)
+                && Multiplexer.CommandMap.IsAvailable(RedisCommand.GET))
             {
                 log?.LogInformationRequestingTieBreak(new(EndPoint), tieBreakerKey);
                 msg = Message.Create(0, flags, RedisCommand.GET, tieBreakerKey);
@@ -680,10 +687,22 @@ namespace StackExchange.Redis
             else
             {
                 map.AssertAvailable(RedisCommand.EXISTS);
-                msg = Message.Create(0, flags, RedisCommand.EXISTS, (RedisValue)Multiplexer.UniqueId);
+                msg = Message.Create(0, flags, RedisCommand.EXISTS, GetTracerKey());
             }
             msg.SetInternalCall();
             return msg;
+        }
+
+        internal RedisKey GetTracerKey()
+        {
+            RedisKey key = Multiplexer.UniqueId;
+            if (ServerType == ServerType.Cluster
+                && GetClusterNode(ClusterConfiguration) is { } node
+                && node.Slots.Count > 0)
+            {
+                key = key.Prepend(ServerSelectionStrategy.GetHashTagPrefix(node.Slots[0].From));
+            }
+            return key;
         }
 
         internal UnselectableFlags GetUnselectableFlags() => unselectableReasons;

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -513,9 +513,13 @@ namespace StackExchange.Redis
                     await WriteDirectOrQueueFireAndForgetAsync(connection, msg, autoConfigProcessor).ForAwait();
                 }
             }
+            // Cluster replicas return MOVED rather than READONLY for writes to their primary's slots, so no
+            // hash tag can make this role probe reliable; skip it whenever cluster mode is already known.
+            // On the first handshake, serverType is seeded as Standalone until the CLUSTER NODES reply is
+            // processed, so neither this guard nor the tie-breaker GET guard below suppresses their initial probes.
             else if (commandMap.IsAvailable(RedisCommand.SET)
                 && !(helloPending || RoleKnownFromHello)
-                && !(ServerType == ServerType.Cluster && GetClusterNode(ClusterConfiguration) is not null))
+                && ServerType != ServerType.Cluster)
             {
                 // This is a nasty way to find if we are a replica, and it will only work on up-level servers, but...
                 // (note we only get here when HELLO isn't going to tell us: the HELLO reply carries "role", and

--- a/src/StackExchange.Redis/ServerSelectionStrategy.HashTags.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.HashTags.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
-using System.Threading;
 
 namespace StackExchange.Redis;
 
@@ -11,24 +10,8 @@ internal sealed partial class ServerSelectionStrategy
     private static class HashTags
     {
         private static readonly string[] Cache = Populate();
-        private static readonly byte[]?[] PrefixCache = new byte[TotalSlots][];
-        private static readonly object PrefixCacheLock = new();
-
         public static ReadOnlySpan<string> Tags => Cache;
         public static string Get(int slot) => Cache[slot];
-
-        public static byte[] GetPrefix(int slot)
-        {
-            var prefix = Volatile.Read(ref PrefixCache[slot]);
-            if (prefix is null)
-            {
-                lock (PrefixCacheLock)
-                {
-                    prefix = PrefixCache[slot] ??= Encoding.ASCII.GetBytes("{" + Get(slot) + "}");
-                }
-            }
-            return prefix;
-        }
 
         private static string[] Populate()
         {

--- a/src/StackExchange.Redis/ServerSelectionStrategy.HashTags.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.HashTags.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 
 namespace StackExchange.Redis;
 
@@ -10,8 +11,24 @@ internal sealed partial class ServerSelectionStrategy
     private static class HashTags
     {
         private static readonly string[] Cache = Populate();
+        private static readonly byte[]?[] PrefixCache = new byte[TotalSlots][];
+        private static readonly object PrefixCacheLock = new();
+
         public static ReadOnlySpan<string> Tags => Cache;
         public static string Get(int slot) => Cache[slot];
+
+        public static byte[] GetPrefix(int slot)
+        {
+            var prefix = Volatile.Read(ref PrefixCache[slot]);
+            if (prefix is null)
+            {
+                lock (PrefixCacheLock)
+                {
+                    prefix = PrefixCache[slot] ??= Encoding.ASCII.GetBytes("{" + Get(slot) + "}");
+                }
+            }
+            return prefix;
+        }
 
         private static string[] Populate()
         {

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -442,5 +442,7 @@ namespace StackExchange.Redis
         /// Gets a string that can be used as a hash-tag to reference a specific slot.
         /// </summary>
         internal static string GetHashTag(int slot) => slot < 0 ? "" : HashTags.Get(slot);
+
+        internal static RedisKey GetHashTagPrefix(int slot) => HashTags.GetPrefix(slot);
     }
 }

--- a/src/StackExchange.Redis/ServerSelectionStrategy.cs
+++ b/src/StackExchange.Redis/ServerSelectionStrategy.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 
 namespace StackExchange.Redis
@@ -422,27 +423,9 @@ namespace StackExchange.Redis
         /// <summary>
         /// Gets a string that can be used as a hash-tag to reference a specific slot.
         /// </summary>
-        internal string GetHashTag(ServerEndPoint endpoint)
-        {
-            if (map is { } arr)
-            {
-                // inefficient way of finding a slot for a given endpoint, but: it'll work
-                for (int i = 0; i < arr.Length; i++)
-                {
-                    if (arr[i] == endpoint)
-                    {
-                        return HashTags.Get(i);
-                    }
-                }
-            }
-            return "";
-        }
-
-        /// <summary>
-        /// Gets a string that can be used as a hash-tag to reference a specific slot.
-        /// </summary>
         internal static string GetHashTag(int slot) => slot < 0 ? "" : HashTags.Get(slot);
 
-        internal static RedisKey GetHashTagPrefix(int slot) => HashTags.GetPrefix(slot);
+        internal static RedisKey CreateKeyForSlot(int slot, RedisKey suffix) =>
+            suffix.Prepend(Encoding.ASCII.GetBytes("{" + HashTags.Get(slot) + "}"));
     }
 }

--- a/tests/StackExchange.Redis.Tests/HashTagUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/HashTagUnitTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
@@ -25,5 +25,19 @@ public class HashTagUnitTests
             Assert.Equal(i, slot);
         }
         Assert.Equal(ServerSelectionStrategy.TotalSlots, uniques.Count);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(8191)]
+    [InlineData(16383)]
+    public void TestHashTagPrefixTargetsSlot(int slot)
+    {
+        var prefix = ServerSelectionStrategy.GetHashTagPrefix(slot);
+        RedisKey key = ((RedisKey)"probe-id").Prepend(prefix);
+
+        Assert.Equal(slot, ServerSelectionStrategy.GetHashSlot(key));
+        Assert.Same((byte[]?)prefix, (byte[]?)ServerSelectionStrategy.GetHashTagPrefix(slot));
     }
 }

--- a/tests/StackExchange.Redis.Tests/HashTagUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/HashTagUnitTests.cs
@@ -32,12 +32,10 @@ public class HashTagUnitTests
     [InlineData(1)]
     [InlineData(8191)]
     [InlineData(16383)]
-    public void TestHashTagPrefixTargetsSlot(int slot)
+    public void TestCreateKeyForSlotTargetsSlot(int slot)
     {
-        var prefix = ServerSelectionStrategy.GetHashTagPrefix(slot);
-        RedisKey key = ((RedisKey)"probe-id").Prepend(prefix);
+        var key = ServerSelectionStrategy.CreateKeyForSlot(slot, "probe-id");
 
         Assert.Equal(slot, ServerSelectionStrategy.GetHashSlot(key));
-        Assert.Same((byte[]?)prefix, (byte[]?)ServerSelectionStrategy.GetHashTagPrefix(slot));
     }
 }

--- a/tests/StackExchange.Redis.Tests/ServerEndPointClusterProbeUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/ServerEndPointClusterProbeUnitTests.cs
@@ -29,12 +29,7 @@ public class ServerEndPointClusterProbeUnitTests
         Assert.Equal(RedisCommand.EXISTS, message.Command);
         Assert.Equal(targetSlot, message.GetHashSlot(connection.ServerSelectionStrategy));
         var key = endpoint.GetTracerKey();
-        var keyBytes = (byte[]?)key;
-        var prefixBytes = (byte[]?)ServerSelectionStrategy.GetHashTagPrefix(targetSlot);
-        Assert.NotNull(keyBytes);
-        Assert.NotNull(prefixBytes);
-        Assert.True(keyBytes.Take(prefixBytes.Length).SequenceEqual(prefixBytes));
-        Assert.True(keyBytes.Skip(keyBytes.Length - connection.UniqueId.Length).SequenceEqual(connection.UniqueId));
+        Assert.Equal(ServerSelectionStrategy.CreateKeyForSlot(targetSlot, connection.UniqueId), key);
     }
 
     [Theory]

--- a/tests/StackExchange.Redis.Tests/ServerEndPointClusterProbeUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/ServerEndPointClusterProbeUnitTests.cs
@@ -1,12 +1,42 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using StackExchange.Redis.Server;
 using Xunit;
 
 namespace StackExchange.Redis.Tests;
 
 public class ServerEndPointClusterProbeUnitTests
 {
+    [Fact]
+    public async Task AutoConfigureSkipsKeyProbesWhenClusterTopologyKnown()
+    {
+        const string tieBreakerKey = "cluster-tie-breaker";
+        using var server = new RecordingServer { ServerType = ServerType.Cluster };
+        var config = server.GetClientConfig(defaultOnly: true);
+        var commands = server.GetCommands();
+        commands.Remove(nameof(RedisCommand.INFO));
+        config.CommandMap = CommandMap.Create(commands);
+        config.Protocol = RedisProtocol.Resp2;
+        config.TieBreaker = tieBreakerKey;
+
+        await using var connection = await ConnectionMultiplexer.ConnectAsync(config);
+        var endpoint = connection.GetServerEndPoint(server.DefaultEndPoint);
+        Assert.NotNull(await connection.GetServer(server.DefaultEndPoint).ClusterNodesAsync());
+        Assert.Equal(ServerType.Cluster, endpoint.ServerType);
+        Assert.NotNull(endpoint.ClusterConfiguration?[endpoint.EndPoint]);
+        endpoint.RoleKnownFromHello = false;
+        server.ClearRecorded();
+
+        await endpoint.AutoConfigureAsync(null);
+        await connection.GetDatabase().PingAsync();
+
+        Assert.DoesNotContain(server.Recorded("GET"), args => args.Contains(tieBreakerKey, StringComparer.Ordinal));
+        Assert.DoesNotContain(server.Recorded("SET"), args => args.Contains("replica_read_only", StringComparer.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public async Task ExistsTracerUsesOwnedClusterSlot()
     {
@@ -32,10 +62,8 @@ public class ServerEndPointClusterProbeUnitTests
         Assert.Equal(ServerSelectionStrategy.CreateKeyForSlot(targetSlot, connection.UniqueId), key);
     }
 
-    [Theory]
-    [InlineData(ServerType.Standalone)]
-    [InlineData(ServerType.Cluster)]
-    public async Task ExistsTracerUsesPlainKeyWithoutKnownOwnedSlots(ServerType serverType)
+    [Fact]
+    public async Task ExistsTracerUsesPlainKeyWithoutKnownOwnedSlots()
     {
         using var server = new InProcessTestServer();
         var config = server.GetClientConfig(defaultOnly: true);
@@ -46,9 +74,9 @@ public class ServerEndPointClusterProbeUnitTests
         config.CommandMap = CommandMap.Create(commands);
 
         await using var connection = await ConnectionMultiplexer.ConnectAsync(config);
-        var endpoint = new ServerEndPoint(connection, new IPEndPoint(IPAddress.Loopback, 12345))
+        using var endpoint = new ServerEndPoint(connection, new IPEndPoint(IPAddress.Loopback, 12345))
         {
-            ServerType = serverType,
+            ServerType = ServerType.Standalone,
         };
 
         var message = endpoint.GetTracerMessage(checkResponse: true);
@@ -57,5 +85,97 @@ public class ServerEndPointClusterProbeUnitTests
         Assert.Equal(RedisCommand.EXISTS, message.Command);
         Assert.Equal(ServerSelectionStrategy.GetHashSlot((RedisKey)connection.UniqueId), message.GetHashSlot(clusterStrategy));
         Assert.Equal(connection.UniqueId, (byte[]?)endpoint.GetTracerKey());
+    }
+
+    [Fact]
+    public async Task ExistsTracerUsesPlainKeyWhileClusterTopologyIsNotKnown()
+    {
+        using var server = new InProcessTestServer();
+        var config = server.GetClientConfig(defaultOnly: true);
+        var commands = server.GetCommands();
+        commands.Remove(nameof(RedisCommand.ECHO));
+        commands.Remove(nameof(RedisCommand.PING));
+        commands.Remove(nameof(RedisCommand.TIME));
+        config.CommandMap = CommandMap.Create(commands);
+
+        await using var connection = await ConnectionMultiplexer.ConnectAsync(config);
+        using var endpoint = new ServerEndPoint(connection, new IPEndPoint(IPAddress.Loopback, 12345))
+        {
+            ServerType = ServerType.Cluster,
+        };
+
+        // Cluster mode can be known before the first CLUSTER NODES reply supplies this endpoint's topology.
+        Assert.Null(endpoint.ClusterConfiguration);
+        var message = endpoint.GetTracerMessage(checkResponse: true);
+        var clusterStrategy = new ServerSelectionStrategy(null) { ServerType = ServerType.Cluster };
+
+        Assert.Equal(RedisCommand.EXISTS, message.Command);
+        Assert.Equal(ServerSelectionStrategy.GetHashSlot((RedisKey)connection.UniqueId), message.GetHashSlot(clusterStrategy));
+        Assert.Equal(connection.UniqueId, (byte[]?)endpoint.GetTracerKey());
+    }
+
+    [Fact]
+    public async Task ExistsTracerOnClusterReplicaUsesPrimarySlot()
+    {
+        const int targetSlot = 1234;
+        using var server = new InProcessTestServer();
+        var config = server.GetClientConfig(defaultOnly: true);
+        var commands = server.GetCommands();
+        commands.Remove(nameof(RedisCommand.ECHO));
+        commands.Remove(nameof(RedisCommand.PING));
+        commands.Remove(nameof(RedisCommand.TIME));
+        config.CommandMap = CommandMap.Create(commands);
+
+        await using var connection = await ConnectionMultiplexer.ConnectAsync(config);
+        var primaryEndPoint = new IPEndPoint(IPAddress.Loopback, 12344);
+        var replicaEndPoint = new IPEndPoint(IPAddress.Loopback, 12345);
+        var clusterConfiguration = new ClusterConfiguration(
+            connection.ServerSelectionStrategy,
+            $"primary-id {primaryEndPoint} master - 0 0 1 connected {targetSlot}-{targetSlot}{Environment.NewLine}" +
+            $"replica-id {replicaEndPoint} replica primary-id 0 0 2 connected",
+            replicaEndPoint);
+        using var endpoint = new ServerEndPoint(connection, replicaEndPoint)
+        {
+            ServerType = ServerType.Cluster,
+            IsReplica = true,
+        };
+        endpoint.SetClusterConfiguration(clusterConfiguration);
+        var replicaNode = clusterConfiguration[replicaEndPoint];
+
+        Assert.NotNull(replicaNode);
+        Assert.Empty(replicaNode.Slots);
+        Assert.Equal(targetSlot, replicaNode.Parent?.Slots[0].From);
+        Assert.Equal(targetSlot, endpoint.GetServableSlot());
+
+        var message = endpoint.GetTracerMessage(checkResponse: true);
+        var clusterStrategy = new ServerSelectionStrategy(null) { ServerType = ServerType.Cluster };
+
+        Assert.Equal(RedisCommand.EXISTS, message.Command);
+        Assert.Equal(targetSlot, message.GetHashSlot(clusterStrategy));
+        Assert.Equal(ServerSelectionStrategy.CreateKeyForSlot(targetSlot, connection.UniqueId), endpoint.GetTracerKey());
+    }
+
+    private sealed class RecordingServer : InProcessTestServer
+    {
+        private readonly ConcurrentQueue<(string Command, string[] Args)> _commands = new();
+
+        public override TypedRedisValue Execute(RedisClient client, in RedisRequest request)
+        {
+            var args = new string[Math.Max(request.Count - 1, 0)];
+            for (int i = 0; i < args.Length; i++)
+            {
+                args[i] = request.GetString(i + 1);
+            }
+            _commands.Enqueue((request.GetString(0).ToUpperInvariant(), args));
+            return base.Execute(client, in request);
+        }
+
+        public void ClearRecorded()
+        {
+            while (_commands.TryDequeue(out _)) { }
+        }
+
+        public string[][] Recorded(string command)
+            => _commands.Where(x => x.Command == command).Select(x => x.Args).ToArray();
     }
 }

--- a/tests/StackExchange.Redis.Tests/ServerEndPointClusterProbeUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/ServerEndPointClusterProbeUnitTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+public class ServerEndPointClusterProbeUnitTests
+{
+    [Fact]
+    public async Task ExistsTracerUsesOwnedClusterSlot()
+    {
+        using var server = new InProcessTestServer { ServerType = ServerType.Cluster };
+        var config = server.GetClientConfig(defaultOnly: true);
+        var commands = server.GetCommands();
+        commands.Remove(nameof(RedisCommand.ECHO));
+        commands.Remove(nameof(RedisCommand.PING));
+        commands.Remove(nameof(RedisCommand.TIME));
+        config.CommandMap = CommandMap.Create(commands);
+
+        await using var connection = await ConnectionMultiplexer.ConnectAsync(config);
+        var endpoint = connection.GetServerEndPoint(server.DefaultEndPoint);
+        var node = endpoint.ClusterConfiguration?.Nodes.Single(x => x.EndPoint?.Equals(endpoint.EndPoint) == true);
+        Assert.NotNull(node);
+        var targetSlot = node.Slots[0].From;
+
+        var message = endpoint.GetTracerMessage(checkResponse: true);
+
+        Assert.Equal(RedisCommand.EXISTS, message.Command);
+        Assert.Equal(targetSlot, message.GetHashSlot(connection.ServerSelectionStrategy));
+        var key = endpoint.GetTracerKey();
+        var keyBytes = (byte[]?)key;
+        var prefixBytes = (byte[]?)ServerSelectionStrategy.GetHashTagPrefix(targetSlot);
+        Assert.NotNull(keyBytes);
+        Assert.NotNull(prefixBytes);
+        Assert.True(keyBytes.Take(prefixBytes.Length).SequenceEqual(prefixBytes));
+        Assert.True(keyBytes.Skip(keyBytes.Length - connection.UniqueId.Length).SequenceEqual(connection.UniqueId));
+    }
+
+    [Theory]
+    [InlineData(ServerType.Standalone)]
+    [InlineData(ServerType.Cluster)]
+    public async Task ExistsTracerUsesPlainKeyWithoutKnownOwnedSlots(ServerType serverType)
+    {
+        using var server = new InProcessTestServer();
+        var config = server.GetClientConfig(defaultOnly: true);
+        var commands = server.GetCommands();
+        commands.Remove(nameof(RedisCommand.ECHO));
+        commands.Remove(nameof(RedisCommand.PING));
+        commands.Remove(nameof(RedisCommand.TIME));
+        config.CommandMap = CommandMap.Create(commands);
+
+        await using var connection = await ConnectionMultiplexer.ConnectAsync(config);
+        var endpoint = new ServerEndPoint(connection, new IPEndPoint(IPAddress.Loopback, 12345))
+        {
+            ServerType = serverType,
+        };
+
+        var message = endpoint.GetTracerMessage(checkResponse: true);
+        var clusterStrategy = new ServerSelectionStrategy(null) { ServerType = ServerType.Cluster };
+
+        Assert.Equal(RedisCommand.EXISTS, message.Command);
+        Assert.Equal(ServerSelectionStrategy.GetHashSlot((RedisKey)connection.UniqueId), message.GetHashSlot(clusterStrategy));
+        Assert.Equal(connection.UniqueId, (byte[]?)endpoint.GetTracerKey());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2970.

On OSS Redis Cluster, the internal discovery/keep-alive probe messages sent by `ServerEndPoint` (the `replica_read_only` SET fallback, the tie-breaker GET, and the `EXISTS` tracer fallback) are written directly to a specific node's connection with `CommandFlags.NoRedirect`, bypassing `ServerSelectionStrategy`'s slot-aware routing. If the probe key's hash slot isn't owned by that node, the server replies `MOVED` instead of the expected reply, and because `NoRedirect` is set the client never follows it — so the probe silently fails on cluster.

- `AutoConfigureAsync`: skip the `SET $uniqueid$ replica_read_only PX 1 NX` fallback once cluster topology (`CLUSTER NODES`) already tells us our role — it's both redundant and slot-unsafe there.
- `AutoConfigureAsync`: skip the tie-breaker `GET` fallback on cluster, where a tie-breaker key isn't meaningful.
- `GetTracerMessage`: when ECHO/PING/TIME are all disabled and we fall back to `EXISTS`, build the key with a hash-tag targeting a slot this endpoint actually owns (reusing the existing `ServerSelectionStrategy.HashTags` cache), so the probe always lands on a slot the node itself serves.

Standalone/Twemproxy/Envoyproxy/Sentinel behavior is unchanged, as is behavior when cluster topology isn't known yet (falls back to the prior plain-key behavior, matching current best-effort semantics).

Note: this is unrelated to #3175/#2968, which addressed a different problem (ACL key-pattern restrictions breaking the replica-detection probe) — this change is additive to that fix, not a replacement.

## Test plan

- [x] `dotnet build Build.csproj -c Release` — 0 errors, 0 warnings
- [x] New unit tests: `HashTagUnitTests.TestHashTagPrefixTargetsSlot` (slots 0, 1, 8191, 16383) and `ServerEndPointClusterProbeUnitTests` (tracer key selection with/without known owned slots) — all pass
- [x] Verified pre-existing/unrelated failures (`MultiPrimaryTests.TestMultiWithTiebreak`, requires a live standalone/failover Redis server not available in this sandbox) are present identically on `main` before this change