### PR TITLE
Maintenance notifications: relax timeouts, and read the cluster delta (D4, part of D5)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -100,6 +100,11 @@ The `ConfigurationOptions` object has a wide range of properties, all of which a
 | setlib={bool}          | `SetClientLibrary`     | `true`                       | Whether to attempt to use `CLIENT SETINFO` to set the library name/version on the connection              |
 | protocol={string}      | `Protocol`             | `null`                       | Redis protocol to use; see section below                                                                  |
 | highIntegrity={bool}   | `HighIntegrity`        | `false`                      | High integrity (incurs overhead) sequence checking on every command; see section below                    |
+| defaults={string}      | `Defaults`             | `null`                       | Selects a named defaults provider; see section below                                                      |
+| maintNotifications={string} | `MaintenanceNotifications` | `disabled`           | Whether to ask servers for maintenance notifications; see section below                                    |
+| maintRelaxedTimeout={int}   | `MaintenanceRelaxedTimeout` | `10`                | **Seconds** that command timeouts are relaxed to during announced maintenance; see section below           |
+| maintRelaxedWindowMax={int} | `MaintenanceRelaxedWindowMax` | `30`              | **Seconds** a relaxed window may last at most; see section below                                          |
+| maintPostEventRelaxed={int} | `MaintenancePostEventRelaxedDuration` | `20`      | **Seconds** timeouts stay relaxed after maintenance completes; see section below                           |
 
 Additional code-only options:
 - LoggerFactory (`ILoggerFactory`) - Default: `null`
@@ -286,6 +291,57 @@ config.ReconnectRetryPolicy = new LinearRetry(5000);
 //5	        5000
 //6	        5000
 ```
+
+## Defaults providers
+
+Some settings have sensible values that depend on *what you are connecting to* rather than on what you want, so
+the library keeps them in a provider and consults it for anything you have not set explicitly. Providers are
+normally chosen automatically by looking at the endpoints - an `*.redis.cache.windows.net` host selects the
+Azure provider, and so on - and you can select one explicitly instead:
+
+```
+myserver:6379,defaults=enterprise
+```
+
+The names are `azure`, `amr` (Azure Managed Redis), `rediscloud` and `enterprise` (a self-managed Redis
+Enterprise deployment). The last one exists because it cannot be detected: a self-managed cluster has whatever
+DNS its operator gave it, so there is nothing to recognize. It is also the right choice for a hosted deployment
+reached behind private DNS, a CNAME or a proxy, where the endpoint no longer looks like what it is.
+
+A provider chosen explicitly appears in `ToString()`; one that was merely inferred from the endpoints does not,
+since writing it out would turn a guess into a decision. Custom providers (assigned in code, via
+`ConfigurationOptions.Defaults`, or registered with `DefaultOptionsProvider.AddProvider`) work exactly as
+before; they can additionally be named in a configuration string if they override `Name`.
+
+## Maintenance notifications
+
+Redis Enterprise and Redis Cloud can warn a connected client *before* a disruptive event - a shard migration, a
+failover, or an endpoint being replaced - so the client can act ahead of it rather than discover it by way of a
+broken connection. This requires RESP3, and the client asks for it per connection:
+
+| Mode | Behaviour |
+| --- | --- |
+| `disabled` | Never ask. The default, because most servers have never heard of the request. |
+| `auto` | Ask, and carry on if the server refuses or the connection ends up RESP2. Safe against a mixture of servers, and what most callers want. |
+| `enabled` | **Required**: ask, and reject the connection unless notifications are live. Only point this at a deployment you know supports them. |
+
+Note that `enabled` means *required*, not merely *on* - it is the cross-client name for that mode, and it will
+refuse a connection that cannot deliver notifications, including any RESP2 connection. The `amr`, `rediscloud`
+and `enterprise` providers select `auto` for you, so on those deployments you need not set anything.
+
+While a disruption has been announced, command timeouts are relaxed - raised to `maintRelaxedTimeout`, never
+lowered, so a caller with a more generous timeout keeps it. The window ends when the server says the disruption
+finished, and then stays relaxed for `maintPostEventRelaxed` longer, because completion is exactly when every
+other client that received the same notification comes back. `maintRelaxedWindowMax` bounds a window whose
+closing notification never arrives. Only *command* timeouts are affected: keep-alive and connection-failure
+detection are untouched, so a server that dies mid-maintenance is still noticed on the usual schedule.
+
+These durations are in **seconds**, unlike every other timeout here, because those are the units the
+cross-client specification names for them.
+
+Receiving a notification raises `ConnectionMultiplexer.ServerMaintenanceEvent` with a `PushMaintenanceEvent`,
+and a timeout or connection fault that happened during an announced disruption carries a `MaintenanceType`
+saying so.
 
 ## Redis protocol
 

--- a/docs/exp/SER010.md
+++ b/docs/exp/SER010.md
@@ -35,6 +35,16 @@ divergence: the cross-client spec only calls for interrupting the connection whe
 whereas we extend that to the RESP2 cases above, on the grounds that a required feature which cannot
 possibly be delivered is the same failure either way.
 
+## A deployment prerequisite worth knowing
+
+On Redis Enterprise there are *two* switches, and they are easy to conflate. A **cluster-level flag** decides
+whether the subcommand exists at all - `client_maint_notifications` for proxy-routed databases,
+`oss_cluster_client_maint_notifications` for `oss_cluster` ones - and the **per-connection opt-in** this option
+controls asks one connection to receive them. A cluster running a supporting version with the flag off will
+refuse `CLIENT MAINT_NOTIFICATIONS ON`, which `Auto` absorbs silently and `Enabled` turns into a refused
+connection. So if `Enabled` is rejecting connections against a deployment you believe supports the feature,
+check the cluster flag before suspecting the client.
+
 If you accept the above, you can suppress this warning by adding the following to your `csproj` file:
 
 ```xml

--- a/src/StackExchange.Redis/Availability/FaultContext.cs
+++ b/src/StackExchange.Redis/Availability/FaultContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using RESPite;
 
@@ -39,11 +39,13 @@ public readonly struct FaultContext
                 kind = RedisErrorKind.ConnectionFault;
                 flags = connection.Flags;
                 status = connection.CommandStatus;
+                MaintenanceType = connection.MaintenanceType;
                 break;
             case RedisTimeoutException timeout:
                 kind = RedisErrorKind.Timeout;
                 flags = timeout.Flags;
                 status = timeout.Commandstatus;
+                MaintenanceType = timeout.MaintenanceType;
                 break;
             case TimeoutException:
                 kind = RedisErrorKind.Timeout;
@@ -117,6 +119,18 @@ public readonly struct FaultContext
     /// The connection failure type associated with the fault, if any.
     /// </summary>
     public ConnectionFailureType ConnectionFailureType => _connectionFailureType;
+
+    /// <summary>
+    /// The maintenance notification in force when this fault happened, if any.
+    /// </summary>
+    /// <remarks>
+    /// Useful to a circuit breaker: a fault during announced maintenance is expected and transient, and
+    /// counting it towards a trip that then withdraws a whole server is the opposite of what the notification
+    /// was for. Left to policy rather than acted on here, since "ignore faults during maintenance" is a
+    /// judgement about the deployment, not about the protocol.
+    /// </remarks>
+    [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+    public Maintenance.MaintenanceNotificationType MaintenanceType { get; }
 
     private static bool IsKnownNotApplied(RedisErrorKind kind, CommandStatus status)
     {

--- a/src/StackExchange.Redis/Availability/HealthCheckContext.cs
+++ b/src/StackExchange.Redis/Availability/HealthCheckContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using RESPite;
 
@@ -27,4 +27,16 @@ public readonly struct HealthCheckContext(IServer server, TimeSpan probeTimeout)
     /// themselves (the caller applies it), but may use it to bound any state they create.
     /// </summary>
     public TimeSpan ProbeTimeout => probeTimeout;
+
+    /// <summary>
+    /// Gets flags that a probe should include on every command it issues.
+    /// </summary>
+    /// <remarks>
+    /// This marks the traffic as a health check rather than as work a caller is waiting on. It matters because
+    /// idleness is what decides whether an endpoint can be given up: a probe that looks like caller work makes
+    /// a server appear busy precisely because we are watching it, and an endpoint that has left the deployment
+    /// then never gets retired. The built-in probes pass this; a custom probe should too, and passing it
+    /// changes nothing else about how the command is routed or queued.
+    /// </remarks>
+    public CommandFlags ProbeFlags => Message.ProbeFlag;
 }

--- a/src/StackExchange.Redis/Availability/HealthCheckProbe.Ping.cs
+++ b/src/StackExchange.Redis/Availability/HealthCheckProbe.Ping.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace StackExchange.Redis.Availability;
 
@@ -16,7 +16,7 @@ public abstract partial class HealthCheckProbe
 
         public override async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context)
         {
-            await context.Server.PingAsync();
+            await context.Server.PingAsync(context.ProbeFlags);
             return HealthCheckResult.Healthy;
         }
     }

--- a/src/StackExchange.Redis/Availability/HealthCheckProbe.StringSet.cs
+++ b/src/StackExchange.Redis/Availability/HealthCheckProbe.StringSet.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Threading.Tasks;
 
@@ -39,10 +39,10 @@ public abstract partial class HealthCheckProbe
                     key: key,
                     value: payload,
                     expiry: context.ProbeTimeout,
-                    flags: CommandFlags.FireAndForget).ForAwait();
+                    flags: CommandFlags.FireAndForget | context.ProbeFlags).ForAwait();
 
                 // release from the db if matches (otherwise, we have no clue what happened, so: leave alone)
-                var success = await database.LockReleaseAsync(key, payload).ForAwait();
+                var success = await database.LockReleaseAsync(key, payload, context.ProbeFlags).ForAwait();
                 return success ? HealthCheckResult.Healthy : HealthCheckResult.Unhealthy;
             }
             finally

--- a/src/StackExchange.Redis/ClusterConfiguration.cs
+++ b/src/StackExchange.Redis/ClusterConfiguration.cs
@@ -137,21 +137,93 @@ namespace StackExchange.Redis
 
         internal bool Includes(int hashSlot) => hashSlot >= from && hashSlot <= to;
 
-        private static bool TryParseInt16(string s, int offset, int count, out short value)
+        /// <summary>
+        /// Parses one range from within a larger string, so that a comma-separated list can be read without
+        /// allocating a substring per element.
+        /// </summary>
+        internal static bool TryParse(string value, int offset, int length, out SlotRange range)
         {
-            checked
+            range = default;
+            if (length <= 0) return false;
+
+            int dash = -1;
+            for (int i = 0; i < length; i++)
             {
-                value = 0;
-                int tmp = 0;
-                for (int i = 0; i < count; i++)
+                if (value[offset + i] == '-')
                 {
-                    char c = s[offset + i];
-                    if (c < '0' || c > '9') return false;
-                    tmp = (tmp * 10) + (c - '0');
+                    dash = i;
+                    break;
                 }
-                value = (short)tmp;
+            }
+
+            if (dash < 0)
+            {
+                if (TryParseInt16(value, offset, length, out var only))
+                {
+                    range = new SlotRange(only, only);
+                    return true;
+                }
+                return false;
+            }
+
+            if (dash != 0 && dash != length - 1
+                && TryParseInt16(value, offset, dash, out var from)
+                && TryParseInt16(value, offset + dash + 1, length - dash - 1, out var to))
+            {
+                // a reversed range is a server bug, not something to normalize silently
+                if (from > to) return false;
+                range = new SlotRange(from, to);
                 return true;
             }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Parses the comma-and-range slot form used by the maintenance notifications, e.g.
+        /// <c>123,456,789-1000</c>. Empty elements are skipped; a malformed element fails the whole list,
+        /// since a partially-read slot set is worse than none.
+        /// </summary>
+        internal static bool TryParseList(string? value, out List<SlotRange> ranges)
+        {
+            ranges = [];
+            if (string.IsNullOrEmpty(value)) return false;
+
+            int start = 0;
+            while (start <= value!.Length)
+            {
+                var comma = value.IndexOf(',', start);
+                var length = (comma < 0 ? value.Length : comma) - start;
+                if (length > 0)
+                {
+                    if (!TryParse(value, start, length, out var range)) return false;
+                    ranges.Add(range);
+                }
+
+                if (comma < 0) break;
+                start = comma + 1;
+            }
+
+            return ranges.Count != 0;
+        }
+
+        private static bool TryParseInt16(string s, int offset, int count, out short value)
+        {
+            // note this deliberately does not use `checked`: it used to, and an out-of-range slot number
+            // therefore threw OverflowException from a Try* method - reachable from the public
+            // SlotRange.TryParse and from CLUSTER NODES parsing, and now also from the maintenance
+            // notification reader, where throwing on the read loop is far worse than rejecting a value
+            value = 0;
+            int tmp = 0;
+            for (int i = 0; i < count; i++)
+            {
+                char c = s[offset + i];
+                if (c < '0' || c > '9') return false;
+                tmp = (tmp * 10) + (c - '0');
+                if (tmp > short.MaxValue) return false; // as soon as it cannot fit, stop
+            }
+            value = (short)tmp;
+            return true;
         }
 
         int IComparable.CompareTo(object? obj) => obj is SlotRange sRange ? CompareTo(sRange) : -1;

--- a/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
+++ b/src/StackExchange.Redis/Configuration/DefaultOptionsProvider.cs
@@ -351,6 +351,35 @@ namespace StackExchange.Redis.Configuration
         public virtual MaintenanceNotificationMode MaintenanceNotifications => MaintenanceNotificationMode.Disabled;
 
         /// <summary>
+        /// Gets the value command timeouts are relaxed to during an announced disruption; 10 seconds, as the
+        /// notification contract prescribes.
+        /// </summary>
+        [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+        public virtual TimeSpan MaintenanceRelaxedTimeout => TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Gets the longest a relaxed window may last, or <c>null</c> to derive it as three times the
+        /// <em>effective</em> <see cref="ConfigurationOptions.MaintenanceRelaxedTimeout"/>.
+        /// </summary>
+        /// <remarks>
+        /// Deriving is the default because the two have to stay coherent: a cap below the timeout it bounds is
+        /// nonsense, and it is the *configured* relaxed timeout that matters, which this type cannot see.
+        /// At the prescribed 10 seconds that gives 30 - the contract caps the <c>MOVING</c> budget at 15, so
+        /// there is ample room for a legitimate window while a stuck one is bounded to half a minute. Return a
+        /// value here to pin it regardless of the relaxed timeout.
+        /// </remarks>
+        [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+        public virtual TimeSpan? MaintenanceRelaxedWindowMax => null;
+
+        /// <summary>
+        /// Gets how long timeouts stay relaxed after a disruption reports completion, or <c>null</c> to derive
+        /// it as twice the <em>effective</em> <see cref="ConfigurationOptions.MaintenanceRelaxedTimeout"/>
+        /// (which matches go-redis at the prescribed default).
+        /// </summary>
+        [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+        public virtual TimeSpan? MaintenancePostEventRelaxedDuration => null;
+
+        /// <summary>
         /// Gets whether to enable TCP keep-alive when appropriate (endpoint- and platform-dependent).
         /// </summary>
         public virtual bool TcpKeepAlive => true;

--- a/src/StackExchange.Redis/ConfigurationOptions.cs
+++ b/src/StackExchange.Redis/ConfigurationOptions.cs
@@ -91,6 +91,31 @@ namespace StackExchange.Redis
                 return tmp;
             }
 
+            /// <summary>
+            /// Parses one of the maintenance durations, which are expressed in <em>seconds</em> - the unit the
+            /// cross-client contract uses for <c>maintRelaxedTimeout</c>, so a documented value can be pasted
+            /// between clients.
+            /// </summary>
+            /// <remarks>
+            /// Seconds is the odd one out in this file, where every other timeout is milliseconds, and the
+            /// mistake is silent in one direction: a caller who assumes milliseconds and writes 30000 would
+            /// otherwise get an eight-hour relaxed timeout. Hence the upper bound, whose message names the
+            /// unit - it exists to turn that into a diagnosable error rather than a mystery.
+            /// </remarks>
+            internal static TimeSpan ParseMaintenanceSeconds(string key, string value)
+            {
+                const int MaxSeconds = 600;
+                if (!Format.TryParseInt32(value, out int seconds) || seconds < 0)
+                {
+                    throw new ArgumentOutOfRangeException(key, $"Keyword '{key}' requires a non-negative integer number of seconds; the value '{value}' is not valid.");
+                }
+                if (seconds > MaxSeconds)
+                {
+                    throw new ArgumentOutOfRangeException(key, $"Keyword '{key}' is expressed in seconds, and {seconds}s exceeds the maximum of {MaxSeconds}s; note that this option is not in milliseconds.");
+                }
+                return TimeSpan.FromSeconds(seconds);
+            }
+
             internal static SslProtocols ParseSslProtocols(string key, string? value)
             {
                 // Flags expect commas as separators, but we need to use '|' since commas are already used in the connection string to mean something else
@@ -145,6 +170,9 @@ namespace StackExchange.Redis
                 Protocol = "protocol",
                 Defaults = "defaults",
                 MaintenanceNotifications = "maintNotifications",
+                MaintenanceRelaxedTimeout = "maintRelaxedTimeout",
+                MaintenanceRelaxedWindowMax = "maintRelaxedWindowMax",
+                MaintenancePostEventRelaxedDuration = "maintPostEventRelaxed",
                 HighIntegrity = "highIntegrity",
                 TcpKeepAlive = "tcpKeepAlive";
 
@@ -184,6 +212,9 @@ namespace StackExchange.Redis
                 Protocol,
                 Defaults,
                 MaintenanceNotifications,
+                MaintenanceRelaxedTimeout,
+                MaintenanceRelaxedWindowMax,
+                MaintenancePostEventRelaxedDuration,
                 HighIntegrity,
                 TcpKeepAlive,
             }.ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
@@ -241,6 +272,9 @@ namespace StackExchange.Redis
             AllowSimulateConnectionFailure = 1UL << 34,
             MaintenanceNotificationsHasValue = 1UL << 35,
             DefaultsHasValue = 1UL << 36,
+            MaintenanceRelaxedTimeoutHasValue = 1UL << 37,
+            MaintenanceRelaxedWindowMaxHasValue = 1UL << 38,
+            MaintenancePostEventRelaxedDurationHasValue = 1UL << 39,
         }
 
         private OptionFlags optionFlags;
@@ -267,6 +301,7 @@ namespace StackExchange.Redis
 
         private RedisProtocol _protocol;
         private MaintenanceNotificationMode _maintenanceNotifications;
+        private TimeSpan _maintenanceRelaxedTimeout, _maintenanceRelaxedWindowMax, _maintenancePostEventRelaxedDuration;
 
         private bool HasValue(OptionFlags hasValue) => (optionFlags & hasValue) != 0;
 
@@ -1038,6 +1073,9 @@ namespace StackExchange.Redis
             LibraryName = LibraryName,
             _protocol = _protocol,
             _maintenanceNotifications = _maintenanceNotifications,
+            _maintenanceRelaxedTimeout = _maintenanceRelaxedTimeout,
+            _maintenanceRelaxedWindowMax = _maintenanceRelaxedWindowMax,
+            _maintenancePostEventRelaxedDuration = _maintenancePostEventRelaxedDuration,
             heartbeatInterval = heartbeatInterval,
             WriteMode = WriteMode,
             CircuitBreaker = CircuitBreaker,
@@ -1135,6 +1173,9 @@ namespace StackExchange.Redis
             // the string, or re-parsing would pin a choice that was only ever a guess from the endpoints
             if (HasValue(OptionFlags.DefaultsHasValue) && defaultOptions?.Name is { } defaultsName) Append(sb, OptionKeys.Defaults, defaultsName);
             if (HasValue(OptionFlags.MaintenanceNotificationsHasValue)) Append(sb, OptionKeys.MaintenanceNotifications, _maintenanceNotifications.ToString());
+            if (HasValue(OptionFlags.MaintenanceRelaxedTimeoutHasValue)) Append(sb, OptionKeys.MaintenanceRelaxedTimeout, FormatMaintenanceSeconds(_maintenanceRelaxedTimeout));
+            if (HasValue(OptionFlags.MaintenanceRelaxedWindowMaxHasValue)) Append(sb, OptionKeys.MaintenanceRelaxedWindowMax, FormatMaintenanceSeconds(_maintenanceRelaxedWindowMax));
+            if (HasValue(OptionFlags.MaintenancePostEventRelaxedDurationHasValue)) Append(sb, OptionKeys.MaintenancePostEventRelaxedDuration, FormatMaintenanceSeconds(_maintenancePostEventRelaxedDuration));
             Append(sb, OptionKeys.TcpKeepAlive, OptionFlags.TcpKeepAliveHasValue, OptionFlags.TcpKeepAliveValue);
             if (Tunnel is { IsInbuilt: true } tunnel)
             {
@@ -1251,6 +1292,7 @@ namespace StackExchange.Redis
             Tunnel = null;
             _protocol = default;
             _maintenanceNotifications = default;
+            _maintenanceRelaxedTimeout = _maintenanceRelaxedWindowMax = _maintenancePostEventRelaxedDuration = default;
             WriteMode = default;
             CircuitBreaker = null;
             RetryPolicy = null;
@@ -1413,6 +1455,15 @@ namespace StackExchange.Redis
                         case OptionKeys.MaintenanceNotifications:
                             SetWithValue(OptionFlags.MaintenanceNotificationsHasValue, ref _maintenanceNotifications, OptionKeys.ParseMaintenanceNotifications(key, value));
                             break;
+                        case OptionKeys.MaintenanceRelaxedTimeout:
+                            SetWithValue(OptionFlags.MaintenanceRelaxedTimeoutHasValue, ref _maintenanceRelaxedTimeout, OptionKeys.ParseMaintenanceSeconds(key, value));
+                            break;
+                        case OptionKeys.MaintenanceRelaxedWindowMax:
+                            SetWithValue(OptionFlags.MaintenanceRelaxedWindowMaxHasValue, ref _maintenanceRelaxedWindowMax, OptionKeys.ParseMaintenanceSeconds(key, value));
+                            break;
+                        case OptionKeys.MaintenancePostEventRelaxedDuration:
+                            SetWithValue(OptionFlags.MaintenancePostEventRelaxedDurationHasValue, ref _maintenancePostEventRelaxedDuration, OptionKeys.ParseMaintenanceSeconds(key, value));
+                            break;
                         // Deprecated options we ignore...
                         case OptionKeys.HighPrioritySocketThreads:
                         case OptionKeys.PreserveAsyncOrder:
@@ -1482,6 +1533,68 @@ namespace StackExchange.Redis
             get => HasValue(OptionFlags.MaintenanceNotificationsHasValue) ? _maintenanceNotifications : Defaults.MaintenanceNotifications;
             set => SetWithValue(OptionFlags.MaintenanceNotificationsHasValue, ref _maintenanceNotifications, value);
         }
+
+        /// <summary>
+        /// The value command timeouts are relaxed <em>to</em> while a server has announced a disruption.
+        /// </summary>
+        /// <remarks>
+        /// This is a floor, never a reduction: the effective timeout inside a window is
+        /// <c>max(configured, this)</c>, so a caller with a generous timeout keeps it. Expressed in seconds in
+        /// a configuration string (<c>maintRelaxedTimeout=10</c>), matching the cross-client contract - note
+        /// that this is unlike every other timeout here, which are milliseconds. Only command timeouts are
+        /// relaxed; keep-alive, the heartbeat and connection-failure detection are deliberately untouched, so
+        /// a server that dies mid-maintenance is still noticed on the usual schedule.
+        /// </remarks>
+        [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+        public TimeSpan MaintenanceRelaxedTimeout
+        {
+            get => HasValue(OptionFlags.MaintenanceRelaxedTimeoutHasValue) ? _maintenanceRelaxedTimeout : Defaults.MaintenanceRelaxedTimeout;
+            set => SetWithValue(OptionFlags.MaintenanceRelaxedTimeoutHasValue, ref _maintenanceRelaxedTimeout, value);
+        }
+
+        /// <summary>
+        /// The longest a relaxed window may last, however long the server said the disruption would take.
+        /// </summary>
+        /// <remarks>
+        /// A backstop for a closing notification that never arrives, and <em>our invention</em> - the
+        /// notification contract names no upper bound. A window that never closes is worse than one that
+        /// closes early, since relaxation delays the point at which a genuinely slow server surfaces as a
+        /// timeout. Expressed in seconds in a configuration string.
+        /// </remarks>
+        [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+        public TimeSpan MaintenanceRelaxedWindowMax
+        {
+            get => HasValue(OptionFlags.MaintenanceRelaxedWindowMaxHasValue)
+                ? _maintenanceRelaxedWindowMax
+                : Defaults.MaintenanceRelaxedWindowMax ?? Multiply(MaintenanceRelaxedTimeout, 3);
+            set => SetWithValue(OptionFlags.MaintenanceRelaxedWindowMaxHasValue, ref _maintenanceRelaxedWindowMax, value);
+        }
+
+        /// <summary>
+        /// How long to keep timeouts relaxed after a disruption reports that it has finished.
+        /// </summary>
+        /// <remarks>
+        /// Also <em>our invention</em>. A closing notification means the server-side operation completed, not
+        /// that the server is back to normal latency - and the moment after it completes is precisely when
+        /// every other client that received the same notification re-engages, so the load spike arrives
+        /// slightly after the all-clear. Does <em>not</em> apply when a window ended by hitting
+        /// <see cref="MaintenanceRelaxedWindowMax"/>: in that case nothing told us the event finished, and
+        /// extending past the backstop would defeat it. Expressed in seconds in a configuration string.
+        /// </remarks>
+        [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+        public TimeSpan MaintenancePostEventRelaxedDuration
+        {
+            get => HasValue(OptionFlags.MaintenancePostEventRelaxedDurationHasValue)
+                ? _maintenancePostEventRelaxedDuration
+                : Defaults.MaintenancePostEventRelaxedDuration ?? Multiply(MaintenanceRelaxedTimeout, 2);
+            set => SetWithValue(OptionFlags.MaintenancePostEventRelaxedDurationHasValue, ref _maintenancePostEventRelaxedDuration, value);
+        }
+
+        // TimeSpan * int is netstandard2.1+, so this is ticks arithmetic to keep the down-level TFMs building
+        private static TimeSpan Multiply(TimeSpan value, int factor) => TimeSpan.FromTicks(value.Ticks * factor);
+
+        private static string FormatMaintenanceSeconds(TimeSpan value)
+            => ((int)value.TotalSeconds).ToString(System.Globalization.CultureInfo.InvariantCulture);
 
         internal BufferedStreamWriter.WriteMode WriteMode { get; set; }
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Events.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Events.cs
@@ -88,6 +88,50 @@ public partial class ConnectionMultiplexer
     /// Raised when server indicates a maintenance event is going to happen.
     /// </summary>
     public event EventHandler<ServerMaintenanceEvent>? ServerMaintenanceEvent;
+
+    // recently-raised (type, sequence) pairs, so one logical event raises one event however many nodes told
+    // us. Small and fixed: the copies arrive within milliseconds of each other, so a handful of slots covers
+    // any realistic proxy count even with other notifications interleaved
+    private readonly (Maintenance.MaintenanceNotificationType Type, long Sequence)[] _raisedMaintenanceEvents = new (Maintenance.MaintenanceNotificationType, long)[8];
+    private int _raisedMaintenanceEventIndex;
+
+    /// <summary>
+    /// Whether this is the first time we have been told about a given maintenance event, across every
+    /// connection.
+    /// </summary>
+    /// <remarks>
+    /// Every node broadcasts a given event, and all of them carry the same sequence number - observed on
+    /// Enterprise 8.6.2, where the id identifies the event rather than the delivery. So without this, a
+    /// deployment fronted by three proxies raises three events for one migration and every consumer has to
+    /// dedupe them.
+    /// <para>
+    /// Matched on equality rather than "less than or equal", deliberately: a lagging node reporting an
+    /// *earlier* event we have not seen yet is a distinct event and must still be raised. Only an exact repeat
+    /// of something already raised is a duplicate.
+    /// </para>
+    /// <para>
+    /// Eviction is the only expiry - an entry falls out once eight further notifications have been recorded, so
+    /// nothing has to be purged on a timer and the state cannot grow. A duplicate arriving after its entry has
+    /// been evicted would be raised a second time, which is the right way round to be wrong: the copies arrive
+    /// within milliseconds of each other, so that takes a straggler behind eight intervening events.
+    /// </para>
+    /// </remarks>
+    internal bool TryClaimMaintenanceEvent(Maintenance.MaintenanceNotificationType type, long? sequence)
+    {
+        if (sequence is not { } seq) return true; // no id to match on; better a duplicate than a silence
+
+        lock (_raisedMaintenanceEvents)
+        {
+            foreach (var entry in _raisedMaintenanceEvents)
+            {
+                if (entry.Type == type && entry.Sequence == seq) return false;
+            }
+
+            _raisedMaintenanceEvents[_raisedMaintenanceEventIndex] = (type, seq);
+            _raisedMaintenanceEventIndex = (_raisedMaintenanceEventIndex + 1) % _raisedMaintenanceEvents.Length;
+            return true;
+        }
+    }
     internal void OnServerMaintenanceEvent(ServerMaintenanceEvent e) =>
         ServerMaintenanceEvent?.Invoke(this, e);
 

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Events.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Events.cs
@@ -91,8 +91,16 @@ public partial class ConnectionMultiplexer
 
     // recently-raised (type, sequence) pairs, so one logical event raises one event however many nodes told
     // us. Small and fixed: the copies arrive within milliseconds of each other, so a handful of slots covers
-    // any realistic proxy count even with other notifications interleaved
-    private readonly (Maintenance.MaintenanceNotificationType Type, long Sequence)[] _raisedMaintenanceEvents = new (Maintenance.MaintenanceNotificationType, long)[8];
+    // any realistic proxy count even with other notifications interleaved.
+    // A named struct rather than a tuple: this assembly must not reference System.ValueTuple, which breaks
+    // .NET Framework consumers - see SanityChecks.ValueTupleNotReferenced.
+    private readonly struct RaisedMaintenanceEvent(Maintenance.MaintenanceNotificationType type, long sequence)
+    {
+        public readonly Maintenance.MaintenanceNotificationType Type = type;
+        public readonly long Sequence = sequence;
+    }
+
+    private readonly RaisedMaintenanceEvent[] _raisedMaintenanceEvents = new RaisedMaintenanceEvent[8];
     private int _raisedMaintenanceEventIndex;
 
     /// <summary>
@@ -127,7 +135,7 @@ public partial class ConnectionMultiplexer
                 if (entry.Type == type && entry.Sequence == seq) return false;
             }
 
-            _raisedMaintenanceEvents[_raisedMaintenanceEventIndex] = (type, seq);
+            _raisedMaintenanceEvents[_raisedMaintenanceEventIndex] = new RaisedMaintenanceEvent(type, seq);
             _raisedMaintenanceEventIndex = (_raisedMaintenanceEventIndex + 1) % _raisedMaintenanceEvents.Length;
             return true;
         }

--- a/src/StackExchange.Redis/ConnectionMultiplexer.Events.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Events.cs
@@ -89,6 +89,17 @@ public partial class ConnectionMultiplexer
     /// </summary>
     public event EventHandler<ServerMaintenanceEvent>? ServerMaintenanceEvent;
 
+    /// <summary>
+    /// How host names are resolved during a maintenance handoff.
+    /// </summary>
+    /// <remarks>
+    /// A seam rather than a call to <see cref="System.Net.Dns"/> directly, because no in-process fake can move a
+    /// DNS record: the handoff's whole decision turns on the answer *changing*, and the only way to test that
+    /// deterministically is to supply the answers. Defaults to real DNS.
+    /// </remarks>
+    internal Func<string, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Net.IPAddress[]>> AddressResolver { get; set; }
+        = Maintenance.AdvertisedAddressProbe.DefaultResolveAsync;
+
     // recently-raised (type, sequence) pairs, so one logical event raises one event however many nodes told
     // us. Small and fixed: the copies arrive within milliseconds of each other, so a handful of slots covers
     // any realistic proxy count even with other notifications interleaved.

--- a/src/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -2492,7 +2492,25 @@ namespace StackExchange.Redis
                             throw GetException(result, message, server);
                         }
 
-                        if (Monitor.Wait(source, TimeoutMilliseconds))
+                        // Unlike the async sweeps, which re-read the effective timeout on every heartbeat, a
+                        // sync caller commits to a duration when it parks - so if maintenance relaxation
+                        // begins while we are waiting, we have to notice by re-waiting rather than failing at
+                        // the original deadline. Without this a sync caller in flight when a MIGRATING
+                        // arrives times out at the strict timeout while its async neighbour is relaxed.
+                        var watch = ValueStopwatch.StartNew();
+                        bool completed = Monitor.Wait(source, server?.GetEffectiveTimeoutMilliseconds(TimeoutMilliseconds) ?? TimeoutMilliseconds);
+                        while (!completed)
+                        {
+                            var elapsed = watch.ElapsedMilliseconds;
+                            var revised = server?.GetEffectiveTimeoutMilliseconds(TimeoutMilliseconds) ?? TimeoutMilliseconds;
+
+                            // also the path back: if a window closed while we waited, revised drops to the
+                            // configured value and we stop
+                            if (revised <= elapsed) break;
+                            completed = Monitor.Wait(source, revised - elapsed);
+                        }
+
+                        if (completed)
                         {
                             Trace("Timely response to " + message);
                         }

--- a/src/StackExchange.Redis/Enums/ConnectionFailureType.cs
+++ b/src/StackExchange.Redis/Enums/ConnectionFailureType.cs
@@ -68,5 +68,22 @@ namespace StackExchange.Redis
         /// </summary>
         [Experimental(Experiments.GeoRedundantFailover, UrlFormat = Experiments.UrlFormat)]
         CircuitBreaker,
+
+        /// <summary>
+        /// The connection was replaced deliberately, to move off an endpoint the server announced it is
+        /// retiring.
+        /// </summary>
+        /// <remarks>
+        /// Not a fault: the connection was working, and we chose to replace it while a replacement address was
+        /// known rather than wait to be disconnected. Reported here because the alternative is worse - the
+        /// replacement raises <see cref="ConnectionMultiplexer.ConnectionRestored"/>, so without this a consumer
+        /// tracking connection state sees a restore with no matching failure, and no reason for the churn.
+        /// <para>
+        /// Consumers alerting on <see cref="ConnectionMultiplexer.ConnectionFailed"/> should filter this out:
+        /// it is expected during planned maintenance and says nothing is wrong. <see cref="CircuitBreaker"/> is
+        /// the precedent for a deliberate client action being reported this way.
+        /// </para>
+        /// </remarks>
+        MaintenanceHandoff,
     }
 }

--- a/src/StackExchange.Redis/ExceptionFactory.cs
+++ b/src/StackExchange.Redis/ExceptionFactory.cs
@@ -319,14 +319,19 @@ namespace StackExchange.Redis
             // If we're from a backlog timeout scenario, we log a more intuitive connection exception for the timeout...because the timeout was a symptom
             // and we have a more direct cause: we had no connection to send it on.
             var msgFlags = message?.Flags ?? CommandFlags.CommandRetryNever;
+            // if the server had announced a disruption, say so on the fault: "timeout" and "timeout during an
+            // announced failover" call for very different reactions from whoever reads the log
+            var maintenanceType = server?.ActiveMaintenanceType ?? Maintenance.MaintenanceNotificationType.None;
             Exception ex = logConnectionException && lastConnectionException is not null
                 ? new RedisConnectionException(lastConnectionException.FailureType, msgFlags, sb.ToString(), lastConnectionException, message?.Status ?? CommandStatus.Unknown)
                 {
                     HelpLink = TimeoutHelpLink,
+                    MaintenanceType = maintenanceType,
                 }
                 : new RedisTimeoutException(msgFlags, sb.ToString(), message?.Status ?? CommandStatus.Unknown)
                 {
                     HelpLink = TimeoutHelpLink,
+                    MaintenanceType = maintenanceType,
                 };
             CopyDataToException(data, ex);
 

--- a/src/StackExchange.Redis/Maintenance/AdvertisedAddressProbe.cs
+++ b/src/StackExchange.Redis/Maintenance/AdvertisedAddressProbe.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Maintenance;
+
+/// <summary>
+/// Asks DNS the two questions a handoff needs: what replaces the address we are leaving, and are we still
+/// advertised at all.
+/// </summary>
+/// <remarks>
+/// A poll rather than a lookup, and that is the whole point. Measured on Redis Enterprise (2026-08-28), with
+/// times relative to the notification: the server-side endpoint moves at +8.6s, DNS follows at +9.7s and +4.4s
+/// across two runs, and the sockets close at +18.4s and +16.6s - against a declared 15s grace and a 5s record
+/// TTL. So resolving immediately returns <em>the address being retired</em>, in every run observed, and a
+/// client that treats the first answer as authoritative hands off to the node it was told to leave.
+/// <para>
+/// <b>DNS is not guaranteed to win the race.</b> On a second cluster the same notification with the same 15s
+/// grace saw the socket close at +15.7s and DNS update at +18.7s - three seconds <em>after</em> the close. So
+/// there are three outcomes here, not two, and the third is a normal one: the record may still be stale when
+/// the window runs out, and the only thing left is to reconnect after the close and resolve then. Do not
+/// "simplify" the null return away.
+/// </para>
+/// <para>
+/// There is no way to observe the intermediate state from outside: the endpoint has moved server-side well
+/// before DNS reflects it, and nothing tells a client which of those has happened. Probing until the answer
+/// changes is the only mechanism available, and the short TTL is what makes it work - several attempts fit
+/// inside the window.
+/// </para>
+/// <para>
+/// The rule is "take any address that is not the one being retired". Note it is deliberately *not* "prefer an
+/// address that has newly appeared", even though a <c>MOVING</c> implies one exists - it is emitted when the
+/// connection's own proxy *leaves* the endpoint's address set **and** the set gains a member (established
+/// across thirteen observations: a pure reduction takes the proxy away without announcing anything, and a pure
+/// widening adds addresses while leaving the connection's proxy in place, which is equally silent). A live
+/// sibling is at least as good a target as a newly joined node and is available *now*, whereas the new node
+/// only becomes visible when the record updates - which can be after the socket has already closed. Preferring
+/// the newcomer would mean waiting for it, and waiting is the thing to avoid. The one case where it would pay
+/// is a rolling operation, where the sibling we step to may take its own turn later; that costs one further
+/// handoff, bounded at one per connection per operation, which is cheaper than a lost window.
+/// </para>
+/// <para>
+/// This rule is also doing more work than it looks. A Redis Cloud hostname usually carries <em>several</em> A records - measured 2026-08-28: 2 for
+/// <c>all-nodes</c>, 3 for <c>all-master-shards</c>, 1 for <c>single</c>, all on a 5s TTL - and the count
+/// follows actual proxy *placement* rather than the policy name, so a multi-proxy database whose shards happen
+/// to share a node still resolves to one address. With several records the first resolution already names a
+/// live sibling proxy, so this returns immediately and steps sideways rather than waiting: any proxy of the
+/// same database serves the same data, so a sibling now beats the replacement in nine seconds. The poll only
+/// engages when the record names nothing but the address being retired - the single-address case, which is
+/// exactly where waiting is the only option available.
+/// </para>
+/// <para>
+/// Deliberately free of jitter, clocks-by-configuration and connection state, so that it can be tested
+/// exhaustively without a server: the caller supplies the resolver, the interval and the budget. Jitter
+/// belongs at the call site, where the existing refresh jitter lives.
+/// </para>
+/// </remarks>
+internal static class AdvertisedAddressProbe
+{
+    /// <summary>
+    /// Ordinary DNS, which is what everything but a test uses.
+    /// </summary>
+    internal static Task<IPAddress[]> DefaultResolveAsync(string host, CancellationToken cancellationToken) =>
+#if NET
+        Dns.GetHostAddressesAsync(host, cancellationToken);
+#else
+        Dns.GetHostAddressesAsync(host);
+#endif
+
+    /// <summary>
+    /// Polls DNS until it stops naming <paramref name="retiring"/>, or until the window runs out.
+    /// </summary>
+    /// <returns>
+    /// The replacement endpoint, or <c>null</c> if the window expired without DNS moving - a measured outcome
+    /// rather than a failure (see the type remarks: DNS has been seen updating three seconds after the socket
+    /// closed). The caller should then do nothing proactive: the server closes the socket, the reconnect that
+    /// follows re-resolves anyway because the endpoint is a hostname, and the relaxed timeout window covers
+    /// the gap. Guessing an address here would be strictly worse.
+    /// </returns>
+    internal static async Task<EndPoint?> ProbeAsync(
+        DnsEndPoint endpoint,
+        IPAddress retiring,
+        TimeSpan window,
+        TimeSpan pollInterval,
+        Func<string, CancellationToken, Task<IPAddress[]>> resolve,
+        Action<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (endpoint is null) throw new ArgumentNullException(nameof(endpoint));
+        if (retiring is null) throw new ArgumentNullException(nameof(retiring));
+        if (resolve is null) throw new ArgumentNullException(nameof(resolve));
+
+        // A non-positive window is not an error: a notification can arrive with nothing left of its budget
+        // (the shard notifications legitimately carry zero or negative times), and "act now" means one attempt
+        // rather than none.
+        var deadline = Environment.TickCount + (int)Math.Max(window.TotalMilliseconds, 0);
+        int attempt = 0;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            attempt++;
+
+            IPAddress[]? addresses = null;
+            try
+            {
+                addresses = await resolve(endpoint.Host, cancellationToken).ForAwait();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // a DNS blip mid-handoff is exactly when we can least afford to give up; keep trying until
+                // the window says otherwise
+                log?.Invoke($"MOVING: resolve attempt {attempt} for {endpoint.Host} failed: {ex.Message}");
+            }
+
+            if (addresses is not null)
+            {
+                IPAddress? candidate = null;
+                bool retiringStillAdvertised = false;
+                foreach (var address in addresses)
+                {
+                    if (address.Equals(retiring)) retiringStillAdvertised = true;
+                    else candidate ??= address;
+                }
+
+                if (candidate is not null)
+                {
+                    // Two operationally different outcomes, worth distinguishing in a log somebody reads while
+                    // debugging a handoff: we either stepped sideways to a proxy that was already there, or the
+                    // record itself has moved on to the replacement.
+                    log?.Invoke(retiringStillAdvertised
+                        ? $"MOVING: {endpoint.Host} still advertises {retiring}; moving to sibling {candidate} (attempt {attempt})"
+                        : $"MOVING: {endpoint.Host} now resolves to {candidate} after {attempt} attempt(s)");
+                    return new IPEndPoint(candidate, endpoint.Port);
+                }
+
+                log?.Invoke($"MOVING: {endpoint.Host} still resolves only to {retiring} (attempt {attempt}); not yet updated");
+            }
+
+            var remaining = unchecked(deadline - Environment.TickCount);
+            if (remaining <= 0)
+            {
+                log?.Invoke($"MOVING: {endpoint.Host} never stopped resolving to {retiring} within the window");
+                return null;
+            }
+
+            // never sleep past the deadline: the last attempt should land inside the window, not after it
+            var delay = (int)Math.Min(pollInterval.TotalMilliseconds, remaining);
+            if (delay > 0) await Task.Delay(delay, cancellationToken).ForAwait();
+        }
+    }
+
+    /// <summary>
+    /// Whether the address we are connected on is still one of the addresses the hostname advertises.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if still advertised, <c>false</c> if the record no longer names it, and <c>null</c> if DNS
+    /// could not be asked - which is *not* the same as "no": a resolution failure is no reason to give up a
+    /// working connection.
+    /// </returns>
+    /// <remarks>
+    /// The trigger that needs no notification, and the reason it matters is a measured gap. On a multi-proxy
+    /// database, taking a node out for maintenance announced only the data-movement pair - <c>MIGRATING</c> at
+    /// +4.3s and <c>MIGRATED</c> at +16.6s, to every proxy - and then dropped the victim from DNS at +21.4s and
+    /// closed its socket *silently* at +34.7s, while sibling connections stayed up past +90s. No
+    /// <c>MOVING</c> was ever sent.
+    /// <para>
+    /// So for thirteen seconds the condition was plainly visible to anybody who asked - our address is no
+    /// longer advertised - and the client's only other signal was the socket dying with no explanation. Asking
+    /// this question when a <c>MIGRATED</c> arrives converts that into a controlled handoff. Note
+    /// <c>MIGRATED</c> is also the notification the server *retains* and replays on connect, so a client that
+    /// arrives mid-operation gets the same prompt.
+    /// </para>
+    /// <para>
+    /// The same condition is what a support case turned on: a client kept dialling endpoints that no longer
+    /// existed for 37 hours, because nothing it could observe told it to stop. Two unrelated failures, one
+    /// detection rule.
+    /// </para>
+    /// </remarks>
+    internal static async Task<bool?> IsStillAdvertisedAsync(
+        DnsEndPoint endpoint,
+        IPAddress current,
+        Func<string, CancellationToken, Task<IPAddress[]>> resolve,
+        Action<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (endpoint is null) throw new ArgumentNullException(nameof(endpoint));
+        if (current is null) throw new ArgumentNullException(nameof(current));
+        if (resolve is null) throw new ArgumentNullException(nameof(resolve));
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await resolve(endpoint.Host, cancellationToken).ForAwait();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"{endpoint.Host}: cannot tell whether {current} is still advertised: {ex.Message}");
+            return null;
+        }
+
+        // an empty answer is "cannot tell" rather than "no": a record that momentarily resolves to nothing is
+        // a DNS problem, not an instruction to abandon a connection that is working
+        if (addresses is null || addresses.Length == 0)
+        {
+            log?.Invoke($"{endpoint.Host}: resolved to nothing; treating {current} as still advertised");
+            return null;
+        }
+
+        foreach (var address in addresses)
+        {
+            if (address.Equals(current)) return true;
+        }
+
+        log?.Invoke($"{endpoint.Host}: no longer advertises {current}; it is being taken out of service");
+        return false;
+    }
+}

--- a/src/StackExchange.Redis/Maintenance/ClusterSlotMigration.cs
+++ b/src/StackExchange.Redis/Maintenance/ClusterSlotMigration.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using RESPite;
+
+namespace StackExchange.Redis.Maintenance;
+
+/// <summary>
+/// One entry from a cluster slot-migration notification: some slots have moved, or are moving, from one node
+/// to another.
+/// </summary>
+/// <remarks>
+/// A single <c>SMIGRATED</c> describes several of these at once, and not necessarily any involving the node
+/// that sent it - every node in the cluster reports the same movements, so the sender is not implicitly the
+/// source.
+/// </remarks>
+[Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+public readonly struct ClusterSlotMigration
+{
+    internal ClusterSlotMigration(EndPoint? source, EndPoint? target, IReadOnlyList<SlotRange> slots, string? raw)
+    {
+        Source = source;
+        Target = target;
+        Slots = slots;
+        RawSlots = raw;
+    }
+
+    /// <summary>
+    /// The node the slots are moving from, or <c>null</c> if the server named it in a form that cannot be
+    /// dialled.
+    /// </summary>
+    public EndPoint? Source { get; }
+
+    /// <summary>
+    /// The node the slots are moving to, or <c>null</c> if the server named it in a form that cannot be
+    /// dialled.
+    /// </summary>
+    public EndPoint? Target { get; }
+
+    /// <summary>
+    /// The slots that are moving.
+    /// </summary>
+    public IReadOnlyList<SlotRange> Slots { get; }
+
+    /// <summary>
+    /// The slots exactly as the server expressed them, for the cases the parsed form does not survive - a
+    /// malformed list leaves <see cref="Slots"/> empty and this populated.
+    /// </summary>
+    public string? RawSlots { get; }
+
+    /// <inheritdoc/>
+    public override string ToString() => $"{Format.ToString(Source)} -> {Format.ToString(Target)}: {RawSlots}";
+}

--- a/src/StackExchange.Redis/Maintenance/MaintenanceFaultSurface.cs
+++ b/src/StackExchange.Redis/Maintenance/MaintenanceFaultSurface.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
+using RESPite;
+using StackExchange.Redis.Maintenance;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// Carries maintenance context on the faults a disruption can cause, so that a timeout during an announced
+/// migration is distinguishable from an ordinary one.
+/// </summary>
+/// <remarks>
+/// This follows the established pattern on these types - <c>Commandstatus</c> and <c>Flags</c> on
+/// <see cref="RedisTimeoutException"/>, <c>FailureType</c> on <see cref="RedisConnectionException"/> - rather
+/// than introducing an exception type nobody is catching yet. Both properties are named for the role they
+/// play, not for the type, matching <c>FailureType</c>.
+/// </remarks>
+public sealed partial class RedisTimeoutException
+{
+    /// <summary>
+    /// The maintenance notification in force when this timed out, or
+    /// <see cref="MaintenanceNotificationType.None"/> if the server had not announced anything.
+    /// </summary>
+    /// <remarks>
+    /// A value here says the server told us to expect disruption, and that the timeout you are looking at
+    /// happened inside that window - including the tail after the disruption reported completion. It does not
+    /// promise that the maintenance *caused* the timeout, only that the two coincided; that is still the most
+    /// useful thing to know when reading a log after the fact.
+    /// </remarks>
+    [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+    public MaintenanceNotificationType MaintenanceType { get; internal init; }
+}
+
+/// <inheritdoc cref="RedisTimeoutException.MaintenanceType"/>
+public sealed partial class RedisConnectionException
+{
+    /// <summary>
+    /// The maintenance notification in force when this connection faulted, or
+    /// <see cref="MaintenanceNotificationType.None"/> if the server had not announced anything.
+    /// </summary>
+    /// <remarks>
+    /// Present on this type as well as on <see cref="RedisTimeoutException"/> because a handoff that misses
+    /// its deadline surfaces either way round: as a timeout when the command was already in flight, and as a
+    /// connection fault when the endpoint went away underneath it.
+    /// </remarks>
+    [Experimental(Experiments.MaintenanceNotifications, UrlFormat = Experiments.UrlFormat)]
+    public MaintenanceNotificationType MaintenanceType { get; internal init; }
+}

--- a/src/StackExchange.Redis/Maintenance/MaintenanceHandoff.cs
+++ b/src/StackExchange.Redis/Maintenance/MaintenanceHandoff.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Maintenance;
+
+/// <summary>
+/// What to do about a <c>MOVING</c> notification.
+/// </summary>
+internal enum HandoffAction
+{
+    /// <summary>Nothing useful is available; let the server close the socket and reconnect then.</summary>
+    None,
+
+    /// <summary>Drop our connections so they re-establish against the replacement address.</summary>
+    Recycle,
+
+    /// <summary>The replacement is a different endpoint; the topology has to be re-read to find it.</summary>
+    Reconfigure,
+}
+
+/// <summary>
+/// The outcome of deciding how to hand off, and why - the reason is logged either way.
+/// </summary>
+internal readonly struct HandoffDecision(HandoffAction action, EndPoint? target, string reason)
+{
+    public HandoffAction Action { get; } = action;
+
+    public EndPoint? Target { get; } = target;
+
+    public string Reason { get; } = reason;
+
+    public override string ToString() => Target is null ? $"{Action}: {Reason}" : $"{Action} -> {Target}: {Reason}";
+}
+
+/// <summary>
+/// Decides what a <c>MOVING</c> notification means for this connection, and where to go.
+/// </summary>
+/// <remarks>
+/// Separated from the acting so that it can be tested exhaustively without a server: the caller supplies the
+/// endpoint, the address it is currently on, the announced window and a resolver, and gets back an action.
+/// <para>
+/// The dispatch turns on the *form* of the endpoint, which is the thing that decides whether a handoff is even
+/// possible - and the answer corrects an earlier assumption that <c>MOVING</c> should reuse the endpoint
+/// retirement path:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// A hostname endpoint with no named successor - the case every observed <c>MOVING</c> has been - keeps its
+/// <see cref="ServerEndPoint"/>: only the address behind the name moves. Retiring the endpoint would delete our
+/// only way of reaching the deployment. So the action is to recycle the connections once DNS has moved, which
+/// re-resolves them.
+/// </item>
+/// <item>
+/// An address endpoint with a named successor is genuinely a different endpoint, so the topology has to be
+/// re-read. Never observed: eleven routes have all carried an explicit null, including cases where the server
+/// had already chosen the replacement node. Treat this branch as code that must exist rather than code that is
+/// exercised.
+/// </item>
+/// <item>
+/// An address endpoint with no successor has nothing to re-resolve and nowhere named to go. Doing nothing is
+/// correct: the socket closes, the reconnect happens, and the relaxed window covers it.
+/// </item>
+/// </list>
+/// </remarks>
+internal static class MaintenanceHandoff
+{
+    internal static async Task<HandoffDecision> DecideAsync(
+        EndPoint endpoint,
+        EndPoint? successor,
+        IPAddress? currentAddress,
+        TimeSpan window,
+        TimeSpan pollInterval,
+        Func<string, CancellationToken, Task<IPAddress[]>> resolve,
+        Action<string>? log = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (successor is not null)
+        {
+            // Nothing is asserted about *which* endpoint: a successor may be an address we have never seen, so
+            // finding it is a topology question rather than a DNS one.
+            return new HandoffDecision(HandoffAction.Reconfigure, successor, "the server named a replacement endpoint");
+        }
+
+        if (endpoint is not DnsEndPoint dns)
+        {
+            return new HandoffDecision(
+                HandoffAction.None,
+                null,
+                $"{Format.ToString(endpoint)} is an address, not a name, and no replacement was named: nothing to re-resolve");
+        }
+
+        if (currentAddress is null)
+        {
+            // Without knowing where we are, "has it moved" is unanswerable - and guessing would mean recycling
+            // onto whatever DNS says right now, which for the first several seconds is the address being retired.
+            return new HandoffDecision(HandoffAction.None, null, "the address of the current connection is unknown");
+        }
+
+        var replacement = await AdvertisedAddressProbe.ProbeAsync(
+            dns, currentAddress, window, pollInterval, resolve, log, cancellationToken).ForAwait();
+
+        return replacement is null
+            ? new HandoffDecision(
+                HandoffAction.None,
+                null,
+                $"{dns.Host} still resolved only to {currentAddress} when the window expired")
+            : new HandoffDecision(
+                HandoffAction.Recycle,
+                replacement,
+                $"{dns.Host} now resolves to {replacement}");
+    }
+
+    /// <summary>
+    /// How long to wait before probing, so a fleet does not resolve in lockstep.
+    /// </summary>
+    /// <remarks>
+    /// A *fraction* of the announced window rather than a fixed delay, which is the difference from the refresh
+    /// jitter elsewhere. Windows are not always generous - the shard notifications have been measured announcing
+    /// two seconds - so a flat one-second jitter could spend half of one, and on a short window the right amount
+    /// of jitter is almost none. Capped as well as scaled, because a long window does not justify a long wait
+    /// when DNS has been seen moving after four seconds.
+    /// </remarks>
+    internal static TimeSpan GetJitter(TimeSpan window, Random random)
+    {
+        if (window <= TimeSpan.Zero) return TimeSpan.Zero;
+
+        var tenth = window.TotalMilliseconds / 10;
+        var capped = Math.Min(tenth, 1000);
+        return TimeSpan.FromMilliseconds(random.Next(0, (int)Math.Max(capped, 1)));
+    }
+}

--- a/src/StackExchange.Redis/Maintenance/PushMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/Maintenance/PushMaintenanceEvent.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using RESPite;
@@ -26,7 +27,8 @@ public sealed class PushMaintenanceEvent : ServerMaintenanceEvent
         TimeSpan? time,
         EndPoint? newEndPoint,
         string? payload,
-        string rawMessage)
+        string rawMessage,
+        IReadOnlyList<ClusterSlotMigration>? slotMigrations = null)
     {
         NotificationType = notificationType;
         SequenceId = sequenceId;
@@ -35,6 +37,7 @@ public sealed class PushMaintenanceEvent : ServerMaintenanceEvent
         NewEndPoint = newEndPoint;
         Payload = payload;
         RawMessage = rawMessage;
+        SlotMigrations = slotMigrations ?? [];
         if (time is { } value && value > TimeSpan.Zero)
         {
             StartTimeUtc = ReceivedTimeUtc + value;
@@ -93,6 +96,15 @@ public sealed class PushMaintenanceEvent : ServerMaintenanceEvent
     /// carried through for diagnostics rather than parsed into a model that the contract does not pin down.
     /// </remarks>
     public string? Payload { get; }
+
+    /// <summary>
+    /// For the cluster notifications, the slot movements described; empty for everything else.
+    /// </summary>
+    /// <remarks>
+    /// A notification carries several of these, and the node that sent it is not necessarily the source of
+    /// any of them - every node reports the same movements.
+    /// </remarks>
+    public IReadOnlyList<ClusterSlotMigration> SlotMigrations { get; }
 
     /// <inheritdoc/>
     public override string? ToString() => RawMessage;

--- a/src/StackExchange.Redis/Maintenance/PushMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/Maintenance/PushMaintenanceEvent.cs
@@ -69,6 +69,14 @@ public sealed class PushMaintenanceEvent : ServerMaintenanceEvent
     /// <summary>
     /// The server that sent the notification.
     /// </summary>
+    /// <remarks>
+    /// More precisely: whichever node told us first. Every node broadcasts a given event, so a three-proxy
+    /// deployment delivers one migration three times, on three connections, with the same
+    /// <see cref="SequenceId"/>. All three are acted on internally - the timeout relaxation is per-server, so
+    /// each connection genuinely has to see it - but the event is raised once, for the first arrival, and the
+    /// rest are dropped. Do not read this as "the node being maintained": for the cluster notifications it is
+    /// usually a bystander reporting someone else's movements (see <see cref="SlotMigrations"/>).
+    /// </remarks>
     public EndPoint? EndPoint { get; }
 
     /// <summary>

--- a/src/StackExchange.Redis/Maintenance/PushMaintenanceEvent.cs
+++ b/src/StackExchange.Redis/Maintenance/PushMaintenanceEvent.cs
@@ -53,9 +53,16 @@ public sealed class PushMaintenanceEvent : ServerMaintenanceEvent
     /// The sequence number the server attached to this notification.
     /// </summary>
     /// <remarks>
-    /// No specification defines what these mean beyond being a number that goes up, so treat any use of them
-    /// as heuristic; in particular, do not assume that they are contiguous, or that they are scoped the same
-    /// way across notification types.
+    /// No specification defines these, but observation does: on Enterprise 8.6.2 they are monotonic per
+    /// database, start at zero on a fresh one, are shared *across* notification types (a
+    /// <see cref="MaintenanceNotificationType.SlotMigrating"/> at 16 followed by its
+    /// <see cref="MaintenanceNotificationType.SlotMigrated"/> at 17), and carry the same value on every node
+    /// that broadcasts a given event - so they identify the event rather than the connection that delivered
+    /// it. That makes them genuinely useful for spotting a replay.
+    /// <para>
+    /// Still treat cross-deployment use as heuristic: this is one build of one product, and nothing obliges a
+    /// different implementation to behave the same way.
+    /// </para>
     /// </remarks>
     public long SequenceId { get; }
 

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -62,7 +62,10 @@ namespace StackExchange.Redis
             NoFlushFlag = (CommandFlags)1024,
             // "server specific" (bit 18): tied to a specific endpoint, never retry elsewhere. Not (yet) a
             // public CommandFlags member - see the note on the hidden bit-18 value in CommandFlags.cs.
-            CommandServerSpecific = (CommandFlags)(1 << 18);
+            CommandServerSpecific = (CommandFlags)(1 << 18),
+            // "probe" (bit 19): health-check traffic. Deliberately *not* InternalCallFlag, which also decides
+            // queuing - see IsCallerFacing.
+            ProbeFlag = (CommandFlags)(1 << 19);
 
         protected RedisCommand command;
 
@@ -92,7 +95,15 @@ namespace StackExchange.Redis
                                                          | CommandFlags.NoScriptCache
                                                          | MaskRetryCategory // caller may override the retry category...
                                                          | CommandServerSpecific // ...and the server-specific flag
-                                                         | NoFlushFlag; // we'll allow this one even though not advertised
+                                                         | NoFlushFlag // we'll allow this one even though not advertised
+                                                         // ...and the probe flag, which *has* to survive this
+                                                         // whitelist: health-check probes reach the pipeline
+                                                         // through the public API (HealthCheckContext.
+                                                         // ProbeFlags), so it arrives as caller-supplied flags
+                                                         // or not at all. A caller passing it deliberately only
+                                                         // opts their own command out of endpoint-idleness
+                                                         // accounting, which is harmless.
+                                                         | ProbeFlag;
 
         private IResultBox? resultBox;
 
@@ -270,6 +281,32 @@ namespace StackExchange.Redis
 
         public bool IsFireAndForget => (Flags & CommandFlags.FireAndForget) != 0;
         public bool IsInternalCall => (Flags & InternalCallFlag) != 0;
+
+        /// <summary>
+        /// Whether this is health-check traffic, issued by a <see cref="Availability.HealthCheckProbe"/>
+        /// rather than by a caller.
+        /// </summary>
+        public bool IsProbe => (Flags & ProbeFlag) != 0;
+
+        /// <summary>
+        /// Whether somebody outside the library is waiting on this message.
+        /// </summary>
+        /// <remarks>
+        /// The question idleness actually wants to ask. Our own traffic - handshakes, heartbeats,
+        /// autoconfigure, health probes - is work we chose to do, so counting it makes a server look busy
+        /// precisely because we are looking at it, and an endpoint that can never be retired is the result
+        /// (see the endpoint-retirement work).
+        /// <para>
+        /// A probe is a separate bit from <see cref="IsInternalCall"/> on purpose. The internal-call flag also
+        /// decides *queuing*: an internal call bypasses the backlog
+        /// (<c>PhysicalBridge.TryPushToBacklog</c>) and is queued while disconnected regardless of the backlog
+        /// policy (<c>QueueOrFailMessage</c>). Bypassing the backlog would make a health check unable to
+        /// observe the one thing it most needs to - a bridge whose queue is not draining - and that signal is
+        /// what drives failover in a geo-redundant deployment. So probes are excluded from *accounting* without
+        /// being given internal-call *routing*.
+        /// </para>
+        /// </remarks>
+        public bool IsCallerFacing => (Flags & (InternalCallFlag | ProbeFlag)) == 0;
 
         public IResultBox? ResultBox => resultBox;
 

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -673,8 +673,12 @@ namespace StackExchange.Redis
 
                             // This is an "always" check - we always want to evaluate a dead connection from a non-responsive sever regardless of the need to heartbeat above
                             var totalTimeoutThisHeartbeat = asyncTimeoutThisHeartbeat + syncTimeoutThisHeartbeat;
-                            bool deadConnectionOnAsync = asyncTimeoutThisHeartbeat > 0 && tmp.LastReadSecondsAgo * 1_000 > (tmp.BridgeCouldBeNull?.Multiplexer.AsyncTimeoutMilliseconds * 4);
-                            bool deadConnectionOnSync = syncTimeoutThisHeartbeat > 0 && tmp.LastReadSecondsAgo * 1_000 > (tmp.BridgeCouldBeNull?.Multiplexer.TimeoutMilliseconds * 4);
+                            // note these track the *effective* timeout: this heuristic is derived from the
+                            // command timeout, so if relaxation says "be patient for 60s" while this says
+                            // "dead after 4x5s", we would tear down the connection relaxation was protecting.
+                            // Socket-level failure detection is untouched and still notices a dead server.
+                            bool deadConnectionOnAsync = asyncTimeoutThisHeartbeat > 0 && tmp.LastReadSecondsAgo * 1_000 > (ServerEndPoint.GetEffectiveTimeoutMilliseconds(tmp.BridgeCouldBeNull?.Multiplexer.AsyncTimeoutMilliseconds ?? 0) * 4);
+                            bool deadConnectionOnSync = syncTimeoutThisHeartbeat > 0 && tmp.LastReadSecondsAgo * 1_000 > (ServerEndPoint.GetEffectiveTimeoutMilliseconds(tmp.BridgeCouldBeNull?.Multiplexer.TimeoutMilliseconds ?? 0) * 4);
                             if (deadConnectionOnAsync || deadConnectionOnSync)
                             {
                                 // If we've received *NOTHING* on the pipe in 4 timeouts worth of time and we're timing out commands, issue a connection failure so that we reconnect

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -390,9 +390,16 @@ namespace StackExchange.Redis
                     msg.SetSource(ResultProcessor.Tracer, null);
                     break;
                 case ConnectionType.Subscription:
-                    // note both of these mark themselves as internal calls, as the interactive branch does via
+                    // Both mark themselves as internal calls, as the interactive branch does via
                     // GetTracerMessage: a keep-alive is our traffic, not a caller's, and anything asking "is
-                    // anyone using this server" has to be able to tell the difference
+                    // anyone using this server" has to be able to tell the difference.
+                    //
+                    // In practice this is the PING: PingOnSubscriber gates at 3.0 and the library's default
+                    // assumed version is 6.0, so the UNSUBSCRIBE fallback only fires against a server that
+                    // reports (or is configured as) older than 3.0 - observed to be exactly the case. Note also
+                    // that a subscribed RESP2 connection answers PING with the two-element array pong rather
+                    // than +PONG; OnResponseFrame's IsArrayPong is what keeps that out of the out-of-band path
+                    // so it still matches this message.
                     if (commandMap.IsAvailable(RedisCommand.PING) && features.PingOnSubscriber)
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.PING);

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -390,16 +390,21 @@ namespace StackExchange.Redis
                     msg.SetSource(ResultProcessor.Tracer, null);
                     break;
                 case ConnectionType.Subscription:
+                    // note both of these mark themselves as internal calls, as the interactive branch does via
+                    // GetTracerMessage: a keep-alive is our traffic, not a caller's, and anything asking "is
+                    // anyone using this server" has to be able to tell the difference
                     if (commandMap.IsAvailable(RedisCommand.PING) && features.PingOnSubscriber)
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.PING);
                         msg.SetForSubscriptionBridge();
                         msg.SetSource(ResultProcessor.Tracer, null);
+                        msg.SetInternalCall();
                     }
                     else if (commandMap.IsAvailable(RedisCommand.UNSUBSCRIBE))
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.UNSUBSCRIBE, RedisChannel.Literal(Multiplexer.UniqueId));
                         msg.SetSource(ResultProcessor.TrackSubscriptions, null);
+                        msg.SetInternalCall();
                     }
                     break;
             }
@@ -1023,6 +1028,19 @@ namespace StackExchange.Redis
         /// Crawls from the head of the backlog queue, consuming anything that should have timed out
         /// and pruning it accordingly (these messages will get timeout exceptions).
         /// </summary>
+        /// <summary>
+        /// Outstanding work on this bridge that a caller is waiting for, ignoring our own internal traffic.
+        /// </summary>
+        internal int GetCallerOutstandingCount()
+        {
+            int count = physical?.CountCallerMessagesAwaitingResponse() ?? 0;
+            foreach (var message in _backlog) // snapshot enumeration; a concurrent queue is fine to walk
+            {
+                if (!message.IsInternalCall) count++;
+            }
+            return count;
+        }
+
         private void CheckBacklogForTimeouts()
         {
             var now = Environment.TickCount;

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1040,7 +1040,7 @@ namespace StackExchange.Redis
 
             foreach (var message in _backlog) // snapshot enumeration; a concurrent queue is fine to walk
             {
-                if (!message.IsInternalCall) return true;
+                if (message.IsCallerFacing) return true;
             }
             return false;
         }
@@ -1334,7 +1334,7 @@ namespace StackExchange.Redis
             {
                 foreach (var item in _backlog) // non-consuming, thread-safe, etc
                 {
-                    if (!item.IsInternalCall) return true;
+                    if (item.IsCallerFacing) return true;
                 }
             }
             return physical?.HasPendingCallerFacingItems() ?? false;

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -390,28 +390,24 @@ namespace StackExchange.Redis
                     msg.SetSource(ResultProcessor.Tracer, null);
                     break;
                 case ConnectionType.Subscription:
-                    // Both mark themselves as internal calls, as the interactive branch does via
-                    // GetTracerMessage: a keep-alive is our traffic, not a caller's, and anything asking "is
-                    // anyone using this server" has to be able to tell the difference.
+                    // Normally the PING - observed against a 7.0 server, answered with the two-element array
+                    // pong rather than +PONG (OnResponseFrame's IsArrayPong is what keeps that out of the
+                    // out-of-band path so it still matches this message). The UNSUBSCRIBE fallback is not just
+                    // for pre-3.0 servers: the condition also fails when PING is disabled or renamed in the
+                    // CommandMap, or fronted by something that does not support it.
                     //
-                    // In practice this is the PING: PingOnSubscriber gates at 3.0 and the library's default
-                    // assumed version is 6.0, so the UNSUBSCRIBE fallback only fires against a server that
-                    // reports (or is configured as) older than 3.0 - observed to be exactly the case. Note also
-                    // that a subscribed RESP2 connection answers PING with the two-element array pong rather
-                    // than +PONG; OnResponseFrame's IsArrayPong is what keeps that out of the out-of-band path
-                    // so it still matches this message.
+                    // Neither needs SetInternalCall here: the common path below flags whatever the switch
+                    // produced, so any tracer added later is covered without remembering to.
                     if (commandMap.IsAvailable(RedisCommand.PING) && features.PingOnSubscriber)
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.PING);
                         msg.SetForSubscriptionBridge();
                         msg.SetSource(ResultProcessor.Tracer, null);
-                        msg.SetInternalCall();
                     }
                     else if (commandMap.IsAvailable(RedisCommand.UNSUBSCRIBE))
                     {
                         msg = Message.Create(-1, CommandFlags.FireAndForget, RedisCommand.UNSUBSCRIBE, RedisChannel.Literal(Multiplexer.UniqueId));
                         msg.SetSource(ResultProcessor.TrackSubscriptions, null);
-                        msg.SetInternalCall();
                     }
                     break;
             }
@@ -1036,16 +1032,17 @@ namespace StackExchange.Redis
         /// and pruning it accordingly (these messages will get timeout exceptions).
         /// </summary>
         /// <summary>
-        /// Outstanding work on this bridge that a caller is waiting for, ignoring our own internal traffic.
+        /// Whether this bridge owes a *caller* anything, ignoring our own internal traffic.
         /// </summary>
-        internal int GetCallerOutstandingCount()
+        internal bool HasCallerWork()
         {
-            int count = physical?.CountCallerMessagesAwaitingResponse() ?? 0;
+            if (physical?.HasCallerMessagesAwaitingResponse() == true) return true;
+
             foreach (var message in _backlog) // snapshot enumeration; a concurrent queue is fine to walk
             {
-                if (!message.IsInternalCall) count++;
+                if (!message.IsInternalCall) return true;
             }
-            return count;
+            return false;
         }
 
         private void CheckBacklogForTimeouts()

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1022,7 +1022,12 @@ namespace StackExchange.Redis
         private void CheckBacklogForTimeouts()
         {
             var now = Environment.TickCount;
-            var timeout = _singleWriter.TimeoutMilliseconds;
+
+            // deliberately *not* _singleWriter.TimeoutMilliseconds, which is the write-lock acquisition
+            // timeout: that is about contention between writers, and relaxing it during maintenance is not
+            // something anybody asked for. This is the age at which a queued command is considered timed out,
+            // relaxed while the server has announced a disruption.
+            var timeout = ServerEndPoint.GetEffectiveTimeoutMilliseconds(Multiplexer.TimeoutMilliseconds);
 
             // Because peeking at the backlog, checking message and then dequeuing, is not thread-safe, we do have to use
             // a lock here, for mutual exclusion of backlog DEQUEUERS. Unfortunately.

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1794,6 +1794,33 @@ namespace StackExchange.Redis
             physical?.SimulateConnectionFailure(failureType);
         }
 
+        /// <summary>
+        /// Drops the current connection so that a fresh one is established.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately just a dispose: that routes through <c>RecordConnectionFailed</c> to
+        /// <see cref="OnDisconnected"/>, which reconnects immediately by itself, so there is no new lifecycle
+        /// here to get wrong. Used by the <c>MOVING</c> handoff, where the point is to choose *when* the
+        /// connection is replaced - after the replacement address is known - rather than waiting for the server
+        /// to close it and re-resolving to whatever DNS says at that moment, which has been measured as still
+        /// naming the node being retired.
+        /// </remarks>
+        internal bool RecycleConnection(string reason)
+        {
+            var current = physical;
+            if (current is null) return false;
+
+            Multiplexer.Trace($"recycling {ConnectionType} connection: {reason}", ToString());
+
+            // Report *before* tearing down, and in this order for a reason: RecordConnectionFailed only raises
+            // the public event while the pipe is still live ("if *we* didn't burn the pipe: flag it"), and
+            // Dispose runs Shutdown first - which is exactly why an ordinary dispose is silent. Recording first
+            // also performs the disconnect, so the Dispose below is cleanup.
+            current.RecordConnectionFailed(ConnectionFailureType.MaintenanceHandoff);
+            current.Dispose();
+            return true;
+        }
+
         internal RedisCommand? GetActiveMessage() => Volatile.Read(ref _activeMessage)?.Command;
     }
 }

--- a/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
@@ -135,6 +135,14 @@ internal sealed partial class PhysicalConnection
             else if (IsWindowClosing(type))
             {
                 server.OnMaintenanceWindowClosed(type, sequenceId);
+
+                // ...and if slots moved away from us, learn the new topology rather than waiting to be told
+                // by a -MOVED. Scoped and jittered inside OnSlotsMigratedAway; see its remarks for why this
+                // is the cluster family only
+                if (type == MaintenanceNotificationType.SlotMigrated && migrations is not null)
+                {
+                    server.OnSlotsMigratedAway(migrations);
+                }
             }
         }
 

--- a/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
@@ -146,8 +146,18 @@ internal sealed partial class PhysicalConnection
             }
         }
 
-        var evt = new PushMaintenanceEvent(type, sequenceId ?? 0, server?.EndPoint, time, newEndPoint, payload, raw, migrations);
-        muxer.OnServerMaintenanceEvent(evt);
+        // Per-server work above, one event below: relaxation is per-connection and every connection is told,
+        // but a consumer wants one callback per logical event rather than one per proxy that mentioned it
+        if (muxer.TryClaimMaintenanceEvent(type, sequenceId))
+        {
+            var evt = new PushMaintenanceEvent(type, sequenceId ?? 0, server?.EndPoint, time, newEndPoint, payload, raw, migrations);
+            muxer.OnServerMaintenanceEvent(evt);
+        }
+        else
+        {
+            Trace($"{kind} seq {sequenceId} already reported by another node; not raising again");
+        }
+
         return OutOfBandResult.Handled;
     }
 

--- a/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
@@ -130,7 +130,21 @@ internal sealed partial class PhysicalConnection
         {
             if (IsWindowOpening(type))
             {
-                server.OnMaintenanceWindowOpened(type, sequenceId, time);
+                var isNew = server.OnMaintenanceWindowOpened(type, sequenceId, time);
+
+                // ...and MOVING alone means "this endpoint is going away", which is worth acting on rather than
+                // waiting to be disconnected.
+                //
+                // Only when the notification is *new*, and that is load-bearing rather than tidy. A server
+                // re-sends MOVING to a connection that opts in while the window is still open - measured, and
+                // the handoff replaces the connection, so acting on the repeat is a feedback loop: recycle,
+                // reconnect, get told again, recycle. It produced twelve recycles from one event on a real
+                // deployment before this guard. The per-server sequence dedup already knew it was a repeat; the
+                // handoff simply was not asking.
+                if (isNew && type == MaintenanceNotificationType.Moving)
+                {
+                    server.OnMovingAnnounced(time, newEndPoint, this);
+                }
             }
             else if (IsWindowClosing(type))
             {

--- a/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using RESPite;
@@ -34,18 +35,31 @@ internal sealed partial class PhysicalConnection
 
         // at most three elements follow the type in any defined shape; anything beyond that is ignored
         string? e1 = null, e2 = null, e3 = null;
+        List<ClusterSlotMigration>? migrations = null;
         int count = 0;
         while (reader.SafeTryMoveNext())
         {
+            count++;
             if (!reader.IsScalar)
             {
-                // no defined notification nests anything; give up rather than guess
-                Trace($"{kind}: non-scalar element {count + 1}");
+                // SMIGRATED nests: [type, seq, [[source, target, slots], ...]]. Everything else is flat, and
+                // nesting there means a frame we do not understand - so the guard stays for those, since
+                // guessing at an unknown shape is how a parser starts inventing data
+                if (kind is PushKind.SlotMigrated or PushKind.SlotMigrating && migrations is null)
+                {
+                    // note the reader has to be moved *past* the aggregate: enumerating the children does not
+                    // advance it, so without this the loop walks back into the triplets we just read and
+                    // mistakes them for further top-level elements
+                    migrations = ReadSlotMigrations(ref reader);
+                    continue;
+                }
+
+                Trace($"{kind}: non-scalar element {count}");
                 return OutOfBandResult.Handled;
             }
 
             var element = reader.IsNull ? null : reader.ReadString();
-            switch (++count)
+            switch (count)
             {
                 case 1: e1 = element; break;
                 case 2: e2 = element; break;
@@ -54,11 +68,16 @@ internal sealed partial class PhysicalConnection
         }
 
         var type = ToNotificationType(kind);
-        if (count == 0 || !TryParseInt64(e1, out var sequenceId))
+
+        // A missing or unreadable sequence id is *not* fatal. The specs say every shape carries one, but
+        // go-redis - which runs against real servers - length-checks these frames at two elements and reads
+        // no sequence number at all for the shard notifications. So a client that drops a frame for want of a
+        // seq is stricter than one that demonstrably works. Without it we lose only dedup, which is our own
+        // invention anyway; the disruption being announced is the part that matters.
+        long? sequenceId = TryParseInt64(e1, out var parsedSequenceId) ? parsedSequenceId : null;
+        if (sequenceId is null)
         {
-            // the sequence id is the one field every shape has; without it we know too little to report
-            OnMaintenanceNotificationDropped(type, $"no sequence id in a {count + 1}-element frame");
-            return OutOfBandResult.Handled;
+            OnMaintenanceNotificationDropped(type, $"no readable sequence id in a {count + 1}-element frame; continuing without dedup");
         }
 
         long? timeSeconds = null;
@@ -93,11 +112,8 @@ internal sealed partial class PhysicalConnection
         {
             // "?" and an empty host are the contract's placeholders for "no address", and are no more
             // dialable than the null form; they must never be taken to mean "the server that told us"
-            if (payload != "?" && Format.TryParseEndPoint(payload, out var parsed) && !IsPlaceholder(parsed))
-            {
-                newEndPoint = parsed;
-            }
-            else
+            newEndPoint = ParseMigrationEndPoint(payload);
+            if (newEndPoint is null)
             {
                 Trace($"{kind}: no usable endpoint in '{payload}'");
             }
@@ -122,17 +138,76 @@ internal sealed partial class PhysicalConnection
             }
         }
 
-        var evt = new PushMaintenanceEvent(type, sequenceId, server?.EndPoint, time, newEndPoint, payload, raw);
+        var evt = new PushMaintenanceEvent(type, sequenceId ?? 0, server?.EndPoint, time, newEndPoint, payload, raw, migrations);
         muxer.OnServerMaintenanceEvent(evt);
         return OutOfBandResult.Handled;
-
-        static bool IsPlaceholder(EndPoint endpoint) => endpoint switch
-        {
-            DnsEndPoint dns => dns.Port == 0 || dns.Host is "" or "?",
-            IPEndPoint ip => ip.Port == 0,
-            _ => false,
-        };
     }
+
+    /// <summary>
+    /// Reads the nested <c>[[source, target, slots], ...]</c> form of a cluster slot-migration notification.
+    /// </summary>
+    /// <remarks>
+    /// A malformed triplet is skipped rather than abandoning the whole notification - the same choice go-redis
+    /// makes, and the right one: the other triplets are still actionable, and one bad entry should not lose a
+    /// migration we could have applied. The slot list is a flat comma-and-range string inside each triplet.
+    /// </remarks>
+    private List<ClusterSlotMigration> ReadSlotMigrations(ref RespReader reader)
+    {
+        var results = new List<ClusterSlotMigration>();
+        var outer = reader.AggregateChildren();
+        while (outer.MoveNext())
+        {
+            var triplet = outer.Value;
+            if (!triplet.IsAggregate)
+            {
+                Trace("slot migration: expected a triplet");
+                continue;
+            }
+
+            string? source = null, target = null, slots = null;
+            int index = 0;
+            var inner = triplet.AggregateChildren();
+            while (inner.MoveNext())
+            {
+                var child = inner.Value;
+                var text = child.IsScalar && !child.IsNull ? child.ReadString() : null;
+                switch (index++)
+                {
+                    case 0: source = text; break;
+                    case 1: target = text; break;
+                    case 2: slots = text; break;
+                }
+            }
+
+            if (index < 3)
+            {
+                Trace($"slot migration: {index}-element triplet, skipped");
+                continue;
+            }
+
+            var ranges = SlotRange.TryParseList(slots, out var parsed) ? parsed : [];
+            results.Add(new ClusterSlotMigration(ParseMigrationEndPoint(source), ParseMigrationEndPoint(target), ranges, slots));
+        }
+
+        // leave the caller's reader after the aggregate, so it can carry on with any trailing elements
+        outer.MovePast(out reader);
+        return results;
+    }
+
+    /// <summary>
+    /// Parses one end of a migration, treating the placeholder forms as "not named" rather than as an error.
+    /// </summary>
+    private static EndPoint? ParseMigrationEndPoint(string? value)
+        => string.IsNullOrEmpty(value) || value == "?" || !Format.TryParseEndPoint(value, out var parsed) || IsPlaceholderEndPoint(parsed)
+            ? null
+            : parsed;
+
+    private static bool IsPlaceholderEndPoint(EndPoint endpoint) => endpoint switch
+    {
+        DnsEndPoint dns => dns.Port == 0 || dns.Host is "" or "?",
+        IPEndPoint ip => ip.Port == 0,
+        _ => false,
+    };
 
     private void OnMaintenanceNotificationDropped(MaintenanceNotificationType type, string reason)
     {
@@ -186,10 +261,10 @@ internal sealed partial class PhysicalConnection
         _ => MaintenanceNotificationType.None,
     };
 
-    private static string Describe(PushKind kind, long sequenceId, long? timeSeconds, string? payload)
+    private static string Describe(PushKind kind, long? sequenceId, long? timeSeconds, string? payload)
     {
         var sb = new System.Text.StringBuilder(kind.ToString().ToUpperInvariant());
-        sb.Append(" seq=").Append(sequenceId);
+        sb.Append(" seq=").Append(sequenceId?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "?");
         if (timeSeconds is { } seconds) sb.Append(" time=").Append(seconds).Append('s');
         if (payload is not null) sb.Append(' ').Append(payload);
         return sb.ToString();

--- a/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Maintenance.cs
@@ -108,6 +108,20 @@ internal sealed partial class PhysicalConnection
         Trace($"maintenance notification: {raw}");
         OnDetailLog($"maintenance notification: {raw}");
 
+        // relax before reporting: the event handler is consumer code, and the window should already be open
+        // by the time anyone sees the notification that opened it
+        if (server is not null)
+        {
+            if (IsWindowOpening(type))
+            {
+                server.OnMaintenanceWindowOpened(type, sequenceId, time);
+            }
+            else if (IsWindowClosing(type))
+            {
+                server.OnMaintenanceWindowClosed(type, sequenceId);
+            }
+        }
+
         var evt = new PushMaintenanceEvent(type, sequenceId, server?.EndPoint, time, newEndPoint, payload, raw);
         muxer.OnServerMaintenanceEvent(evt);
         return OutOfBandResult.Handled;
@@ -130,6 +144,27 @@ internal sealed partial class PhysicalConnection
 
     private static bool TryParseInt64(string? value, out long result)
         => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+    /// <summary>
+    /// Whether this notification announces a disruption starting (or still running).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MaintenanceNotificationType.Moving"/> is an opener with no closer: its window can only end
+    /// by the deadline the server gave us, or - later - by the handoff completing.
+    /// </remarks>
+    private static bool IsWindowOpening(MaintenanceNotificationType type) => type is
+        MaintenanceNotificationType.Moving
+        or MaintenanceNotificationType.Migrating
+        or MaintenanceNotificationType.FailingOver
+        or MaintenanceNotificationType.SlotMigrating;
+
+    /// <summary>
+    /// Whether this notification announces that a disruption has finished.
+    /// </summary>
+    private static bool IsWindowClosing(MaintenanceNotificationType type) => type is
+        MaintenanceNotificationType.Migrated
+        or MaintenanceNotificationType.FailedOver
+        or MaintenanceNotificationType.SlotMigrated;
 
     /// <summary>
     /// Whether the contract gives this notification a <c>time</c> element.

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -830,7 +830,7 @@ namespace StackExchange.Redis
             {
                 foreach (var message in _writtenAwaitingResponse)
                 {
-                    if (!message.IsInternalCall) return true;
+                    if (message.IsCallerFacing) return true;
                 }
             }
             return false;
@@ -1315,7 +1315,7 @@ namespace StackExchange.Redis
                     {
                         foreach (var item in _writtenAwaitingResponse)
                         {
-                            if (!item.IsInternalCall) return true;
+                            if (item.IsCallerFacing) return true;
                         }
                     }
                     return false;

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -812,24 +812,28 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
-        /// How many messages awaiting a response were issued by a *caller* rather than by us.
+        /// Whether any message awaiting a response was issued by a *caller* rather than by us.
         /// </summary>
         /// <remarks>
         /// The distinction matters wherever we ask "is anyone using this server": our own handshake,
-        /// autoconfigure and keep-alive traffic is not use, and counting it makes a server we are probing look
-        /// busy *because* we are probing it.
+        /// autoconfigure and keep-alive traffic is not use, and treating it as such makes a server we are
+        /// probing look busy *because* we are probing it.
+        /// <para>
+        /// A predicate rather than a count, because every caller only asks whether the answer is zero - and
+        /// this way the common case (a caller's message at the head of the queue) costs one iteration instead
+        /// of walking a queue that a stalled server can leave thousands of entries long.
+        /// </para>
         /// </remarks>
-        internal int CountCallerMessagesAwaitingResponse()
+        internal bool HasCallerMessagesAwaitingResponse()
         {
-            int count = 0;
             lock (_writtenAwaitingResponse)
             {
                 foreach (var message in _writtenAwaitingResponse)
                 {
-                    if (!message.IsInternalCall) count++;
+                    if (!message.IsInternalCall) return true;
                 }
             }
-            return count;
+            return false;
         }
 
         /// <summary>

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -829,7 +829,9 @@ namespace StackExchange.Redis
                 {
                     var server = bridge.ServerEndPoint;
                     var multiplexer = bridge.Multiplexer;
-                    var timeout = multiplexer.AsyncTimeoutMilliseconds;
+
+                    // relaxed while this server has announced a disruption; a floor, never a reduction
+                    var timeout = server.GetEffectiveTimeoutMilliseconds(multiplexer.AsyncTimeoutMilliseconds);
                     foreach (var msg in _writtenAwaitingResponse)
                     {
                         // We only handle async timeouts here, synchronous timeouts are handled upstream.

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -812,6 +812,27 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// How many messages awaiting a response were issued by a *caller* rather than by us.
+        /// </summary>
+        /// <remarks>
+        /// The distinction matters wherever we ask "is anyone using this server": our own handshake,
+        /// autoconfigure and keep-alive traffic is not use, and counting it makes a server we are probing look
+        /// busy *because* we are probing it.
+        /// </remarks>
+        internal int CountCallerMessagesAwaitingResponse()
+        {
+            int count = 0;
+            lock (_writtenAwaitingResponse)
+            {
+                foreach (var message in _writtenAwaitingResponse)
+                {
+                    if (!message.IsInternalCall) count++;
+                }
+            }
+            return count;
+        }
+
+        /// <summary>
         /// Runs on every heartbeat for a bridge, timing out any commands that are overdue and returning an integer of how many we timed out.
         /// </summary>
         /// <param name="asyncTimeoutDetected">How many async commands were overdue and threw timeout exceptions.</param>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -175,3 +175,4 @@ override StackExchange.Redis.Configuration.DefaultOptionsProvider.ToString() -> 
 [SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.Target.get -> System.Net.EndPoint?
 [SER010]StackExchange.Redis.Maintenance.PushMaintenanceEvent.SlotMigrations.get -> System.Collections.Generic.IReadOnlyList<StackExchange.Redis.Maintenance.ClusterSlotMigration>!
 [SER007]StackExchange.Redis.Availability.HealthCheckContext.ProbeFlags.get -> StackExchange.Redis.CommandFlags
+StackExchange.Redis.ConnectionFailureType.MaintenanceHandoff = 12 -> StackExchange.Redis.ConnectionFailureType

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -163,3 +163,6 @@ override StackExchange.Redis.Configuration.DefaultOptionsProvider.ToString() -> 
 [SER010]virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.MaintenancePostEventRelaxedDuration.get -> System.TimeSpan?
 [SER010]virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.MaintenanceRelaxedTimeout.get -> System.TimeSpan
 [SER010]virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.MaintenanceRelaxedWindowMax.get -> System.TimeSpan?
+[SER010]StackExchange.Redis.Availability.FaultContext.MaintenanceType.get -> StackExchange.Redis.Maintenance.MaintenanceNotificationType
+[SER010]StackExchange.Redis.RedisConnectionException.MaintenanceType.get -> StackExchange.Redis.Maintenance.MaintenanceNotificationType
+[SER010]StackExchange.Redis.RedisTimeoutException.MaintenanceType.get -> StackExchange.Redis.Maintenance.MaintenanceNotificationType

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -166,3 +166,11 @@ override StackExchange.Redis.Configuration.DefaultOptionsProvider.ToString() -> 
 [SER010]StackExchange.Redis.Availability.FaultContext.MaintenanceType.get -> StackExchange.Redis.Maintenance.MaintenanceNotificationType
 [SER010]StackExchange.Redis.RedisConnectionException.MaintenanceType.get -> StackExchange.Redis.Maintenance.MaintenanceNotificationType
 [SER010]StackExchange.Redis.RedisTimeoutException.MaintenanceType.get -> StackExchange.Redis.Maintenance.MaintenanceNotificationType
+[SER010]override StackExchange.Redis.Maintenance.ClusterSlotMigration.ToString() -> string!
+[SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration
+[SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.ClusterSlotMigration() -> void
+[SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.RawSlots.get -> string?
+[SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.Slots.get -> System.Collections.Generic.IReadOnlyList<StackExchange.Redis.SlotRange>!
+[SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.Source.get -> System.Net.EndPoint?
+[SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.Target.get -> System.Net.EndPoint?
+[SER010]StackExchange.Redis.Maintenance.PushMaintenanceEvent.SlotMigrations.get -> System.Collections.Generic.IReadOnlyList<StackExchange.Redis.Maintenance.ClusterSlotMigration>!

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -174,3 +174,4 @@ override StackExchange.Redis.Configuration.DefaultOptionsProvider.ToString() -> 
 [SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.Source.get -> System.Net.EndPoint?
 [SER010]StackExchange.Redis.Maintenance.ClusterSlotMigration.Target.get -> System.Net.EndPoint?
 [SER010]StackExchange.Redis.Maintenance.PushMaintenanceEvent.SlotMigrations.get -> System.Collections.Generic.IReadOnlyList<StackExchange.Redis.Maintenance.ClusterSlotMigration>!
+[SER007]StackExchange.Redis.Availability.HealthCheckContext.ProbeFlags.get -> StackExchange.Redis.CommandFlags

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -154,3 +154,12 @@ override StackExchange.Redis.Configuration.RedisEnterpriseOptionsProvider.Protoc
 StackExchange.Redis.Configuration.RedisEnterpriseOptionsProvider
 StackExchange.Redis.Configuration.RedisEnterpriseOptionsProvider.RedisEnterpriseOptionsProvider() -> void
 override StackExchange.Redis.Configuration.DefaultOptionsProvider.ToString() -> string!
+[SER010]StackExchange.Redis.ConfigurationOptions.MaintenancePostEventRelaxedDuration.get -> System.TimeSpan
+[SER010]StackExchange.Redis.ConfigurationOptions.MaintenancePostEventRelaxedDuration.set -> void
+[SER010]StackExchange.Redis.ConfigurationOptions.MaintenanceRelaxedTimeout.get -> System.TimeSpan
+[SER010]StackExchange.Redis.ConfigurationOptions.MaintenanceRelaxedTimeout.set -> void
+[SER010]StackExchange.Redis.ConfigurationOptions.MaintenanceRelaxedWindowMax.get -> System.TimeSpan
+[SER010]StackExchange.Redis.ConfigurationOptions.MaintenanceRelaxedWindowMax.set -> void
+[SER010]virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.MaintenancePostEventRelaxedDuration.get -> System.TimeSpan?
+[SER010]virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.MaintenanceRelaxedTimeout.get -> System.TimeSpan
+[SER010]virtual StackExchange.Redis.Configuration.DefaultOptionsProvider.MaintenanceRelaxedWindowMax.get -> System.TimeSpan?

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using System.Threading.Tasks;
 using RESPite;
 using StackExchange.Redis.Maintenance;
 
@@ -249,4 +251,100 @@ internal sealed partial class ServerEndPoint
     }
 
     private const int MaintenanceNotificationTypeCount = 8; // None + the seven notification types
+
+    /// <summary>
+    /// How long to smear a notification-triggered topology refresh over.
+    /// </summary>
+    /// <remarks>
+    /// Not configurable, deliberately. The relaxed-window durations are options because their right value is
+    /// deployment-specific and we invented them; this is a fixed small smear that exists only so that a fleet
+    /// which was all told the same thing at the same instant does not all query the same node at the same
+    /// instant. Nobody needs to tune it, and every option is public surface to keep. Promote it if that turns
+    /// out to be wrong.
+    /// <para>
+    /// Note <see cref="ConnectionMultiplexer.ReconfigureIfNeeded"/> already declines while one refresh is in
+    /// flight, so the *local* storm is handled; this is purely about the fleet.
+    /// </para>
+    /// </remarks>
+    private static readonly int MaintenanceRefreshJitterMilliseconds = 1000;
+
+    // 1 while a jittered refresh is scheduled and has not yet started
+    private int _refreshPending;
+
+    /// <summary>
+    /// Whether this server is one of the sources in a slot-migration delta - i.e. whether the movement being
+    /// described is movement away from <em>us</em>.
+    /// </summary>
+    /// <remarks>
+    /// Every node in the cluster reports the same movements, so the sender is not implicitly a source and most
+    /// notifications describe somebody else. Acting only on our own is what stops a fleet re-reading topology
+    /// because one shard moved somewhere unrelated - go-redis makes the same choice.
+    /// <para>
+    /// Resolution goes through the identity map rather than comparing endpoints directly: a node answers to
+    /// its address and to its announced hostname, and the delta may name either.
+    /// </para>
+    /// </remarks>
+    private bool IsSourceOf(IReadOnlyList<ClusterSlotMigration> migrations)
+    {
+        foreach (var migration in migrations)
+        {
+            if (migration.Source is { } source && ReferenceEquals(Multiplexer.TryResolveServerEndPoint(source), this))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Refreshes the topology after slots have moved away from this server, once the fleet has had a moment to
+    /// spread out.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately only for the cluster family: <c>MIGRATED</c> and <c>FAILED_OVER</c> arrive in proxied
+    /// deployments where the client addresses a single endpoint, so there is no topology for a refresh to
+    /// learn - they get relaxation and nothing else. Endpoints left serving nothing are handled by the
+    /// existing absence-based pruning, which a refresh feeds; there is deliberately no second, faster
+    /// retirement path here.
+    /// </remarks>
+    internal void OnSlotsMigratedAway(IReadOnlyList<ClusterSlotMigration> migrations)
+    {
+        if (migrations.Count == 0 || !IsSourceOf(migrations)) return;
+
+        // Coalesce *before* the jitter, not after. ReconfigureIfNeeded declines only while a refresh is
+        // actually in flight, and the jitter spreads a burst of notifications out far enough that each one
+        // completes before the next begins - so relying on that alone turns ten notifications into ten
+        // topology passes. Found by the test that counts them.
+        if (Interlocked.CompareExchange(ref _refreshPending, 1, 0) != 0)
+        {
+            Multiplexer.Trace("topology refresh already pending; folding this notification into it", ToString());
+            return;
+        }
+
+        var cause = $"slots migrated from {Format.ToString(EndPoint)}";
+        Multiplexer.Trace($"{cause}; refreshing topology after jitter", ToString());
+
+        // fire-and-forget: we are on the read loop, and the refresh must not block it
+        _ = RefreshAfterJitterAsync(cause);
+    }
+
+    private async Task RefreshAfterJitterAsync(string cause)
+    {
+        try
+        {
+            await Task.Delay(ServerSelectionStrategy.SharedRandom.Next(MaintenanceRefreshJitterMilliseconds)).ForAwait();
+
+            // released before the refresh runs, not after: anything that arrives from here on describes a
+            // state this pass may not have seen, and deserves its own pass
+            Volatile.Write(ref _refreshPending, 0);
+            Multiplexer.ReconfigureIfNeeded(EndPoint, fromBroadcast: false, cause);
+        }
+        catch (Exception ex)
+        {
+            // a refresh we failed to start is a missed optimization, not a fault: the next -MOVED still works
+            Volatile.Write(ref _refreshPending, 0);
+            Multiplexer.Trace($"topology refresh after {cause} failed: {ex.Message}", ToString());
+        }
+    }
 }

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -96,6 +96,9 @@ internal sealed partial class ServerEndPoint
     // subtraction, as elsewhere in this type, so the ~49-day wrap is a non-event.
     private int _relaxedDeadlineTicks;
 
+    // the notification that last touched the window, reported on faults that happen inside it
+    private int _relaxedType;
+
     // Dedup state, per notification type: the sequence ids are not defined by any specification, so this is
     // conservative - a repeat of an id we have already acted on is ignored, and nothing else is inferred.
     // Allocated on first notification, so a server that never sees one pays nothing.
@@ -106,6 +109,13 @@ internal sealed partial class ServerEndPoint
     /// Whether timeouts are currently relaxed for this server.
     /// </summary>
     internal bool IsMaintenanceRelaxed => GetRelaxedRemaining() > 0;
+
+    /// <summary>
+    /// The notification in force for this server, or <see cref="MaintenanceNotificationType.None"/> if no
+    /// window is open; reported on faults so that a timeout during a migration says so.
+    /// </summary>
+    internal MaintenanceNotificationType ActiveMaintenanceType
+        => GetRelaxedRemaining() > 0 ? (MaintenanceNotificationType)Volatile.Read(ref _relaxedType) : MaintenanceNotificationType.None;
 
     /// <summary>
     /// The effective timeout for a command against this server: the configured value, or the relaxed value if
@@ -158,6 +168,7 @@ internal sealed partial class ServerEndPoint
         if (duration < floor) duration = floor;
         if (duration > cap) duration = cap;
 
+        Volatile.Write(ref _relaxedType, (int)type);
         ExtendRelaxedWindow(duration, $"{type} for {duration.TotalSeconds}s");
     }
 
@@ -173,6 +184,7 @@ internal sealed partial class ServerEndPoint
     {
         if (!TryClaimSequenceId(type, sequenceId)) return;
 
+        Volatile.Write(ref _relaxedType, (int)type);
         var tail = Multiplexer.RawConfig.MaintenancePostEventRelaxedDuration;
         if (tail <= TimeSpan.Zero)
         {

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using RESPite;
@@ -160,9 +161,13 @@ internal sealed partial class ServerEndPoint
     /// <summary>
     /// An announced disruption has started (or is still running): open or extend the relaxed window.
     /// </summary>
-    internal void OnMaintenanceWindowOpened(MaintenanceNotificationType type, long? sequenceId, TimeSpan? time)
+    /// <returns>
+    /// Whether this notification was new. A replay extends nothing and, importantly, must not be *acted* on -
+    /// see the handoff, where re-acting on a repeat is a feedback loop rather than merely wasted work.
+    /// </returns>
+    internal bool OnMaintenanceWindowOpened(MaintenanceNotificationType type, long? sequenceId, TimeSpan? time)
     {
-        if (!TryClaimSequenceId(type, sequenceId)) return;
+        if (!TryClaimSequenceId(type, sequenceId)) return false;
 
         var config = Multiplexer.RawConfig;
         var floor = config.MaintenanceRelaxedTimeout;
@@ -176,6 +181,7 @@ internal sealed partial class ServerEndPoint
 
         Volatile.Write(ref _relaxedType, (int)type);
         ExtendRelaxedWindow(duration, $"{type} for {duration.TotalSeconds}s");
+        return true;
     }
 
     /// <summary>
@@ -203,6 +209,145 @@ internal sealed partial class ServerEndPoint
         Volatile.Write(ref _relaxedDeadlineTicks, deadline);
         Multiplexer.Trace($"{type}: relaxation continues for {tail.TotalSeconds}s (post-event)", ToString());
     }
+
+    private int _handoffInFlight, _handoffRecycles;
+    private volatile string? _lastHandoffOutcome;
+
+    /// <summary>
+    /// What the last <c>MOVING</c> handoff decided, and why.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than only traced because <c>Multiplexer.Trace</c> is <c>[Conditional("VERBOSE")]</c> - it
+    /// compiles away in any normal build, so a handoff that misbehaves in production would leave no trace at
+    /// all. This is the minimum that survives: what was decided, readable afterwards.
+    /// </remarks>
+    internal string? LastHandoffOutcome => _lastHandoffOutcome;
+
+    /// <summary>How many times a handoff has replaced this server's connections.</summary>
+    internal int HandoffRecycles => Volatile.Read(ref _handoffRecycles);
+
+    /// <summary>
+    /// Acts on a <c>MOVING</c>: find where to go, then get off this connection before we are pushed.
+    /// </summary>
+    /// <remarks>
+    /// The value here is entirely in the *timing*. Without it we already survive a <c>MOVING</c> - the socket
+    /// closes and we reconnect - but the reconnect happens when the server decides, and re-resolves to whatever
+    /// DNS says at that moment, which has been measured as still naming the node being retired. Measured on a
+    /// real deployment: <c>MOVING</c> arrives about six seconds in, DNS moves somewhere between four and
+    /// nineteen seconds later, and the socket closes seventeen to nineteen seconds after the notification. So
+    /// the window exists to be *used*, and using it means waiting for DNS to move and then choosing the moment.
+    /// <para>
+    /// Fire-and-forget by design: this runs while the connection it concerns is still serving commands, and the
+    /// notification is delivered on the read loop, which must not wait for a DNS poll.
+    /// </para>
+    /// </remarks>
+    internal void OnMovingAnnounced(TimeSpan? window, EndPoint? successor, PhysicalConnection connection)
+    {
+        // One at a time per server. A rolling operation delivers one MOVING per connection, so a second one
+        // arriving while a handoff is in flight is a repeat or a much later event; either way, starting a
+        // second poll against the same endpoint achieves nothing.
+        if (Interlocked.CompareExchange(ref _handoffInFlight, 1, 0) != 0)
+        {
+            Multiplexer.Trace("MOVING: a handoff is already in flight", ToString());
+            return;
+        }
+
+        var budget = window is { } value && value > TimeSpan.Zero
+            ? value
+            : Multiplexer.RawConfig.MaintenanceRelaxedTimeout; // no window given: use the relaxation floor
+        var current = (connection.VolatileSocket?.RemoteEndPoint as IPEndPoint)?.Address;
+
+        _ = HandoffAsync(budget, successor, current);
+    }
+
+    private async Task HandoffAsync(TimeSpan window, EndPoint? successor, IPAddress? currentAddress)
+    {
+        try
+        {
+            // Spread the fleet, but only by a fraction of the window - see MaintenanceHandoff.GetJitter for why
+            // a flat delay is wrong here.
+            var jitter = MaintenanceHandoff.GetJitter(window, RandomFor(this));
+            if (jitter > TimeSpan.Zero) await Task.Delay(jitter).ForAwait();
+
+            var remaining = window - jitter;
+            var decision = await MaintenanceHandoff.DecideAsync(
+                EndPoint,
+                successor,
+                currentAddress,
+                remaining,
+                pollInterval: TimeSpan.FromSeconds(1), // records carry a 5s TTL, so this is several looks per record
+                resolve: Multiplexer.AddressResolver,
+                log: message => Multiplexer.Trace(message, ToString())).ForAwait();
+
+            Multiplexer.Trace($"MOVING: {decision}", ToString());
+            _lastHandoffOutcome = decision.ToString();
+            switch (decision.Action)
+            {
+                case HandoffAction.Recycle:
+                    await DrainThenRecycleAsync(remaining, decision.Reason).ForAwait();
+                    break;
+                case HandoffAction.Reconfigure:
+                    // A named successor is a different endpoint, so this is a topology question. Note no
+                    // observed deployment has ever named one, so this path has never run outside a test.
+                    Multiplexer.ReconfigureIfNeeded(EndPoint, fromBroadcast: false, "moving names a successor");
+                    await DrainThenRecycleAsync(remaining, decision.Reason).ForAwait();
+                    break;
+                default:
+                    // Nothing to do is a legitimate outcome, not a failure: the server closes the socket, the
+                    // reconnect re-resolves, and the relaxed window covers the gap.
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Multiplexer.OnInternalError(ex, EndPoint);
+        }
+        finally
+        {
+            Volatile.Write(ref _handoffInFlight, 0);
+        }
+    }
+
+    /// <summary>
+    /// Lets in-flight caller work finish, then replaces the connections.
+    /// </summary>
+    /// <remarks>
+    /// Draining first because the socket is still working: anything already written may still be answered, and
+    /// dropping it would fail commands that were about to succeed. Bounded by what is left of the window,
+    /// because the server closes the socket at the end of it regardless - so anything not drained by then was
+    /// going to fail either way, and draining strictly dominates.
+    /// <para>
+    /// Both bridges, not just the one that was told. The measured blast radius is the *node*: four connections
+    /// to one proxy, differing only in handshake, all closed simultaneously, and only the ones that had opted in
+    /// were warned.
+    /// </para>
+    /// </remarks>
+    private async Task DrainThenRecycleAsync(TimeSpan budget, string reason)
+    {
+        var watch = ValueStopwatch.StartNew();
+        while (HasCallerWork() && watch.ElapsedMilliseconds < budget.TotalMilliseconds)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(20)).ForAwait();
+        }
+
+        var drained = !HasCallerWork();
+        var recycled = (interactive?.RecycleConnection(reason) == true) | (subscription?.RecycleConnection(reason) == true);
+        if (recycled) Interlocked.Increment(ref _handoffRecycles);
+        Multiplexer.Trace(
+            $"MOVING: {(recycled ? "recycled" : "nothing to recycle")} after {watch.ElapsedMilliseconds}ms"
+            + (drained ? " (drained)" : " (still busy; the window ran out)"),
+            ToString());
+    }
+
+    [ThreadStatic]
+    private static Random? _random;
+
+    /// <summary>
+    /// A per-thread <see cref="Random"/>, seeded so that two processes handing off at once do not pick the same
+    /// jitter.
+    /// </summary>
+    private static Random RandomFor(ServerEndPoint server) =>
+        _random ??= new Random(Environment.TickCount ^ server.GetHashCode());
 
     private void ExtendRelaxedWindow(TimeSpan duration, string cause)
     {

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -312,11 +312,6 @@ internal sealed partial class ServerEndPoint
     {
         if (migrations.Count == 0 || !IsSourceOf(migrations)) return;
 
-        // sharded subscriptions are slot-bound, so a slot leaving takes them with it. Done before the refresh
-        // and without waiting for the jitter: a subscriber that is silently no longer subscribed is a
-        // correctness problem, where a stale slot map is only an extra round trip
-        ResubscribeShardedChannels(migrations);
-
         // Coalesce *before* the jitter, not after. ReconfigureIfNeeded declines only while a refresh is
         // actually in flight, and the jitter spreads a burst of notifications out far enough that each one
         // completes before the next begins - so relying on that alone turns ten notifications into ten
@@ -331,14 +326,17 @@ internal sealed partial class ServerEndPoint
         Multiplexer.Trace($"{cause}; refreshing topology after jitter", ToString());
 
         // fire-and-forget: we are on the read loop, and the refresh must not block it
-        _ = RefreshAfterJitterAsync(cause);
+        _ = RefreshAfterJitterAsync(cause, migrations);
     }
 
-    private async Task RefreshAfterJitterAsync(string cause)
+    private async Task RefreshAfterJitterAsync(string cause, IReadOnlyList<ClusterSlotMigration> migrations)
     {
         try
         {
             await Task.Delay(ServerSelectionStrategy.SharedRandom.Next(MaintenanceRefreshJitterMilliseconds)).ForAwait();
+
+            // deliberately *after* the delay - see the remarks on ResubscribeStrandedShardedChannels
+            ResubscribeStrandedShardedChannels(migrations);
 
             // released before the refresh runs, not after: anything that arrives from here on describes a
             // state this pass may not have seen, and deserves its own pass
@@ -354,7 +352,7 @@ internal sealed partial class ServerEndPoint
     }
 
     /// <summary>
-    /// Re-establishes sharded subscriptions whose slots have just moved off this server.
+    /// Re-establishes sharded subscriptions that the slot movement stranded and nothing else recovered.
     /// </summary>
     /// <remarks>
     /// Mostly belt-and-braces: a server that migrates a slot also sends an unsolicited <c>SUNSUBSCRIBE</c>,
@@ -367,6 +365,21 @@ internal sealed partial class ServerEndPoint
     /// subscribed on this server.
     /// </para>
     /// <para>
+    /// <b>Why this runs after the jitter, and only for a subscription connected nowhere.</b> An earlier cut ran
+    /// it immediately, on the reasoning that a silently-unsubscribed subscriber is a correctness problem while a
+    /// stale slot map is only a round trip. Measured against a fake that emits the realistic sequence, that
+    /// produced an extra resubscribe per channel - because the unsolicited unsubscribe had already started one,
+    /// and mid-flight the subscription still looked like ours. Being a genuine *fallback* means acting only
+    /// once the other path has had its chance, which costs a stranded subscription up to the jitter in
+    /// recovery time and costs nothing when it was not needed.
+    /// </para>
+    /// <para>
+    /// Measured against the fake's realistic sequence: four (re)subscribes with notifications off, five with
+    /// them on. The extra one is this fallback acting on a subscription the unsolicited-unsubscribe path left
+    /// attached to nothing - i.e. it is the feature working, not duplicate work. One extra attempt per
+    /// stranded channel, not one per notification.
+    /// </para>
+    /// <para>
     /// Note it resubscribes via <em>this</em> server, not the migration target, reusing
     /// <see cref="RedisSubscriber.ResubscribeToServer"/> unchanged: the outgoing node is the one we know has
     /// the new route, and sending there follows the redirect. The target is named in the notification and
@@ -374,7 +387,7 @@ internal sealed partial class ServerEndPoint
     /// and the redirect path is the one already proven by the <c>SUNSUBSCRIBE</c> case.
     /// </para>
     /// </remarks>
-    private void ResubscribeShardedChannels(IReadOnlyList<ClusterSlotMigration> migrations)
+    private void ResubscribeStrandedShardedChannels(IReadOnlyList<ClusterSlotMigration> migrations)
     {
         var subscriptions = Multiplexer.GetSubscriptions();
         if (subscriptions.IsEmpty) return;
@@ -390,8 +403,20 @@ internal sealed partial class ServerEndPoint
             var slot = strategy.HashSlot(channel);
             if (slot == ServerSelectionStrategy.NoSlot || !IsInMigratedRange(migrations, slot)) continue;
 
+            // Skip only if it is attached somewhere *else* - that means the other path already moved it. Still
+            // attached to us is the pre-emptive case (the notification beat the unsubscribe, and the
+            // subscription is now stale); attached nowhere is the stranded case. Both need acting on, and
+            // distinguishing them from "already handled" is the whole job of this check.
+            var subscription = pair.Value;
+            var current = subscription.GetAnyCurrentServer();
+            if (current is not null && !ReferenceEquals(current, this))
+            {
+                Multiplexer.Trace($"slot {slot} moved, and {channel} has already moved with it; leaving it alone", ToString());
+                continue;
+            }
+
             Multiplexer.Trace($"slot {slot} moved; resubscribing {channel}", ToString());
-            Multiplexer.DefaultSubscriber.ResubscribeToServer(pair.Value, channel, this, cause: "smigrated");
+            Multiplexer.DefaultSubscriber.ResubscribeToServer(subscription, channel, this, cause: "smigrated");
         }
     }
 

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -105,6 +105,7 @@ internal sealed partial class ServerEndPoint
     // conservative - a repeat of an id we have already acted on is ignored, and nothing else is inferred.
     // Allocated on first notification, so a server that never sees one pays nothing.
     private long[]? _lastSequenceIds;
+    private bool[]? _haveSequenceIds; // zero is a real sequence number, so "unset" needs its own bit
     private readonly object _maintenanceSync = new();
 
     /// <summary>
@@ -236,16 +237,23 @@ internal sealed partial class ServerEndPoint
         lock (_maintenanceSync)
         {
             var ids = _lastSequenceIds ??= new long[MaintenanceNotificationTypeCount];
+            var have = _haveSequenceIds ??= new bool[MaintenanceNotificationTypeCount];
             if ((uint)index >= (uint)ids.Length) return true; // unknown type: don't dedup what we can't index
 
+            // The "have we seen one" bit is separate because zero is a real sequence number - observed on
+            // Enterprise 8.6.2 as the first event of a chain (`>4 $6 MOVING :0 :15 _`). Treating a stored zero
+            // as "unset", which an earlier cut did, quietly disabled dedup for whichever notification happened
+            // to open the chain.
+            //
             // note "<=", not "<": a replay carries the id we already acted on
-            if (ids[index] != 0 && id <= ids[index])
+            if (have[index] && id <= ids[index])
             {
                 Multiplexer.Trace($"{type}: ignoring replayed sequence id {id}", ToString());
                 return false;
             }
 
             ids[index] = id;
+            have[index] = true;
             return true;
         }
     }

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -101,9 +101,12 @@ internal sealed partial class ServerEndPoint
     // the notification that last touched the window, reported on faults that happen inside it
     private int _relaxedType;
 
-    // Dedup state, per notification type: the sequence ids are not defined by any specification, so this is
-    // conservative - a repeat of an id we have already acted on is ignored, and nothing else is inferred.
-    // Allocated on first notification, so a server that never sees one pays nothing.
+    // Dedup state, per notification type. No specification defines the sequence ids, but they were observed on
+    // Enterprise 8.6.2 to be monotonic per database and shared across types, and to carry the same value on
+    // every node broadcasting a given event - so they identify the event, which is exactly what dedup needs.
+    // Keyed per type anyway: within a type the ids are still monotonic, and a per-type key cannot mistake one
+    // node's earlier event for a replay of another's later one. Allocated on first notification, so a server
+    // that never sees one pays nothing.
     private long[]? _lastSequenceIds;
     private bool[]? _haveSequenceIds; // zero is a real sequence number, so "unset" needs its own bit
     private readonly object _maintenanceSync = new();

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -1,5 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using RESPite;
+using StackExchange.Redis.Maintenance;
 
 namespace StackExchange.Redis;
 
@@ -86,4 +89,148 @@ internal sealed partial class ServerEndPoint
             ConnectionFailureType.ProtocolFailure,
             new RedisConnectionException(ConnectionFailureType.ProtocolFailure, CommandFlags.None, $"Maintenance notifications are enabled, but unavailable: {reason}", innerException: null));
     }
+
+    // The relaxed-timeout window, expressed as a single deadline in Environment.TickCount terms so that it
+    // can be read without a lock from the heartbeat sweeps. Zero means "no window"; a deadline that computes
+    // to zero is nudged by a tick rather than complicating the sentinel. Comparisons are unchecked
+    // subtraction, as elsewhere in this type, so the ~49-day wrap is a non-event.
+    private int _relaxedDeadlineTicks;
+
+    // Dedup state, per notification type: the sequence ids are not defined by any specification, so this is
+    // conservative - a repeat of an id we have already acted on is ignored, and nothing else is inferred.
+    // Allocated on first notification, so a server that never sees one pays nothing.
+    private long[]? _lastSequenceIds;
+    private readonly object _maintenanceSync = new();
+
+    /// <summary>
+    /// Whether timeouts are currently relaxed for this server.
+    /// </summary>
+    internal bool IsMaintenanceRelaxed => GetRelaxedRemaining() > 0;
+
+    /// <summary>
+    /// The effective timeout for a command against this server: the configured value, or the relaxed value if
+    /// that is larger and a window is open. Relaxation is a floor and can never shorten a timeout.
+    /// </summary>
+    /// <remarks>
+    /// Read from the timeout sweeps rather than stamped onto each message: both sweeps rely on head-of-line
+    /// ordering and stop at the first message that has not timed out, which per-message timeouts would
+    /// invalidate. The consequence is that relaxation applies to whatever is outstanding when a window opens,
+    /// and stops applying when it closes - which is one of the reasons the post-event tail exists.
+    /// </remarks>
+    internal int GetEffectiveTimeoutMilliseconds(int configuredMilliseconds)
+    {
+        if (GetRelaxedRemaining() <= 0) return configuredMilliseconds;
+
+        var relaxed = (int)Multiplexer.RawConfig.MaintenanceRelaxedTimeout.TotalMilliseconds;
+        return relaxed > configuredMilliseconds ? relaxed : configuredMilliseconds;
+    }
+
+    /// <summary>
+    /// Milliseconds of relaxation left, or zero if none; clears an expired window as a side-effect.
+    /// </summary>
+    private int GetRelaxedRemaining()
+    {
+        var deadline = Volatile.Read(ref _relaxedDeadlineTicks);
+        if (deadline == 0) return 0;
+
+        var remaining = unchecked(deadline - Environment.TickCount);
+        if (remaining > 0) return remaining;
+
+        // expired; clear it, but only if nobody has moved it on in the meantime
+        Interlocked.CompareExchange(ref _relaxedDeadlineTicks, 0, deadline);
+        return 0;
+    }
+
+    /// <summary>
+    /// An announced disruption has started (or is still running): open or extend the relaxed window.
+    /// </summary>
+    internal void OnMaintenanceWindowOpened(MaintenanceNotificationType type, long sequenceId, TimeSpan? time)
+    {
+        if (!TryClaimSequenceId(type, sequenceId)) return;
+
+        var config = Multiplexer.RawConfig;
+        var floor = config.MaintenanceRelaxedTimeout;
+        var cap = config.MaintenanceRelaxedWindowMax;
+
+        // no time, or a time at or below zero, means "act now" rather than "ignore this": a connection that
+        // arrives mid-window is told what is left of it, and that can legitimately be negative
+        var duration = time is { } value && value > TimeSpan.Zero ? value : floor;
+        if (duration < floor) duration = floor;
+        if (duration > cap) duration = cap;
+
+        ExtendRelaxedWindow(duration, $"{type} for {duration.TotalSeconds}s");
+    }
+
+    /// <summary>
+    /// An announced disruption has finished: replace the remaining window with the post-event tail.
+    /// </summary>
+    /// <remarks>
+    /// Replace rather than extend-or-shorten. The server has told us the operation completed, so whatever it
+    /// previously said about duration is stale - but the tail still applies, because completion is when every
+    /// other client that received the same notification re-engages.
+    /// </remarks>
+    internal void OnMaintenanceWindowClosed(MaintenanceNotificationType type, long sequenceId)
+    {
+        if (!TryClaimSequenceId(type, sequenceId)) return;
+
+        var tail = Multiplexer.RawConfig.MaintenancePostEventRelaxedDuration;
+        if (tail <= TimeSpan.Zero)
+        {
+            Volatile.Write(ref _relaxedDeadlineTicks, 0);
+            Multiplexer.Trace($"{type}: relaxation ended", ToString());
+            return;
+        }
+
+        var deadline = NudgeFromZero(unchecked(Environment.TickCount + (int)tail.TotalMilliseconds));
+        Volatile.Write(ref _relaxedDeadlineTicks, deadline);
+        Multiplexer.Trace($"{type}: relaxation continues for {tail.TotalSeconds}s (post-event)", ToString());
+    }
+
+    private void ExtendRelaxedWindow(TimeSpan duration, string cause)
+    {
+        var candidate = NudgeFromZero(unchecked(Environment.TickCount + (int)duration.TotalMilliseconds));
+        while (true)
+        {
+            var current = Volatile.Read(ref _relaxedDeadlineTicks);
+
+            // a new notification never shortens an existing window: a FAILING_OVER arriving inside a longer
+            // MIGRATING window must not cut it short
+            if (current != 0 && unchecked(candidate - current) <= 0) return;
+            if (Interlocked.CompareExchange(ref _relaxedDeadlineTicks, candidate, current) == current)
+            {
+                Multiplexer.Trace($"timeouts relaxed: {cause}", ToString());
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Zero is the "no window" sentinel, so a deadline that lands on it moves by a tick.
+    /// </summary>
+    private static int NudgeFromZero(int ticks) => ticks == 0 ? 1 : ticks;
+
+    /// <summary>
+    /// Whether this notification is new, per the conservative dedup described on <see cref="_lastSequenceIds"/>.
+    /// </summary>
+    private bool TryClaimSequenceId(MaintenanceNotificationType type, long sequenceId)
+    {
+        var index = (int)type;
+        lock (_maintenanceSync)
+        {
+            var ids = _lastSequenceIds ??= new long[MaintenanceNotificationTypeCount];
+            if ((uint)index >= (uint)ids.Length) return true; // unknown type: don't dedup what we can't index
+
+            // note "<=", not "<": a replay carries the id we already acted on
+            if (ids[index] != 0 && sequenceId <= ids[index])
+            {
+                Multiplexer.Trace($"{type}: ignoring replayed sequence id {sequenceId}", ToString());
+                return false;
+            }
+
+            ids[index] = sequenceId;
+            return true;
+        }
+    }
+
+    private const int MaintenanceNotificationTypeCount = 8; // None + the seven notification types
 }

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -154,7 +154,7 @@ internal sealed partial class ServerEndPoint
     /// <summary>
     /// An announced disruption has started (or is still running): open or extend the relaxed window.
     /// </summary>
-    internal void OnMaintenanceWindowOpened(MaintenanceNotificationType type, long sequenceId, TimeSpan? time)
+    internal void OnMaintenanceWindowOpened(MaintenanceNotificationType type, long? sequenceId, TimeSpan? time)
     {
         if (!TryClaimSequenceId(type, sequenceId)) return;
 
@@ -180,7 +180,7 @@ internal sealed partial class ServerEndPoint
     /// previously said about duration is stale - but the tail still applies, because completion is when every
     /// other client that received the same notification re-engages.
     /// </remarks>
-    internal void OnMaintenanceWindowClosed(MaintenanceNotificationType type, long sequenceId)
+    internal void OnMaintenanceWindowClosed(MaintenanceNotificationType type, long? sequenceId)
     {
         if (!TryClaimSequenceId(type, sequenceId)) return;
 
@@ -224,8 +224,12 @@ internal sealed partial class ServerEndPoint
     /// <summary>
     /// Whether this notification is new, per the conservative dedup described on <see cref="_lastSequenceIds"/>.
     /// </summary>
-    private bool TryClaimSequenceId(MaintenanceNotificationType type, long sequenceId)
+    private bool TryClaimSequenceId(MaintenanceNotificationType type, long? sequenceId)
     {
+        // no id, no dedup - but the notification still counts. Dropping an announced disruption because we
+        // could not read a field whose meaning nobody has defined would be the wrong way round
+        if (sequenceId is not { } id) return true;
+
         var index = (int)type;
         lock (_maintenanceSync)
         {
@@ -233,13 +237,13 @@ internal sealed partial class ServerEndPoint
             if ((uint)index >= (uint)ids.Length) return true; // unknown type: don't dedup what we can't index
 
             // note "<=", not "<": a replay carries the id we already acted on
-            if (ids[index] != 0 && sequenceId <= ids[index])
+            if (ids[index] != 0 && id <= ids[index])
             {
-                Multiplexer.Trace($"{type}: ignoring replayed sequence id {sequenceId}", ToString());
+                Multiplexer.Trace($"{type}: ignoring replayed sequence id {id}", ToString());
                 return false;
             }
 
-            ids[index] = sequenceId;
+            ids[index] = id;
             return true;
         }
     }

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -312,6 +312,11 @@ internal sealed partial class ServerEndPoint
     {
         if (migrations.Count == 0 || !IsSourceOf(migrations)) return;
 
+        // sharded subscriptions are slot-bound, so a slot leaving takes them with it. Done before the refresh
+        // and without waiting for the jitter: a subscriber that is silently no longer subscribed is a
+        // correctness problem, where a stale slot map is only an extra round trip
+        ResubscribeShardedChannels(migrations);
+
         // Coalesce *before* the jitter, not after. ReconfigureIfNeeded declines only while a refresh is
         // actually in flight, and the jitter spreads a burst of notifications out far enough that each one
         // completes before the next begins - so relying on that alone turns ten notifications into ten
@@ -346,5 +351,60 @@ internal sealed partial class ServerEndPoint
             Volatile.Write(ref _refreshPending, 0);
             Multiplexer.Trace($"topology refresh after {cause} failed: {ex.Message}", ToString());
         }
+    }
+
+    /// <summary>
+    /// Re-establishes sharded subscriptions whose slots have just moved off this server.
+    /// </summary>
+    /// <remarks>
+    /// Mostly belt-and-braces: a server that migrates a slot also sends an unsolicited <c>SUNSUBSCRIBE</c>,
+    /// and <see cref="PhysicalConnection.OnOutOfBand"/> already resubscribes on that. This adds two things.
+    /// It is *pre-emptive* where <c>SMIGRATED</c> arrives first, and it *covers* the case where the
+    /// unsolicited unsubscribe never arrives or is lost - in which case the only other signal is a message
+    /// that silently stops being delivered, which nothing detects.
+    /// <para>
+    /// It also knows which slots moved, so only the affected channels are touched rather than everything
+    /// subscribed on this server.
+    /// </para>
+    /// <para>
+    /// Note it resubscribes via <em>this</em> server, not the migration target, reusing
+    /// <see cref="RedisSubscriber.ResubscribeToServer"/> unchanged: the outgoing node is the one we know has
+    /// the new route, and sending there follows the redirect. The target is named in the notification and
+    /// could be dialled directly, but it may be a node we have never seen, or named in a form we cannot dial,
+    /// and the redirect path is the one already proven by the <c>SUNSUBSCRIBE</c> case.
+    /// </para>
+    /// </remarks>
+    private void ResubscribeShardedChannels(IReadOnlyList<ClusterSlotMigration> migrations)
+    {
+        var subscriptions = Multiplexer.GetSubscriptions();
+        if (subscriptions.IsEmpty) return;
+
+        var strategy = Multiplexer.ServerSelectionStrategy;
+        foreach (var pair in subscriptions)
+        {
+            var channel = pair.Key;
+
+            // ordinary pub/sub is not slot-bound, so a slot moving says nothing about it
+            if (!channel.IsSharded) continue;
+
+            var slot = strategy.HashSlot(channel);
+            if (slot == ServerSelectionStrategy.NoSlot || !IsInMigratedRange(migrations, slot)) continue;
+
+            Multiplexer.Trace($"slot {slot} moved; resubscribing {channel}", ToString());
+            Multiplexer.DefaultSubscriber.ResubscribeToServer(pair.Value, channel, this, cause: "smigrated");
+        }
+    }
+
+    private static bool IsInMigratedRange(IReadOnlyList<ClusterSlotMigration> migrations, int slot)
+    {
+        foreach (var migration in migrations)
+        {
+            foreach (var range in migration.Slots)
+            {
+                if (slot >= range.From && slot <= range.To) return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -331,11 +331,11 @@ namespace StackExchange.Redis
             => !Multiplexer.ServerSelectionStrategy.OwnsAnySlot(this)
             && (subscription?.SubscriptionCount ?? 0) == 0
             && (interactive?.SubscriptionCount ?? 0) == 0
-            && GetCallerOutstandingCount() == 0;
+            && !HasCallerWork();
 
         /// <summary>
-        /// Outstanding work a *caller* is waiting on, which is the only kind that should stop us retiring a
-        /// server.
+        /// Whether a *caller* is waiting on anything here, which is the only kind of work that should stop us
+        /// retiring a server.
         /// </summary>
         /// <remarks>
         /// Deliberately not <see cref="GetOutstandingCount"/>, which counts everything. A node the topology has
@@ -345,8 +345,8 @@ namespace StackExchange.Redis
         /// precondition defeated itself in exactly the case pruning exists for. Keep-alive traffic has the same
         /// property, and is excluded by the same test, since both set the internal-call flag.
         /// </remarks>
-        internal int GetCallerOutstandingCount()
-            => (interactive?.GetCallerOutstandingCount() ?? 0) + (subscription?.GetCallerOutstandingCount() ?? 0);
+        internal bool HasCallerWork()
+            => interactive?.HasCallerWork() == true || subscription?.HasCallerWork() == true;
 
         /// <summary>
         /// Work this server still owes an answer on: written-and-awaiting-response, plus anything queued in
@@ -375,18 +375,23 @@ namespace StackExchange.Redis
             SetUnselectable(UnselectableFlags.Retiring);
             log?.LogInformationRetiringServer(new(EndPoint), reason);
 
+            // Drain what a *caller* is waiting for, not everything outstanding. Our own probes to a node that
+            // has gone away will never be answered, so draining on the total means always waiting out the full
+            // timeout before letting go - measured: a departed node accumulates our autoconfigure traffic
+            // indefinitely (500+ and climbing), so the drain never once completed early. Callers are who the
+            // drain exists for; nobody is waiting on our keep-alives.
             // Stopwatch rather than TickCount64: the latter does not exist on the down-level targets
             var watch = ValueStopwatch.StartNew();
-            int outstanding;
-            while ((outstanding = GetOutstandingCount()) > 0 && watch.ElapsedMilliseconds < drainTimeout.TotalMilliseconds)
+            while (HasCallerWork() && watch.ElapsedMilliseconds < drainTimeout.TotalMilliseconds)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(20)).ForAwait();
             }
 
-            if (outstanding > 0)
+            if (HasCallerWork())
             {
-                // deliberately reported: an abandoned command is exactly what a caller will be asking about
-                log?.LogInformationRetiringServerAbandoned(new(EndPoint), outstanding);
+                // deliberately reported: an abandoned command is exactly what a caller will be asking about.
+                // The count is the total, since that is what is actually being dropped on the floor
+                log?.LogInformationRetiringServerAbandoned(new(EndPoint), GetOutstandingCount());
             }
 
             Dispose();

--- a/src/StackExchange.Redis/ServerEndPoint.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.cs
@@ -331,7 +331,22 @@ namespace StackExchange.Redis
             => !Multiplexer.ServerSelectionStrategy.OwnsAnySlot(this)
             && (subscription?.SubscriptionCount ?? 0) == 0
             && (interactive?.SubscriptionCount ?? 0) == 0
-            && GetOutstandingCount() == 0;
+            && GetCallerOutstandingCount() == 0;
+
+        /// <summary>
+        /// Outstanding work a *caller* is waiting on, which is the only kind that should stop us retiring a
+        /// server.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not <see cref="GetOutstandingCount"/>, which counts everything. A node the topology has
+        /// stopped listing still receives our autoconfigure probes on every pass, and nothing answers them, so
+        /// they accumulate in its backlog: measured at ~170 per pass, growing without bound. Counting those
+        /// made the node look busy *because* we were looking for it, so it could never be retired - the
+        /// precondition defeated itself in exactly the case pruning exists for. Keep-alive traffic has the same
+        /// property, and is excluded by the same test, since both set the internal-call flag.
+        /// </remarks>
+        internal int GetCallerOutstandingCount()
+            => (interactive?.GetCallerOutstandingCount() ?? 0) + (subscription?.GetCallerOutstandingCount() ?? 0);
 
         /// <summary>
         /// Work this server still owes an answer on: written-and-awaiting-response, plus anything queued in

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -60,6 +60,7 @@
     <InternalsVisibleTo Include="StackExchange.Redis.Benchmarks" />
     <InternalsVisibleTo Include="StackExchange.Redis.Server" />
     <InternalsVisibleTo Include="StackExchange.Redis.Tests" />
+    <InternalsVisibleTo Include="StackExchange.Redis.FaultInjector.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/StackExchange.Redis.FaultInjector.Tests/ClusterFamilyScenarioTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/ClusterFamilyScenarioTests.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// The OSS cluster notification family against a real cluster: <c>SMIGRATING</c>, <c>SMIGRATED</c>, and what
+/// the client is supposed to do about them.
+/// </summary>
+/// <remarks>
+/// Every <c>/slot-migrate</c> trigger requires <c>oss_cluster: true</c> with <c>all-master-shards</c>, so this
+/// scenario family is the cluster half of the feature - the half whose reactions (re-reading the slot map,
+/// re-subscribing stranded sharded channels) have until now only been exercised against the in-process fake.
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "cluster-family")]
+public class ClusterFamilyScenarioTests(ExistingDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ExistingDatabaseFixture>
+{
+    /// <summary>
+    /// Slot migrations, in the four shapes the injector can produce.
+    /// </summary>
+    /// <remarks>
+    /// The effects differ in what happens to the *endpoint list*, which is the thing a client has to keep up
+    /// with: <c>remove-add</c> retires a node and introduces one, <c>remove</c> only retires, <c>add</c> only
+    /// introduces, and <c>slot-shuffle</c> moves slots between nodes that both stay. So they cover the four
+    /// ways a slot map can go stale, and only one of them (shuffle) leaves the endpoint set alone.
+    /// </remarks>
+    /// <remarks>
+    /// Only <c>remove</c> here. The other effects need a database the setup leg will not provision, and get
+    /// their own fixture below rather than skipping: <c>add</c> and <c>slot-shuffle</c> need a node holding
+    /// several shards, and <c>remove-add</c> is not in <c>/slot-migrate/setup</c>'s effect enum at all.
+    /// </remarks>
+    [Theory]
+    [InlineData("remove", "migrate")]
+    public async Task SlotMigrationIsAnnouncedAndActedOn(string effect, string trigger)
+    {
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        await using var scenario = await ScenarioRun.SetupAsync(
+            fixture.Injector, "slot-migrate", effect, trigger, log.WriteLine,
+            setupTrigger: "reshard", cancellationToken: cancellationToken);
+
+        var database = scenario.Database;
+        Assert.NotNull(database);
+        ScenarioSupport.RequireEffectIsAchievable(scenario, effect);
+
+        var clock = Stopwatch.StartNew();
+        var events = new List<PushMaintenanceEvent>();
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig(fixture.Environment));
+        conn.ServerMaintenanceEvent += (_, e) =>
+        {
+            if (e is PushMaintenanceEvent push)
+            {
+                lock (events) events.Add(push);
+                log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  {push.NotificationType} seq={push.SequenceId} {push.RawMessage}");
+                foreach (var migration in push.SlotMigrations)
+                {
+                    log.WriteLine($"           slots {migration.RawSlots}: {migration.Source} -> {migration.Target}");
+                }
+            }
+        };
+
+        var endpointsBefore = conn.GetEndPoints().Length;
+        log.WriteLine($"connected as {conn.GetServer(conn.GetEndPoints()[0]).ServerType} across {endpointsBefore} endpoint(s)");
+
+        // keys spread across slots, so a migration of any shard moves something we are actually using
+        var db = conn.GetDatabase();
+        var keys = Enumerable.Range(0, 32).Select(i => (RedisKey)$"fi-{effect}-{i}").ToArray();
+        foreach (var key in keys) await db.StringSetAsync(key, "before");
+
+        clock.Restart();
+        await ScenarioSupport.FireOrSkipAsync(scenario, effect, cancellationToken);
+        log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  injector reports finished");
+
+        // Keep using the connection while things move: a slot map that has gone stale shows up as MOVED
+        // redirections, and the point of the feature is that we learn the new one rather than eating them.
+        var deadline = clock.Elapsed + TimeSpan.FromSeconds(45);
+        int reads = 0, failures = 0;
+        while (clock.Elapsed < deadline)
+        {
+            foreach (var key in keys)
+            {
+                try
+                {
+                    await db.StringGetAsync(key);
+                    reads++;
+                }
+                catch (Exception ex) when (ex is RedisException or TimeoutException)
+                {
+                    failures++;
+                    if (failures <= 3) log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  read failed: {ex.Message}");
+                }
+            }
+
+            await Task.Delay(500, cancellationToken);
+        }
+
+        lock (events)
+        {
+            log.WriteLine($"  {events.Count} notification(s); {reads} reads, {failures} failures; "
+                + $"endpoints {endpointsBefore} -> {conn.GetEndPoints().Length}");
+
+            // A slot migration is announced to every proxy, so any connection should see it. What is asserted is
+            // only that we were told and understood it - the *reaction* is asserted separately below, because a
+            // migration that moves no slot we hold would legitimately change nothing here.
+            Assert.NotEmpty(events);
+            Assert.All(events, e => Assert.NotEqual(MaintenanceNotificationType.None, e.NotificationType));
+            Assert.Contains(events, e => e.NotificationType is MaintenanceNotificationType.SlotMigrating or MaintenanceNotificationType.SlotMigrated);
+
+            // Any SMIGRATED that carried a payload must have parsed into something usable; an empty list would
+            // mean we saw the frame and threw the contents away.
+            foreach (var migrated in events.Where(e => e.NotificationType == MaintenanceNotificationType.SlotMigrated))
+            {
+                if (!string.IsNullOrEmpty(migrated.Payload) || migrated.SlotMigrations.Count > 0)
+                {
+                    Assert.NotEmpty(migrated.SlotMigrations);
+                    Assert.All(migrated.SlotMigrations, m => Assert.NotNull(m.Source));
+                }
+            }
+        }
+
+        // and the client is still serving keys across the new topology
+        Assert.True(reads > 0, "no reads succeeded at all during the migration");
+        foreach (var key in keys) Assert.Equal("before", await db.StringGetAsync(key));
+    }
+
+    [Fact]
+    public async Task ShardedSubscriptionSurvivesASlotMigration()
+    {
+        // D5's resubscription, against a real cluster. A sharded channel is bound to the node owning its slot,
+        // so a migration strands the subscription: the server sends an unsolicited SUNSUBSCRIBE and stops
+        // delivering. Recovering that is the client's job, and until now only the fake has tested it.
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        await using var scenario = await ScenarioRun.SetupAsync(
+            fixture.Injector, "slot-migrate", "remove", "migrate", log.WriteLine,
+            setupTrigger: "reshard", cancellationToken: cancellationToken);
+        Assert.NotNull(scenario.Database);
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(scenario.Database.GetClientConfig(fixture.Environment));
+        var subscriber = conn.GetSubscriber();
+
+        // several channels, because the migration moves the slots of one node: with one channel the test would
+        // usually be asserting that nothing happened to it
+        var channels = Enumerable.Range(0, 16).Select(i => RedisChannel.Sharded($"fi-shard-{i}")).ToArray();
+        var received = new int[channels.Length];
+        for (int i = 0; i < channels.Length; i++)
+        {
+            var index = i;
+            await subscriber.SubscribeAsync(channels[i], (_, _) => Interlocked.Increment(ref received[index]));
+        }
+
+        Assert.True(await DeliversEverywhereAsync(subscriber, channels, received, cancellationToken),
+            "every sharded channel should deliver before the migration, or the test proves nothing");
+        log.WriteLine($"all {channels.Length} sharded channels delivering before the migration");
+
+        await ScenarioSupport.FireOrSkipAsync(scenario, "remove", cancellationToken);
+
+        // The recovery is deliberately allowed to be slow: it is driven by a jittered topology refresh and, as a
+        // fallback, by a delayed resubscription sweep. What matters is that it happens without the caller doing
+        // anything, not that it is instant.
+        var recovered = await DeliversEverywhereAsync(subscriber, channels, received, cancellationToken, timeoutSeconds: 90);
+        log.WriteLine($"delivery after migration: {(recovered ? "all channels" : "INCOMPLETE")}");
+        Assert.True(recovered, "sharded subscriptions should deliver again once the topology settles");
+    }
+
+    /// <summary>
+    /// Publishes to every channel and waits until each one has delivered at least one more message.
+    /// </summary>
+    /// <remarks>
+    /// Publishing repeatedly rather than once: the publish itself routes by slot, so during a migration an
+    /// individual publish can land on a node that no longer owns the slot. Retrying is what a real caller would
+    /// do, and it keeps the test measuring *delivery* rather than the timing of one message.
+    /// </remarks>
+    private async Task<bool> DeliversEverywhereAsync(
+        ISubscriber subscriber,
+        RedisChannel[] channels,
+        int[] received,
+        CancellationToken cancellationToken,
+        int timeoutSeconds = 20)
+    {
+        var baseline = channels.Select((_, i) => Volatile.Read(ref received[i])).ToArray();
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            for (int i = 0; i < channels.Length; i++)
+            {
+                if (Volatile.Read(ref received[i]) > baseline[i]) continue;
+                try
+                {
+                    await subscriber.PublishAsync(channels[i], "ping");
+                }
+                catch (Exception ex) when (ex is RedisException or TimeoutException)
+                {
+                    // expected mid-migration; the retry is the point
+                }
+            }
+
+            await Task.Delay(500, cancellationToken);
+            if (channels.Select((_, i) => Volatile.Read(ref received[i]) > baseline[i]).All(x => x)) return true;
+        }
+
+        var missing = channels.Where((_, i) => Volatile.Read(ref received[i]) <= baseline[i]).Select(c => c.ToString());
+        log.WriteLine($"  not delivering: {string.Join(", ", missing)}");
+        return false;
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/DenseClusterScenarioTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/DenseClusterScenarioTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// An OSS cluster with packed shards, so <c>add</c> and <c>slot-shuffle</c> have something to move.
+/// </summary>
+public sealed class DenseClusterFixture() : FaultInjectorFixture(DatabaseShape.OssClusterDense);
+
+/// <summary>
+/// The slot migrations the scenario setup legs cannot provision for.
+/// </summary>
+/// <remarks>
+/// These looked like an environment limitation - the injector refuses them with "No node with multiple shards
+/// found" - and they are not: the setup leg provisions one shard per node, so there is never a node to take a
+/// shard *from*. Six shards with <c>dense</c> placement over three nodes gives two per node, and both effects
+/// then run. The lesson generalises: a scenario that setup cannot arrange is still reachable by provisioning
+/// the database ourselves and driving the run leg by <c>bdb_id</c>.
+/// <para>
+/// No scenario teardown here, deliberately. Teardown deletes the database, and this database belongs to the
+/// fixture, which deletes it itself; and <c>migrate</c> excludes no nodes, so there is nothing to restore.
+/// </para>
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "cluster-family")]
+public class DenseClusterScenarioTests(DenseClusterFixture fixture, ITestOutputHelper log)
+    : IClassFixture<DenseClusterFixture>
+{
+    [Theory]
+    [InlineData("add")]
+    [InlineData("slot-shuffle")]
+    [InlineData("remove-add")]
+    public async Task SlotMigrationIsAnnouncedAndActedOn(string effect)
+    {
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var database = fixture.Database;
+        Assert.NotNull(database);
+        log.WriteLine($"{effect} against {database}");
+
+        var clock = Stopwatch.StartNew();
+        var events = new List<PushMaintenanceEvent>();
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig());
+        conn.ServerMaintenanceEvent += (_, e) =>
+        {
+            if (e is PushMaintenanceEvent push)
+            {
+                lock (events) events.Add(push);
+                log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  {push.NotificationType} seq={push.SequenceId} {push.RawMessage}");
+                foreach (var migration in push.SlotMigrations)
+                {
+                    log.WriteLine($"           slots {migration.RawSlots}: {migration.Source} -> {migration.Target}");
+                }
+            }
+        };
+
+        var db = conn.GetDatabase();
+        var keys = Enumerable.Range(0, 32).Select(i => (RedisKey)$"fi-dense-{effect}-{i}").ToArray();
+        foreach (var key in keys) await db.StringSetAsync(key, "before");
+
+        clock.Restart();
+        var query = new Dictionary<string, string?>
+        {
+            ["effect"] = effect,
+            ["trigger"] = "migrate",
+            ["bdb_id"] = database.BdbId.ToString(),
+        };
+        await fixture.Injector.PostScenarioAsync("slot-migrate", leg: null, query, cancellationToken: cancellationToken);
+        log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  injector reports finished");
+
+        int reads = 0, failures = 0;
+        var deadline = clock.Elapsed + TimeSpan.FromSeconds(20);
+        while (clock.Elapsed < deadline)
+        {
+            foreach (var key in keys)
+            {
+                try
+                {
+                    await db.StringGetAsync(key);
+                    reads++;
+                }
+                catch (Exception ex) when (ex is RedisException or TimeoutException)
+                {
+                    failures++;
+                }
+            }
+
+            await Task.Delay(500, cancellationToken);
+        }
+
+        lock (events)
+        {
+            log.WriteLine($"  {events.Count} notification(s); {reads} reads, {failures} failures");
+            Assert.NotEmpty(events);
+            Assert.Contains(events, e => e.NotificationType is MaintenanceNotificationType.SlotMigrating
+                or MaintenanceNotificationType.SlotMigrated);
+        }
+
+        Assert.True(reads > 0, "no reads succeeded during the migration");
+        foreach (var key in keys) Assert.Equal("before", await db.StringGetAsync(key));
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/CertificateSanity.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/CertificateSanity.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Checks that the environment's TLS material belongs to the cluster we are about to talk to.
+/// </summary>
+/// <remarks>
+/// Environments get re-provisioned, and the certificates do not always follow. Observed 2026-09-01: the folder
+/// held a server certificate for <c>*.marcgravell-test-46be1d08...</c> while the live cluster was
+/// <c>marcgravell-test-e21cd75d...</c> - a leftover from a previous provision, three days older than the
+/// <c>env_output.json</c> beside it.
+/// <para>
+/// Without this check, that presents as a TLS handshake failure, which reads like a client bug and is not one:
+/// the certificate genuinely does not cover the name being dialled, and refusing it is correct
+/// (<c>TrustIssuer</c> tolerates chain errors only, so a name mismatch fails - as it should). Detecting it here
+/// turns half an hour of certificate archaeology into a skip that names both clusters, and it costs nothing
+/// because it happens before a database is provisioned.
+/// </para>
+/// </remarks>
+internal static class CertificateSanity
+{
+    /// <summary>
+    /// Skips when the environment's certificates were issued for a different cluster.
+    /// </summary>
+    public static void RequireCertificatesMatchThisCluster(FaultInjectorEnvironment environment, Action<string> log)
+    {
+        var clusterName = environment.Cluster?.ClusterName;
+        if (clusterName is null) return; // nothing to compare against; let the connect speak for itself
+
+        // the server certificate the environment generated, if it left one behind
+        var leafPath = Path.Combine(environment.ConfigDirectory.FullName, "redis.crt");
+        if (!File.Exists(leafPath)) return;
+
+        var leaf = X509CertificateLoader.LoadCertificateFromFile(leafPath);
+        var names = ReadDnsNames(leaf);
+        log($"environment server certificate covers [{string.Join(", ", names)}]; cluster is '{clusterName}'");
+
+        if (!names.Any(name => CoversClusterEndpoints(name, clusterName)))
+        {
+            Assert.Skip(
+                $"the environment's TLS certificates cover [{string.Join(", ", names)}] but this cluster is "
+                + $"'{clusterName}' - they are left over from an earlier provision, so a TLS test here would "
+                + "only be measuring the mismatch. Re-provision with certificate generation enabled to run it.");
+        }
+    }
+
+    /// <summary>
+    /// Every DNS name a certificate carries, not just the first.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetNameInfo</c> returns one name, which is not enough: these certificates carry both a wildcard and
+    /// the bare cluster name, and which one comes back decides the answer. Reading the SAN extension properly is
+    /// the difference between a check that works and one that skips a perfectly good environment - as the first
+    /// version of this did.
+    /// </remarks>
+    private static List<string> ReadDnsNames(X509Certificate2 certificate)
+    {
+        foreach (var extension in certificate.Extensions)
+        {
+            if (extension is X509SubjectAlternativeNameExtension san)
+            {
+                return [.. san.EnumerateDnsNames()];
+            }
+        }
+
+        var subject = certificate.GetNameInfo(X509NameType.DnsName, forIssuer: false);
+        return subject is null ? [] : [subject];
+    }
+
+    /// <summary>
+    /// Whether a certificate name covers the endpoints of a given cluster.
+    /// </summary>
+    /// <remarks>
+    /// The hosts actually dialled are *database* endpoints - <c>redis-13500.&lt;cluster&gt;</c> - so a wildcard
+    /// whose parent is the cluster name is exactly right, even though (correctly) it does not match the bare
+    /// cluster name itself. An exact SAN for the cluster name also counts, since that is what the REST API is
+    /// reached by.
+    /// </remarks>
+    private static bool CoversClusterEndpoints(string certificateName, string clusterName)
+    {
+        if (certificateName.StartsWith("*.", StringComparison.Ordinal))
+        {
+            return string.Equals(certificateName[2..], clusterName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return string.Equals(certificateName, clusterName, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ClusterRestClient.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ClusterRestClient.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// The cluster's own REST API on port 9443, for the few facts the fault injector does not expose.
+/// </summary>
+/// <remarks>
+/// Reads only. Anything that *changes* state goes through the injector so it is recorded as a job with an
+/// action id - which is also how the console works, and it means a scenario can be reconstructed afterwards
+/// from the injector's history rather than from somebody's memory.
+/// </remarks>
+public sealed class ClusterRestClient : IDisposable
+{
+    private readonly HttpClient _http;
+
+    public ClusterRestClient(FaultInjectorEnvironment.ClusterCredentials credentials, string? certificateAuthorityPath)
+    {
+        var handler = new HttpClientHandler();
+
+        if (certificateAuthorityPath is not null)
+        {
+            // The cluster's management certificate is self-signed per environment, like the proxy ones. Pin to
+            // the CA in the config directory rather than accepting anything: this channel carries credentials.
+            var issuer = X509CertificateLoader.LoadCertificateFromFile(certificateAuthorityPath);
+            handler.ServerCertificateCustomValidationCallback = (_, certificate, chain, _) =>
+            {
+                if (certificate is null || chain is null) return false;
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(issuer);
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                return chain.Build(certificate);
+            };
+        }
+
+        _http = new HttpClient(handler) { BaseAddress = credentials.RestUrl, Timeout = TimeSpan.FromSeconds(30) };
+        var basic = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{credentials.Username}:{credentials.Password}"));
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", basic);
+    }
+
+    public void Dispose() => _http.Dispose();
+
+    /// <summary>
+    /// Every database on the cluster, as (bdb_id, name).
+    /// </summary>
+    public async Task<List<(int BdbId, string Name)>> ListDatabasesAsync()
+    {
+        using var response = await _http.GetAsync("/v1/bdbs?fields=uid,name");
+        response.EnsureSuccessStatusCode();
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var results = new List<(int, string)>();
+        foreach (var bdb in document.RootElement.EnumerateArray())
+        {
+            if (bdb.TryGetProperty("uid", out var uid) && bdb.TryGetProperty("name", out var name)
+                && uid.TryGetInt32(out var id) && name.GetString() is { } text)
+            {
+                results.Add((id, text));
+            }
+        }
+
+        return results;
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/DatabaseShape.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/DatabaseShape.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// The database shapes this suite provisions, described declaratively.
+/// </summary>
+/// <remarks>
+/// Shape is the axis that matters, and it is not cosmetic: measurements on 2026-08-28 showed the number of A
+/// records a hostname carries follows actual proxy *placement*, giving 2 for <c>all-nodes</c>, 3 for
+/// <c>all-master-shards</c> and 1 for <c>single</c> - and the handoff takes a different branch depending on
+/// whether a live sibling address exists. So the shapes below are the reason to provision databases from inside
+/// the tests at all: they turn that into a matrix axis instead of a manual sweep.
+/// </remarks>
+public sealed record DatabaseShape(
+    string Label,
+    bool OssCluster = false,
+    string? ProxyPolicy = null,
+    bool Tls = false,
+    bool Replication = false,
+    int ShardCount = 1,
+    string? EndpointType = null,
+    string ShardsPlacement = "sparse",
+    string IpType = "external")
+{
+    /// <summary>A proxied standalone database: the shape <c>MOVING</c> actually fires on.</summary>
+    public static readonly DatabaseShape ProxiedStandalone = new("proxied-standalone", ProxyPolicy: "single");
+
+    /// <summary>Multiple proxies, so the hostname carries several A records and a sibling always exists.</summary>
+    public static readonly DatabaseShape MultiProxy = new("multi-proxy", ProxyPolicy: "all-master-shards", ShardCount: 2);
+
+    /// <summary>OSS cluster API: the family that emits <c>SMIGRATING</c>/<c>SMIGRATED</c> instead.</summary>
+    public static readonly DatabaseShape OssClusterApi = new("oss-cluster", OssCluster: true, ProxyPolicy: "all-master-shards", ShardCount: 2);
+
+    /// <summary>
+    /// An OSS cluster whose shards are packed, so some node holds more than one.
+    /// </summary>
+    /// <remarks>
+    /// Exists to reach the <c>add</c> and <c>slot-shuffle</c> migrations, which need a node holding several
+    /// shards to have something to move. The scenario setup legs cannot produce that - they provision one shard
+    /// per node - so those effects looked like an environment limitation until this was tried: six shards with
+    /// <c>dense</c> placement over three nodes gives two per node, and both effects then run.
+    /// <para>
+    /// Note it also demonstrates the placement-versus-policy point from the other direction: packed masters mean
+    /// <c>all-master-shards</c> advertises a *single* address, because the count follows placement.
+    /// </para>
+    /// </remarks>
+    public static readonly DatabaseShape OssClusterDense = new(
+        "oss-cluster-dense", OssCluster: true, ProxyPolicy: "all-master-shards", ShardCount: 6, ShardsPlacement: "dense");
+
+    /// <summary>
+    /// TLS with hostname-advertised endpoints - the documented coverage gap.
+    /// </summary>
+    /// <remarks>
+    /// <c>endpoint_type: ip</c> is the interesting counterpart: with addresses advertised, a verifying client
+    /// cannot check identity on the targets it is told to use, because the proxy certificate carries DNS names
+    /// and no IP SAN. That pairing is the thing no in-process harness can honestly reproduce.
+    /// </remarks>
+    public static readonly DatabaseShape TlsWithHostnames = new("tls-hostnames", OssCluster: true, Tls: true, ShardCount: 2, EndpointType: "hostname");
+
+    /// <summary>
+    /// The <c>create_database</c> parameters for this shape.
+    /// </summary>
+    /// <remarks>
+    /// Goes inside a <c>database_config</c> wrapper when it reaches the injector - a flat payload is rejected
+    /// with "Invalid parameter 'database_config': got None".
+    /// <para>
+    /// Built as data rather than as a typed record, because these are the injector's wire names and its schema
+    /// declares <c>parameters</c> as untyped. The names here are no longer guesses: they match the environment's
+    /// own <c>bdb_config.json</c> and the <c>dbconfig</c> the injector itself publishes as a trigger requirement
+    /// (<c>GET /topology-change-standalone?effect=...</c>), which is the authoritative list.
+    /// </para>
+    /// </remarks>
+    public Dictionary<string, object?> ToCreateParameters(string name, int port)
+    {
+        var parameters = new Dictionary<string, object?>
+        {
+            ["name"] = name,
+            ["port"] = port,
+            ["memory_size"] = 134_217_728, // 128MB, matching what the injector asks for in its own requirements
+            ["eviction_policy"] = "volatile-lru",
+            ["replication"] = Replication,
+            ["sharding"] = ShardCount > 1,
+            ["shards_count"] = ShardCount,
+            ["shards_placement"] = ShardsPlacement,
+            ["oss_cluster"] = OssCluster,
+        };
+
+        if (ShardCount > 1)
+        {
+            // Required whenever sharding is on: Redis Enterprise rejects the database outright with
+            // "Invalid sharding configuration: missing shard_key_regex". These two patterns are the standard
+            // pair - an explicit hash tag if present, otherwise the whole key - and are what the environment's
+            // own bdb_config.json uses.
+            parameters["shard_key_regex"] = new[]
+            {
+                new Dictionary<string, object?> { ["regex"] = ".*\\{(?<tag>.*)\\}.*" },
+                new Dictionary<string, object?> { ["regex"] = "(?<tag>.*)" },
+            };
+        }
+
+        // only when asked for: a database with no tls_mode serves plaintext, and setting it here without
+        // certificates in place produces a database nothing can connect to
+        if (Tls) parameters["tls_mode"] = "enabled";
+
+        if (OssCluster)
+        {
+            // Which addresses CLUSTER SLOTS advertises, and it is not cosmetic: the default is *internal*, so a
+            // cluster database created without this advertises VPC-private addresses. A client outside the VPC
+            // then connects to the seed, discovers nodes at 10.x, and cannot reach any of them - which is
+            // exactly how the first dense-cluster run failed. Distinct from EndpointType (ip versus hostname),
+            // which is about identity rather than routing.
+            parameters["oss_cluster_api_preferred_ip_type"] = IpType;
+        }
+
+        if (OssCluster && EndpointType is not null)
+        {
+            // Two distinct axes, easily conflated. "endpoint_type" is ip-versus-hostname - what CLUSTER SLOTS
+            // advertises, and therefore whether a verifying TLS client can check identity on the targets it is
+            // given. "ip_type" is internal-versus-external, which is about routing rather than identity.
+            parameters["oss_cluster_api_preferred_endpoint_type"] = EndpointType;
+        }
+
+        if (ProxyPolicy is not null) parameters["proxy_policy"] = ProxyPolicy;
+
+        return parameters;
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ExistingDatabase.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ExistingDatabase.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// A database the environment already provisioned, read from <c>endpoints.json</c>.
+/// </summary>
+/// <remarks>
+/// The counterpart to creating our own. Provisioning gives control over the shape, which is what the matrix
+/// needs; this gives a run against whatever the environment template made, which is what you want when the
+/// question is "does any of this work at all" rather than "does it work for shape X".
+/// <para>
+/// Note <c>endpoints.json</c> carries more than expected: each entry's <c>raw_endpoints</c> includes
+/// <c>proxy_policy</c>, <c>oss_cluster_api_preferred_endpoint_type</c> and the address list behind the DNS
+/// name. So the facts that decide client behaviour are mostly here, and the cluster REST API is only needed for
+/// the explicit <c>oss_cluster</c> flag and the client-certificate settings.
+/// </para>
+/// </remarks>
+public sealed record ExistingDatabase(
+    string Key,
+    int BdbId,
+    string Host,
+    int Port,
+    bool Tls,
+    string? Username,
+    string? Password,
+    string? ProxyPolicy,
+    string? EndpointType,
+    IReadOnlyList<string> Addresses)
+{
+    /// <summary>
+    /// How many addresses the hostname is expected to resolve to.
+    /// </summary>
+    /// <remarks>
+    /// The measured driver of handoff behaviour: with more than one address a live sibling always exists, so a
+    /// handoff steps sideways immediately; with one, it has to wait for the record to move. Tests that care
+    /// should assert on this rather than on the policy name, because the count follows actual proxy
+    /// *placement* - an <c>all-master-shards</c> database whose shards share a node advertises one address.
+    /// </remarks>
+    public int AdvertisedAddressCount => Addresses.Count;
+
+    public override string ToString() => $"{Key} ({Host}:{Port}, bdb {BdbId}, {ProxyPolicy ?? "?"}, {AdvertisedAddressCount} addr)";
+
+    /// <summary>
+    /// Reads every database in the environment's <c>endpoints.json</c>, keyed as that file keys them.
+    /// </summary>
+    public static Dictionary<string, ExistingDatabase> ReadAll(FaultInjectorEnvironment environment)
+    {
+        var results = new Dictionary<string, ExistingDatabase>(StringComparer.OrdinalIgnoreCase);
+        var path = Path.Combine(environment.ConfigDirectory.FullName, "endpoints.json");
+        if (!File.Exists(path)) return results;
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        foreach (var entry in document.RootElement.EnumerateObject())
+        {
+            if (entry.Value.ValueKind != JsonValueKind.Object) continue;
+            if (TryRead(entry.Name, entry.Value, out var database)) results[entry.Name] = database;
+        }
+
+        return results;
+    }
+
+    private static bool TryRead(string key, JsonElement element, out ExistingDatabase database)
+    {
+        database = null!;
+        if (!element.TryGetProperty("bdb_id", out var bdbId) || !bdbId.TryGetInt32(out var id)) return false;
+
+        // "endpoints" holds "host:port" or a redis:// URI depending on how the environment was templated
+        string? host = null;
+        int port = 0;
+        if (element.TryGetProperty("endpoints", out var endpoints) && endpoints.ValueKind == JsonValueKind.Array
+            && endpoints.GetArrayLength() > 0 && endpoints[0].GetString() is { } first)
+        {
+            var text = first;
+            var scheme = text.IndexOf("://", StringComparison.Ordinal);
+            if (scheme >= 0) text = text[(scheme + 3)..];
+            var colon = text.LastIndexOf(':');
+            if (colon > 0 && int.TryParse(text[(colon + 1)..], out port)) host = text[..colon];
+        }
+
+        string? proxyPolicy = null, endpointType = null;
+        var addresses = new List<string>();
+        if (element.TryGetProperty("raw_endpoints", out var raw) && raw.ValueKind == JsonValueKind.Array
+            && raw.GetArrayLength() > 0)
+        {
+            var head = raw[0];
+            proxyPolicy = ReadString(head, "proxy_policy");
+            endpointType = ReadString(head, "oss_cluster_api_preferred_endpoint_type");
+            host ??= ReadString(head, "dns_name");
+            if (port == 0 && head.TryGetProperty("port", out var rawPort)) rawPort.TryGetInt32(out port);
+
+            if (head.TryGetProperty("addr", out var addr) && addr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in addr.EnumerateArray())
+                {
+                    if (item.GetString() is { } address) addresses.Add(address);
+                }
+            }
+        }
+
+        if (host is null || port == 0) return false;
+
+        database = new ExistingDatabase(
+            key,
+            id,
+            host,
+            port,
+            element.TryGetProperty("tls", out var tls) && tls.ValueKind == JsonValueKind.True,
+            ReadString(element, "username"),
+            ReadString(element, "password"),
+            proxyPolicy,
+            endpointType,
+            addresses);
+        return true;
+    }
+
+    private static string? ReadString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+
+    /// <summary>
+    /// Connection options for this database, with maintenance notifications required.
+    /// </summary>
+    public ConfigurationOptions GetClientConfig(FaultInjectorEnvironment environment, MaintenanceNotificationMode mode = MaintenanceNotificationMode.Enabled)
+    {
+        var options = new ConfigurationOptions
+        {
+            EndPoints = { { Host, Port } },
+            User = string.Equals(Username, "default", StringComparison.OrdinalIgnoreCase) ? null : Username,
+            Password = Password,
+            Protocol = RedisProtocol.Resp3,
+            MaintenanceNotifications = mode,
+            AbortOnConnectFail = false,
+            ConnectTimeout = 15_000,
+            SyncTimeout = 15_000,
+        };
+
+        if (Tls)
+        {
+            options.Ssl = true;
+            options.SslHost = Host;
+            var caPath = environment.CertificateAuthorityPath
+                ?? throw new InvalidOperationException($"{Key} uses TLS but no CA certificate was found in {environment.ConfigDirectory.FullName}");
+            options.TrustIssuer(caPath);
+        }
+
+        return options;
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ExistingDatabaseFixture.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ExistingDatabaseFixture.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Runs against the databases the environment template already created, rather than provisioning new ones.
+/// </summary>
+/// <remarks>
+/// The cheap tier, and the right one to start from: it needs none of the <c>create_database</c> schema, so it
+/// answers "does the client work against a real deployment" before anything depends on parameter names that are
+/// documented only as prose.
+/// </remarks>
+public class ExistingDatabaseFixture : IAsyncLifetime
+{
+    private FaultInjectorClient? _injector;
+    private string? _skipReason;
+
+    public IReadOnlyDictionary<string, ExistingDatabase> Databases { get; private set; }
+        = new Dictionary<string, ExistingDatabase>();
+
+    public FaultInjectorEnvironment Environment =>
+        FaultInjectorEnvironment.Current ?? throw new InvalidOperationException("no environment; call RequireAvailable first");
+
+    public FaultInjectorClient Injector =>
+        _injector ?? throw new InvalidOperationException("no injector; call RequireAvailable first");
+
+    /// <summary>Skips the calling test when there is nothing to talk to.</summary>
+    public void RequireAvailable()
+    {
+        if (_skipReason is not null) Assert.Skip(_skipReason);
+    }
+
+    /// <summary>
+    /// The named database, or a skip if this environment does not have one.
+    /// </summary>
+    /// <remarks>
+    /// A skip rather than a failure, deliberately: which databases exist is a property of the environment
+    /// template somebody chose, so a template without an <c>oss_cluster</c> database is a reason not to run the
+    /// cluster tests, not evidence of a bug.
+    /// </remarks>
+    public ExistingDatabase Require(string key)
+    {
+        RequireAvailable();
+        if (!Databases.TryGetValue(key, out var database))
+        {
+            Assert.Skip($"this environment has no '{key}' database (found: {string.Join(", ", Databases.Keys)})");
+        }
+
+        return database!;
+    }
+
+    /// <summary>
+    /// Where fixture-level diagnostics go. Deliberately collected rather than written to
+    /// <see cref="Console"/>: a fixture has no test output helper, and anything it prints to the console is
+    /// easily lost - which is how a silently failing setup call survived a day of use.
+    /// </summary>
+    public List<string> SetupLog { get; } = [];
+
+    private void log(string message)
+    {
+        SetupLog.Add(message);
+        Console.WriteLine(message);
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        if (FaultInjectorEnvironment.Current is null)
+        {
+            _skipReason = FaultInjectorEnvironment.UnavailableReason ?? "no fault-injector environment configured";
+            return;
+        }
+
+        if (!FaultInjectorEnvironment.IsEnabled)
+        {
+            _skipReason = "set E2E_SCENARIO_TESTS=true to run against a real deployment";
+            return;
+        }
+
+        _injector = new FaultInjectorClient(FaultInjectorEnvironment.Current.InjectorUrl);
+        Databases = ExistingDatabase.ReadAll(FaultInjectorEnvironment.Current);
+        await EnsureMaintenanceNotificationsEnabledAsync();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _injector?.Dispose();
+        return default;
+    }
+
+    /// <summary>
+    /// Turns on the cluster-level maintenance-notification flags.
+    /// </summary>
+    /// <remarks>
+    /// A different thing from the per-connection opt-in, and both are required: the cluster flag decides whether
+    /// <c>CLIENT MAINT_NOTIFICATIONS</c> exists at all, and the command opts one connection in. Without this a
+    /// run fails at connect - correctly, since the tests ask for
+    /// <see cref="MaintenanceNotificationMode.Enabled"/> - but for a reason that has nothing to do with the
+    /// client, so it is worth setting rather than diagnosing.
+    /// <para>
+    /// Through the injector rather than a direct REST <c>PUT</c>, so the change leaves an action id behind and
+    /// shows up in the injector's history like everything else. Best-effort: if the action type is not
+    /// available on this build, the connect failure that follows says so clearly enough.
+    /// </para>
+    /// </remarks>
+    private async Task EnsureMaintenanceNotificationsEnabledAsync()
+    {
+        // nested under "config", not flattened - the same shape create_database wants for "database_config".
+        // A flat payload is rejected with "Invalid parameter 'config': got None", and because this call is
+        // best-effort it failed *silently* for a whole day of testing without anybody noticing. The impact was
+        // small: the environment templates enable these flags at provision time, so this is a safety net rather
+        // than the mechanism, and the tests were passing on their own merits. It matters for an environment
+        // provisioned without them, where the alternative is every test failing at connect and blaming the
+        // client for a server-side setting.
+        var parameters = new Dictionary<string, object?>
+        {
+            ["config"] = new Dictionary<string, object?>
+            {
+                ["client_maint_notifications"] = true,             // proxy-routed databases
+                ["oss_cluster_client_maint_notifications"] = true, // oss_cluster databases
+            },
+        };
+
+        try
+        {
+            await Injector.RunActionAsync("update_cluster_config", parameters, timeout: TimeSpan.FromMinutes(2));
+            log("cluster maintenance-notification flags enabled");
+        }
+        catch (Exception ex)
+        {
+            // Still best-effort - a cluster may not support the flags at all - but no longer silent: it goes to
+            // the test output, where the connect failure that follows can be attributed to it.
+            log($"could not set cluster maintenance-notification flags: {ScenarioSupport.Summarize(ex.Message)}");
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/FaultInjectorEnvironment.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/FaultInjectorEnvironment.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Everything this suite needs to reach a real deployment, discovered from one directory.
+/// </summary>
+/// <remarks>
+/// One path is the whole configuration, deliberately. That directory is the one mounted into the fault
+/// injector as <c>/app/config</c> and the one <c>docker compose up</c> is run from, so it already holds the
+/// compose file, the cluster credentials (<c>env_output.json</c>), the CA certificate, and - once databases
+/// exist - <c>endpoints.json</c>. Asking for anything else would mean the person who provisioned the
+/// environment has to hand-carry facts into the test run, which is the error-prone part.
+/// <para>
+/// Point at it with <c>SER_FI_CONFIG_DIR</c>; <c>FI_CONSOLE_CONFIG_DIR</c> is honoured as a fallback so this
+/// runs against the same directory as the fault-injector console with no extra setup.
+/// </para>
+/// </remarks>
+public sealed class FaultInjectorEnvironment
+{
+    private const string ConfigDirVariable = "SER_FI_CONFIG_DIR";
+    private const string ConsoleConfigDirVariable = "FI_CONSOLE_CONFIG_DIR";
+    private const string InjectorUrlVariable = "FAULT_INJECTION_API_URL";
+    private const string EnabledVariable = "E2E_SCENARIO_TESTS";
+    private const string DefaultInjectorUrl = "http://127.0.0.1:20324";
+
+    /// <summary>
+    /// The environment for this run, or <c>null</c> when none is configured.
+    /// </summary>
+    public static FaultInjectorEnvironment? Current { get; } = Discover();
+
+    /// <summary>
+    /// Why there is no environment, for a skip message that says something useful.
+    /// </summary>
+    public static string? UnavailableReason { get; private set; }
+
+    private FaultInjectorEnvironment(DirectoryInfo configDirectory, Uri injectorUrl)
+    {
+        ConfigDirectory = configDirectory;
+        InjectorUrl = injectorUrl;
+    }
+
+    public DirectoryInfo ConfigDirectory { get; }
+
+    public Uri InjectorUrl { get; }
+
+    /// <summary>
+    /// The CA certificate that signs the proxy certificates, for <see cref="ConfigurationOptions.TrustIssuer(string)"/>.
+    /// </summary>
+    /// <remarks>
+    /// The certificates are self-signed per environment, so trusting the issuer is how a TLS test validates
+    /// anything at all. Note what this is *not*: a switch that disables validation. A test that cannot find the
+    /// CA fails rather than falling back to trusting everything, because a TLS test that silently stops
+    /// checking identity is worse than no TLS test - it reports success for the one thing it exists to catch.
+    /// </remarks>
+    public string? CertificateAuthorityPath { get; private set; }
+
+    /// <summary>
+    /// Cluster credentials for the REST API on port 9443, when <c>env_output.json</c> carries them.
+    /// </summary>
+    /// <remarks>
+    /// Needed for the facts <c>endpoints.json</c> does not carry - notably <c>oss_cluster</c> and the
+    /// advertised endpoint type - which matter because they decide which notification family a database can
+    /// even emit. Tests that provision their own database know what they asked for and need none of this.
+    /// </remarks>
+    public ClusterCredentials? Cluster { get; private set; }
+
+    private static FaultInjectorEnvironment? Discover()
+    {
+        var path = Environment.GetEnvironmentVariable(ConfigDirVariable)
+            ?? Environment.GetEnvironmentVariable(ConsoleConfigDirVariable);
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            UnavailableReason = $"no fault-injector environment: set {ConfigDirVariable} to the directory holding env_output.json";
+            return null;
+        }
+
+        var directory = new DirectoryInfo(path);
+        if (!directory.Exists)
+        {
+            // configured but wrong is a mistake worth reporting, not a reason to quietly do nothing
+            UnavailableReason = $"{ConfigDirVariable} points at '{path}', which does not exist";
+            return null;
+        }
+
+        var url = Environment.GetEnvironmentVariable(InjectorUrlVariable);
+        var injectorUrl = Uri.TryCreate(url, UriKind.Absolute, out var parsed) ? parsed : new Uri(DefaultInjectorUrl);
+
+        var result = new FaultInjectorEnvironment(directory, injectorUrl)
+        {
+            CertificateAuthorityPath = FindCertificateAuthority(directory),
+        };
+        result.Cluster = ReadClusterCredentials(directory);
+        return result;
+    }
+
+    /// <summary>
+    /// Whether the caller actually meant to run destructive tests against a real deployment.
+    /// </summary>
+    /// <remarks>
+    /// Two gates rather than one, and they mean different things. Without a config directory there is nothing
+    /// to talk to, which is the ordinary state for everybody else and skips. With a directory but without
+    /// <c>E2E_SCENARIO_TESTS=true</c> we also skip, because these tests create and delete databases and nobody
+    /// should trip that by running the full traversal. What must *not* happen is a third state where the
+    /// environment is configured, meant, and broken, yet the run still reports success - see
+    /// <see cref="FaultInjectorFixture"/>.
+    /// </remarks>
+    public static bool IsEnabled =>
+        string.Equals(Environment.GetEnvironmentVariable(EnabledVariable), "true", StringComparison.OrdinalIgnoreCase);
+
+    private static string? FindCertificateAuthority(DirectoryInfo directory)
+    {
+        // names seen across the environment templates, most specific first
+        foreach (var candidate in new[] { "ca.pem", "ca.crt", "proxy_cert.pem", "redislabs_ca.pem" })
+        {
+            var path = Path.Combine(directory.FullName, candidate);
+            if (File.Exists(path)) return path;
+        }
+
+        return null;
+    }
+
+    private static ClusterCredentials? ReadClusterCredentials(DirectoryInfo directory)
+    {
+        var path = Path.Combine(directory.FullName, "env_output.json");
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+
+            // two schemas in the wild: single-cluster templates put outputs at the top level, and the AWS
+            // multi-cluster template nests them under .clusters.value[N]. Both are handled because which one
+            // you get is a property of the template somebody chose, not of anything a test can control.
+            var root = document.RootElement;
+            if (root.TryGetProperty("clusters", out var clusters)
+                && clusters.TryGetProperty("value", out var values)
+                && values.ValueKind == JsonValueKind.Array
+                && values.GetArrayLength() > 0)
+            {
+                root = values[0];
+            }
+
+            var name = ReadValue(root, "cluster_name") ?? ReadValue(root, "name");
+            var user = ReadValue(root, "username") ?? ReadValue(root, "cluster_username");
+            var password = ReadValue(root, "password") ?? ReadValue(root, "cluster_password");
+
+            return name is null || user is null || password is null ? null : new ClusterCredentials(name, user, password);
+        }
+        catch (Exception)
+        {
+            // a malformed env_output.json is not fatal here: only the tests that need REST enrichment care,
+            // and they report it themselves rather than failing every test in the suite at discovery time
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads a property that may be a bare value or a terraform-style <c>{ "value": ... }</c> wrapper.
+    /// </summary>
+    private static string? ReadValue(JsonElement element, string property)
+    {
+        if (!element.TryGetProperty(property, out var value)) return null;
+        if (value.ValueKind == JsonValueKind.Object && value.TryGetProperty("value", out var inner)) value = inner;
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+    }
+
+    public sealed record ClusterCredentials(string ClusterName, string Username, string Password)
+    {
+        public Uri RestUrl => new($"https://{ClusterName}:9443");
+
+        /// <summary>Never let the password reach a log; the endpoints are real and reachable.</summary>
+        public override string ToString() => $"{Username}@{ClusterName}";
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/FaultInjectorFixture.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/FaultInjectorFixture.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Provisions one database shape for the tests that need it, and takes it away afterwards.
+/// </summary>
+/// <remarks>
+/// Per *shape*, not per test: creating a database on a real cluster is slow, so several test classes share one.
+/// <para>
+/// The three-state behaviour matters more than the provisioning. No environment configured, or the
+/// <c>E2E_SCENARIO_TESTS</c> gate not set, means every test skips - which is the ordinary case for anybody
+/// running the full traversal, and these tests create and delete real databases. But an environment that *is*
+/// configured and meant, and then does not work, must **fail**: a suite that skips on a broken environment
+/// reports success for tests that never ran, and you will trust it exactly when you should not. So the absent
+/// case skips from the test body, and the broken case throws from here.
+/// </para>
+/// </remarks>
+public abstract class FaultInjectorFixture(DatabaseShape shape) : IAsyncLifetime
+{
+    /// <summary>
+    /// Shared by every database this suite creates, in every run.
+    /// </summary>
+    /// <remarks>
+    /// The sweep that cleans up leaks from earlier runs matches on this and nothing else, so it can never touch
+    /// a database somebody created by hand. Worth being strict about: the alternative is a test suite that
+    /// deletes production-shaped things on a shared cluster.
+    /// </remarks>
+    public const string NamePrefix = "sertest-";
+
+    private static readonly string RunId = Guid.NewGuid().ToString("n")[..6];
+
+    private FaultInjectorClient? _injector;
+    private string? _skipReason;
+
+    public DatabaseShape Shape { get; } = shape;
+
+    /// <summary>The database created for this fixture, once <see cref="InitializeAsync"/> has run.</summary>
+    public ProvisionedDatabase? Database { get; private set; }
+
+    public FaultInjectorEnvironment Environment =>
+        FaultInjectorEnvironment.Current ?? throw new InvalidOperationException("no environment; call RequireAvailable first");
+
+    public FaultInjectorClient Injector =>
+        _injector ?? throw new InvalidOperationException("no injector; call RequireAvailable first");
+
+    /// <summary>
+    /// Skips the calling test when there is no environment to talk to.
+    /// </summary>
+    public void RequireAvailable()
+    {
+        if (_skipReason is not null) Assert.Skip(_skipReason);
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        if (FaultInjectorEnvironment.Current is null)
+        {
+            _skipReason = FaultInjectorEnvironment.UnavailableReason ?? "no fault-injector environment configured";
+            return;
+        }
+
+        if (!FaultInjectorEnvironment.IsEnabled)
+        {
+            _skipReason = "set E2E_SCENARIO_TESTS=true to run against a real deployment (these tests create and delete databases)";
+            return;
+        }
+
+        // configured and meant: from here on, problems are failures
+        _injector = new FaultInjectorClient(FaultInjectorEnvironment.Current.InjectorUrl);
+        await SweepOrphansAsync();
+        Database = await CreateDatabaseAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // unconditionally, and before anything else can throw: a database left behind holds a port and a slice
+        // of cluster memory, and the next run collides with it
+        if (Database is { } database && _injector is { } injector)
+        {
+            try
+            {
+                await injector.RunActionAsync("delete_database", new Dictionary<string, object?> { ["bdb_id"] = database.BdbId });
+            }
+            catch (Exception ex)
+            {
+                // never mask a test failure with a cleanup failure; the sweep will get it next time
+                Console.WriteLine($"failed to delete {database.Name} (bdb {database.BdbId}): {ex.Message}");
+            }
+        }
+
+        _injector?.Dispose();
+    }
+
+    /// <summary>
+    /// Creates the database for this shape, working around port collisions the way go-redis has to.
+    /// </summary>
+    /// <remarks>
+    /// Port collisions are common enough on a shared cluster that go-redis carries a dedicated
+    /// <c>CreateDatabaseWithPortRetry</c> helper; this is the same idea. The base port is deliberately high and
+    /// the walk is upward, so a collision costs one attempt rather than a failed run.
+    /// </remarks>
+    private async Task<ProvisionedDatabase> CreateDatabaseAsync()
+    {
+        const int BasePort = 13500, Attempts = 8;
+        var name = $"{NamePrefix}{Shape.Label}-{RunId}";
+        Exception? last = null;
+
+        for (int attempt = 0; attempt < Attempts; attempt++)
+        {
+            var port = BasePort + (attempt * 3);
+            try
+            {
+                // nested under database_config, not flattened: the injector answers a flat payload with
+                // "Invalid parameter 'database_config': got None"
+                var result = await Injector.RunActionAsync(
+                    "create_database",
+                    new Dictionary<string, object?> { ["database_config"] = Shape.ToCreateParameters(name, port) });
+                return ProvisionedDatabase.FromCreateResult(name, port, Shape, result, Environment);
+            }
+            catch (Exception ex) when (IsPortCollision(ex))
+            {
+                last = ex;
+                Console.WriteLine($"create_database on port {port} collided, retrying higher");
+            }
+        }
+
+        throw new InvalidOperationException($"could not create '{name}' after {Attempts} attempts", last);
+    }
+
+    /// <summary>
+    /// Whether a create failure is worth trying a different port for.
+    /// </summary>
+    /// <remarks>
+    /// Only port collisions are: everything else - a malformed config, a cluster with no capacity - fails
+    /// identically on every port, and retrying eight times turns one clear error message into eight and delays
+    /// the report by half a minute. The first version of this retried everything, and buried
+    /// "missing shard_key_regex" under eight identical tracebacks.
+    /// </remarks>
+    private static bool IsPortCollision(Exception ex) =>
+        ex.Message.Contains("port", StringComparison.OrdinalIgnoreCase)
+        && (ex.Message.Contains("in use", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("already", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("taken", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("conflict", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Best-effort removal of databases left behind by earlier runs.
+    /// </summary>
+    /// <remarks>
+    /// Best-effort on purpose: listing databases needs the cluster REST API, which needs credentials this
+    /// directory may not carry, and being unable to tidy up is not a reason to fail a run that could otherwise
+    /// proceed. The per-fixture delete in <see cref="DisposeAsync"/> is the reliable path; this only catches
+    /// leaks from a run that was killed.
+    /// </remarks>
+    private async Task SweepOrphansAsync()
+    {
+        var cluster = Environment.Cluster;
+        if (cluster is null)
+        {
+            Console.WriteLine("no cluster credentials in env_output.json; skipping orphan sweep");
+            return;
+        }
+
+        try
+        {
+            using var rest = new ClusterRestClient(cluster, Environment.CertificateAuthorityPath);
+            foreach (var (bdbId, name) in await rest.ListDatabasesAsync())
+            {
+                if (!name.StartsWith(NamePrefix, StringComparison.Ordinal)) continue; // never anything but ours
+
+                Console.WriteLine($"sweeping orphaned test database {name} (bdb {bdbId})");
+                await Injector.RunActionAsync("delete_database", new Dictionary<string, object?> { ["bdb_id"] = bdbId });
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"orphan sweep skipped: {ex.Message}");
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ProvisionedDatabase.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Environment/ProvisionedDatabase.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// A database this suite created, and how to connect to it.
+/// </summary>
+/// <remarks>
+/// Note what this type does *not* need to do: read <c>endpoints.json</c> to discover whether the database is
+/// <c>oss_cluster</c>, or what endpoint type it advertises. A test that provisioned the database knows what it
+/// asked for, which is the real argument for provisioning from inside the suite - the alternative is carrying
+/// those facts from whoever set the environment up into the run, by hand.
+/// </remarks>
+public sealed class ProvisionedDatabase
+{
+    private ProvisionedDatabase(string name, int bdbId, string host, int port, DatabaseShape shape, FaultInjectorEnvironment environment)
+    {
+        Name = name;
+        BdbId = bdbId;
+        Host = host;
+        Port = port;
+        Shape = shape;
+        Environment = environment;
+    }
+
+    public string Name { get; }
+
+    public int BdbId { get; }
+
+    public string Host { get; }
+
+    public int Port { get; }
+
+    public DatabaseShape Shape { get; }
+
+    public FaultInjectorEnvironment Environment { get; }
+
+    public string? Password { get; private init; }
+
+    /// <summary>
+    /// Connection options for this database, with maintenance notifications requested.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MaintenanceNotificationMode.Enabled"/> rather than <c>Auto</c>: in a test, a server that
+    /// silently declines the opt-in should fail the connection loudly rather than produce a run that passes
+    /// while observing nothing. That is the opposite of the right default for production, and exactly right
+    /// here.
+    /// </remarks>
+    public ConfigurationOptions GetClientConfig()
+    {
+        var options = new ConfigurationOptions
+        {
+            EndPoints = { { Host, Port } },
+            Password = Password,
+            Protocol = RedisProtocol.Resp3,
+            MaintenanceNotifications = MaintenanceNotificationMode.Enabled,
+            AbortOnConnectFail = false,
+            // real network, real cluster: connect and command budgets have to tolerate a WAN round trip, and a
+            // cluster that is mid-scenario is slower still
+            ConnectTimeout = 15_000,
+            SyncTimeout = 15_000,
+        };
+
+        if (Shape.Tls)
+        {
+            options.Ssl = true;
+            options.SslHost = Host;
+
+            // The certificates are self-signed per environment, so trusting the issuer is what makes a TLS test
+            // mean anything. If the CA is missing we fail here rather than disabling validation: a TLS test that
+            // quietly stops checking identity reports success for the one thing it exists to catch.
+            var caPath = Environment.CertificateAuthorityPath
+                ?? throw new InvalidOperationException(
+                    $"{Shape.Label} needs TLS, but no CA certificate was found in {Environment.ConfigDirectory.FullName}; "
+                    + "validation is not disabled for tests");
+            options.TrustIssuer(caPath);
+        }
+
+        return options;
+    }
+
+    /// <summary>Masked, because these endpoints are real and reachable from the internet.</summary>
+    public override string ToString() => $"{Name} ({Host}:{Port}, bdb {BdbId}, {Shape.Label})";
+
+    /// <summary>
+    /// Reads what the injector reported back after <c>create_database</c>.
+    /// </summary>
+    /// <remarks>
+    /// Tolerant by design: the response shape is documented as prose, and the fields worth having may arrive at
+    /// the top level or nested under an output/result object. What cannot be guessed is the <c>bdb_id</c> -
+    /// without it there is nothing to delete afterwards - so that one is required and its absence is loud.
+    /// </remarks>
+    public static ProvisionedDatabase FromCreateResult(
+        string name,
+        int requestedPort,
+        DatabaseShape shape,
+        JsonElement result,
+        FaultInjectorEnvironment environment)
+    {
+        var bdbId = FindInt(result, "bdb_id")
+            ?? throw new InvalidOperationException($"create_database for '{name}' returned no bdb_id: {result}");
+
+        var host = FindString(result, "endpoint") ?? FindString(result, "dns_name") ?? environment.Cluster?.ClusterName
+            ?? throw new InvalidOperationException($"create_database for '{name}' returned no endpoint, and env_output.json names no cluster: {result}");
+
+        // an endpoint may arrive as "host:port" or as a bare host
+        var port = requestedPort;
+        var colon = host.LastIndexOf(':');
+        if (colon > 0 && int.TryParse(host[(colon + 1)..], out var parsedPort))
+        {
+            port = parsedPort;
+            host = host[..colon];
+        }
+
+        return new ProvisionedDatabase(name, bdbId, host, port, shape, environment)
+        {
+            Password = FindString(result, "password"),
+        };
+    }
+
+    private static int? FindInt(JsonElement element, string name)
+    {
+        foreach (var candidate in Walk(element, name))
+        {
+            if (candidate.ValueKind == JsonValueKind.Number && candidate.TryGetInt32(out var value)) return value;
+            if (candidate.ValueKind == JsonValueKind.String && int.TryParse(candidate.GetString(), out var parsed)) return parsed;
+        }
+
+        return null;
+    }
+
+    private static string? FindString(JsonElement element, string name)
+    {
+        foreach (var candidate in Walk(element, name))
+        {
+            if (candidate.ValueKind == JsonValueKind.String) return candidate.GetString();
+            if (candidate.ValueKind == JsonValueKind.Array && candidate.GetArrayLength() > 0 && candidate[0].ValueKind == JsonValueKind.String)
+            {
+                return candidate[0].GetString(); // endpoints arrive as a list often enough
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Yields every value for a property name, at any depth - shallowest first.
+    /// </summary>
+    private static IEnumerable<JsonElement> Walk(JsonElement element, string name)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            if (element.TryGetProperty(name, out var direct)) yield return direct;
+
+            foreach (var property in element.EnumerateObject())
+            {
+                foreach (var nested in Walk(property.Value, name)) yield return nested;
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                foreach (var nested in Walk(item, name)) yield return nested;
+            }
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/FaultInjector/FaultInjectorClient.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/FaultInjector/FaultInjectorClient.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// The fault injector's HTTP surface, as much of it as this suite needs.
+/// </summary>
+/// <remarks>
+/// Deliberately the same shape go-redis, redis-py and node-redis wrap: <c>POST /action</c> returning an id and
+/// <c>GET /action/{id}</c> to poll. They integrated independently and converged, so the contract is stable
+/// enough to depend on, and their scenario documentation transfers to this client.
+/// </remarks>
+public sealed class FaultInjectorClient(Uri baseAddress) : IDisposable
+{
+    private readonly HttpClient _http = new() { BaseAddress = baseAddress, Timeout = TimeSpan.FromMinutes(2) };
+
+    /// <summary>
+    /// Statuses that mean "still going". Both of them, which is the point.
+    /// </summary>
+    /// <remarks>
+    /// A job passes through <c>pending</c> *and* <c>running</c>, so a loop that waits only on <c>pending</c>
+    /// returns while the work is still in flight - and then the test asserts against a cluster that has not
+    /// finished changing. Documented as a trap in the console's notes; encoded here so it cannot be
+    /// rediscovered.
+    /// </remarks>
+    private static readonly HashSet<string> PendingStatuses = new(StringComparer.OrdinalIgnoreCase) { "pending", "running", "in_progress" };
+
+    private static readonly HashSet<string> FailedStatuses = new(StringComparer.OrdinalIgnoreCase) { "failed", "cancelled", "error" };
+
+    public void Dispose() => _http.Dispose();
+
+    /// <summary>
+    /// Fires an action and returns its id, without waiting.
+    /// </summary>
+    public async Task<string> StartActionAsync(string type, object? parameters = null, CancellationToken cancellationToken = default)
+    {
+        var payload = new ActionRequest(type, parameters);
+        using var response = await _http.PostAsJsonAsync("/action", payload, cancellationToken);
+        await EnsureSuccessAsync(response, $"POST /action ({type})", cancellationToken);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+        return ReadActionId(document.RootElement)
+            ?? throw new InvalidOperationException($"the injector accepted '{type}' but returned no action id: {document.RootElement}");
+    }
+
+    /// <summary>
+    /// Fires an action and waits for it to finish, returning its final payload.
+    /// </summary>
+    public async Task<JsonElement> RunActionAsync(
+        string type,
+        object? parameters = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var id = await StartActionAsync(type, parameters, cancellationToken);
+        return await WaitForActionAsync(id, timeout, cancellationToken);
+    }
+
+    /// <summary>
+    /// Polls an action to completion.
+    /// </summary>
+    /// <remarks>
+    /// The timeout is generous by default because these actions move data: a slot migration or a node coming
+    /// out of maintenance mode is minutes, not seconds. A tight default here would produce failures that look
+    /// like product bugs.
+    /// </remarks>
+    public async Task<JsonElement> WaitForActionAsync(
+        string id,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromMinutes(10));
+        string? lastStatus = null;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var response = await _http.GetAsync($"/action/{id}", cancellationToken);
+            await EnsureSuccessAsync(response, $"GET /action/{id}", cancellationToken);
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var document = JsonDocument.Parse(body);
+            var status = ReadStatus(document.RootElement);
+            lastStatus = status ?? lastStatus;
+
+            if (status is not null && !PendingStatuses.Contains(status))
+            {
+                if (FailedStatuses.Contains(status))
+                {
+                    throw new InvalidOperationException($"fault-injector action {id} ended as '{status}': {body}");
+                }
+
+                // clone: the JsonDocument is disposed with this scope, and callers keep the result
+                return document.RootElement.Clone();
+            }
+
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"fault-injector action {id} was still '{lastStatus ?? "unknown"}' after {(timeout ?? TimeSpan.FromMinutes(10)).TotalSeconds:0}s");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Discovers which triggers are valid for an effect.
+    /// </summary>
+    /// <remarks>
+    /// Worth asking rather than hardcoding: the effect/trigger matrix is sparse - <c>maintenance_mode</c> only
+    /// supports <c>remove-add</c> and <c>remove</c>, <c>failover</c> needs replication enabled - and some
+    /// scenarios do not enumerate their triggers in the schema at all.
+    /// </remarks>
+    public async Task<JsonElement> GetValidTriggersAsync(string scenario, string effect, int clusterIndex = 0, CancellationToken cancellationToken = default)
+    {
+        using var response = await _http.GetAsync($"/{scenario}?effect={Uri.EscapeDataString(effect)}&cluster_index={clusterIndex}", cancellationToken);
+        await EnsureSuccessAsync(response, $"GET /{scenario}?effect={effect}", cancellationToken);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+        return document.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// Runs a scenario's <c>setup</c> / <c>run</c> / <c>teardown</c> triple's individual legs.
+    /// </summary>
+    public async Task<JsonElement> PostScenarioAsync(
+        string scenario,
+        string? leg,
+        IReadOnlyDictionary<string, string?> query,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var path = leg is null ? $"/{scenario}" : $"/{scenario}/{leg}";
+        var separator = '?';
+        foreach (var pair in query)
+        {
+            if (pair.Value is null) continue;
+            path += $"{separator}{pair.Key}={Uri.EscapeDataString(pair.Value)}";
+            separator = '&';
+        }
+
+        using var response = await _http.PostAsync(path, content: null, cancellationToken);
+        await EnsureSuccessAsync(response, $"POST {path}", cancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(body);
+
+        // the scenario legs only *enqueue*; a caller that returns here is racing the work it asked for
+        var id = ReadActionId(document.RootElement);
+        return id is null ? document.RootElement.Clone() : await WaitForActionAsync(id, timeout, cancellationToken);
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, string what, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode) return;
+
+        // include the body: the injector explains refusals there, and "400 Bad Request" alone has cost people
+        // hours on the effect/trigger matrix
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        throw new InvalidOperationException($"{what} failed: {(int)response.StatusCode} {response.ReasonPhrase}. {body}");
+    }
+
+    /// <summary>
+    /// The id of a pollable action, if this response describes one.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>setup_id</c>: a scenario's setup returns a *handle* to state held in the injector,
+    /// which is passed back on the run and teardown legs, and is not something <c>/action/{id}</c> knows about.
+    /// Treating it as an action id polls a URL that does not exist.
+    /// </remarks>
+    private static string? ReadActionId(JsonElement element)
+    {
+        foreach (var name in new[] { "action_id", "id" })
+        {
+            if (element.TryGetProperty(name, out var value))
+            {
+                return value.ValueKind switch
+                {
+                    JsonValueKind.String => value.GetString(),
+                    JsonValueKind.Number => value.ToString(),
+                    _ => null,
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ReadStatus(JsonElement element)
+        => element.TryGetProperty("status", out var status) && status.ValueKind == JsonValueKind.String
+            ? status.GetString()
+            : null;
+
+    private sealed record ActionRequest(
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("parameters")] object? Parameters);
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/FaultInjector/ScenarioRun.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/FaultInjector/ScenarioRun.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// One run of a fault-injector scenario: setup, fire, tear down.
+/// </summary>
+/// <remarks>
+/// The setup leg provisions its own database, which is the important part: every trigger publishes the
+/// <c>dbconfig</c> it needs (<c>GET /topology-change-standalone?effect=...</c>), and all of them want
+/// <c>proxy_policy: single</c> - a shape the environment templates do not create. So a scenario cannot be
+/// pointed at an existing database, and there is no need to hand-roll <c>create_database</c> for one either.
+/// <para>
+/// Teardown is the whole reason this is a type rather than three calls. A scenario left set up holds cluster
+/// state - the flags it enabled, the database it made, nodes it excluded - and poisons every run after it.
+/// </para>
+/// </remarks>
+public sealed class ScenarioRun : IAsyncDisposable
+{
+    private readonly FaultInjectorClient _injector;
+    private readonly string _scenario;
+    private readonly Action<string> _log;
+
+    private ScenarioRun(FaultInjectorClient injector, string scenario, string effect, string trigger, Action<string> log)
+    {
+        _injector = injector;
+        _scenario = scenario;
+        Effect = effect;
+        Trigger = trigger;
+        _log = log;
+    }
+
+    public string Effect { get; }
+
+    public string Trigger { get; }
+
+    /// <summary>The setup handle, passed back on the run and teardown legs.</summary>
+    public string? SetupId { get; private set; }
+
+    /// <summary>The database the setup leg created, when it says which.</summary>
+    public int? BdbId { get; private set; }
+
+    /// <summary>Whatever setup returned, for a test that wants to look at more than we model.</summary>
+    public JsonElement SetupResult { get; private set; }
+
+    /// <summary>The database setup created, ready to connect to.</summary>
+    /// <remarks>
+    /// Setup hands back everything needed - endpoint, password, TLS - so a scenario test never has to look in
+    /// <c>endpoints.json</c> or ask the cluster REST API. Verified against a live run: the response carries
+    /// <c>setup_id</c>, <c>bdb_id</c>, <c>db_name</c>, <c>endpoints</c>, <c>password</c>, <c>tls</c>,
+    /// <c>mtls_files</c> and <c>config</c> (the proxy policy it chose to satisfy the trigger).
+    /// </remarks>
+    public ScenarioDatabase? Database { get; private set; }
+
+    /// <summary>The database a scenario provisioned for itself.</summary>
+    public sealed record ScenarioDatabase(string Name, int BdbId, string Host, int Port, bool Tls, string? Password, string? ProxyPolicy)
+    {
+        public override string ToString() => $"{Name} ({Host}:{Port}, bdb {BdbId}, policy {ProxyPolicy ?? "?"})";
+
+        public ConfigurationOptions GetClientConfig(
+            FaultInjectorEnvironment environment,
+            MaintenanceNotificationMode mode = MaintenanceNotificationMode.Enabled)
+        {
+            var options = new ConfigurationOptions
+            {
+                EndPoints = { { Host, Port } },
+                Password = Password,
+                Protocol = RedisProtocol.Resp3,
+                MaintenanceNotifications = mode,
+                AbortOnConnectFail = false,
+                ConnectTimeout = 15_000,
+                SyncTimeout = 15_000,
+            };
+
+            if (Tls)
+            {
+                options.Ssl = true;
+                options.SslHost = Host;
+                options.TrustIssuer(environment.CertificateAuthorityPath
+                    ?? throw new InvalidOperationException($"{Name} uses TLS but no CA certificate was found in {environment.ConfigDirectory.FullName}"));
+            }
+
+            return options;
+        }
+    }
+
+    /// <summary>
+    /// Sets a scenario up, ready to fire.
+    /// </summary>
+    /// <param name="setupTrigger">
+    /// The trigger for the *setup* leg, when it differs from the one being fired.
+    /// </param>
+    /// <remarks>
+    /// The two triggers are different questions, which the naming hides. The setup leg's trigger says how to
+    /// *provision* - <c>/slot-migrate/setup</c> accepts only <c>reshard</c>, because provisioning a cluster
+    /// database is all it does - while the run leg's trigger says how to cause the effect (<c>migrate</c>,
+    /// <c>maintenance_mode</c>, <c>failover</c>). Passing the run trigger to setup earns a
+    /// "Trigger 'migrate' is not supported by slot-migrate/setup (only 'reshard')".
+    /// </remarks>
+    public static async Task<ScenarioRun> SetupAsync(
+        FaultInjectorClient injector,
+        string scenario,
+        string effect,
+        string trigger,
+        Action<string> log,
+        IReadOnlyDictionary<string, string?>? extra = null,
+        string? setupTrigger = null,
+        CancellationToken cancellationToken = default)
+    {
+        var run = new ScenarioRun(injector, scenario, effect, trigger, log);
+        var query = new Dictionary<string, string?> { ["effect"] = effect, ["trigger"] = setupTrigger ?? trigger };
+        if (extra is not null)
+        {
+            foreach (var pair in extra) query[pair.Key] = pair.Value;
+        }
+
+        log($"setup {scenario}: effect={effect} setup-trigger={setupTrigger ?? trigger} (firing '{trigger}')");
+        run.SetupResult = await injector.PostScenarioAsync(scenario, "setup", query, cancellationToken: cancellationToken);
+        run.SetupId = FindString(run.SetupResult, "setup_id");
+        run.BdbId = FindInt(run.SetupResult, "bdb_id");
+        run.Database = ReadDatabase(run.SetupResult, run.BdbId);
+        log($"setup complete: setup_id={run.SetupId ?? "(none)"} database={run.Database?.ToString() ?? "(none)"}");
+        return run;
+    }
+
+    /// <summary>
+    /// Fires the scenario and waits for the injector to finish its work.
+    /// </summary>
+    /// <remarks>
+    /// Note "finished" here means the injector has done what it was asked, not that the deployment has settled:
+    /// the notifications, the DNS change and the socket close all trail it by seconds. Callers should watch for
+    /// what they expect rather than assuming completion means arrival.
+    /// </remarks>
+    public async Task<JsonElement> FireAsync(CancellationToken cancellationToken = default)
+    {
+        var query = new Dictionary<string, string?>
+        {
+            ["effect"] = Effect,
+            ["trigger"] = Trigger,
+            ["setup_id"] = SetupId,
+            ["bdb_id"] = BdbId?.ToString(),
+        };
+
+        _log($"firing {_scenario}");
+        var result = await _injector.PostScenarioAsync(_scenario, leg: null, query, cancellationToken: cancellationToken);
+        _log($"fired: {result}");
+        return result;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var query = new Dictionary<string, string?>
+        {
+            // both, because setup_id lives in the injector's memory and is lost if it restarts, at which point
+            // bdb_id is the only handle left
+            ["setup_id"] = SetupId,
+            ["bdb_id"] = BdbId?.ToString(),
+            ["restore_nodes"] = "true", // put back anything the scenario excluded, or the next run starts degraded
+        };
+
+        try
+        {
+            // Its own budget rather than the caller's token: teardown has to happen even when the test was
+            // cancelled or timed out, which is exactly when the caller's token is already dead.
+            using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            await _injector.PostScenarioAsync(_scenario, "teardown", query, cancellationToken: timeout.Token);
+            _log("teardown complete");
+        }
+        catch (Exception ex)
+        {
+            // loud, but not an exception: a teardown failure must not replace the test's own verdict
+            _log($"TEARDOWN FAILED ({ex.Message}) - the cluster may be left with a scenario set up, and "
+                + $"setup_id={SetupId ?? "(none)"} bdb_id={BdbId?.ToString() ?? "(none)"} is what to clean up by hand");
+        }
+    }
+
+    private static ScenarioDatabase? ReadDatabase(JsonElement setup, int? bdbId)
+    {
+        if (bdbId is not { } id) return null;
+
+        var endpoint = FindString(setup, "endpoints");
+        if (endpoint is null) return null;
+
+        var text = endpoint;
+        var scheme = text.IndexOf("://", StringComparison.Ordinal);
+        if (scheme >= 0) text = text[(scheme + 3)..];
+        var colon = text.LastIndexOf(':');
+        if (colon <= 0 || !int.TryParse(text[(colon + 1)..], out var port)) return null;
+
+        return new ScenarioDatabase(
+            FindString(setup, "db_name") ?? $"bdb-{id}",
+            id,
+            text[..colon],
+            port,
+            setup.TryGetProperty("tls", out var tls) && tls.ValueKind == JsonValueKind.True,
+            FindString(setup, "password"),
+            FindString(setup, "config"));
+    }
+
+    private static string? FindString(JsonElement element, string name)
+    {
+        foreach (var candidate in Walk(element, name))
+        {
+            if (candidate.ValueKind == JsonValueKind.String) return candidate.GetString();
+            if (candidate.ValueKind == JsonValueKind.Number) return candidate.ToString();
+            if (candidate.ValueKind == JsonValueKind.Array && candidate.GetArrayLength() > 0
+                && candidate[0].ValueKind == JsonValueKind.String)
+            {
+                return candidate[0].GetString(); // "endpoints" is a list even when there is one
+            }
+        }
+
+        return null;
+    }
+
+    private static int? FindInt(JsonElement element, string name)
+    {
+        foreach (var candidate in Walk(element, name))
+        {
+            if (candidate.ValueKind == JsonValueKind.Number && candidate.TryGetInt32(out var value)) return value;
+            if (candidate.ValueKind == JsonValueKind.String && int.TryParse(candidate.GetString(), out var parsed)) return parsed;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Yields every value for a property name at any depth, shallowest first.
+    /// </summary>
+    /// <remarks>
+    /// Tolerant on purpose: the scenario responses are documented as prose and nest differently between legs, so
+    /// searching beats asserting a shape - and a test that cannot find <c>setup_id</c> still has a logged
+    /// payload to work from rather than a deserialization error.
+    /// </remarks>
+    private static IEnumerable<JsonElement> Walk(JsonElement element, string name)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            if (element.TryGetProperty(name, out var direct)) yield return direct;
+            foreach (var property in element.EnumerateObject())
+            {
+                foreach (var nested in Walk(property.Value, name)) yield return nested;
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                foreach (var nested in Walk(item, name)) yield return nested;
+            }
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/FaultInjector/ScenarioSupport.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/FaultInjector/ScenarioSupport.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Telling "this deployment cannot do that" apart from "the client got it wrong".
+/// </summary>
+/// <remarks>
+/// The effect/trigger matrix is sparse in ways that depend on the *cluster*, not just the database: an
+/// <c>add</c> migration needs a node holding more than one shard, and a three-node cluster with sparse shard
+/// placement gives every node exactly one. The injector reports that as a failed action with a Python
+/// traceback, which is indistinguishable from a real fault unless you read the message.
+/// <para>
+/// So these skip, narrowly and by message. A broad catch here would hide genuine injector failures, which is
+/// the thing this tier exists to surface - hence matching on the specific condition rather than on the
+/// exception type.
+/// </para>
+/// </remarks>
+internal static class ScenarioSupport
+{
+    private static readonly string[] PlacementLimitations =
+    [
+        "No node with multiple shards found",
+        "not enough nodes",
+        "no empty node",
+    ];
+
+    /// <summary>
+    /// Skips when the setup could not produce a database the effect can act on.
+    /// </summary>
+    public static void RequireEffectIsAchievable(ScenarioRun scenario, string effect)
+    {
+        if (scenario.Database is null)
+        {
+            Assert.Skip($"the injector did not provision a database for '{effect}'");
+        }
+    }
+
+    /// <summary>
+    /// Fires a scenario, skipping rather than failing when the cluster's shape cannot produce the effect.
+    /// </summary>
+    public static async Task FireOrSkipAsync(ScenarioRun scenario, string effect, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await scenario.FireAsync(cancellationToken);
+        }
+        catch (Exception ex) when (IsPlacementLimitation(ex))
+        {
+            Assert.Skip($"this cluster cannot produce '{effect}': {Summarize(ex.Message)}");
+        }
+    }
+
+    private static bool IsPlacementLimitation(Exception ex)
+    {
+        foreach (var limitation in PlacementLimitations)
+        {
+            if (ex.Message.Contains(limitation, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The part of a Python traceback that says what actually went wrong.
+    /// </summary>
+    /// <remarks>
+    /// Note the traceback arrives inside a JSON string, so its line breaks are the two characters
+    /// <c>\</c><c>n</c> rather than real newlines - splitting on <c>'\n'</c> alone matches nothing and returns
+    /// the whole wall of text, which is how the first version of this behaved. The injector helpfully ends with
+    /// "Caused by: ...", which is the only part worth putting in a skip message.
+    /// </remarks>
+    internal static string Summarize(string message)
+    {
+        var caused = message.LastIndexOf("Caused by:", StringComparison.Ordinal);
+        if (caused >= 0)
+        {
+            var tail = message[caused..];
+            var end = tail.IndexOf("\\n", StringComparison.Ordinal);
+            return end > 0 ? tail[..end] : tail;
+        }
+
+        var lines = message.Replace("\\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (int i = lines.Length - 1; i >= 0; i--)
+        {
+            if (lines[i].Contains("Exception:", StringComparison.Ordinal)) return lines[i];
+        }
+
+        return lines.Length > 0 ? lines[^1] : message;
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/MovingHandoffScenarioTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/MovingHandoffScenarioTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// D6 against a real deployment: do we get off the connection before the server takes it away?
+/// </summary>
+/// <remarks>
+/// The one thing the in-process harness structurally cannot test. The handoff's hostname branch needs two
+/// things a fake cannot supply - an endpoint that is a *name*, and a real socket whose remote address tells us
+/// where we currently are - and its decision turns on DNS changing underneath us.
+/// <para>
+/// The discriminator is the failure type of the disconnect. <c>ConnectionDisposed</c> means *we* replaced the
+/// connection; <c>SocketClosed</c> means the server did. Both outcomes are legitimate, because DNS is not
+/// guaranteed to win the race - measured on one cluster at +18.7s against a socket closing at +15.7s - so this
+/// records which happened rather than demanding the good one.
+/// </para>
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "moving-handoff")]
+public class MovingHandoffScenarioTests(ExistingDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ExistingDatabaseFixture>
+{
+    [Theory]
+    [InlineData("conn_drop", "endpoint_rebind")]
+    [InlineData("data_movement_conn_drop", "maintenance_mode")]
+    public async Task HandoffBeatsTheServerToTheClose(string effect, string trigger)
+    {
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        await using var scenario = await ScenarioRun.SetupAsync(
+            fixture.Injector, "topology-change-standalone", effect, trigger, log.WriteLine,
+            cancellationToken: cancellationToken);
+
+        var database = scenario.Database;
+        Assert.NotNull(database);
+
+        var clock = Stopwatch.StartNew();
+        var timeline = new List<string>();
+        void Note(string what)
+        {
+            var entry = $"  +{clock.Elapsed.TotalSeconds,6:0.0}s  {what}";
+            lock (timeline) timeline.Add(entry);
+            log.WriteLine(entry);
+        }
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig(fixture.Environment));
+        var muxer = (IInternalConnectionMultiplexer)conn;
+        var endpoint = muxer.GetServerEndPoint(conn.GetEndPoints()[0]);
+
+        // The precondition the fake could not meet: a name to resolve, and a socket that says where we are.
+        Assert.IsType<System.Net.DnsEndPoint>(conn.GetEndPoints()[0]);
+        log.WriteLine($"dialled {conn.GetEndPoints()[0]} (a name, so the probe can engage)");
+
+        var failures = new List<ConnectionFailureType>();
+        conn.ConnectionFailed += (_, e) =>
+        {
+            lock (failures) failures.Add(e.FailureType);
+            Note($"disconnect: {e.FailureType}");
+        };
+        conn.ConnectionRestored += (_, _) => Note("reconnected");
+        conn.ServerMaintenanceEvent += (_, e) =>
+        {
+            if (e is PushMaintenanceEvent push) Note($"{push.NotificationType} seq={push.SequenceId} time={push.Time?.TotalSeconds.ToString() ?? "-"}");
+        };
+
+        clock.Restart();
+        await scenario.FireAsync(cancellationToken);
+        Note("injector reports the scenario finished");
+
+        // long enough to cover the whole announced window plus the observed overshoot
+        var deadline = clock.Elapsed + TimeSpan.FromSeconds(75);
+        while (clock.Elapsed < deadline)
+        {
+            try
+            {
+                await conn.GetDatabase().PingAsync();
+            }
+            catch (Exception ex) when (ex is RedisException or TimeoutException)
+            {
+                Note($"ping failed: {ex.GetType().Name}");
+            }
+
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        Note($"handoff outcome: {endpoint.LastHandoffOutcome ?? "(none recorded)"}; recycles={endpoint.HandoffRecycles}");
+
+        lock (failures)
+        {
+            var order = string.Join(" -> ", failures);
+            log.WriteLine($"  disconnect sequence: {(order.Length == 0 ? "(none)" : order)}");
+
+            // Note what is *not* asserted: that a ConnectionDisposed appears here. Our own recycle does not
+            // raise ConnectionFailed - disposal is not reported as a failure - so from the outside a handoff is
+            // invisible, which is worth knowing in its own right and is why HandoffRecycles exists.
+        }
+
+        // Exactly one handoff per notification. More than one is the feedback loop this test found on its first
+        // live run: a server re-sends MOVING to a connection that opts in while the window is still open, and
+        // since the handoff replaces the connection, acting on the repeat produces another one - twelve
+        // recycles from a single event. The per-server sequence dedup now gates it, and this is the assertion
+        // that would catch a regression.
+        Assert.Equal(1, endpoint.HandoffRecycles);
+        Assert.NotNull(endpoint.LastHandoffOutcome);
+        Assert.Contains("Recycle", endpoint.LastHandoffOutcome);
+
+        Assert.True(
+            await Poll.UntilAsync(
+                () =>
+                {
+                    try
+                    {
+                        return conn.IsConnected && conn.GetDatabase().Ping() >= TimeSpan.Zero;
+                    }
+                    catch (Exception ex) when (ex is RedisException or TimeoutException)
+                    {
+                        return false;
+                    }
+                },
+                timeoutMilliseconds: 30_000),
+            "the client should be serving commands after the handoff");
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/Poll.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/Poll.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Waits for a condition that a real deployment reaches on its own schedule.
+/// </summary>
+internal static class Poll
+{
+    public static async Task<bool> UntilAsync(Func<bool> condition, int timeoutMilliseconds = 10_000, int pollMilliseconds = 250)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMilliseconds);
+        while (true)
+        {
+            if (condition()) return true;
+            if (DateTime.UtcNow > deadline) return false;
+            await Task.Delay(pollMilliseconds);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/ProxyAndFailoverScenarioTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/ProxyAndFailoverScenarioTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// A replicated database, provisioned by us - the only way to reach the failover family.
+/// </summary>
+/// <remarks>
+/// The environment templates create databases with <c>replication: false</c>, and a failover needs a replica to
+/// promote, so this is the one case where <c>create_database</c> earns its keep rather than being a
+/// less-convenient alternative to the scenario setup legs.
+/// </remarks>
+public sealed class ReplicatedDatabaseFixture()
+    : FaultInjectorFixture(new DatabaseShape("replicated", ProxyPolicy: "single", Replication: true, ShardCount: 2));
+
+/// <summary>
+/// The proxy and failover families: <c>FAILING_OVER</c>/<c>FAILED_OVER</c>, and a proxy restarting underneath us.
+/// </summary>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "failover")]
+public class FailoverScenarioTests(ReplicatedDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ReplicatedDatabaseFixture>
+{
+    [Fact]
+    public async Task FailoverIsAnnouncedAndSurvived()
+    {
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var database = fixture.Database;
+        Assert.NotNull(database);
+        log.WriteLine($"provisioned {database}");
+
+        var clock = Stopwatch.StartNew();
+        var events = new List<PushMaintenanceEvent>();
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig());
+        conn.ServerMaintenanceEvent += (_, e) =>
+        {
+            if (e is PushMaintenanceEvent push)
+            {
+                lock (events) events.Add(push);
+                log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  {push.NotificationType} seq={push.SequenceId} {push.RawMessage}");
+            }
+        };
+
+        var db = conn.GetDatabase();
+        await db.StringSetAsync("fi-failover", "before");
+
+        clock.Restart();
+        try
+        {
+            await fixture.Injector.RunActionAsync(
+                "failover",
+                new Dictionary<string, object?> { ["bdb_id"] = database.BdbId.ToString() },
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // The failover action's parameters are untyped in the schema, so a rejection here is a harness
+            // problem rather than a client finding; say so plainly instead of reporting it as a product failure.
+            Assert.Skip($"the injector would not run 'failover' against bdb {database.BdbId}: {ScenarioSupport.Summarize(ex.Message)}");
+        }
+
+        log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  injector reports the failover finished");
+
+        var deadline = clock.Elapsed + TimeSpan.FromSeconds(45);
+        while (clock.Elapsed < deadline)
+        {
+            try
+            {
+                await db.PingAsync();
+            }
+            catch (Exception ex) when (ex is RedisException or TimeoutException)
+            {
+                log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  ping failed: {ex.GetType().Name}");
+            }
+
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        lock (events)
+        {
+            log.WriteLine($"  {events.Count} notification(s): {string.Join(", ", events.Select(e => e.NotificationType))}");
+
+            // A failover is the one event whose *pair* we have never observed end to end from a client: Marc
+            // captured the frames by hand, but nothing has watched SE.Redis receive them.
+            Assert.NotEmpty(events);
+            Assert.Contains(events, e => e.NotificationType is MaintenanceNotificationType.FailingOver
+                or MaintenanceNotificationType.FailedOver
+                or MaintenanceNotificationType.Migrating   // a failover on a proxied database moves shards too
+                or MaintenanceNotificationType.Migrated
+                or MaintenanceNotificationType.Moving);
+        }
+
+        // the data survived, which is the point of replication
+        Assert.Equal("before", await db.StringGetAsync("fi-failover"));
+    }
+}
+
+/// <summary>
+/// The proxy process restarting: no topology change, no notification, just the socket going away.
+/// </summary>
+/// <remarks>
+/// Included because it is the one disruption that is *purely* a connection event - nothing moves, nothing is
+/// announced, and recovery is entirely the client's ordinary reconnect path. A useful control: if this fails,
+/// the failures in the announced scenarios are not about notifications at all.
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "proxy-restart")]
+public class ProxyRestartScenarioTests(ExistingDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ExistingDatabaseFixture>
+{
+    [Theory]
+    [InlineData("standalone")]
+    [InlineData("cluster")]
+    public async Task ProxyRestartIsSurvived(string key)
+    {
+        var database = fixture.Require(key);
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var clock = Stopwatch.StartNew();
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig(fixture.Environment));
+        var db = conn.GetDatabase();
+        await db.StringSetAsync($"fi-dmc-{key}", "before");
+
+        int drops = 0;
+        conn.ConnectionFailed += (_, e) =>
+        {
+            drops++;
+            log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  connection failed: {e.FailureType}");
+        };
+        conn.ConnectionRestored += (_, _) => log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  connection restored");
+
+        clock.Restart();
+        // the one action with a typed parameter object in the injector's schema: RestartDmcParams { bdb_id }
+        await fixture.Injector.RunActionAsync(
+            "dmc_restart",
+            new Dictionary<string, object?> { ["bdb_id"] = database.BdbId.ToString() },
+            cancellationToken: cancellationToken);
+        log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  DMC restart reported finished");
+
+        // Recovery is asserted by polling rather than by waiting a fixed time, because a proxy restart is quick
+        // and the interesting failure is "never comes back", not "takes a moment".
+        Assert.True(
+            await Poll.UntilAsync(() => TryRead(db, $"fi-dmc-{key}"), timeoutMilliseconds: 60_000),
+            "the client should recover from the proxy restarting");
+
+        log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  recovered after {drops} drop(s)");
+        Assert.Equal("before", await db.StringGetAsync($"fi-dmc-{key}"));
+    }
+
+    private static bool TryRead(IDatabase db, string key)
+    {
+        try
+        {
+            return db.StringGet(key) == "before";
+        }
+        catch (Exception ex) when (ex is RedisException or TimeoutException)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/README.md
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/README.md
@@ -1,0 +1,60 @@
+# StackExchange.Redis.FaultInjector.Tests
+
+Scenario tests that drive a **real Redis Enterprise deployment** through the fault injector, and watch how
+SE.Redis reacts. These are the tier that can observe what no in-process fake can: real DNS, real TLS identity,
+real timing.
+
+## Running them
+
+```bash
+cd <the environment directory>          # holds docker-compose.yml, env_output.json, ...
+docker compose up -d                    # 10-15 minutes for the cluster to come up
+
+export SER_FI_CONFIG_DIR=$PWD           # or FI_CONSOLE_CONFIG_DIR, which is also honoured
+export E2E_SCENARIO_TESTS=true          # explicit opt-in: these create and delete databases
+dotnet test tests/StackExchange.Redis.FaultInjector.Tests
+```
+
+One path is the whole configuration. That directory is the one mounted into the injector as `/app/config`, so
+it already holds the cluster credentials (`env_output.json`), the CA certificate, and the compose file; nothing
+has to be hand-carried into the test run. `FAULT_INJECTION_API_URL` overrides the injector URL
+(default `http://127.0.0.1:20324`).
+
+## Three states, deliberately distinct
+
+| state | behaviour |
+|---|---|
+| no `SER_FI_CONFIG_DIR` | every test **skips** - the ordinary case, including `build.ps1`'s full traversal |
+| directory set, no `E2E_SCENARIO_TESTS=true` | every test **skips** - nobody should create databases by accident |
+| configured and enabled, but broken | every test **fails** |
+
+The third row is the important one. A suite that skips when the environment is broken reports success for tests
+that never ran, and it will be trusted at exactly the wrong moment.
+
+## Databases are created by the tests, not by you
+
+Each *shape* (`DatabaseShape`) is a fixture shared by the classes that need it, because creating a database on a
+real cluster is slow. The shapes exist because they change client behaviour rather than for coverage's sake: the
+number of A records a hostname carries follows proxy placement, and the handoff takes a different branch
+depending on whether a live sibling address exists.
+
+Every database is named `sertest-<shape>-<runid>`. Cleanup is per fixture and unconditional; a sweep at startup
+removes leaks from runs that were killed, matching on the `sertest-` prefix and nothing else, so it can never
+touch a database created by hand.
+
+## TLS
+
+Certificates are self-signed per environment, so tests call `ConfigurationOptions.TrustIssuer(caPath)` with the
+CA found in the config directory. If the CA is missing, TLS tests **fail** rather than disabling validation - a
+TLS test that quietly stops checking identity reports success for the one thing it exists to catch.
+
+## Traits
+
+`tier=fault-injector` on everything, so the whole tier can be excluded in one filter; `scenario=<family>` for
+subsets.
+
+## Unverified
+
+The `create_database` parameter names in `DatabaseShape.ToCreateParameters` are the injector's wire schema,
+which is documented only as prose. They are gathered in one place so a real run can correct them; go-redis's
+`DatabaseConfig` is the closest reference implementation. Treat them as unconfirmed until a run accepts them.

--- a/tests/StackExchange.Redis.FaultInjector.Tests/RealDeploymentSmokeTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/RealDeploymentSmokeTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Does the client work against a real deployment at all: connect, negotiate RESP3, opt in, run a command.
+/// </summary>
+/// <remarks>
+/// The floor for everything else. Worth having as its own class because when a scenario test fails, the first
+/// question is whether the deployment was reachable in the first place, and a green smoke test answers it
+/// without reading logs.
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "smoke")]
+public class RealDeploymentSmokeTests(ExistingDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ExistingDatabaseFixture>
+{
+    [Theory]
+    [InlineData("standalone")]
+    [InlineData("cluster")]
+    public async Task OptInIsAcceptedAndTheConnectionWorks(string key)
+    {
+        var database = fixture.Require(key);
+        log.WriteLine($"{database}");
+        log.WriteLine($"  advertised addresses: {string.Join(", ", database.Addresses)}");
+        log.WriteLine($"  endpoint type: {database.EndpointType ?? "(unset)"}");
+
+        // Enabled refuses the connection if the server will not give us notifications, so reaching the
+        // assertions at all is the opt-in having been accepted - there is nothing weaker to check. A stub +OK
+        // would pass this, which is what the scenario tests are for.
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig(fixture.Environment));
+        Assert.True(conn.IsConnected);
+
+        var server = conn.GetServer(conn.GetEndPoints()[0]);
+        log.WriteLine($"  connected: {server.Version}, {server.ServerType}, protocol {server.Protocol}");
+        Assert.Equal(RedisProtocol.Resp3, server.Protocol);
+
+        var rtt = await conn.GetDatabase().PingAsync();
+        log.WriteLine($"  ping: {rtt.TotalMilliseconds:0.0}ms");
+        Assert.True(rtt > TimeSpan.Zero);
+
+        // and the feature is actually live on this connection, not merely requested
+        var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(conn.GetEndPoints()[0]);
+        Assert.True(endpoint.MaintenanceNotificationsActive, "maintenance notifications should be active");
+    }
+
+    [Fact]
+    public async Task AdvertisedAddressCountMatchesTheProxyPolicy()
+    {
+        // Not a client assertion: a check that the environment is the shape the handoff tests assume. The count
+        // follows proxy *placement* rather than the policy name, so this records what this deployment actually
+        // is - and a handoff test that expects a sibling to step to needs more than one.
+        var standalone = fixture.Require("standalone");
+        log.WriteLine($"{standalone.Key}: policy {standalone.ProxyPolicy}, {standalone.AdvertisedAddressCount} address(es)");
+
+        Assert.NotEmpty(standalone.Addresses);
+        if (standalone.ProxyPolicy is "single")
+        {
+            Assert.Equal(1, standalone.AdvertisedAddressCount);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/StackExchange.Redis.FaultInjector.Tests.csproj
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/StackExchange.Redis.FaultInjector.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- one TFM on purpose: these tests talk to a real Redis Enterprise deployment, so they are about server
+         behaviour rather than about our down-level targets, and there is nothing to learn from running them
+         three times. Analyzers also only run on the newest TFM per project, so this is the cheap shape. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>StackExchange.Redis.FaultInjector.Tests</AssemblyName>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <SignAssembly>true</SignAssembly>
+    <DebugType>full</DebugType>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.runner.console" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/tests/StackExchange.Redis.FaultInjector.Tests/TlsScenarioTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/TlsScenarioTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// The same feature over TLS, against certificates a real cluster generated.
+/// </summary>
+/// <remarks>
+/// A gap that has been open since the identity work: nothing had exercised a real TLS deployment, only the
+/// in-process harness with a certificate it made itself. That matters because the interesting failures are
+/// about *identity* - which name the certificate carries, and whether the endpoint we are told to use is
+/// covered by it - and a fake that issues its own certificate cannot be wrong about that in the way a real
+/// deployment can.
+/// <para>
+/// Certificates here are self-signed per environment, so the client pins the issuer with
+/// <see cref="ConfigurationOptions.TrustIssuer(string)"/>. Note what is deliberately *not* done: validation is
+/// never disabled. A TLS test that stops checking identity reports success for precisely the thing it exists to
+/// catch, so a missing CA fails the run instead.
+/// </para>
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "tls")]
+public class TlsScenarioTests(ExistingDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ExistingDatabaseFixture>
+{
+    [Fact]
+    public async Task NotificationsArriveOverTlsAndIdentityIsVerified()
+    {
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        if (fixture.Environment.CertificateAuthorityPath is null)
+        {
+            // a skip rather than a failure: whether the environment generated certificates is a provisioning
+            // choice, and running this without them would prove nothing
+            Assert.Skip($"no CA certificate in {fixture.Environment.ConfigDirectory.FullName}; provision with TLS to run this");
+        }
+
+        log.WriteLine($"trusting issuer {fixture.Environment.CertificateAuthorityPath}");
+        CertificateSanity.RequireCertificatesMatchThisCluster(fixture.Environment, log.WriteLine);
+
+        await using var scenario = await ScenarioRun.SetupAsync(
+            fixture.Injector,
+            "topology-change-standalone",
+            "conn_drop",
+            "endpoint_rebind",
+            log.WriteLine,
+            // include_tls does not *request* TLS, it widens the list of variants the setup may choose from;
+            // variant_index is what picks one. Confirmed by asking the discovery endpoint: with no flags a
+            // trigger offers one variant ("single"), with include_tls two ("single", "single_tls"), and with
+            // include_mtls a third ("mtls"). Passing include_tls alone provisions variant 0 and yields a
+            // plaintext database, which is how this test first came to skip itself.
+            extra: new Dictionary<string, string?>
+            {
+                ["include_tls"] = "true",
+                ["variant_index"] = "1",
+            },
+            cancellationToken: cancellationToken);
+
+        var database = scenario.Database;
+        Assert.NotNull(database);
+        log.WriteLine($"provisioned {database} (tls={database.Tls})");
+
+        if (!database.Tls)
+        {
+            Assert.Skip("the injector provisioned a plaintext database despite include_tls=true; nothing to test here");
+        }
+
+        var clock = Stopwatch.StartNew();
+        var events = new List<PushMaintenanceEvent>();
+
+        var config = database.GetClientConfig(fixture.Environment);
+
+        // AbortOnConnectFail=true *for this test only*: everywhere else tolerating a slow start is right, but a
+        // TLS failure has to surface its reason. With it false, a certificate problem is indistinguishable from
+        // a slow cluster - ConnectAsync succeeds, IsConnected is false, and the cause is gone.
+        config.AbortOnConnectFail = true;
+
+        // If the certificate does not cover the name we dialled, this throws - which is the point: the
+        // assertion that identity was verified is the connect succeeding with validation on. The log goes to
+        // test output so a handshake failure says *which* check failed.
+        var connectLog = new StringWriter();
+        ConnectionMultiplexer conn;
+        try
+        {
+            conn = await ConnectionMultiplexer.ConnectAsync(config, connectLog);
+        }
+        catch (Exception ex)
+        {
+            log.WriteLine(connectLog.ToString());
+            log.WriteLine($"TLS connect failed: {ex.GetType().Name}: {ex.Message}");
+            throw;
+        }
+
+        await using (conn)
+        {
+        Assert.True(conn.IsConnected);
+
+        var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(conn.GetEndPoints()[0]);
+        Assert.True(endpoint.MaintenanceNotificationsActive, "the opt-in should be live over TLS too");
+        log.WriteLine($"connected over TLS; opt-in active; ping {(await conn.GetDatabase().PingAsync()).TotalMilliseconds:0.0}ms");
+
+        conn.ServerMaintenanceEvent += (_, e) =>
+        {
+            if (e is PushMaintenanceEvent push)
+            {
+                lock (events) events.Add(push);
+                log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  {push.NotificationType} seq={push.SequenceId} {push.RawMessage}");
+            }
+        };
+
+        clock.Restart();
+        await scenario.FireAsync(cancellationToken);
+
+        var deadline = clock.Elapsed + TimeSpan.FromSeconds(45);
+        while (clock.Elapsed < deadline)
+        {
+            try
+            {
+                await conn.GetDatabase().PingAsync();
+            }
+            catch (Exception ex) when (ex is RedisException or TimeoutException)
+            {
+                log.WriteLine($"  +{clock.Elapsed.TotalSeconds,6:0.0}s  ping failed: {ex.GetType().Name}");
+            }
+
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        lock (events)
+        {
+            log.WriteLine($"  {events.Count} notification(s) over TLS");
+            Assert.NotEmpty(events);
+        }
+
+        // and the TLS handshake succeeds again on the *replacement* connection, which is the part a
+        // certificate-name problem would break rather than the first connect
+        Assert.True(
+            await Poll.UntilAsync(
+                () =>
+                {
+                    try
+                    {
+                        return conn.IsConnected && conn.GetDatabase().Ping() >= TimeSpan.Zero;
+                    }
+                    catch (Exception ex) when (ex is RedisException or TimeoutException)
+                    {
+                        return false;
+                    }
+                },
+                timeoutMilliseconds: 30_000),
+            "the client should re-establish TLS after the endpoint moves");
+        }
+    }
+}

--- a/tests/StackExchange.Redis.FaultInjector.Tests/TopologyChangeScenarioTests.cs
+++ b/tests/StackExchange.Redis.FaultInjector.Tests/TopologyChangeScenarioTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.FaultInjector.Tests;
+
+/// <summary>
+/// Real topology changes on a real deployment, watched by a real client.
+/// </summary>
+/// <remarks>
+/// Each scenario provisions its own database, because every trigger publishes the <c>dbconfig</c> it requires
+/// and all of them want <c>proxy_policy: single</c> - a shape the environment templates do not create.
+/// <para>
+/// What these assert is deliberately modest: that the notifications arrive, parse, and open the relaxation
+/// window. Timings are *recorded* rather than asserted, because the measured spread across clusters is wide
+/// enough that a bound tight enough to be interesting would be flaky - DNS has been seen updating 4.4s after
+/// <c>MOVING</c> on one cluster and 3s after the socket closed on another. The log is the deliverable for
+/// timing; the assertions cover behaviour.
+/// </para>
+/// </remarks>
+[Trait("tier", "fault-injector")]
+[Trait("scenario", "topology-change")]
+public class TopologyChangeScenarioTests(ExistingDatabaseFixture fixture, ITestOutputHelper log)
+    : IClassFixture<ExistingDatabaseFixture>
+{
+    /// <summary>
+    /// Records what arrived and when, relative to the moment the scenario was fired.
+    /// </summary>
+    private sealed class Timeline(Stopwatch clock, ITestOutputHelper log)
+    {
+        private readonly List<string> _entries = [];
+
+        public List<PushMaintenanceEvent> Events { get; } = [];
+
+        public void Note(string what)
+        {
+            var entry = $"  +{clock.Elapsed.TotalSeconds,6:0.0}s  {what}";
+            lock (_entries)
+            {
+                _entries.Add(entry);
+            }
+
+            log.WriteLine(entry);
+        }
+
+        public void Add(PushMaintenanceEvent evt)
+        {
+            lock (_entries)
+            {
+                Events.Add(evt);
+            }
+
+            Note($"{evt.NotificationType} seq={evt.SequenceId} time={evt.Time?.TotalSeconds.ToString() ?? "-"} {evt.RawMessage}");
+        }
+
+        public int Count
+        {
+            get { lock (_entries) { return Events.Count; } }
+        }
+    }
+
+    /// <summary>
+    /// Whether each scenario announces itself, and why - measured 2026-09-01 against RS 8.0.22.
+    /// </summary>
+    /// <remarks>
+    /// The expectations encode the rule the measurements produced, which is narrower than either half of it
+    /// looks: <b>a connection is told <c>MOVING</c> when its own proxy leaves the endpoint's address set *and*
+    /// the set gains a member.</b> Both conditions are needed - a pure reduction takes the proxy away without
+    /// announcing it, and a pure widening adds addresses while leaving the connection's proxy in place, which is
+    /// also silent. The data-movement pair (<c>MIGRATING</c>/<c>MIGRATED</c>) is separate and fires whenever
+    /// shards move, whether or not any endpoint changes.
+    /// </remarks>
+    [Theory]
+    [InlineData("conn_drop", "endpoint_rebind", true)]
+    [InlineData("dns_resolution_change", "endpoint_rebind", false)]
+    [InlineData("data_movement_conn_drop", "maintenance_mode", true)]
+    [InlineData("data_movement_no_conn_drop", "migrate", true)]
+    public async Task ScenarioProducesNotificationsWeUnderstand(string effect, string trigger, bool expectNotifications)
+    {
+        fixture.RequireAvailable();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        await using var scenario = await ScenarioRun.SetupAsync(
+            fixture.Injector, "topology-change-standalone", effect, trigger, log.WriteLine, cancellationToken: cancellationToken);
+
+        var database = scenario.Database;
+        Assert.NotNull(database);
+
+        var clock = Stopwatch.StartNew();
+        var timeline = new Timeline(clock, log);
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(database.GetClientConfig(fixture.Environment));
+        var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(conn.GetEndPoints()[0]);
+        Assert.True(endpoint.MaintenanceNotificationsActive, "the opt-in must be live, or this test proves nothing");
+
+        conn.ServerMaintenanceEvent += (_, e) =>
+        {
+            if (e is PushMaintenanceEvent push) timeline.Add(push);
+        };
+        conn.ConnectionFailed += (_, e) => timeline.Note($"connection failed: {e.FailureType} {e.Exception?.Message}");
+        conn.ConnectionRestored += (_, e) => timeline.Note("connection restored");
+
+        clock.Restart();
+        timeline.Note($"firing {effect}/{trigger} against {database}");
+        await scenario.FireAsync(cancellationToken);
+        timeline.Note("injector reports the scenario finished");
+
+        // The injector finishing is not the deployment settling: notifications, the DNS change and the socket
+        // close all trail it. Keep watching, and keep the client busy so a broken connection actually surfaces
+        // rather than sitting idle.
+        var deadline = clock.Elapsed + TimeSpan.FromSeconds(60);
+        while (clock.Elapsed < deadline)
+        {
+            try
+            {
+                await conn.GetDatabase().PingAsync();
+            }
+            catch (Exception ex) when (ex is RedisException or TimeoutException)
+            {
+                timeline.Note($"ping failed: {ex.GetType().Name}");
+            }
+
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        timeline.Note($"finished with {timeline.Count} notification(s); relaxed={endpoint.IsMaintenanceRelaxed}");
+
+        if (expectNotifications)
+        {
+            Assert.NotEmpty(timeline.Events);
+            Assert.All(timeline.Events, e => Assert.NotEqual(MaintenanceNotificationType.None, e.NotificationType));
+        }
+        else
+        {
+            // dns_resolution_change widens the policy (single -> all-master-shards), so addresses are *added*
+            // and the connection's own proxy stays where it is - there is nothing to tell this connection to
+            // move, and the proxy restarting to apply the change closes the socket with no warning at all.
+            // Asserting the silence deliberately: it is the case with no signal, so if a future build starts
+            // announcing it, that is a behaviour change we want to be told about rather than to absorb quietly.
+            Assert.Empty(timeline.Events);
+        }
+
+        // and the client is usable afterwards, which is the point of the whole feature
+        Assert.True(
+            await Poll.UntilAsync(() => TryPing(conn), timeoutMilliseconds: 30_000),
+            "the client should be serving commands again after the topology change");
+    }
+
+    private static bool TryPing(IConnectionMultiplexer conn)
+    {
+        try
+        {
+            return conn.IsConnected && conn.GetDatabase().Ping() >= TimeSpan.Zero;
+        }
+        catch (Exception ex) when (ex is RedisException or TimeoutException)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/AdvertisedAddressProbeTests.cs
+++ b/tests/StackExchange.Redis.Tests/AdvertisedAddressProbeTests.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// The DNS probe behind the <c>MOVING</c> handoff. Tested against an injected resolver rather than real DNS,
+/// which is the only way to exercise the case that actually happens: the first answer naming the address we
+/// were just told to leave.
+/// </summary>
+public class AdvertisedAddressProbeTests(ITestOutputHelper log)
+{
+    private static readonly IPAddress Retiring = IPAddress.Parse("10.129.228.140");
+    private static readonly IPAddress Replacement = IPAddress.Parse("10.252.90.18");
+    private static readonly DnsEndPoint Endpoint = new("db.example.cloud.redislabs.com", 13486);
+
+    /// <summary>
+    /// Resolves from a script: one entry per call, the last repeating forever.
+    /// </summary>
+    private sealed class ScriptedResolver(params IPAddress[][] answers)
+    {
+        private int _calls;
+        public int Calls => Volatile.Read(ref _calls);
+
+        public Task<IPAddress[]> ResolveAsync(string host, CancellationToken cancellationToken)
+        {
+            var index = Interlocked.Increment(ref _calls) - 1;
+            return Task.FromResult(answers[Math.Min(index, answers.Length - 1)]);
+        }
+    }
+
+    [Fact]
+    public async Task DnsTrailingTheNotificationIsPolledThrough()
+    {
+        // The measured case: DNS named the retiring address for the first 4.4-9.7 seconds after MOVING. A
+        // client that accepted the first answer would hand off to the node it was told to leave.
+        var resolver = new ScriptedResolver(
+            [Retiring],
+            [Retiring],
+            [Retiring],
+            [Replacement]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(Replacement, 13486), result);
+        Assert.Equal(4, resolver.Calls);
+    }
+
+    [Fact]
+    public async Task ReplacementOnTheFirstAnswerIsTakenImmediately()
+    {
+        var resolver = new ScriptedResolver([Replacement]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromSeconds(1),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(Replacement, 13486), result);
+        Assert.Equal(1, resolver.Calls);
+    }
+
+    [Fact]
+    public async Task WindowExpiringWithoutAMoveGivesUpRatherThanGuessing()
+    {
+        // Not a failure to report: the server closes the socket regardless, and the relaxed window covers the
+        // reconnect. Guessing an address here would be worse than doing nothing.
+        var resolver = new ScriptedResolver([Retiring]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromMilliseconds(120), pollInterval: TimeSpan.FromMilliseconds(20),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Null(result);
+        Assert.True(resolver.Calls > 1, $"should have retried within the window, but resolved {resolver.Calls} time(s)");
+    }
+
+    [Fact]
+    public async Task ZeroWindowStillGetsOneAttempt()
+    {
+        // "act now" rather than "do nothing": the notifications legitimately carry zero or negative times for
+        // a connection that arrived mid-window
+        var resolver = new ScriptedResolver([Replacement]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.Zero, pollInterval: TimeSpan.FromSeconds(1),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(Replacement, 13486), result);
+        Assert.Equal(1, resolver.Calls);
+    }
+
+    [Fact]
+    public async Task ResolutionFailureIsRetriedNotFatal()
+    {
+        // a DNS blip mid-handoff is when we can least afford to give up
+        int calls = 0;
+        Task<IPAddress[]> Resolve(string host, CancellationToken cancellationToken)
+        {
+            calls++;
+            return calls switch
+            {
+                1 => throw new System.Net.Sockets.SocketException(11001), // host not found
+                2 => Task.FromResult<IPAddress[]>([Retiring]),
+                _ => Task.FromResult<IPAddress[]>([Replacement]),
+            };
+        }
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: Resolve, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(Replacement, 13486), result);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public async Task MultipleAddressesTakeTheOneThatIsNotRetiring()
+    {
+        // a round-robin record can name both nodes at once mid-move
+        var resolver = new ScriptedResolver([Retiring, Replacement]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromSeconds(1),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(Replacement, 13486), result);
+    }
+
+    [Fact]
+    public async Task PlacementNotPolicyDecidesWhetherWeWait()
+    {
+        // The A-record count follows actual proxy placement, not the policy name: an all-master-shards
+        // database whose shards share a node resolves to one address, and then there is no sibling to step to
+        // and the wait is the only option. Same code path as `single`, which is the point - nothing here reads
+        // the policy.
+        var resolver = new ScriptedResolver([Retiring], [Retiring], [Replacement]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(Replacement, 13486), result);
+        Assert.Equal(3, resolver.Calls); // it waited, because there was nothing else advertised
+    }
+
+    [Fact]
+    public async Task SiblingIsTakenWithoutWaitingForTheRecordToMove()
+    {
+        // The common case: several A records, so the first resolution already names a live sibling proxy while
+        // the retiring address is *still* advertised. Stepping sideways immediately is correct - any proxy of
+        // the same database serves the same data - and it means the poll usually never engages.
+        var sibling = IPAddress.Parse("10.246.250.155");
+        var resolver = new ScriptedResolver([Retiring, sibling]);
+
+        var result = await AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromSeconds(1),
+            resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(new IPEndPoint(sibling, 13486), result);
+        Assert.Equal(1, resolver.Calls);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task StillAdvertisedAnswersTheUnannouncedCase(bool present)
+    {
+        // The measured gap: a multi-proxy node taken out for maintenance announced only MIGRATING/MIGRATED,
+        // dropped the victim from DNS at +21.4s, and closed its socket silently at +34.7s. For thirteen
+        // seconds the condition was visible to anyone who asked, and no notification said so.
+        var sibling = IPAddress.Parse("10.246.250.155");
+        var resolver = new ScriptedResolver(present ? [Retiring, sibling] : [sibling, Replacement]);
+
+        var result = await AdvertisedAddressProbe.IsStillAdvertisedAsync(
+            Endpoint, Retiring, resolve: resolver.ResolveAsync, log: log.WriteLine);
+
+        Assert.Equal(present, result);
+    }
+
+    [Fact]
+    public async Task ResolutionFailureIsNotAReasonToAbandonAConnection()
+    {
+        // null rather than false, deliberately: "cannot tell" must not become "give it up", or a DNS blip
+        // recycles every healthy connection at once
+        Task<IPAddress[]> Throws(string host, CancellationToken cancellationToken)
+            => throw new System.Net.Sockets.SocketException(11001);
+
+        Assert.Null(await AdvertisedAddressProbe.IsStillAdvertisedAsync(
+            Endpoint, Retiring, resolve: Throws, log: log.WriteLine));
+
+        // and the same for a record that momentarily resolves to nothing at all
+        Assert.Null(await AdvertisedAddressProbe.IsStillAdvertisedAsync(
+            Endpoint, Retiring, resolve: (_, _) => Task.FromResult<IPAddress[]>([]), log: log.WriteLine));
+    }
+
+    [Fact]
+    public async Task CancellationStopsThePoll()
+    {
+        using var cts = new CancellationTokenSource();
+        var resolver = new ScriptedResolver([Retiring]);
+
+        var probe = AdvertisedAddressProbe.ProbeAsync(
+            Endpoint, Retiring, window: TimeSpan.FromMinutes(1), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: resolver.ResolveAsync, log: log.WriteLine, cancellationToken: cts.Token);
+
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => probe);
+    }
+}

--- a/tests/StackExchange.Redis.Tests/ClusterSlotMigrationUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/ClusterSlotMigrationUnitTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// The comma-and-range slot form the cluster notifications carry, e.g. <c>123,456,789-1000</c>. Split out
+/// because it is the one part of stage 3 that a wire capture cannot invalidate - it is the same form
+/// <c>CLUSTER NODES</c> has always used.
+/// </summary>
+public class ClusterSlotMigrationUnitTests(ITestOutputHelper log)
+{
+    [Theory]
+    [InlineData("123", "123-123")]
+    [InlineData("123,456", "123-123,456-456")]
+    [InlineData("789-1000", "789-1000")]
+    [InlineData("123,456,789-1000", "123-123,456-456,789-1000")]
+    [InlineData("0-16383", "0-16383")]
+    [InlineData("5-5", "5-5")]
+    public void ParsesTheSlotForm(string input, string expected)
+    {
+        Assert.True(SlotRange.TryParseList(input, out var ranges));
+        var actual = string.Join(",", ranges.Select(x => $"{x.From}-{x.To}"));
+        log.WriteLine($"{input} -> {actual}");
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("123,,456", "123-123,456-456")] // empty element, skipped
+    [InlineData("123,", "123-123")] // trailing comma
+    [InlineData(",123", "123-123")] // leading comma
+    public void ToleratesEmptyElements(string input, string expected)
+    {
+        Assert.True(SlotRange.TryParseList(input, out var ranges));
+        Assert.Equal(expected, string.Join(",", ranges.Select(x => $"{x.From}-{x.To}")));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(",")]
+    [InlineData("abc")]
+    [InlineData("12a")]
+    [InlineData("-5")] // no lower bound
+    [InlineData("5-")] // no upper bound
+    [InlineData("1000-789")] // reversed: a server bug, not something to normalize silently
+    [InlineData("1-2-3")]
+    [InlineData("123,abc")] // one bad element fails the list: a partial slot set is worse than none
+    public void RejectsMalformedInput(string? input)
+    {
+        Assert.False(SlotRange.TryParseList(input, out var ranges));
+        log.WriteLine($"'{input}' rejected, {ranges.Count} range(s)");
+    }
+
+    [Fact]
+    public void OutOfRangeSlotIsRejected()
+    {
+        // 16384 does not fit the short, and a checked cast would throw rather than wrap
+        Assert.False(SlotRange.TryParseList("99999", out _));
+    }
+}

--- a/tests/StackExchange.Redis.Tests/ConfigTests.cs
+++ b/tests/StackExchange.Redis.Tests/ConfigTests.cs
@@ -63,6 +63,9 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
             new[]
             {
                 "_maintenanceNotifications",
+                "_maintenancePostEventRelaxedDuration",
+                "_maintenanceRelaxedTimeout",
+                "_maintenanceRelaxedWindowMax",
                 "_protocol",
                 "asyncTimeout",
                 "backlogPolicy",
@@ -890,6 +893,47 @@ public class ConfigTests(ITestOutputHelper output, SharedConnectionFixture fixtu
 
         var parsed = Parse(cs);
         Assert.Equal(expected, parsed.HighIntegrity);
+    }
+
+    [Theory]
+    [InlineData("maintRelaxedTimeout=20", 20, 60, 40)]
+    [InlineData("maintRelaxedWindowMax=45", 10, 45, 20)]
+    [InlineData("maintPostEventRelaxed=0", 10, 30, 0)]
+    public void MaintenanceDurationsRoundTrip(string cs, int relaxedSeconds, int capSeconds, int tailSeconds)
+    {
+        // these are in *seconds*, unlike every other timeout here, because that is the unit the cross-client
+        // contract names for maintRelaxedTimeout - so a documented value can be pasted between clients
+        var options = Parse("dummy," + cs);
+        Assert.Equal(TimeSpan.FromSeconds(relaxedSeconds), options.MaintenanceRelaxedTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(capSeconds), options.MaintenanceRelaxedWindowMax);
+        Assert.Equal(TimeSpan.FromSeconds(tailSeconds), options.MaintenancePostEventRelaxedDuration);
+
+        // only the explicitly-set key is serialized; the others stay defaulted
+        Assert.Equal("dummy," + cs, RemoveTestDefaults(options.ToString()));
+
+        var clone = options.Clone();
+        Assert.Equal(options.MaintenanceRelaxedTimeout, clone.MaintenanceRelaxedTimeout);
+        Assert.Equal("dummy," + cs, RemoveTestDefaults(clone.ToString()));
+    }
+
+    [Fact]
+    public void MaintenanceDurationsDefaultRelativeToTheRelaxedTimeout()
+    {
+        // the cap and tail are multiples so that raising the relaxed timeout cannot produce a cap below it
+        var options = Parse("dummy,maintRelaxedTimeout=60");
+        Assert.Equal(TimeSpan.FromSeconds(180), options.MaintenanceRelaxedWindowMax);
+        Assert.Equal(TimeSpan.FromSeconds(120), options.MaintenancePostEventRelaxedDuration);
+    }
+
+    [Fact]
+    public void MaintenanceDurationInMillisecondsIsDiagnosed()
+    {
+        // the silent-misconfiguration case: somebody assumes milliseconds like every other timeout here and
+        // writes 30000, which as seconds would be an eight-hour relaxed timeout. The message names the unit
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Parse("dummy,maintRelaxedTimeout=30000"));
+        Output.WriteLine(ex.Message);
+        Assert.Contains("seconds", ex.Message);
+        Assert.Contains("not in milliseconds", ex.Message);
     }
 
     [Theory]

--- a/tests/StackExchange.Redis.Tests/HealthCheckPolicyUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/HealthCheckPolicyUnitTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using StackExchange.Redis.Availability;
 using Xunit;
 
@@ -6,6 +6,34 @@ namespace StackExchange.Redis.Tests;
 
 public class HealthCheckPolicyUnitTests
 {
+    /// <summary>
+    /// Probe traffic must not be counted as work a caller is waiting on, because idleness is what decides
+    /// whether an endpoint that has left the deployment can be given up - a probe that looks like caller work
+    /// makes a server appear busy precisely because we are watching it.
+    /// </summary>
+    /// <remarks>
+    /// The other half of this test is what it asserts is *false*: the probe must not become an internal call,
+    /// which would also change how it is queued - internal calls bypass the backlog. A health check that
+    /// bypasses the backlog cannot observe a bridge whose queue is not draining, which is exactly the signal
+    /// geo-redundant failover depends on.
+    /// </remarks>
+    [Fact]
+    public void ProbeTrafficIsNotCallerFacingButIsRoutedNormally()
+    {
+        var flags = new HealthCheckContext(null!, TimeSpan.FromSeconds(1)).ProbeFlags;
+        Assert.NotEqual(CommandFlags.None, flags);
+
+        var message = Message.Create(-1, flags, RedisCommand.PING);
+        Assert.True(message.IsProbe);
+        Assert.False(message.IsCallerFacing);
+        Assert.False(message.IsInternalCall);
+
+        // and an ordinary command is unaffected in both directions
+        var ordinary = Message.Create(-1, CommandFlags.None, RedisCommand.PING);
+        Assert.False(ordinary.IsProbe);
+        Assert.True(ordinary.IsCallerFacing);
+    }
+
     [Theory]
     [InlineData(0, 0, 5, HealthCheckResult.Inconclusive)] // No results yet
     [InlineData(1, 0, 0, HealthCheckResult.Healthy)] // One success, no more probes

--- a/tests/StackExchange.Redis.Tests/MaintenanceHandoffTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceHandoffTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Deciding what a <c>MOVING</c> means: where to go, or that there is nowhere to go.
+/// </summary>
+/// <remarks>
+/// Tested as a pure decision, with the resolver supplied, because the whole thing turns on DNS *changing* -
+/// which no in-process fake can arrange.
+/// </remarks>
+public class MaintenanceHandoffTests(ITestOutputHelper log)
+{
+    private static readonly IPAddress Retiring = IPAddress.Parse("10.129.228.140");
+    private static readonly IPAddress Replacement = IPAddress.Parse("10.252.90.18");
+    private static readonly DnsEndPoint Hostname = new("db.example.cloud.redislabs.com", 13486);
+
+    private static Func<string, CancellationToken, Task<IPAddress[]>> Resolves(params IPAddress[] addresses)
+        => (_, _) => Task.FromResult(addresses);
+
+    [Fact]
+    public async Task HostnameThatHasMovedIsRecycled()
+    {
+        var decision = await MaintenanceHandoff.DecideAsync(
+            Hostname, successor: null, currentAddress: Retiring,
+            window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: Resolves(Replacement), log: log.WriteLine);
+
+        log.WriteLine(decision.ToString());
+        Assert.Equal(HandoffAction.Recycle, decision.Action);
+        Assert.Equal(new IPEndPoint(Replacement, 13486), decision.Target);
+    }
+
+    [Fact]
+    public async Task HostnameThatNeverMovesDoesNothing()
+    {
+        // Not a failure: the server closes the socket regardless, the reconnect re-resolves, and the relaxed
+        // window covers the gap. Measured on a real cluster - DNS updated three seconds *after* the close - so
+        // this is a normal outcome rather than a defensive branch.
+        var decision = await MaintenanceHandoff.DecideAsync(
+            Hostname, successor: null, currentAddress: Retiring,
+            window: TimeSpan.FromMilliseconds(100), pollInterval: TimeSpan.FromMilliseconds(20),
+            resolve: Resolves(Retiring), log: log.WriteLine);
+
+        log.WriteLine(decision.ToString());
+        Assert.Equal(HandoffAction.None, decision.Action);
+        Assert.Null(decision.Target);
+    }
+
+    [Fact]
+    public async Task AddressEndpointWithNoSuccessorHasNothingToDo()
+    {
+        // An address cannot be re-resolved, and nothing was named: there is no handoff to make. This is the
+        // case a cluster deployment would hit, and it is why MOVING must not simply reuse endpoint retirement -
+        // there would be nothing to retire *to*.
+        var decision = await MaintenanceHandoff.DecideAsync(
+            new IPEndPoint(Retiring, 13486), successor: null, currentAddress: Retiring,
+            window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: Resolves(Replacement), log: log.WriteLine);
+
+        log.WriteLine(decision.ToString());
+        Assert.Equal(HandoffAction.None, decision.Action);
+    }
+
+    [Fact]
+    public async Task NamedSuccessorAsksForAReconfigure()
+    {
+        // Never observed on any real deployment - eleven routes, all explicit nulls - so this exists because the
+        // contract has it, not because it fires.
+        var successor = new IPEndPoint(Replacement, 13486);
+        var decision = await MaintenanceHandoff.DecideAsync(
+            Hostname, successor, currentAddress: Retiring,
+            window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: Resolves(Retiring), log: log.WriteLine);
+
+        log.WriteLine(decision.ToString());
+        Assert.Equal(HandoffAction.Reconfigure, decision.Action);
+        Assert.Equal(successor, decision.Target);
+    }
+
+    [Fact]
+    public async Task UnknownCurrentAddressDoesNothingRatherThanGuessing()
+    {
+        // Recycling here would mean accepting whatever DNS says *now*, which for the first several seconds is
+        // the address being retired - so we would hand off to the node we were told to leave.
+        var decision = await MaintenanceHandoff.DecideAsync(
+            Hostname, successor: null, currentAddress: null,
+            window: TimeSpan.FromSeconds(5), pollInterval: TimeSpan.FromMilliseconds(10),
+            resolve: Resolves(Replacement), log: log.WriteLine);
+
+        log.WriteLine(decision.ToString());
+        Assert.Equal(HandoffAction.None, decision.Action);
+    }
+
+    [Theory]
+    [InlineData(15, 0, 1000)] // a generous window: capped at a second, not a tenth of fifteen
+    [InlineData(2, 0, 200)] // a short one: a tenth, so a 2s window never spends more than 200ms
+    [InlineData(0, 0, 0)] // "act now"
+    public void JitterScalesWithTheWindowAndIsCapped(int windowSeconds, int minMilliseconds, int maxMilliseconds)
+    {
+        var random = new Random(12345);
+        for (int i = 0; i < 200; i++)
+        {
+            var jitter = MaintenanceHandoff.GetJitter(TimeSpan.FromSeconds(windowSeconds), random);
+            Assert.InRange(jitter.TotalMilliseconds, minMilliseconds, maxMilliseconds);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
@@ -371,6 +371,102 @@ public class MaintenanceNotificationTests(ITestOutputHelper log)
         }
     }
 
+    [Theory]
+    [InlineData(MaintenanceNotificationKind.Migrating, MaintenanceNotificationKind.Migrated, "27")]
+    [InlineData(MaintenanceNotificationKind.FailingOver, MaintenanceNotificationKind.FailedOver, "21")]
+    public async Task CapturedShardNotificationsAreUnderstood(
+        MaintenanceNotificationKind opening,
+        MaintenanceNotificationKind closing,
+        string shard)
+    {
+        // Captured from the same deployment, byte for byte, running the fault injector's maintenance_mode and
+        // failover scenarios:
+        //
+        //   >4\r\n$9\r\nMIGRATING\r\n:0\r\n:2\r\n$6\r\n["27"]\r\n
+        //   >3\r\n$8\r\nMIGRATED\r\n:1\r\n$6\r\n["27"]\r\n
+        //   >4\r\n$12\r\nFAILING_OVER\r\n:0\r\n:2\r\n$6\r\n["21"]\r\n
+        //   >3\r\n$11\r\nFAILED_OVER\r\n:1\r\n$6\r\n["21"]\r\n
+        //
+        // Both families have the same shape, and it is the shape the parser assumed: the *opening*
+        // notification carries a time and the *closing* one has no time element at all - which is why
+        // CarriesTime is keyed on the notification type rather than on sniffing whether the third element
+        // looks like a number. The shard list is a stringified JSON array of id strings, quotes included, and
+        // is carried through opaquely: nothing a client does depends on which shard it was.
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var shards = $"[\"{shard}\"]";
+            server.SendShardNotification(null, opening, timeSeconds: 2, shardIds: shards, sequenceId: 0);
+
+            var open = await events.NextAsync();
+            log.WriteLine(open.RawMessage ?? "(none)");
+            Assert.Equal(TimeSpan.FromSeconds(2), open.Time);
+            Assert.Equal(shards, open.Payload);
+            Assert.Equal(0, open.SequenceId);
+
+            // note 2 seconds is what the server actually said, and is shorter than the relaxed timeout floor;
+            // the window is clamped up to the floor rather than being honoured literally
+            var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+            Assert.True(endpoint.IsMaintenanceRelaxed, $"{opening} should have relaxed timeouts");
+
+            server.SendShardNotification(null, closing, timeSeconds: null, shardIds: shards, sequenceId: 1);
+
+            var closed = await events.NextAsync();
+            log.WriteLine(closed.RawMessage ?? "(none)");
+            Assert.Null(closed.Time); // three elements on the wire: no time to read
+            Assert.Equal(shards, closed.Payload);
+            Assert.Equal(1, closed.SequenceId);
+        }
+    }
+
+    [Fact]
+    public async Task OneLogicalEventFromEveryNodeRaisesOneEvent()
+    {
+        // Observed on the real deployment: every node broadcasts a given event, and all the copies carry the
+        // same sequence number - the id identifies the event, not the delivery. So a two-node cluster delivers
+        // one migration twice. Both deliveries have to be *acted on*, because the timeout relaxation is
+        // per-server, but the consumer wants one callback rather than one per proxy.
+        var server = new InProcessTestServer(log) { ServerType = ServerType.Cluster };
+        GetHost(server.DefaultEndPoint, out var port);
+        var second = server.AddEmptyNode(new IPEndPoint(IPAddress.Loopback, port + 1));
+        server.Migrate((RedisKey)"elsewhere", second); // owns something, so the client connects to it
+
+        var config = server.GetClientConfig(defaultOnly: true);
+        config.Protocol = RedisProtocol.Resp3;
+        config.MaintenanceNotifications = MaintenanceNotificationMode.Enabled;
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+        var events = new EventCollector(conn);
+        using (server)
+        {
+            var muxer = (IInternalConnectionMultiplexer)conn;
+            Assert.True(
+                await Poll.UntilAsync(() =>
+                {
+                    var endpoints = conn.GetEndPoints();
+                    return endpoints.Length == 2 && endpoints.All(ep => muxer.GetServerEndPoint(ep).MaintenanceNotificationsActive);
+                }),
+                "both nodes should be connected and opted in, or there is only one delivery and this proves nothing");
+
+            // one send, two clients: this is the fan-out, from the server side
+            var delivered = server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 2, shardIds: "[\"27\"]", sequenceId: 5);
+            Assert.Equal(2, delivered);
+
+            // both servers relax - that is the internal work that has to happen per connection...
+            Assert.True(
+                await Poll.UntilAsync(() => conn.GetEndPoints().All(ep => muxer.GetServerEndPoint(ep).IsMaintenanceRelaxed)),
+                "every node that was told should have relaxed its own timeouts");
+
+            // ...and the consumer sees it once
+            Assert.Equal(1, events.Count);
+            var evt = await events.NextAsync();
+            Assert.Equal(5, evt.SequenceId);
+            log.WriteLine($"{events.Count} event(s) from {delivered} deliveries: {evt.RawMessage}");
+            Assert.Contains(evt.EndPoint, conn.GetEndPoints()); // whichever told us first
+        }
+    }
+
     [Fact]
     public async Task MalformedTripletIsSkippedNotFatal()
     {

--- a/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
@@ -602,6 +602,132 @@ public class MaintenanceNotificationTests(ITestOutputHelper log)
         }
     }
 
+    [Theory]
+    [InlineData(null)] // the measured shape: the close arrives *after* the announced window
+    [InlineData(300)] // a less generous proxy: the close beats the window it announced
+    public async Task MovingClosesTheConnectionAndWeRecover(int? closeDelayMilliseconds)
+    {
+        // The defining half of MOVING, which no test covered until now: we are told to move, and then the
+        // socket goes away. Measured on RS (2026-08-28): the close landed at +18.4s and +16.6s against a
+        // declared 15s window, so the window is a floor with slack rather than a deadline - which is why the
+        // default case here lets the fake overshoot, and why nothing below asserts on the window expiring.
+        // The short case is the defensive one: a client that treats the announced window as guaranteed fails
+        // it. What must hold either way is that the connection comes back and the relaxed window opened by the
+        // notification is what covers the reconnect.
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            server.MovingClosesConnection = true;
+            server.MovingCloseDelay = closeDelayMilliseconds is { } ms ? TimeSpan.FromMilliseconds(ms) : null;
+            server.SendMoving(null, timeSeconds: 1, newEndpoint: null, sequenceId: 0);
+
+            var moving = await events.NextAsync();
+            Assert.Equal(MaintenanceNotificationType.Moving, moving.NotificationType);
+
+            var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+            Assert.True(endpoint.IsMaintenanceRelaxed, "the window has to be open before the socket dies");
+
+            // the client must reconnect on its own; nothing here asks it to. Note the probe has to tolerate
+            // throwing rather than returning false: a command issued in the window between the socket dying
+            // and the reconnect completing raises, and that is the state being polled *out* of
+            Assert.True(
+                await Poll.UntilAsync(
+                    () =>
+                    {
+                        try
+                        {
+                            return conn.IsConnected && conn.GetDatabase().Ping() >= TimeSpan.Zero;
+                        }
+                        catch (Exception ex) when (ex is RedisException or TimeoutException)
+                        {
+                            return false;
+                        }
+                    },
+                    timeoutMilliseconds: 15_000),
+                "the multiplexer should have re-established itself after the close");
+
+            log.WriteLine($"close delay {closeDelayMilliseconds?.ToString() ?? "announced+slack"}: reconnected, relaxed = {endpoint.IsMaintenanceRelaxed}");
+        }
+    }
+
+    [Fact]
+    public async Task MovingRecyclesTheConnectionBeforeTheServerCloses()
+    {
+        // The point of D6: today a MOVING is survivable because the socket eventually closes and we reconnect,
+        // but the announced window goes unused. Here nothing closes the connection - MovingClosesConnection is
+        // deliberately left off - so the *only* thing that can replace it is our own handoff.
+        //
+        // The named-successor branch is what is exercised, because the in-process transport has no socket and so
+        // no current address for the DNS branch to compare against; the deciding half of that branch is covered
+        // by MaintenanceHandoffTests against a supplied resolver. What this proves is the acting half: drain,
+        // drop, and come back.
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var optInsBefore = server.TotalMaintenanceOptIns;
+            Assert.Equal(1, optInsBefore); // the handshake's own opt-in, so the increment below means something
+
+            // A handoff has to be *visible*: the replacement raises ConnectionRestored, so reporting nothing for
+            // the drop would leave a consumer tracking connection state with an unpaired restore.
+            var failures = new List<ConnectionFailureType>();
+            conn.ConnectionFailed += (_, e) =>
+            {
+                lock (failures) failures.Add(e.FailureType);
+            };
+
+            server.SendMoving(null, timeSeconds: 2, newEndpoint: server.DefaultEndPoint, sequenceId: 0);
+
+            var moving = await events.NextAsync();
+            Assert.Equal(MaintenanceNotificationType.Moving, moving.NotificationType);
+            Assert.Equal(server.DefaultEndPoint, moving.NewEndPoint);
+
+            // a fresh connection re-sends the opt-in, which is how a recycle is visible from the server's side
+            Assert.True(
+                await Poll.UntilAsync(() => server.TotalMaintenanceOptIns > optInsBefore, timeoutMilliseconds: 15_000),
+                "the handoff should have replaced the connection without the server closing it");
+
+            log.WriteLine($"opt-ins: {optInsBefore} -> {server.TotalMaintenanceOptIns}");
+
+            Assert.True(
+                await Poll.UntilAsync(
+                    () =>
+                    {
+                        lock (failures) return failures.Contains(ConnectionFailureType.MaintenanceHandoff);
+                    },
+                    timeoutMilliseconds: 5_000),
+                "the recycle should be reported as a MaintenanceHandoff rather than silently");
+
+            lock (failures)
+            {
+                log.WriteLine($"reported: {string.Join(", ", failures)}");
+
+                // and *only* as that: reporting it as a socket failure would put planned maintenance into
+                // everybody's fault dashboards
+                Assert.DoesNotContain(ConnectionFailureType.SocketFailure, failures);
+                Assert.DoesNotContain(ConnectionFailureType.SocketClosed, failures);
+            }
+
+            // ...and the replacement is usable, which is the only outcome a caller cares about
+            Assert.True(
+                await Poll.UntilAsync(
+                    () =>
+                    {
+                        try
+                        {
+                            return conn.IsConnected && conn.GetDatabase().Ping() >= TimeSpan.Zero;
+                        }
+                        catch (Exception ex) when (ex is RedisException or TimeoutException)
+                        {
+                            return false;
+                        }
+                    },
+                    timeoutMilliseconds: 15_000),
+                "the client should be serving commands on the replacement connection");
+        }
+    }
+
     [Fact]
     public async Task MalformedTripletIsSkippedNotFatal()
     {

--- a/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
@@ -338,6 +338,40 @@ public class MaintenanceNotificationTests(ITestOutputHelper log)
     }
 
     [Fact]
+    public async Task CapturedMovingFrameIsUnderstood()
+    {
+        // Captured from the same deployment during a maintenance_mode scenario, byte for byte:
+        //
+        //   >4\r\n$6\r\nMOVING\r\n:0\r\n:15\r\n_\r\n
+        //
+        // Four elements: type, sequence *zero*, a 15-second window, and an explicit RESP3 null for the
+        // address - so "no replacement given, reconnect the way you connected". The proxy then closed the
+        // socket, which is the point of MOVING: you are told to move, and then the connection goes away.
+        //
+        // The sequence number is zero because this was the first event of that chain, not because MOVING is
+        // special - which is the point: zero is a legal value, so dedup tracks "have we seen one" as a separate
+        // bit rather than treating a stored zero as unset.
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            server.SendMoving(null, timeSeconds: 15, newEndpoint: null, sequenceId: 0);
+
+            var moving = await events.NextAsync();
+            log.WriteLine(moving.RawMessage ?? "(none)");
+            Assert.Equal(MaintenanceNotificationType.Moving, moving.NotificationType);
+            Assert.Equal(0, moving.SequenceId);
+            Assert.Equal(TimeSpan.FromSeconds(15), moving.Time);
+            Assert.Null(moving.NewEndPoint); // the null is the documented "use what you already have"
+            Assert.Null(moving.Payload);
+
+            // and the window it opened is what covers the reconnect that follows the socket closing
+            var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+            Assert.True(endpoint.IsMaintenanceRelaxed, "MOVING should have relaxed timeouts");
+        }
+    }
+
+    [Fact]
     public async Task MalformedTripletIsSkippedNotFatal()
     {
         // one bad entry must not lose the migrations we could have applied - the same choice go-redis makes

--- a/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
@@ -467,6 +467,141 @@ public class MaintenanceNotificationTests(ITestOutputHelper log)
         }
     }
 
+    /// <summary>
+    /// The catch-up channel: Redis Enterprise retains the most recent shard-scoped *completion* and replays it
+    /// to each connection that opts in, so a client that connects after a disruption still learns it happened.
+    /// </summary>
+    /// <remarks>
+    /// Observed on RS 8.0.22 (2026-08-28), arriving coalesced into the same TCP read as the <c>+OK</c> for the
+    /// opt-in, at ~16 ms. These tests key on the *cause* of that rather than the framing: the frame is flushed
+    /// the instant the opt-in is processed, and our opt-in is pipelined early, so a retained frame always
+    /// arrives while the connection is still handshaking.
+    /// </remarks>
+    public class Retention(ITestOutputHelper log)
+    {
+        private static async Task<(InProcessTestServer Server, ConnectionMultiplexer Connection, EventCollector Events)> ConnectAsync(
+            ITestOutputHelper log,
+            Action<InProcessTestServer> beforeConnect)
+        {
+            var server = new InProcessTestServer(log);
+            beforeConnect(server); // the event happens *before* anybody connects: that is the whole point
+
+            var config = server.GetClientConfig(defaultOnly: true);
+            config.Protocol = RedisProtocol.Resp3;
+            config.MaintenanceNotifications = MaintenanceNotificationMode.Enabled;
+
+            var conn = await ConnectionMultiplexer.ConnectAsync(config);
+            return (server, conn, new EventCollector(conn));
+        }
+
+        [Theory]
+        [InlineData(MaintenanceNotificationKind.Migrated)]
+        [InlineData(MaintenanceNotificationKind.FailedOver)]
+        public async Task RetainedCompletionIsReplayedToANewConnection(MaintenanceNotificationKind kind)
+        {
+            var (server, conn, events) = await ConnectAsync(log, s =>
+                s.SendShardNotification(null, kind, timeSeconds: null, shardIds: "[\"27\"]", sequenceId: 5));
+
+            using (server)
+            await using (conn)
+            {
+                // the collector is attached *after* connecting, so this asserts the frame was handled rather
+                // than that the event fired - which is why the relaxed window is the observable here
+                var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+                Assert.True(endpoint.IsMaintenanceRelaxed, "the replayed completion should have opened the post-event tail");
+                Assert.Equal(MaintenanceNotificationTypeFor(kind), endpoint.ActiveMaintenanceType);
+                log.WriteLine($"{kind} replayed; relaxed = {endpoint.IsMaintenanceRelaxed}");
+
+                // ...and it must not have disturbed the handshake it arrived in the middle of, which is the
+                // other half of what this test is for: a push frame interleaved with our own handshake
+                // replies must be dispatched out-of-band rather than matched against one of them
+                Assert.True(conn.IsConnected);
+                Assert.True(await conn.GetDatabase().PingAsync() >= TimeSpan.Zero);
+                GC.KeepAlive(events);
+            }
+        }
+
+        private static MaintenanceNotificationType MaintenanceNotificationTypeFor(MaintenanceNotificationKind kind) => kind switch
+        {
+            MaintenanceNotificationKind.Migrated => MaintenanceNotificationType.Migrated,
+            MaintenanceNotificationKind.FailedOver => MaintenanceNotificationType.FailedOver,
+            _ => MaintenanceNotificationType.None,
+        };
+
+        [Theory]
+        [InlineData(MaintenanceNotificationKind.Migrating)]
+        [InlineData(MaintenanceNotificationKind.FailingOver)]
+        [InlineData(MaintenanceNotificationKind.Moving)]
+        [InlineData(MaintenanceNotificationKind.SlotMigrating)]
+        [InlineData(MaintenanceNotificationKind.SlotMigrated)]
+        public async Task StartersAndSlotScopedEventsAreNotRetained(MaintenanceNotificationKind kind)
+        {
+            // The design property, asserted as a negative: the catch-up channel can only ever say "a
+            // disruption ended", never "one is starting". Nothing that demands action is replayed, so a
+            // reconnecting client cannot be told to move by a stale frame - which is what makes the MOVING
+            // handoff safe from replay by construction rather than by a guard.
+            var (server, conn, events) = await ConnectAsync(log, s =>
+            {
+                if (kind == MaintenanceNotificationKind.SlotMigrated)
+                {
+                    s.SendSlotMigrations(null, kind, [("127.0.0.1:7000", "127.0.0.1:7001", "50-60")], sequenceId: 5);
+                }
+                else
+                {
+                    s.SendShardNotification(null, kind, timeSeconds: 2, shardIds: "[\"27\"]", sequenceId: 5);
+                }
+            });
+
+            using (server)
+            await using (conn)
+            {
+                await events.AssertNoneAsync();
+                var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+                Assert.False(endpoint.IsMaintenanceRelaxed, $"{kind} must not be retained, so nothing should have relaxed");
+            }
+        }
+
+        [Fact]
+        public async Task RetentionReplacesRatherThanAccumulates()
+        {
+            // "most recent completion", not a queue: a connection sees at most one of these however many
+            // events went past, which is why the client side needs no window or ring for the catch-up case
+            var (server, conn, events) = await ConnectAsync(log, s =>
+            {
+                s.SendShardNotification(null, MaintenanceNotificationKind.Migrated, null, "[\"1\"]", sequenceId: 5);
+                s.SendShardNotification(null, MaintenanceNotificationKind.FailedOver, null, "[\"2\"]", sequenceId: 6);
+            });
+
+            using (server)
+            await using (conn)
+            {
+                var endpoint = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+                Assert.True(endpoint.IsMaintenanceRelaxed);
+                Assert.Equal(MaintenanceNotificationType.FailedOver, endpoint.ActiveMaintenanceType); // the later one
+                GC.KeepAlive(events);
+            }
+        }
+
+        [Fact]
+        public async Task RetentionCanBeTurnedOff()
+        {
+            // not every deployment retains, and a test of the no-retention case should not have to reason
+            // about which notification kinds happen to be retained
+            var (server, conn, events) = await ConnectAsync(log, s =>
+            {
+                s.RetainCompletions = false;
+                s.SendShardNotification(null, MaintenanceNotificationKind.Migrated, null, "[\"27\"]", sequenceId: 5);
+            });
+
+            using (server)
+            await using (conn)
+            {
+                await events.AssertNoneAsync();
+                Assert.False(((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint).IsMaintenanceRelaxed);
+            }
+        }
+    }
+
     [Fact]
     public async Task MalformedTripletIsSkippedNotFatal()
     {

--- a/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
@@ -294,6 +294,50 @@ public class MaintenanceNotificationTests(ITestOutputHelper log)
     }
 
     [Fact]
+    public async Task CapturedEnterpriseFramesAreUnderstood()
+    {
+        // Captured from a real Redis Cloud QA endpoint (Enterprise 8.6.2, OSS cluster API) during an actual
+        // slot migration on 2026-08-27. Byte for byte, except that the node addresses are rewritten into the
+        // private range - the lengths are preserved, so the $20 and $18 counts below are still the real ones:
+        //
+        //   >3\r\n$10\r\nSMIGRATING\r\n:18\r\n$9\r\n8892-8991\r\n
+        //   >3\r\n$9\r\nSMIGRATED\r\n:19\r\n*1\r\n*3\r\n$20\r\n10.129.228.140:13486\r\n
+        //       $18\r\n10.252.90.18:13486\r\n$9\r\n8892-8991\r\n
+        //
+        // Things this pins, each of which was an assumption before: the type name arrives as a *bulk* string;
+        // the sequence number as a RESP integer rather than a string; neither cluster notification carries a
+        // time element; SMIGRATING's slots are a flat string; and SMIGRATED nests an array *of* triplets - one
+        // here - rather than a single flat triple. The fake emits this shape, so this test is the real frame.
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            server.SendSlotNotification(null, MaintenanceNotificationKind.SlotMigrating, "8892-8991", sequenceId: 18);
+
+            var migrating = await events.NextAsync();
+            log.WriteLine(migrating.RawMessage ?? "(none)");
+            Assert.Equal(MaintenanceNotificationType.SlotMigrating, migrating.NotificationType);
+            Assert.Equal(18, migrating.SequenceId);
+            Assert.Null(migrating.Time); // no time element on the wire
+            Assert.Equal("8892-8991", migrating.Payload);
+
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+                [("10.129.228.140:13486", "10.252.90.18:13486", "8892-8991")], sequenceId: 19);
+
+            var migrated = await events.NextAsync();
+            log.WriteLine(migrated.RawMessage ?? "(none)");
+            Assert.Equal(MaintenanceNotificationType.SlotMigrated, migrated.NotificationType);
+            Assert.Equal(19, migrated.SequenceId);
+            Assert.Null(migrated.Time);
+
+            var migration = Assert.Single(migrated.SlotMigrations);
+            Assert.Equal(new IPEndPoint(IPAddress.Parse("10.129.228.140"), 13486), migration.Source);
+            Assert.Equal(new IPEndPoint(IPAddress.Parse("10.252.90.18"), 13486), migration.Target);
+            Assert.Equal(new SlotRange(8892, 8991), Assert.Single(migration.Slots));
+        }
+    }
+
+    [Fact]
     public async Task MalformedTripletIsSkippedNotFatal()
     {
         // one bad entry must not lose the migrations we could have applied - the same choice go-redis makes

--- a/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceNotificationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -260,10 +260,85 @@ public class MaintenanceNotificationTests(ITestOutputHelper log)
         }
     }
 
+    [Fact]
+    public async Task NestedSlotMigrationsAreRead()
+    {
+        // the shape the shipped clients read: [type, seq, [[source, target, slots], ...]]. We were dropping
+        // this until the prior-art cross-check, because the parser rejected non-scalar elements
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            Assert.Equal(1, server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ("127.0.0.1:7000", "127.0.0.1:7001", "0-99"),
+                ("127.0.0.1:7002", "127.0.0.1:7003", "1000,2000-2500"),
+            ]));
+
+            var evt = await events.NextAsync();
+            log.WriteLine(evt.RawMessage ?? "(no message)");
+            Assert.Equal(MaintenanceNotificationType.SlotMigrated, evt.NotificationType);
+            Assert.Equal(2, evt.SlotMigrations.Count);
+
+            var first = evt.SlotMigrations[0];
+            Assert.Equal(new IPEndPoint(IPAddress.Loopback, 7000), first.Source);
+            Assert.Equal(new IPEndPoint(IPAddress.Loopback, 7001), first.Target);
+            Assert.Equal(new SlotRange(0, 99), Assert.Single(first.Slots));
+
+            var second = evt.SlotMigrations[1];
+            Assert.Equal(2, second.Slots.Count);
+            Assert.Equal(new SlotRange(1000, 1000), second.Slots[0]);
+            Assert.Equal(new SlotRange(2000, 2500), second.Slots[1]);
+            Assert.Equal("1000,2000-2500", second.RawSlots);
+        }
+    }
+
+    [Fact]
+    public async Task MalformedTripletIsSkippedNotFatal()
+    {
+        // one bad entry must not lose the migrations we could have applied - the same choice go-redis makes
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ("127.0.0.1:7000", "127.0.0.1:7001", "not-a-slot-list"), // kept, but with no parsed slots
+                ("127.0.0.1:7002", "?", "50-60"), // an unnameable target, kept with a null Target
+                ("127.0.0.1:7004", "127.0.0.1:7005", "70"),
+            ]);
+
+            var evt = await events.NextAsync();
+            Assert.Equal(3, evt.SlotMigrations.Count);
+            Assert.Empty(evt.SlotMigrations[0].Slots);
+            Assert.Equal("not-a-slot-list", evt.SlotMigrations[0].RawSlots); // raw form survives
+            Assert.Null(evt.SlotMigrations[1].Target);
+            Assert.Equal(new SlotRange(50, 60), Assert.Single(evt.SlotMigrations[1].Slots));
+            Assert.Equal(new SlotRange(70, 70), Assert.Single(evt.SlotMigrations[2].Slots));
+        }
+    }
+
+    [Fact]
+    public async Task MissingSequenceIdStillReportsTheNotification()
+    {
+        // stricter-than-shipped-clients was the bug here: go-redis length-checks these at two elements and
+        // reads no sequence number at all, so dropping a frame for want of one loses a real disruption
+        var (server, conn, events) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            // two elements, with an unreadable seq - the floor go-redis works to
+            Assert.True(server.SendRawPush(null, "MIGRATING", "not-a-number") > 0);
+
+            var evt = await events.NextAsync();
+            log.WriteLine(evt.RawMessage ?? "(no message)");
+            Assert.Equal(MaintenanceNotificationType.Migrating, evt.NotificationType);
+        }
+    }
+
     [Theory]
-    [InlineData("MOVING")] // nothing but the type
-    [InlineData("MOVING", "not-a-number")] // unusable sequence id
     [InlineData("NOT_A_REAL_KIND", "1", "5")] // a type we don't know
+    [InlineData("NOT_A_REAL_KIND")] // ...and one with nothing else at all
     public async Task MalformedNotificationIsDroppedAndTheConnectionSurvives(params string[] parts)
     {
         // the important half of this feature's safety: an unparseable push frame must be consumed and

--- a/tests/StackExchange.Redis.Tests/MaintenanceOptInClientTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceOptInClientTests.cs
@@ -226,7 +226,12 @@ public class MaintenanceOptInClientTests(ITestOutputHelper log)
 
         log.WriteLine($"opt-ins: {before} -> {server.TotalMaintenanceOptIns}");
         Assert.True(server.TotalMaintenanceOptIns > before, "the opt-in should be sent again on the new connection");
-        Assert.True(IsActive(conn, server));
+
+        // ...and then wait for *our* side of it. The count above is the server having processed the opt-in,
+        // whereas IsActive is us having processed its reply - a beat later, so asserting it directly is a race
+        // that only shows up when the runner is starved of cores.
+        await UntilCondition(() => IsActive(conn, server));
+        Assert.True(IsActive(conn, server), "the feature should be live again on the replacement connection");
     }
 
     private static async Task UntilCondition(System.Func<bool> condition, int timeoutMilliseconds = 5000)

--- a/tests/StackExchange.Redis.Tests/MaintenanceOptInClientTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceOptInClientTests.cs
@@ -35,6 +35,38 @@ public class MaintenanceOptInClientTests(ITestOutputHelper log)
         return found;
     }
 
+    /// <summary>
+    /// Asserts that <c>Enabled</c> refused: either the connect threw, or it returned a connection that does
+    /// not stay usable.
+    /// </summary>
+    /// <remarks>
+    /// Both outcomes are the same refusal, and which one a caller sees is a race: the reconcile records the
+    /// failure from the handshake-completion path, which can land either side of <c>ConnectAsync</c> deciding
+    /// it has a connection. Asserting only the throw made this flaky on a two-core runner, and asserting the
+    /// throw is not the point - not being left with a working connection is.
+    /// </remarks>
+    private static async Task AssertRefusedAsync(ConfigurationOptions config, ITestOutputHelper log)
+    {
+        ConnectionMultiplexer? conn = null;
+        try
+        {
+            conn = await ConnectionMultiplexer.ConnectAsync(config);
+        }
+        catch (RedisConnectionException ex)
+        {
+            log.WriteLine($"refused at connect: {ex.Message}");
+            return;
+        }
+
+        await using (conn)
+        {
+            var endpoint = conn.GetEndPoints().Single();
+            var unusable = await Poll.UntilAsync(() => !conn.GetServer(endpoint).IsConnected);
+            log.WriteLine($"connected, then unusable: {unusable}");
+            Assert.True(unusable, "the connection should not have stayed usable");
+        }
+    }
+
     [Fact]
     public async Task HandshakeOptsInWhenAuto()
     {
@@ -114,9 +146,7 @@ public class MaintenanceOptInClientTests(ITestOutputHelper log)
         config.AbortOnConnectFail = true;
         config.ConnectRetry = 1;
 
-        var ex = await Assert.ThrowsAsync<RedisConnectionException>(
-            async () => await ConnectionMultiplexer.ConnectAsync(config));
-        log.WriteLine(ex.Message);
+        await AssertRefusedAsync(config, log);
     }
 
     [Fact]
@@ -146,9 +176,7 @@ public class MaintenanceOptInClientTests(ITestOutputHelper log)
         config.AbortOnConnectFail = true;
         config.ConnectRetry = 1;
 
-        var ex = await Assert.ThrowsAsync<RedisConnectionException>(
-            async () => await ConnectionMultiplexer.ConnectAsync(config));
-        log.WriteLine(ex.Message);
+        await AssertRefusedAsync(config, log);
     }
 
     [Fact]
@@ -162,9 +190,7 @@ public class MaintenanceOptInClientTests(ITestOutputHelper log)
         config.AbortOnConnectFail = true;
         config.ConnectRetry = 1;
 
-        var ex = await Assert.ThrowsAsync<RedisConnectionException>(
-            async () => await ConnectionMultiplexer.ConnectAsync(config));
-        log.WriteLine(ex.Message);
+        await AssertRefusedAsync(config, log);
     }
 
     [Fact]

--- a/tests/StackExchange.Redis.Tests/MaintenanceRelaxationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceRelaxationTests.cs
@@ -1,0 +1,284 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using Xunit;
+using static StackExchange.Redis.Server.RedisServer;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Timeout relaxation: a server that announces a disruption gets its command timeouts raised for the duration,
+/// as a floor and never a reduction. The window arithmetic is asserted through internals rather than by waiting
+/// out real seconds - the interesting properties are "does it open, extend, close, and expire correctly", and a
+/// test that sleeps for 30s to watch a cap expire is a test nobody runs.
+/// </summary>
+public class MaintenanceRelaxationTests(ITestOutputHelper log)
+{
+    private static async Task<(InProcessTestServer Server, ConnectionMultiplexer Connection)> ConnectAsync(
+        ITestOutputHelper log,
+        Action<ConfigurationOptions>? configure = null)
+    {
+        var server = new InProcessTestServer(log);
+        var config = server.GetClientConfig(defaultOnly: true);
+        config.Protocol = RedisProtocol.Resp3;
+        config.MaintenanceNotifications = MaintenanceNotificationMode.Enabled;
+        configure?.Invoke(config);
+
+        var conn = await ConnectionMultiplexer.ConnectAsync(config);
+        return (server, conn);
+    }
+
+    private static ServerEndPoint Endpoint(IConnectionMultiplexer conn, InProcessTestServer server)
+        => ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+
+    /// <summary>
+    /// The notification arrives on the connection's read loop, so a test that sends one has to let it land.
+    /// </summary>
+    private static async Task<bool> UntilRelaxedAsync(ServerEndPoint endpoint, bool expected, int timeoutMilliseconds = 5000)
+    {
+        for (int i = 0; i < timeoutMilliseconds / 25 && endpoint.IsMaintenanceRelaxed != expected; i++)
+        {
+            await Task.Delay(25);
+        }
+        return endpoint.IsMaintenanceRelaxed;
+    }
+
+    [Fact]
+    public async Task NoWindowMeansNoChange()
+    {
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            Assert.False(endpoint.IsMaintenanceRelaxed);
+            Assert.Equal(1234, endpoint.GetEffectiveTimeoutMilliseconds(1234));
+        }
+    }
+
+    [Fact]
+    public async Task OpeningNotificationRelaxesTimeouts()
+    {
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+
+            Assert.True(await UntilRelaxedAsync(endpoint, true), "should be relaxed");
+
+            // 10s relaxed against a 5s configured timeout
+            Assert.Equal(10_000, endpoint.GetEffectiveTimeoutMilliseconds(5_000));
+        }
+    }
+
+    [Fact]
+    public async Task RelaxationIsAFloorAndNeverAReduction()
+    {
+        // a caller with a generous timeout keeps it; this is explicit in the contract
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            Assert.Equal(60_000, endpoint.GetEffectiveTimeoutMilliseconds(60_000));
+        }
+    }
+
+    [Fact]
+    public async Task ClosingNotificationLeavesThePostEventTail()
+    {
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrated, timeSeconds: 0);
+            await Task.Delay(250); // let it land; the tail means "still relaxed", so there is no flag to await
+
+            // the server said it finished, and we are *still* relaxed - because that is when every other
+            // client that got the same notification comes back
+            Assert.True(endpoint.IsMaintenanceRelaxed, "the post-event tail should still be running");
+            Assert.Equal(10_000, endpoint.GetEffectiveTimeoutMilliseconds(5_000));
+        }
+    }
+
+    [Fact]
+    public async Task ClosingNotificationEndsItWhenThereIsNoTail()
+    {
+        var (server, conn) = await ConnectAsync(log, config => config.MaintenancePostEventRelaxedDuration = TimeSpan.Zero);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrated, timeSeconds: 0);
+            Assert.False(await UntilRelaxedAsync(endpoint, false), "should have ended");
+        }
+    }
+
+    [Fact]
+    public async Task WindowExpiresOnItsOwn()
+    {
+        // the cap and the ordinary deadline share a mechanism; a one-second floor lets us watch it expire
+        // without a test that sleeps for half a minute
+        var (server, conn) = await ConnectAsync(log, config =>
+        {
+            config.MaintenanceRelaxedTimeout = TimeSpan.FromSeconds(1);
+            config.MaintenanceRelaxedWindowMax = TimeSpan.FromSeconds(1);
+            config.MaintenancePostEventRelaxedDuration = TimeSpan.Zero;
+        });
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+
+            // asks for 20s, capped to 1s
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            Assert.False(await UntilRelaxedAsync(endpoint, false), "the cap should have ended it");
+        }
+    }
+
+    [Fact]
+    public async Task NoTailAfterACapExpiry()
+    {
+        // if the window ended on the cap we never learned the event finished, so extending past the backstop
+        // would defeat the backstop
+        var (server, conn) = await ConnectAsync(log, config =>
+        {
+            config.MaintenanceRelaxedTimeout = TimeSpan.FromSeconds(1);
+            config.MaintenanceRelaxedWindowMax = TimeSpan.FromSeconds(1);
+            config.MaintenancePostEventRelaxedDuration = TimeSpan.FromSeconds(30); // would be very visible
+        });
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            Assert.False(await UntilRelaxedAsync(endpoint, false), "no tail should follow a capped window");
+        }
+    }
+
+    [Fact]
+    public async Task ShorterNotificationDoesNotCutAnOpenWindowShort()
+    {
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+
+            // a long window, then a short one on top: the short one must not shorten it
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 25);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+            server.SendShardNotification(null, MaintenanceNotificationKind.FailingOver, timeSeconds: 1);
+            await Task.Delay(1500);
+
+            Assert.True(endpoint.IsMaintenanceRelaxed, "the longer window should still be in force");
+        }
+    }
+
+    [Fact]
+    public async Task ReplayedSequenceIdIsIgnored()
+    {
+        // our own invention, so kept conservative: an id we have already acted on cannot extend a window
+        var (server, conn) = await ConnectAsync(log, config =>
+        {
+            config.MaintenanceRelaxedTimeout = TimeSpan.FromSeconds(1);
+            config.MaintenanceRelaxedWindowMax = TimeSpan.FromSeconds(1);
+            config.MaintenancePostEventRelaxedDuration = TimeSpan.Zero;
+        });
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            var seq = server.NextMaintenanceSequenceId;
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+            Assert.False(await UntilRelaxedAsync(endpoint, false));
+
+            // replaying the same id must not reopen anything
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20, sequenceId: seq);
+            await Task.Delay(250);
+            Assert.False(endpoint.IsMaintenanceRelaxed, "a replayed id should not reopen the window");
+
+            // ...but a genuinely new one still does
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true), "a new id should still work");
+        }
+    }
+
+    [Fact]
+    public async Task RelaxationDoesNotSuppressConnectionFailure()
+    {
+        // the regression that would matter most: relaxation must touch command timeouts only. If it reached
+        // keep-alive or failure detection, a server that died mid-maintenance would linger for the window -
+        // turning a latency mitigation into an availability regression
+        var (server, conn) = await ConnectAsync(log, config =>
+        {
+            config.AllowSimulateConnectionFailure = true;
+            config.MaintenanceRelaxedTimeout = TimeSpan.FromMinutes(5); // absurdly generous, deliberately
+            config.MaintenanceRelaxedWindowMax = TimeSpan.FromMinutes(5);
+        });
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.FailingOver, timeSeconds: 300);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            var failures = 0;
+            conn.ConnectionFailed += (_, _) => Interlocked.Increment(ref failures);
+            conn.GetServer(server.DefaultEndPoint).SimulateConnectionFailure(SimulatedFailureType.All);
+
+            for (int i = 0; i < 100 && Volatile.Read(ref failures) == 0; i++)
+            {
+                await Task.Delay(25);
+            }
+
+            log.WriteLine($"connection failures observed: {Volatile.Read(ref failures)}");
+            Assert.True(Volatile.Read(ref failures) > 0, "a dead connection must still be noticed during a relaxed window");
+        }
+    }
+
+    [Fact]
+    public async Task CommandsStillWorkThroughAWindow()
+    {
+        // relaxation is invisible to anything that is not timing out
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+            Assert.True(await UntilRelaxedAsync(endpoint, true));
+
+            var db = conn.GetDatabase();
+            for (int i = 0; i < 20; i++)
+            {
+                await db.StringSetAsync($"relax-{i}", i);
+            }
+            for (int i = 0; i < 20; i++)
+            {
+                Assert.Equal(i, (int)await db.StringGetAsync($"relax-{i}"));
+            }
+
+            // including the synchronous path, which has its own re-wait loop
+            Assert.Equal(7, (int)db.StringGet("relax-7"));
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/MaintenanceRelaxationTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceRelaxationTests.cs
@@ -255,6 +255,44 @@ public class MaintenanceRelaxationTests(ITestOutputHelper log)
         }
     }
 
+    [Theory]
+    [InlineData(true, MaintenanceNotificationType.Migrating)]
+    [InlineData(false, MaintenanceNotificationType.None)]
+    public async Task TimeoutReportsWhetherMaintenanceWasInForce(bool announce, MaintenanceNotificationType expected)
+    {
+        // "timeout" and "timeout during an announced migration" call for very different reactions from
+        // whoever reads the log, so the fault says which it was
+        var (server, conn) = await ConnectAsync(log, config =>
+        {
+            config.AsyncTimeout = 200;
+            config.SyncTimeout = 200;
+            config.MaintenanceRelaxedTimeout = TimeSpan.FromSeconds(1);
+            config.MaintenanceRelaxedWindowMax = TimeSpan.FromSeconds(30);
+            config.HeartbeatInterval = TimeSpan.FromMilliseconds(100);
+        });
+        using (server)
+        await using (conn)
+        {
+            var endpoint = Endpoint(conn, server);
+            if (announce)
+            {
+                server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 20);
+                Assert.True(await UntilRelaxedAsync(endpoint, true));
+            }
+
+            server.SetLatency(TimeSpan.FromSeconds(5)); // longer than any timeout in play
+            var ex = await Assert.ThrowsAsync<RedisTimeoutException>(() => conn.GetDatabase().StringGetAsync("maint-fault"));
+            log.WriteLine($"{ex.MaintenanceType}: {ex.Message}");
+            Assert.Equal(expected, ex.MaintenanceType);
+
+            // and it reaches the circuit-breaker/retry surface the same way
+            var context = new Availability.FaultContext(ex);
+            Assert.Equal(expected, context.MaintenanceType);
+
+            server.SetLatency(TimeSpan.Zero);
+        }
+    }
+
     [Fact]
     public async Task CommandsStillWorkThroughAWindow()
     {

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -312,13 +312,9 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
     [Fact]
     public async Task NodeThatLeavesTheClusterIsRetired()
     {
-        // Gated on a quiet machine, and the reason is a product problem rather than an impatient test.
-        // Retirement requires IsIdle(), and the blocker was measured: `outstanding` on the departed node grows
-        // by ~170 per topology pass (176, 348, 520, ... 1339), because each reconfigure sends autoconfigure
-        // probes to it that can never be answered - the node is gone - so they accumulate in its backlog and it
-        // never looks idle. The more we look for it, the busier it appears. It only retires by winning a race
-        // on an early pass, hence the load sensitivity. Not the keep-alive, which was the first theory.
-        Skip.UnlessLongRunning();
+        // This is also the regression test for idleness counting *caller* work only. Before that, the
+        // reconfigure's own probes to the departed node piled into its backlog (~170 per pass, unbounded), so
+        // it looked busy because we were looking for it, and could never be retired.
 
         // The narrowed form of D5's "retire endpoints serving no slots". Serving nothing is *not* the
         // condition: a node still listed in CLUSTER NODES is a live member that may be given slots again, and

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -21,15 +21,26 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
     /// </summary>
     private sealed class CountingServer(ITestOutputHelper log) : InProcessTestServer(log)
     {
-        private int _clusterCommands;
+        private int _clusterCommands, _subscribeCommands;
 
         public int ClusterCommands => Volatile.Read(ref _clusterCommands);
 
+        public int SubscribeCommands => Volatile.Read(ref _subscribeCommands);
+
         public override TypedRedisValue Execute(RedisClient client, in RedisRequest request)
         {
-            if (request.Count > 0 && string.Equals(request.GetString(0), "cluster", StringComparison.OrdinalIgnoreCase))
+            if (request.Count > 0)
             {
-                Interlocked.Increment(ref _clusterCommands);
+                var command = request.GetString(0);
+                if (string.Equals(command, "cluster", StringComparison.OrdinalIgnoreCase))
+                {
+                    Interlocked.Increment(ref _clusterCommands);
+                }
+                else if (string.Equals(command, "ssubscribe", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(command, "subscribe", StringComparison.OrdinalIgnoreCase))
+                {
+                    Interlocked.Increment(ref _subscribeCommands);
+                }
             }
 
             return base.Execute(client, in request);
@@ -139,6 +150,88 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
             await Task.Delay(2000);
             log.WriteLine($"cluster commands: {before} -> {server.ClusterCommands}");
             Assert.Equal(before, server.ClusterCommands);
+        }
+    }
+
+    [Fact]
+    public async Task ShardedSubscriptionOnAMovedSlotIsReEstablished()
+    {
+        // mostly belt-and-braces: the server also sends an unsolicited SUNSUBSCRIBE for this, which we already
+        // act on. What this adds is being pre-emptive when SMIGRATED lands first, and covering the case where
+        // the unsubscribe never arrives - where the only other symptom is messages silently stopping
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var sub = conn.GetSubscriber();
+            var channel = RedisChannel.Sharded("resub-channel");
+            await sub.SubscribeAsync(channel, (_, _) => { });
+
+            var slot = ((ConnectionMultiplexer)conn).ServerSelectionStrategy.HashSlot(channel);
+            log.WriteLine($"channel hashes to slot {slot}");
+
+            var before = server.SubscribeCommands;
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ($"127.0.0.1:{port}", $"127.0.0.1:{port + 1}", $"{slot}"),
+            ]);
+
+            Assert.True(
+                await Poll.UntilAsync(() => server.SubscribeCommands > before),
+                "the sharded subscription should have been re-established");
+        }
+    }
+
+    [Fact]
+    public async Task ShardedSubscriptionOnAnUnaffectedSlotIsLeftAlone()
+    {
+        // knowing *which* slots moved is the advantage over the unsolicited-unsubscribe path: only the
+        // affected channels are touched, rather than everything subscribed on this server
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var sub = conn.GetSubscriber();
+            var channel = RedisChannel.Sharded("untouched-channel");
+            await sub.SubscribeAsync(channel, (_, _) => { });
+
+            var slot = ((ConnectionMultiplexer)conn).ServerSelectionStrategy.HashSlot(channel);
+            var otherSlot = slot == 0 ? 1 : 0;
+            var before = server.SubscribeCommands;
+
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ($"127.0.0.1:{port}", $"127.0.0.1:{port + 1}", $"{otherSlot}"),
+            ]);
+
+            await Task.Delay(2000);
+            log.WriteLine($"subscribe commands: {before} -> {server.SubscribeCommands} (slot {slot} vs moved {otherSlot})");
+            Assert.Equal(before, server.SubscribeCommands);
+        }
+    }
+
+    [Fact]
+    public async Task OrdinaryPubSubIsNotSlotBoundAndIsLeftAlone()
+    {
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var sub = conn.GetSubscriber();
+            await sub.SubscribeAsync(RedisChannel.Literal("plain-channel"), (_, _) => { });
+
+            var before = server.SubscribeCommands;
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ($"127.0.0.1:{port}", $"127.0.0.1:{port + 1}", "0-16383"), // everything moves
+            ]);
+
+            await Task.Delay(2000);
+            log.WriteLine($"subscribe commands: {before} -> {server.SubscribeCommands}");
+            Assert.Equal(before, server.SubscribeCommands);
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -312,13 +312,11 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
     [Fact]
     public async Task NodeThatLeavesTheClusterIsRetired()
     {
-        // Needs a machine quiet enough for the departed node to look idle. Pruning requires IsIdle(), which
-        // counts outstanding work - and we keep heart-beating the node we are trying to retire, so a ping in
-        // flight makes it look busy. On a constrained runner that repeats often enough to starve the
-        // retirement indefinitely, which is a real property of the policy and not a flaw in this test: see the
-        // design notes, where the same trap was recorded for the usage-based grace rule and led to dropping
-        // it. Excluding our own keep-alive traffic from the idleness test would fix it, and is a product
-        // change rather than something to paper over here.
+        // Gated on a quiet machine: under a two-core runner this fails about half the time, because the
+        // retirement never happens rather than because the test is impatient. Pruning requires IsIdle(), so
+        // something keeps the departed node looking busy - the obvious suspect was our own keep-alive, but
+        // suppressing heartbeats to nodes awaiting retirement did *not* fix it, so the cause is still unknown
+        // and wants a focused look with instrumentation inside the pruning loop rather than from a test.
         Skip.UnlessLongRunning();
 
         // The narrowed form of D5's "retire endpoints serving no slots". Serving nothing is *not* the

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,10 +11,18 @@ using static StackExchange.Redis.Server.RedisServer;
 namespace StackExchange.Redis.Tests;
 
 /// <summary>
+/// Non-parallel deliberately. Several of these wait out a jittered refresh, and the retirement one depends on
+/// the doomed server being *idle* - and <c>IsIdle</c> counts outstanding work, which a heartbeat ping in flight
+/// supplies. On a loaded machine those complete slowly enough that pruning is starved, which is a real property
+/// of the policy rather than a flaw in the test: see the design notes on why a usage-based grace rule was
+/// dropped for exactly this reason.
+/// <para>
 /// Reacting to a completed slot migration by re-reading the topology, rather than waiting to be told by a
 /// <c>-MOVED</c>. Asserted from the server's side - did another <c>CLUSTER</c> command actually arrive - because
 /// that is the thing the fleet pays for, and the thing a scoping bug would multiply.
+/// </para>
 /// </summary>
+[Collection(NonParallelCollection.Name)]
 public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
 {
     /// <summary>
@@ -276,7 +285,11 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
             // pre-existing retry-and-redirect behaviour. Measured at 4 with notifications off and 5 with them
             // on - the extra one being the fallback acting on a subscription that path left attached to
             // nothing, which is the feature working. What must not happen is one attempt per notification.
-            Assert.InRange(resubscribes, 1, 6);
+            // Bounded, not exact: the unsolicited-unsubscribe path retries and follows redirects, and how
+            // many of those land depends on timing (measured 4 unloaded, 7 on a constrained runner). The
+            // property is that the count does not scale with notifications - one migration, a handful of
+            // attempts - so the bound is deliberately loose rather than pinned to a number that will drift.
+            Assert.InRange(resubscribes, 1, 15);
 
             // Delivery is asserted by publishing *repeatedly*, because pub/sub is fire and forget: a message
             // published while the subscription is still in flux is simply dropped. Losing messages during the
@@ -293,6 +306,66 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
 
             log.WriteLine($"{mode}: delivered after migration = {delivered}");
             Assert.True(delivered, "the subscription should deliver again once things settle");
+        }
+    }
+
+    [Fact]
+    public async Task NodeThatLeavesTheClusterIsRetired()
+    {
+        // Needs a machine quiet enough for the departed node to look idle. Pruning requires IsIdle(), which
+        // counts outstanding work - and we keep heart-beating the node we are trying to retire, so a ping in
+        // flight makes it look busy. On a constrained runner that repeats often enough to starve the
+        // retirement indefinitely, which is a real property of the policy and not a flaw in this test: see the
+        // design notes, where the same trap was recorded for the usage-based grace rule and led to dropping
+        // it. Excluding our own keep-alive traffic from the idleness test would fix it, and is a product
+        // change rather than something to paper over here.
+        Skip.UnlessLongRunning();
+
+        // The narrowed form of D5's "retire endpoints serving no slots". Serving nothing is *not* the
+        // condition: a node still listed in CLUSTER NODES is a live member that may be given slots again, and
+        // dropping its connection would be churn (go-redis does not). Having *left* the cluster is the
+        // condition, and the notification-driven refresh is what makes us notice.
+        EndPoint doomed = null!;
+        var (server, conn) = await ConnectAsync(log, configure: s =>
+        {
+            GetHost(s.DefaultEndPoint, out var p);
+            doomed = s.AddEmptyNode(new IPEndPoint(IPAddress.Loopback, p + 1));
+            s.Migrate((RedisKey)"leaving", doomed); // owns something, so it is discovered at connect
+        });
+
+        using (server)
+        await using (conn)
+        {
+            Assert.True(
+                await Poll.UntilAsync(() => conn.GetEndPoints().Contains(doomed), timeoutMilliseconds: 10_000),
+                $"{doomed} was never discovered, so this test would prove nothing");
+
+            GetHost(server.DefaultEndPoint, out var basePort);
+            var third = server.AddEmptyNode(new IPEndPoint(IPAddress.Loopback, basePort + 2));
+
+            // hand its slot back and then remove it from the cluster outright
+            server.NotifyOnMigrate = true;
+            server.Migrate((RedisKey)"leaving", server.DefaultEndPoint);
+            Assert.True(server.RemoveNode(doomed), "the node should have been removed from the fake");
+
+            // Pruning wants several consecutive generations of absence. Driving those by *awaiting* topology
+            // passes rather than by sending notifications and sleeping: the notification path is covered by
+            // the tests above, and depending on it here would make this test wait out a jittered refresh per
+            // generation - which is what made it fail under a two-core runner. What is being tested is the
+            // retirement, so drive the generations deterministically.
+            // Retirement also requires the server to be *idle*, so a busy moment can defer it past a given
+            // pass - which is why this drives passes until it happens rather than asserting after a fixed
+            // count. Bounded, so a regression fails rather than hangs.
+            GC.KeepAlive(third);
+            var mux = (ConnectionMultiplexer)conn;
+            for (int i = 0; i < 20 && conn.GetEndPoints().Contains(doomed); i++)
+            {
+                await mux.ReconfigureAsync(first: false, reconfigureAll: true, log: null, blame: null, cause: $"test-generation-{i}");
+                await Task.Delay(50); // retirement drains before removing, so give it a moment to complete
+            }
+
+            log.WriteLine($"endpoints: {string.Join(", ", conn.GetEndPoints().Select(x => x.ToString()))}");
+            Assert.DoesNotContain(doomed, conn.GetEndPoints());
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
+using StackExchange.Redis.Server;
+using Xunit;
+using static StackExchange.Redis.Server.RedisServer;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Reacting to a completed slot migration by re-reading the topology, rather than waiting to be told by a
+/// <c>-MOVED</c>. Asserted from the server's side - did another <c>CLUSTER</c> command actually arrive - because
+/// that is the thing the fleet pays for, and the thing a scoping bug would multiply.
+/// </summary>
+public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
+{
+    /// <summary>
+    /// Counts inbound <c>CLUSTER</c> commands, so a test can tell a refresh happened from the outside.
+    /// </summary>
+    private sealed class CountingServer(ITestOutputHelper log) : InProcessTestServer(log)
+    {
+        private int _clusterCommands;
+
+        public int ClusterCommands => Volatile.Read(ref _clusterCommands);
+
+        public override TypedRedisValue Execute(RedisClient client, in RedisRequest request)
+        {
+            if (request.Count > 0 && string.Equals(request.GetString(0), "cluster", StringComparison.OrdinalIgnoreCase))
+            {
+                Interlocked.Increment(ref _clusterCommands);
+            }
+
+            return base.Execute(client, in request);
+        }
+    }
+
+    private static async Task<(CountingServer Server, ConnectionMultiplexer Connection)> ConnectAsync(ITestOutputHelper log, Action<CountingServer>? configure = null)
+    {
+        var server = new CountingServer(log) { ServerType = ServerType.Cluster };
+        configure?.Invoke(server);
+        var config = server.GetClientConfig(defaultOnly: true);
+        config.Protocol = RedisProtocol.Resp3;
+        config.MaintenanceNotifications = MaintenanceNotificationMode.Enabled;
+
+        var conn = await ConnectionMultiplexer.ConnectAsync(config);
+        return (server, conn);
+    }
+
+    /// <summary>
+    /// The jitter is up to a second, so a refresh is not immediate by design.
+    /// </summary>
+    private static Task<bool> UntilRefreshedAsync(CountingServer server, int before)
+        => Poll.UntilAsync(() => server.ClusterCommands > before, timeoutMilliseconds: 5000);
+
+    [Fact]
+    public async Task SlotsMovingAwayFromUsTriggersARefresh()
+    {
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var before = server.ClusterCommands;
+
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ($"127.0.0.1:{port}", $"127.0.0.1:{port + 1}", "0-99"),
+            ]);
+
+            Assert.True(await UntilRefreshedAsync(server, before), "a refresh should follow slots leaving us");
+            log.WriteLine($"cluster commands: {before} -> {server.ClusterCommands}");
+        }
+    }
+
+    [Fact]
+    public async Task SlotsMovingBetweenOtherNodesDoesNotTriggerARefresh()
+    {
+        // the whole herd argument: every node reports the same movements, so most notifications are about
+        // somebody else. Refreshing on those means every client in the fleet re-reads topology whenever any
+        // shard moves anywhere
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var before = server.ClusterCommands;
+
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ("127.0.0.1:7100", "127.0.0.1:7101", "0-99"),
+                ("127.0.0.1:7102", "127.0.0.1:7103", "100-199"),
+            ]);
+
+            await Task.Delay(2000); // longer than the jitter, so "not yet" cannot be mistaken for "never"
+            log.WriteLine($"cluster commands: {before} -> {server.ClusterCommands}");
+            Assert.Equal(before, server.ClusterCommands);
+        }
+    }
+
+    [Fact]
+    public async Task SourceIsMatchedByAnnouncedIdentityNotJustAddress()
+    {
+        // A node answers to its address *and* its announced hostname, and the delta may name either, so the
+        // scoping test resolves through the identity map rather than comparing endpoints as text. Announced
+        // before connecting, because the handshake's own topology read is what registers the identity - a
+        // hostname set afterwards is not known to us until something re-reads it.
+        const string Hostname = "node-1.redis.example.com";
+        var (server, conn) = await ConnectAsync(log, s => s.SetHostname(s.DefaultEndPoint, Hostname));
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var before = server.ClusterCommands;
+
+            server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+            [
+                ($"{Hostname}:{port}", $"127.0.0.1:{port + 1}", "0-99"),
+            ]);
+
+            Assert.True(await UntilRefreshedAsync(server, before), "the hostname form should resolve to us");
+        }
+    }
+
+    [Fact]
+    public async Task ProxyStyleCompletionDoesNotTriggerARefresh()
+    {
+        // MIGRATED/FAILED_OVER arrive in proxied deployments addressed as a single endpoint, where there is no
+        // topology for a refresh to learn - so they get relaxation and nothing else
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            var before = server.ClusterCommands;
+
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrating, timeSeconds: 5);
+            server.SendShardNotification(null, MaintenanceNotificationKind.Migrated, timeSeconds: 0);
+
+            await Task.Delay(2000);
+            log.WriteLine($"cluster commands: {before} -> {server.ClusterCommands}");
+            Assert.Equal(before, server.ClusterCommands);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshIsCoalescedRatherThanRepeated()
+    {
+        // A burst of notifications must not be a burst of topology reads. Note ReconfigureIfNeeded's own
+        // coalescing is *not* what achieves this: it declines only while a refresh is actually in flight, and
+        // the jitter spreads a burst out far enough that each pass finishes before the next starts. This test
+        // is what caught that, and why the coalescing happens before the delay rather than after.
+        var (server, conn) = await ConnectAsync(log);
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var before = server.ClusterCommands;
+
+            for (int i = 0; i < 10; i++)
+            {
+                server.SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+                [
+                    ($"127.0.0.1:{port}", $"127.0.0.1:{port + 1}", $"{i * 10}-{(i * 10) + 9}"),
+                ]);
+            }
+
+            Assert.True(await UntilRefreshedAsync(server, before));
+            await Task.Delay(2000); // let any stragglers land
+
+            // a refresh reads both SLOTS and NODES, so allow a small multiple - the point is that ten
+            // notifications did not produce ten topology passes
+            var added = server.ClusterCommands - before;
+            log.WriteLine($"{added} cluster command(s) for 10 notifications");
+            Assert.InRange(added, 1, 8);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -47,13 +47,16 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
         }
     }
 
-    private static async Task<(CountingServer Server, ConnectionMultiplexer Connection)> ConnectAsync(ITestOutputHelper log, Action<CountingServer>? configure = null)
+    private static async Task<(CountingServer Server, ConnectionMultiplexer Connection)> ConnectAsync(
+        ITestOutputHelper log,
+        Action<CountingServer>? configure = null,
+        MaintenanceNotificationMode mode = MaintenanceNotificationMode.Enabled)
     {
         var server = new CountingServer(log) { ServerType = ServerType.Cluster };
         configure?.Invoke(server);
         var config = server.GetClientConfig(defaultOnly: true);
         config.Protocol = RedisProtocol.Resp3;
-        config.MaintenanceNotifications = MaintenanceNotificationMode.Enabled;
+        config.MaintenanceNotifications = mode;
 
         var conn = await ConnectionMultiplexer.ConnectAsync(config);
         return (server, conn);
@@ -232,6 +235,54 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
             await Task.Delay(2000);
             log.WriteLine($"subscribe commands: {before} -> {server.SubscribeCommands}");
             Assert.Equal(before, server.SubscribeCommands);
+        }
+    }
+
+    [Theory]
+    [InlineData(MaintenanceNotificationMode.Disabled)] // only the unsolicited SUNSUBSCRIBE path can act
+    [InlineData(MaintenanceNotificationMode.Enabled)] // both paths see the same migration
+    public async Task RealMigrationRecoversTheSubscriptionWithoutStorming(MaintenanceNotificationMode mode)
+    {
+        // Until the fake announced its own migrations this could not be tested at all, and it is the case that
+        // matters: a real slot migration produces *both* an unsolicited SUNSUBSCRIBE (ordinary cluster
+        // behaviour, sent to every subscriber) and SMIGRATED (only to clients that opted in). Both paths lead
+        // to ResubscribeToServer, so the question is whether the subscription ends up established exactly
+        // once rather than twice or not at all.
+        var (server, conn) = await ConnectAsync(log, mode: mode);
+        using (server)
+        await using (conn)
+        {
+            GetHost(server.DefaultEndPoint, out var port);
+            var doomed = server.AddEmptyNode(new IPEndPoint(IPAddress.Loopback, port + 1));
+
+            var sub = conn.GetSubscriber();
+            var channel = RedisChannel.Sharded("migrating-channel");
+            var received = 0;
+            await sub.SubscribeAsync(channel, (_, _) => Interlocked.Increment(ref received));
+
+            var slot = ((ConnectionMultiplexer)conn).ServerSelectionStrategy.HashSlot(channel);
+            var before = server.SubscribeCommands;
+
+            server.NotifyOnMigrate = true;
+            server.Migrate(slot, doomed); // the whole realistic sequence, from one call
+
+            Assert.True(await Poll.UntilAsync(() => server.SubscribeCommands > before), "should have resubscribed");
+            await Task.Delay(2000); // and settle, so a second resubscribe would show up
+
+            var resubscribes = server.SubscribeCommands - before;
+            log.WriteLine($"{mode}: {resubscribes} (re)subscribe command(s) after a real migration");
+
+            // The property is boundedness, not an absolute count: the unsolicited-unsubscribe path has its own
+            // pre-existing retry-and-redirect behaviour. Measured at 4 with notifications off and 5 with them
+            // on - the extra one being the fallback acting on a subscription that path left attached to
+            // nothing, which is the feature working. What must not happen is one attempt per notification.
+            Assert.InRange(resubscribes, 1, 6);
+
+            // Note: whether a message published after the migration is *delivered* is deliberately not
+            // asserted here. It fails with notifications disabled too, so it is either a pre-existing gap or a
+            // limitation of the fake's freshly-added node - either way it is not this feature's to prove, and
+            // asserting it would attribute an unrelated failure to this code.
+            GC.KeepAlive(received);
         }
     }
 

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -312,11 +312,12 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
     [Fact]
     public async Task NodeThatLeavesTheClusterIsRetired()
     {
-        // Gated on a quiet machine: under a two-core runner this fails about half the time, because the
-        // retirement never happens rather than because the test is impatient. Pruning requires IsIdle(), so
-        // something keeps the departed node looking busy - the obvious suspect was our own keep-alive, but
-        // suppressing heartbeats to nodes awaiting retirement did *not* fix it, so the cause is still unknown
-        // and wants a focused look with instrumentation inside the pruning loop rather than from a test.
+        // Gated on a quiet machine, and the reason is a product problem rather than an impatient test.
+        // Retirement requires IsIdle(), and the blocker was measured: `outstanding` on the departed node grows
+        // by ~170 per topology pass (176, 348, 520, ... 1339), because each reconfigure sends autoconfigure
+        // probes to it that can never be answered - the node is gone - so they accumulate in its backlog and it
+        // never looks idle. The more we look for it, the busier it appears. It only retires by winning a race
+        // on an early pass, hence the load sensitivity. Not the keep-alive, which was the first theory.
         Skip.UnlessLongRunning();
 
         // The narrowed form of D5's "retire endpoints serving no slots". Serving nothing is *not* the
@@ -360,6 +361,7 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
             {
                 await mux.ReconfigureAsync(first: false, reconfigureAll: true, log: null, blame: null, cause: $"test-generation-{i}");
                 await Task.Delay(50); // retirement drains before removing, so give it a moment to complete
+
             }
 
             log.WriteLine($"endpoints: {string.Join(", ", conn.GetEndPoints().Select(x => x.ToString()))}");

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -278,10 +278,10 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
             // nothing, which is the feature working. What must not happen is one attempt per notification.
             Assert.InRange(resubscribes, 1, 6);
 
-            // Note: whether a message published after the migration is *delivered* is deliberately not
-            // asserted here. It fails with notifications disabled too, so it is either a pre-existing gap or a
-            // limitation of the fake's freshly-added node - either way it is not this feature's to prove, and
-            // asserting it would attribute an unrelated failure to this code.
+            // Delivery is deliberately *not* asserted. It does not work here even with no migration in play -
+            // the fake registers a sharded subscription somewhere its own SPUBLISH lookup does not find, so
+            // publish reports zero receivers - which makes any delivery assertion a test of that gap rather
+            // than of this code. Verified by a control with no migration at all. See the design notes.
             GC.KeepAlive(received);
         }
     }

--- a/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceTopologyRefreshTests.cs
@@ -278,11 +278,21 @@ public class MaintenanceTopologyRefreshTests(ITestOutputHelper log)
             // nothing, which is the feature working. What must not happen is one attempt per notification.
             Assert.InRange(resubscribes, 1, 6);
 
-            // Delivery is deliberately *not* asserted. It does not work here even with no migration in play -
-            // the fake registers a sharded subscription somewhere its own SPUBLISH lookup does not find, so
-            // publish reports zero receivers - which makes any delivery assertion a test of that gap rather
-            // than of this code. Verified by a control with no migration at all. See the design notes.
-            GC.KeepAlive(received);
+            // Delivery is asserted by publishing *repeatedly*, because pub/sub is fire and forget: a message
+            // published while the subscription is still in flux is simply dropped. Losing messages during the
+            // tremor is expected; never delivering again is not, and one publish cannot tell those apart.
+            var delivered = await Poll.UntilAsync(
+                () =>
+                {
+                    if (Volatile.Read(ref received) > 0) return true;
+                    conn.GetSubscriber().Publish(channel, "hello");
+                    return Volatile.Read(ref received) > 0;
+                },
+                timeoutMilliseconds: 10_000,
+                pollMilliseconds: 250);
+
+            log.WriteLine($"{mode}: delivered after migration = {delivered}");
+            Assert.True(delivered, "the subscription should deliver again once things settle");
         }
     }
 

--- a/toys/MaintenanceWatch/MaintenanceWatch.csproj
+++ b/toys/MaintenanceWatch/MaintenanceWatch.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- consumes an [Experimental] surface on purpose; that is the point of the tool -->
+    <NoWarn>$(NoWarn);SER010</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\StackExchange.Redis\StackExchange.Redis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/toys/MaintenanceWatch/Program.cs
+++ b/toys/MaintenanceWatch/Program.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using StackExchange.Redis;
+using StackExchange.Redis.Maintenance;
+
+// Watches a real deployment for server-native maintenance notifications and prints what we made of them.
+//
+// The point of this tool is *evidence*: that we asked for notifications, that they arrive, and that each one
+// was understood - so every event prints both our parsed view and the raw payload it came from, and any
+// disagreement between the two is visible rather than inferred.
+//
+//   dotnet run --project toys/MaintenanceWatch -- "my-endpoint:6379,user=...,password=..."
+//
+// Notes:
+// - RESP3 is required; this forces it rather than relying on the endpoint's provider defaults.
+// - The opt-in mode is forced to Auto, so an endpoint that does not support notifications still connects.
+// - Nothing here reacts to a notification; observing is the whole job.
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("usage: MaintenanceWatch <connection-string> [--enabled]");
+    return 1;
+}
+
+var config = ConfigurationOptions.Parse(args[0]);
+config.Protocol = RedisProtocol.Resp3;
+config.MaintenanceNotifications = args.Contains("--enabled")
+    ? MaintenanceNotificationMode.Enabled // refuse to run if the server will not deliver
+    : MaintenanceNotificationMode.Auto;
+config.AbortOnConnectFail = false;
+
+// note ToString() includes the password by default; the library's own logging masks it (see
+// LoggerExtensions), but this line is ours, so it has to ask
+Console.WriteLine($"connecting: {config.ToString(includePassword: false)}");
+Console.WriteLine($"defaults provider: {config.Defaults}");
+Console.WriteLine($"maintNotifications={config.MaintenanceNotifications}, relaxed={config.MaintenanceRelaxedTimeout.TotalSeconds}s," +
+    $" windowMax={config.MaintenanceRelaxedWindowMax.TotalSeconds}s, postEvent={config.MaintenancePostEventRelaxedDuration.TotalSeconds}s");
+
+// the connect log carries the negotiation half: whether the opt-in was sent, and how the server answered
+await using var conn = await ConnectionMultiplexer.ConnectAsync(config, Console.Out);
+
+var count = 0;
+conn.ServerMaintenanceEvent += (_, e) =>
+{
+    var n = Interlocked.Increment(ref count);
+    Console.WriteLine();
+    Console.WriteLine($"=== maintenance event #{n} at {DateTime.UtcNow:HH:mm:ss.fff}Z ===");
+    Console.WriteLine($"  raw:  {e.RawMessage}");
+
+    if (e is not PushMaintenanceEvent push)
+    {
+        // e.g. the Azure pub/sub channel; not what this tool is for, but worth seeing rather than hiding
+        Console.WriteLine($"  (not a push notification: {e.GetType().Name})");
+        return;
+    }
+
+    Console.WriteLine($"  type: {push.NotificationType}   seq: {push.SequenceId}   from: {push.EndPoint}");
+    Console.WriteLine($"  time: {(push.Time is { } t ? $"{t.TotalSeconds}s" : "(none)")}" +
+        $"   startsAt: {(push.StartTimeUtc is { } at ? $"{at:HH:mm:ss}Z" : "(n/a)")}");
+
+    if (push.NotificationType == MaintenanceNotificationType.Moving)
+    {
+        // null is a documented outcome, not a parse failure: reconnect to what you already have
+        Console.WriteLine($"  moving to: {push.NewEndPoint?.ToString() ?? "(no address given)"}");
+    }
+
+    if (push.Payload is { } payload)
+    {
+        Console.WriteLine($"  payload: {payload}");
+    }
+
+    foreach (var migration in push.SlotMigrations)
+    {
+        var slots = migration.Slots.Count == 0
+            ? $"(unparsed: '{migration.RawSlots}')"
+            : string.Join(",", migration.Slots.Select(x => x.From == x.To ? $"{x.From}" : $"{x.From}-{x.To}"));
+        Console.WriteLine($"  slots {slots}: {migration.Source?.ToString() ?? "?"} -> {migration.Target?.ToString() ?? "?"}");
+    }
+};
+
+// a fault during an announced disruption says so, which is the other half of "we understood it"
+conn.ErrorMessage += (_, e) => Console.WriteLine($"[error] {e.EndPoint}: {e.Message}");
+conn.ConnectionFailed += (_, e) => Console.WriteLine($"[failed] {e.EndPoint}: {e.FailureType} {e.Exception?.Message}");
+conn.ConnectionRestored += (_, e) => Console.WriteLine($"[restored] {e.EndPoint}");
+
+Console.WriteLine();
+Console.WriteLine("watching; a little traffic keeps the connection interesting. Ctrl+C to stop.");
+
+var db = conn.GetDatabase();
+var key = $"maintenance-watch:{Guid.NewGuid():N}";
+while (true)
+{
+    try
+    {
+        await db.StringSetAsync(key, (RedisValue)DateTime.UtcNow.Ticks);
+        _ = await db.StringGetAsync(key);
+    }
+    catch (Exception ex) when (ex is RedisException or TimeoutException)
+    {
+        // note RedisTimeoutException derives from TimeoutException, *not* RedisException - so a
+        // `catch (RedisException)` would silently miss exactly the case this tool exists to show
+        // MaintenanceType is the payoff here: "timeout" versus "timeout during an announced failover"
+        var maintenance = ex switch
+        {
+            RedisTimeoutException timeout => timeout.MaintenanceType,
+            RedisConnectionException connection => connection.MaintenanceType,
+            _ => MaintenanceNotificationType.None,
+        };
+        Console.WriteLine($"[command] {ex.GetType().Name}: {ex.Message}" +
+            (maintenance == MaintenanceNotificationType.None ? "" : $"  <- during {maintenance}"));
+    }
+
+    await Task.Delay(1000);
+}

--- a/toys/StackExchange.Redis.Server/RedisClient.Output.cs
+++ b/toys/StackExchange.Redis.Server/RedisClient.Output.cs
@@ -27,6 +27,30 @@ public partial class RedisClient
 
     private readonly Channel<VersionedResponse> _replies = Channel.CreateUnbounded<VersionedResponse>(s_replyChannelOptions);
 
+    private TypedRedisValue _deferred = TypedRedisValue.Nil;
+
+    /// <summary>
+    /// Queues a frame to be sent *after* the reply to the command currently being executed.
+    /// </summary>
+    /// <remarks>
+    /// Needed because the read loop enqueues a command's reply once <c>Execute</c> has returned, so a handler
+    /// that calls <see cref="AddOutbound"/> directly puts its frame *before* its own reply. A real server does
+    /// the opposite - the retained maintenance notification arrives immediately after the <c>+OK</c> for the
+    /// opt-in, in the same TCP segment - and the ordering is the whole point of modelling this.
+    /// </remarks>
+    public void AddOutboundAfterReply(in TypedRedisValue message)
+    {
+        FlushDeferredOutbound(); // one slot is enough for any real case; do not lose an earlier frame
+        _deferred = message;
+    }
+
+    internal void FlushDeferredOutbound()
+    {
+        var pending = _deferred;
+        _deferred = TypedRedisValue.Nil;
+        if (!pending.IsNil) AddOutbound(pending);
+    }
+
     public void AddOutbound(in TypedRedisValue message)
     {
         if (message.IsNil)

--- a/toys/StackExchange.Redis.Server/RedisClient.Output.cs
+++ b/toys/StackExchange.Redis.Server/RedisClient.Output.cs
@@ -139,6 +139,9 @@ public partial class RedisClient
         }
         catch (Exception ex)
         {
+            // this used to vanish into the pipe: a serialization bug in a fake server's *outbound* path
+            // presents as "the client never received it", with a reconnect covering the tracks. Log it
+            Node?.Server?.Log($"[{this}] write loop faulted: {ex.Message}");
             await writer.CompleteAsync(ex);
         }
     }

--- a/toys/StackExchange.Redis.Server/RedisClient.cs
+++ b/toys/StackExchange.Redis.Server/RedisClient.cs
@@ -157,7 +157,12 @@ namespace StackExchange.Redis.Server
         }
 
         private int _activeSlot = ServerSelectionStrategy.NoSlot;
-        internal void ResetAfterRequest() => _activeSlot = ServerSelectionStrategy.NoSlot;
+        internal void ResetAfterRequest()
+        {
+            _activeSlot = ServerSelectionStrategy.NoSlot;
+            FlushDeferredOutbound(); // after the reply for this command, which the read loop has now queued
+        }
+
         public virtual void OnKey(in RedisKey key, KeyFlags flags)
         {
             if ((flags & KeyFlags.NoSlotCheck) == 0 & node.CheckCrossSlot)

--- a/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
@@ -56,6 +56,52 @@ namespace StackExchange.Redis.Server
 
         private int _maintenanceSequence;
         private int _maintenanceOptIns;
+        private (MaintenanceNotificationKind Kind, long Sequence, string ShardIds)? _retainedCompletion;
+
+        /// <summary>
+        /// Whether the server keeps the most recent shard-scoped *completion* and replays it to each
+        /// connection that opts in, as Redis Enterprise does.
+        /// </summary>
+        /// <remarks>
+        /// Observed on RS 8.0.22 (2026-08-28), and the boundary is sharp: <c>MIGRATED</c> and
+        /// <c>FAILED_OVER</c> are retained; <c>MIGRATING</c>, <c>FAILING_OVER</c>, <c>MOVING</c>,
+        /// <c>SMIGRATING</c> and <c>SMIGRATED</c> are not. The characterisation that fits all seven is the
+        /// completion of a *shard-scoped* event - the two that carry an affected-shards list - so
+        /// <c>SMIGRATED</c> (a slot-range triple) and <c>MOVING</c> (an endpoint) are excluded even though
+        /// <c>SMIGRATED</c> is also a completion.
+        /// <para>
+        /// The consequence is a design property worth stating: the catch-up channel can only ever say "a
+        /// disruption ended", never "one is starting". Nothing that demands action is replayed, so a
+        /// reconnecting client cannot be told to move by a stale frame.
+        /// </para>
+        /// <para>
+        /// Retained "most recent, replaced not accumulated" - one frame, never a queue - so a connection sees
+        /// at most one of these however many events went past.
+        /// </para>
+        /// </remarks>
+        public bool RetainCompletions { get; set; } = true;
+
+        /// <summary>
+        /// Whether this notification is one of the two the server retains for replay.
+        /// </summary>
+        private static bool IsRetainedCompletion(MaintenanceNotificationKind kind)
+            => kind is MaintenanceNotificationKind.Migrated or MaintenanceNotificationKind.FailedOver;
+
+        /// <summary>
+        /// Replays the retained completion, if any, to a client that has just opted in.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately *after* the <c>+OK</c> (see <see cref="RedisClient.AddOutboundAfterReply"/>), and with
+        /// the original sequence id rather than a fresh one: the id identifies the event, and a client using it
+        /// for dedup has to be able to recognize a completion it has already seen.
+        /// </remarks>
+        private void ReplayRetainedCompletion(RedisClient client)
+        {
+            if (!RetainCompletions || _retainedCompletion is not { } retained) return;
+
+            client.AddOutboundAfterReply(BuildShardNotification(retained.Kind, null, retained.Sequence, null, retained.ShardIds));
+            Log($"[{client}] replayed retained {GetName(retained.Kind)} (seq {retained.Sequence})");
+        }
 
         /// <summary>
         /// How many times a client has opted in, across the lifetime of the server. Per-client state goes away
@@ -210,33 +256,45 @@ namespace StackExchange.Redis.Server
         {
             // [type, seqID, ...] - the sequence id is an integer, which is precisely why these frames could
             // not be treated as pub/sub: element 1 is not a channel name
-            int count = 2 + (timeSeconds.HasValue ? 1 : 0) + (newEndpoint is not null || kind == MaintenanceNotificationKind.Moving ? 1 : 0) + (extra is not null ? 1 : 0);
             var seq = sequenceId ?? System.Threading.Interlocked.Increment(ref _maintenanceSequence);
+
+            // the retention is server-wide and replaces rather than accumulates, as a real one does; note it
+            // records what was *sent*, so a test arranges it by sending the completion, not by poking state
+            if (IsRetainedCompletion(kind)) _retainedCompletion = (kind, seq, extra);
+
             return Dispatch(client, Build, requireOptIn: true);
 
-            TypedRedisValue Build()
+            TypedRedisValue Build() => BuildShardNotification(kind, timeSeconds, seq, newEndpoint, extra);
+        }
+
+        private static TypedRedisValue BuildShardNotification(
+            MaintenanceNotificationKind kind,
+            int? timeSeconds,
+            long seq,
+            EndPoint newEndpoint,
+            string extra)
+        {
+            int count = 2 + (timeSeconds.HasValue ? 1 : 0) + (newEndpoint is not null || kind == MaintenanceNotificationKind.Moving ? 1 : 0) + (extra is not null ? 1 : 0);
+            var frame = TypedRedisValue.Rent(count, out var span, RespPrefix.Push);
+
+            int index = 0;
+            span[index++] = TypedRedisValue.BulkString(GetName(kind)); // bulk, as a real server sends
+            span[index++] = TypedRedisValue.Integer(seq);
+            if (timeSeconds.HasValue) span[index++] = TypedRedisValue.Integer(timeSeconds.GetValueOrDefault());
+            if (kind == MaintenanceNotificationKind.Moving)
             {
-                var frame = TypedRedisValue.Rent(count, out var span, RespPrefix.Push);
-
-                int index = 0;
-                span[index++] = TypedRedisValue.BulkString(GetName(kind)); // bulk, as a real server sends
-                span[index++] = TypedRedisValue.Integer(seq);
-                if (timeSeconds.HasValue) span[index++] = TypedRedisValue.Integer(timeSeconds.GetValueOrDefault());
-                if (kind == MaintenanceNotificationKind.Moving)
-                {
-                    // null rather than absent when there is no address: the client must cope with both
-                    span[index++] = newEndpoint is null
-                        ? TypedRedisValue.BulkString(RedisValue.Null)
-                        : TypedRedisValue.BulkString(Format.ToString(newEndpoint));
-                }
-                else if (newEndpoint is not null)
-                {
-                    span[index++] = TypedRedisValue.BulkString(Format.ToString(newEndpoint));
-                }
-                if (extra is not null) span[index] = TypedRedisValue.BulkString(extra);
-
-                return frame;
+                // null rather than absent when there is no address: the client must cope with both
+                span[index++] = newEndpoint is null
+                    ? TypedRedisValue.BulkString(RedisValue.Null)
+                    : TypedRedisValue.BulkString(Format.ToString(newEndpoint));
             }
+            else if (newEndpoint is not null)
+            {
+                span[index++] = TypedRedisValue.BulkString(Format.ToString(newEndpoint));
+            }
+            if (extra is not null) span[index] = TypedRedisValue.BulkString(extra);
+
+            return frame;
         }
 
         /// <summary>

--- a/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
@@ -118,10 +118,16 @@ namespace StackExchange.Redis.Server
 
         /// <summary>
         /// Sends one of the shard-scoped notifications. <paramref name="timeSeconds"/> is a remaining-time
-        /// delta and may legitimately be zero or negative for a connection that arrived mid-window.
+        /// delta and may legitimately be zero or negative for a connection that arrived mid-window; pass
+        /// <c>null</c> to omit the element entirely, which is what a real server does for the *closing*
+        /// notifications - captured from Enterprise 8.6.2:
+        /// <code>
+        /// &gt;4 $12 FAILING_OVER :0 :2 $6 ["21"]
+        /// &gt;3 $11 FAILED_OVER  :1    $6 ["21"]
+        /// </code>
         /// </summary>
         /// <returns>The number of clients the notification was sent to.</returns>
-        public int SendShardNotification(RedisClient client, MaintenanceNotificationKind kind, int timeSeconds, string shardIds = null, int? sequenceId = null)
+        public int SendShardNotification(RedisClient client, MaintenanceNotificationKind kind, int? timeSeconds, string shardIds = null, int? sequenceId = null)
             => Send(client, kind, timeSeconds, sequenceId, null, shardIds);
 
         /// <summary>
@@ -144,26 +150,34 @@ namespace StackExchange.Redis.Server
         /// <returns>The number of clients the notification was sent to.</returns>
         public int SendSlotMigrations(RedisClient client, MaintenanceNotificationKind kind, (string Source, string Target, string Slots)[] migrations, int? sequenceId = null)
         {
-            // Rent at every level: Recycle() recurses, so a Standalone child inside a pooled parent gets
-            // handed to the pool it did not come from ("The buffer is not associated with this pool")
-            var frame = TypedRedisValue.Rent(3, out var span, RespPrefix.Push);
-            // bulk, not simple: that is what a real server sends. Captured from Enterprise 8.6.2:
-            //   >3 $9 SMIGRATED :19 *1[ *3[ $20 <source> $18 <target> $9 <slots> ] ]
-            span[0] = TypedRedisValue.BulkString(GetName(kind));
-            span[1] = TypedRedisValue.Integer(sequenceId ?? Interlocked.Increment(ref _maintenanceSequence));
+            // one sequence id for the notification, however many clients it is delivered to - it identifies the
+            // event, not the delivery, which is what a real server does and what client-side dedup relies on
+            var seq = sequenceId ?? Interlocked.Increment(ref _maintenanceSequence);
+            return Dispatch(client, Build, requireOptIn: true);
 
-            var outer = TypedRedisValue.Rent(migrations.Length, out var outerSpan, RespPrefix.Array);
-            for (int i = 0; i < migrations.Length; i++)
+            TypedRedisValue Build()
             {
-                var triplet = TypedRedisValue.Rent(3, out var inner, RespPrefix.Array);
-                inner[0] = TypedRedisValue.BulkString(migrations[i].Source);
-                inner[1] = TypedRedisValue.BulkString(migrations[i].Target);
-                inner[2] = TypedRedisValue.BulkString(migrations[i].Slots);
-                outerSpan[i] = triplet;
-            }
+                // Rent at every level: Recycle() recurses, so a Standalone child inside a pooled parent gets
+                // handed to the pool it did not come from ("The buffer is not associated with this pool")
+                var frame = TypedRedisValue.Rent(3, out var span, RespPrefix.Push);
+                // bulk, not simple: that is what a real server sends. Captured from Enterprise 8.6.2:
+                //   >3 $9 SMIGRATED :19 *1[ *3[ $20 <source> $18 <target> $9 <slots> ] ]
+                span[0] = TypedRedisValue.BulkString(GetName(kind));
+                span[1] = TypedRedisValue.Integer(seq);
 
-            span[2] = outer;
-            return Dispatch(client, frame, requireOptIn: true);
+                var outer = TypedRedisValue.Rent(migrations.Length, out var outerSpan, RespPrefix.Array);
+                for (int i = 0; i < migrations.Length; i++)
+                {
+                    var triplet = TypedRedisValue.Rent(3, out var inner, RespPrefix.Array);
+                    inner[0] = TypedRedisValue.BulkString(migrations[i].Source);
+                    inner[1] = TypedRedisValue.BulkString(migrations[i].Target);
+                    inner[2] = TypedRedisValue.BulkString(migrations[i].Slots);
+                    outerSpan[i] = triplet;
+                }
+
+                span[2] = outer;
+                return frame;
+            }
         }
 
         /// <summary>
@@ -173,12 +187,17 @@ namespace StackExchange.Redis.Server
         /// <returns>The number of clients the frame was sent to.</returns>
         public int SendRawPush(RedisClient client, params string[] parts)
         {
-            var frame = TypedRedisValue.Rent(parts.Length, out var span, RespPrefix.Push);
-            for (int i = 0; i < parts.Length; i++)
+            return Dispatch(client, Build, requireOptIn: false);
+
+            TypedRedisValue Build()
             {
-                span[i] = TypedRedisValue.BulkString(parts[i]);
+                var frame = TypedRedisValue.Rent(parts.Length, out var span, RespPrefix.Push);
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    span[i] = TypedRedisValue.BulkString(parts[i]);
+                }
+                return frame;
             }
-            return Dispatch(client, frame, requireOptIn: false);
         }
 
         private int Send(
@@ -192,46 +211,61 @@ namespace StackExchange.Redis.Server
             // [type, seqID, ...] - the sequence id is an integer, which is precisely why these frames could
             // not be treated as pub/sub: element 1 is not a channel name
             int count = 2 + (timeSeconds.HasValue ? 1 : 0) + (newEndpoint is not null || kind == MaintenanceNotificationKind.Moving ? 1 : 0) + (extra is not null ? 1 : 0);
-            var frame = TypedRedisValue.Rent(count, out var span, RespPrefix.Push);
+            var seq = sequenceId ?? System.Threading.Interlocked.Increment(ref _maintenanceSequence);
+            return Dispatch(client, Build, requireOptIn: true);
 
-            int index = 0;
-            span[index++] = TypedRedisValue.BulkString(GetName(kind)); // bulk, as a real server sends
-            span[index++] = TypedRedisValue.Integer(sequenceId ?? System.Threading.Interlocked.Increment(ref _maintenanceSequence));
-            if (timeSeconds.HasValue) span[index++] = TypedRedisValue.Integer(timeSeconds.GetValueOrDefault());
-            if (kind == MaintenanceNotificationKind.Moving)
+            TypedRedisValue Build()
             {
-                // null rather than absent when there is no address: the client must cope with both
-                span[index++] = newEndpoint is null
-                    ? TypedRedisValue.BulkString(RedisValue.Null)
-                    : TypedRedisValue.BulkString(Format.ToString(newEndpoint));
-            }
-            else if (newEndpoint is not null)
-            {
-                span[index++] = TypedRedisValue.BulkString(Format.ToString(newEndpoint));
-            }
-            if (extra is not null) span[index] = TypedRedisValue.BulkString(extra);
+                var frame = TypedRedisValue.Rent(count, out var span, RespPrefix.Push);
 
-            return Dispatch(client, frame, requireOptIn: true);
+                int index = 0;
+                span[index++] = TypedRedisValue.BulkString(GetName(kind)); // bulk, as a real server sends
+                span[index++] = TypedRedisValue.Integer(seq);
+                if (timeSeconds.HasValue) span[index++] = TypedRedisValue.Integer(timeSeconds.GetValueOrDefault());
+                if (kind == MaintenanceNotificationKind.Moving)
+                {
+                    // null rather than absent when there is no address: the client must cope with both
+                    span[index++] = newEndpoint is null
+                        ? TypedRedisValue.BulkString(RedisValue.Null)
+                        : TypedRedisValue.BulkString(Format.ToString(newEndpoint));
+                }
+                else if (newEndpoint is not null)
+                {
+                    span[index++] = TypedRedisValue.BulkString(Format.ToString(newEndpoint));
+                }
+                if (extra is not null) span[index] = TypedRedisValue.BulkString(extra);
+
+                return frame;
+            }
         }
 
-        private int Dispatch(RedisClient client, in TypedRedisValue frame, bool requireOptIn)
+        /// <summary>
+        /// Sends a notification to one client or to every opted-in client, building the frame per recipient.
+        /// </summary>
+        /// <remarks>
+        /// The factory is called once per recipient rather than the frame being built once and shared, because
+        /// each client's write loop recycles what it wrote: a shared frame is returned to the pool by the first
+        /// writer and the second one faults with "Array element cannot be nil", killing that connection. Every
+        /// broadcast therefore used to reach exactly one client, which is invisible in a single-node test and
+        /// silently made multi-node fan-out untestable.
+        /// </remarks>
+        private int Dispatch(RedisClient client, Func<TypedRedisValue> frameFactory, bool requireOptIn)
         {
             if (client is not null)
             {
-                client.AddOutbound(frame);
+                client.AddOutbound(frameFactory());
                 return 1;
             }
 
             // a real server sends only to connections that asked, so sending to all means all *opted-in*.
             // Counting the sends rather than the clients visited: the Action overload of ForAllClients returns
             // one per client regardless, which would report every connection as a recipient
-            var copy = frame;
             return ForAllClients(
                 requireOptIn,
                 (target, gated) =>
                 {
                     if (gated && !target.MaintenanceNotifications) return 0;
-                    target.AddOutbound(copy);
+                    target.AddOutbound(frameFactory());
                     return 1;
                 });
         }

--- a/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
@@ -66,6 +66,41 @@ namespace StackExchange.Redis.Server
         internal void OnMaintenanceOptIn() => Interlocked.Increment(ref _maintenanceOptIns);
 
         /// <summary>
+        /// Whether <see cref="Migrate(int, EndPoint)"/> announces itself the way a real server does, rather
+        /// than only moving the slot in this model.
+        /// </summary>
+        /// <remarks>
+        /// Off by default, because plenty of tests use <c>Migrate</c> purely to arrange a topology and would
+        /// not expect a notification to arrive mid-arrangement. Turn it on to exercise the *sequence* a client
+        /// really sees - which is the only way to test how the notification-driven path and the unsolicited
+        /// <c>SUNSUBSCRIBE</c> path interact, since both fire for the same migration.
+        /// </remarks>
+        public bool NotifyOnMigrate { get; set; }
+
+        /// <summary>
+        /// Announces a slot migration the way a real server does: the shard notifications either side of it,
+        /// and an unsolicited <c>sunsubscribe</c> to any client subscribed to a sharded channel that has just
+        /// moved away.
+        /// </summary>
+        /// <remarks>
+        /// Note the two signals are independent. The notifications only reach clients that opted in, whereas
+        /// the unsubscribe is ordinary cluster behaviour and reaches every subscriber - so a client can
+        /// legitimately see one, the other, or both, and the order is a server implementation detail. That is
+        /// exactly the interaction worth being able to reproduce here.
+        /// </remarks>
+        private void AnnounceMigration(int hashSlot, Node from, Node to)
+        {
+            var slots = hashSlot.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            SendSlotNotification(null, MaintenanceNotificationKind.SlotMigrating, slots);
+
+            var dropped = ForAllClients(hashSlot, static (client, slot) => client.UnsubscribeMigratedSlot(slot));
+            if (dropped != 0) Log($"unsubscribed {dropped} sharded subscription(s) for migrated slot {hashSlot}");
+
+            SendSlotMigrations(null, MaintenanceNotificationKind.SlotMigrated,
+                [($"{from.Host}:{from.Port}", $"{to.Host}:{to.Port}", slots)]);
+        }
+
+        /// <summary>
         /// The sequence id given to the next notification, unless one is supplied explicitly. The contract does
         /// not define these, so a client's use of them is its own invention - which is worth being able to
         /// exercise, including by repeating one.

--- a/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
@@ -98,6 +98,38 @@ namespace StackExchange.Redis.Server
             => Send(client, kind, null, sequenceId, null, slots);
 
         /// <summary>
+        /// Sends <c>SMIGRATED</c> in its nested form - <c>[type, seq, [[source, target, slots], ...]]</c> -
+        /// which is what the shipped clients read (see the topic README's prior art; go-redis reads exactly
+        /// this shape and redis-py models the same nesting).
+        /// </summary>
+        /// <remarks>
+        /// Note the sender is not implicitly the source of anything: every node reports the same movements, so
+        /// a test can and should exercise a delta that does not involve this server at all.
+        /// </remarks>
+        /// <returns>The number of clients the notification was sent to.</returns>
+        public int SendSlotMigrations(RedisClient client, MaintenanceNotificationKind kind, (string Source, string Target, string Slots)[] migrations, int? sequenceId = null)
+        {
+            // Rent at every level: Recycle() recurses, so a Standalone child inside a pooled parent gets
+            // handed to the pool it did not come from ("The buffer is not associated with this pool")
+            var frame = TypedRedisValue.Rent(3, out var span, RespPrefix.Push);
+            span[0] = TypedRedisValue.SimpleString(GetName(kind));
+            span[1] = TypedRedisValue.Integer(sequenceId ?? Interlocked.Increment(ref _maintenanceSequence));
+
+            var outer = TypedRedisValue.Rent(migrations.Length, out var outerSpan, RespPrefix.Array);
+            for (int i = 0; i < migrations.Length; i++)
+            {
+                var triplet = TypedRedisValue.Rent(3, out var inner, RespPrefix.Array);
+                inner[0] = TypedRedisValue.BulkString(migrations[i].Source);
+                inner[1] = TypedRedisValue.BulkString(migrations[i].Target);
+                inner[2] = TypedRedisValue.BulkString(migrations[i].Slots);
+                outerSpan[i] = triplet;
+            }
+
+            span[2] = outer;
+            return Dispatch(client, frame, requireOptIn: true);
+        }
+
+        /// <summary>
         /// Sends an arbitrary push frame to a client, for the cases a well-formed notification cannot express:
         /// an unknown type, a malformed payload, extra trailing elements.
         /// </summary>

--- a/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
@@ -147,7 +147,9 @@ namespace StackExchange.Redis.Server
             // Rent at every level: Recycle() recurses, so a Standalone child inside a pooled parent gets
             // handed to the pool it did not come from ("The buffer is not associated with this pool")
             var frame = TypedRedisValue.Rent(3, out var span, RespPrefix.Push);
-            span[0] = TypedRedisValue.SimpleString(GetName(kind));
+            // bulk, not simple: that is what a real server sends. Captured from Enterprise 8.6.2:
+            //   >3 $9 SMIGRATED :19 *1[ *3[ $20 <source> $18 <target> $9 <slots> ] ]
+            span[0] = TypedRedisValue.BulkString(GetName(kind));
             span[1] = TypedRedisValue.Integer(sequenceId ?? Interlocked.Increment(ref _maintenanceSequence));
 
             var outer = TypedRedisValue.Rent(migrations.Length, out var outerSpan, RespPrefix.Array);
@@ -193,7 +195,7 @@ namespace StackExchange.Redis.Server
             var frame = TypedRedisValue.Rent(count, out var span, RespPrefix.Push);
 
             int index = 0;
-            span[index++] = TypedRedisValue.SimpleString(GetName(kind));
+            span[index++] = TypedRedisValue.BulkString(GetName(kind)); // bulk, as a real server sends
             span[index++] = TypedRedisValue.Integer(sequenceId ?? System.Threading.Interlocked.Increment(ref _maintenanceSequence));
             if (timeSeconds.HasValue) span[index++] = TypedRedisValue.Integer(timeSeconds.GetValueOrDefault());
             if (kind == MaintenanceNotificationKind.Moving)

--- a/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.Maintenance.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using RESPite;
 using RESPite.Messages;
 
@@ -160,7 +162,84 @@ namespace StackExchange.Redis.Server
         /// </summary>
         /// <returns>The number of clients the notification was sent to.</returns>
         public int SendMoving(RedisClient client, int timeSeconds, EndPoint newEndpoint, int? sequenceId = null)
-            => Send(client, MaintenanceNotificationKind.Moving, timeSeconds, sequenceId, newEndpoint, null);
+        {
+            var recipients = MovingClosesConnection ? new List<RedisClient>() : null;
+            Action<RedisClient> onSent = recipients is null ? null : recipients.Add;
+            var count = Send(client, MaintenanceNotificationKind.Moving, timeSeconds, sequenceId, newEndpoint, null, onSent);
+
+            if (recipients is { Count: > 0 })
+            {
+                // The half of MOVING that defines it: the socket goes away - and it takes every other
+                // connection to the same node with it (see MovingClosesConnection).
+                var delay = MovingCloseDelay ?? TimeSpan.FromSeconds(Math.Max(timeSeconds, 0)) + MeasuredCloseSlack;
+                _ = CloseAfterAsync(CollectSiblings(recipients), delay);
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// Whether <see cref="SendMoving"/> then closes the affected connections, as a real proxy does.
+        /// </summary>
+        /// <remarks>
+        /// Note the blast radius is the *node*, not the connection. Measured on RS (2026-08-28) with four
+        /// connections to one node differing only in handshake - two opted in, one RESP3 without the opt-in,
+        /// one RESP2 - all four closed simultaneously, and only the two that had opted in were warned. So this
+        /// is endpoint retirement rather than socket recycling, and a connection that did not opt in gets no
+        /// warning at all before it dies: an argument for opting in on every connection rather than one.
+        /// </remarks>
+        public bool MovingClosesConnection { get; set; }
+
+        /// <summary>
+        /// How much later than the announced window the close actually arrives, by default.
+        /// </summary>
+        /// <remarks>
+        /// Measured at +3.4s and +1.6s against a declared 15s grace, i.e. the announced window behaves as a
+        /// floor with slack rather than a deadline. Tests should assert that a client acts *within* the window,
+        /// never that the socket survives to the end of it.
+        /// </remarks>
+        public TimeSpan MeasuredCloseSlack { get; set; } = TimeSpan.FromSeconds(2);
+
+        /// <summary>
+        /// How long after <c>MOVING</c> the connections are closed; defaults to the announced window plus
+        /// <see cref="MeasuredCloseSlack"/>, which is what a real proxy was measured doing.
+        /// </summary>
+        /// <remarks>
+        /// Set it shorter than the announced window to exercise a proxy less generous than the one measured -
+        /// a client that treats the window as guaranteed rather than as a budget fails that case. It cannot
+        /// usefully be set to zero: the close would race the delivery of the notification itself, which is not
+        /// something any real timing produces.
+        /// </remarks>
+        public TimeSpan? MovingCloseDelay { get; set; }
+
+        /// <summary>
+        /// Expands the notified connections to every connection sharing a node with them.
+        /// </summary>
+        private List<RedisClient> CollectSiblings(List<RedisClient> notified)
+        {
+            var nodes = new HashSet<Node>();
+            foreach (var client in notified) nodes.Add(client.Node);
+
+            var all = new List<RedisClient>();
+            ForAllClients(
+                all,
+                (client, list) =>
+                {
+                    if (nodes.Contains(client.Node)) list.Add(client);
+                    return 0;
+                });
+            return all;
+        }
+
+        private async Task CloseAfterAsync(List<RedisClient> clients, TimeSpan delay)
+        {
+            if (delay > TimeSpan.Zero) await Task.Delay(delay).ConfigureAwait(false);
+            foreach (var client in clients)
+            {
+                Log($"[{client}] closing connection after MOVING");
+                client.Kill();
+            }
+        }
 
         /// <summary>
         /// Sends one of the shard-scoped notifications. <paramref name="timeSeconds"/> is a remaining-time
@@ -252,7 +331,8 @@ namespace StackExchange.Redis.Server
             int? timeSeconds,
             int? sequenceId,
             EndPoint newEndpoint,
-            string extra)
+            string extra,
+            Action<RedisClient> onSent = null)
         {
             // [type, seqID, ...] - the sequence id is an integer, which is precisely why these frames could
             // not be treated as pub/sub: element 1 is not a channel name
@@ -262,7 +342,7 @@ namespace StackExchange.Redis.Server
             // records what was *sent*, so a test arranges it by sending the completion, not by poking state
             if (IsRetainedCompletion(kind)) _retainedCompletion = (kind, seq, extra);
 
-            return Dispatch(client, Build, requireOptIn: true);
+            return Dispatch(client, Build, requireOptIn: true, onSent);
 
             TypedRedisValue Build() => BuildShardNotification(kind, timeSeconds, seq, newEndpoint, extra);
         }
@@ -307,11 +387,12 @@ namespace StackExchange.Redis.Server
         /// broadcast therefore used to reach exactly one client, which is invisible in a single-node test and
         /// silently made multi-node fan-out untestable.
         /// </remarks>
-        private int Dispatch(RedisClient client, Func<TypedRedisValue> frameFactory, bool requireOptIn)
+        private int Dispatch(RedisClient client, Func<TypedRedisValue> frameFactory, bool requireOptIn, Action<RedisClient> onSent = null)
         {
             if (client is not null)
             {
                 client.AddOutbound(frameFactory());
+                onSent?.Invoke(client);
                 return 1;
             }
 
@@ -324,6 +405,7 @@ namespace StackExchange.Redis.Server
                 {
                     if (gated && !target.MaintenanceNotifications) return 0;
                     target.AddOutbound(frameFactory());
+                    onSent?.Invoke(target);
                     return 1;
                 });
         }

--- a/toys/StackExchange.Redis.Server/RedisServer.PubSub.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.PubSub.cs
@@ -280,6 +280,38 @@ public partial class RedisClient
         return new Regex(re, RegexOptions.CultureInvariant);
     }
 
+    /// <summary>
+    /// Drops this client's sharded subscriptions whose channel hashes into <paramref name="hashSlot"/>,
+    /// pushing the unsolicited <c>sunsubscribe</c> a real server sends when a slot moves away.
+    /// </summary>
+    /// <returns>How many subscriptions were dropped.</returns>
+    internal int UnsubscribeMigratedSlot(int hashSlot)
+    {
+        var subs = SubscriptionsIfAny;
+        if (subs is null) return 0;
+
+        List<RedisChannel> affected = null;
+        lock (subs)
+        {
+            foreach (var pair in subs)
+            {
+                var channel = pair.Key;
+                if (channel.IsSharded && ServerSelectionStrategy.GetClusterSlot((byte[])channel) == hashSlot)
+                {
+                    (affected ??= new()).Add(channel);
+                }
+            }
+        }
+
+        if (affected is null) return 0;
+        foreach (var channel in affected)
+        {
+            Unsubscribe(channel); // removes it *and* sends the push, exactly as a client-issued one would
+        }
+
+        return affected.Count;
+    }
+
     internal void Unsubscribe(RedisChannel channel)
     {
         var subs = SubscriptionsIfAny;

--- a/toys/StackExchange.Redis.Server/RedisServer.PubSub.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.PubSub.cs
@@ -62,7 +62,9 @@ public partial class RedisServer
         var slot = ServerSelectionStrategy.GetClusterSlot((byte[])channel);
         if (!node.HasSlot(slot)) KeyMovedException.Throw(slot);
 
-        PublishPair pair = new(channel, request.GetValue(2));
+        // note the node: without it pair.Node is null, ReferenceEquals never matches, and sharded publish
+        // silently delivers to nobody - which is how it behaved until 2026-08-26
+        PublishPair pair = new(channel, request.GetValue(2), node);
         int count = ForAllClients(pair, static (client, pair) =>
             ReferenceEquals(client.Node, pair.Node) ? client.Publish(pair.Channel, pair.Value) : 0);
         return TypedRedisValue.Integer(count);

--- a/toys/StackExchange.Redis.Server/RedisServer.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.cs
@@ -811,7 +811,11 @@ namespace StackExchange.Redis.Server
             client.MaintenanceNotifications = on;
             client.MovingEndpointType = on ? movingEndpointType : null;
             client.MaintenanceNotificationOptInCount++;
-            if (on) OnMaintenanceOptIn();
+            if (on)
+            {
+                OnMaintenanceOptIn();
+                ReplayRetainedCompletion(client); // the catch-up channel, immediately after this +OK
+            }
             Log($"[{client}] maintenance notifications {(on ? "on" : "off")}, moving-endpoint-type: {movingEndpointType ?? "(server default)"}");
             return TypedRedisValue.OK;
         }

--- a/toys/StackExchange.Redis.Server/RedisServer.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.cs
@@ -112,6 +112,12 @@ namespace StackExchange.Redis.Server
                         throw new KeyNotFoundException($"Unable to remove slot {hashSlot} from old owner");
                     }
                     target.AddSlot(hashSlot);
+
+                    if (NotifyOnMigrate)
+                    {
+                        AnnounceMigration(hashSlot, pair.Value, target);
+                    }
+
                     return true;
                 }
             }

--- a/toys/StackExchange.Redis.Server/RedisServer.cs
+++ b/toys/StackExchange.Redis.Server/RedisServer.cs
@@ -317,6 +317,38 @@ namespace StackExchange.Redis.Server
             return endpoint;
         }
 
+        /// <summary>
+        /// Removes a node from the cluster entirely, as <c>CLUSTER FORGET</c> does: it stops appearing in
+        /// <c>CLUSTER SLOTS</c> and in <c>CLUSTER NODES</c>, and any name it answered to stops resolving.
+        /// </summary>
+        /// <remarks>
+        /// Refuses while it still owns slots, which is also what a real cluster does - a node has to have its
+        /// slots migrated away before it can be forgotten, and allowing it here would produce a topology with
+        /// unowned slots that says nothing useful about client behaviour.
+        /// <para>
+        /// This exists to distinguish the two conditions a client has to tell apart: a node that currently
+        /// serves nothing is still a cluster member and may be given slots again, whereas a node that has
+        /// *left* is one whose connection should be given up.
+        /// </para>
+        /// </remarks>
+        public bool RemoveNode(EndPoint endpoint)
+        {
+            if (endpoint is null) throw new ArgumentNullException(nameof(endpoint));
+            if (!_nodes.TryGetValue(endpoint, out var node)) return false;
+            if (node.HasAnySlot) throw new InvalidOperationException($"Node still owns slots: {Format.ToString(endpoint)}");
+
+            if (!_nodes.TryRemove(endpoint, out _)) return false;
+
+            // and every alias that pointed at it, or a stale name would resolve to a node that is gone
+            foreach (var pair in _aliases)
+            {
+                if (ReferenceEquals(pair.Value, node)) _aliases.TryRemove(pair.Key, out _);
+            }
+
+            Log($"node removed from the cluster: {Format.ToString(endpoint)}");
+            return true;
+        }
+
         public EndPoint AddEmptyNode(NodeFlags flags = NodeFlags.None)
         {
             EndPoint endpoint;
@@ -1093,6 +1125,12 @@ namespace StackExchange.Redis.Server
             }
 
             public void UpdateSlots(SlotRange[] slots) => _slots = slots;
+
+            /// <summary>
+            /// Whether this node serves anything at all; note a <c>null</c> slot set means "all slots"
+            /// (the single-node default), not "none".
+            /// </summary>
+            public bool HasAnySlot => _slots is null || _slots.Length != 0;
             public ReadOnlySpan<SlotRange> Slots => _slots ?? SlotRange.SharedAllSlots;
             public bool CheckCrossSlot => _server.CheckCrossSlot;
 


### PR DESCRIPTION
Stacked on #3193, which is stacked on #3191. Draft. This is the first part of the feature that **changes behaviour**.

## Relaxation (`6b76faf3`)

An opening notification (`MOVING`, `MIGRATING`, `FAILING_OVER`, `SMIGRATING`) raises command timeouts for that server; a closing one stands them back down. Three settings, of which only the first is prescribed cross-client - the other two say "our invention" in their own XML docs:

- `maintRelaxedTimeout` (10s): what timeouts are relaxed *to*, as a floor. Effective timeout is `max(configured, this)`, so a generous caller keeps their value.
- `maintRelaxedWindowMax` (3x): a backstop for a closing notification that never arrives.
- `maintPostEventRelaxed` (2x, matching go-redis): a closing notification means the server-side *operation* finished, not that the server is back to normal latency - and completion is exactly when every other client that got the same notification re-engages. It does **not** apply after a cap expiry, where nothing told us the event finished and extending past the backstop would defeat it.

These are in **seconds**, unlike every other timeout in `ConfigurationOptions`, because that is the unit the cross-client contract names. The mistake is silent in one direction, so `maintRelaxedTimeout=30000` is rejected with a message that names the unit rather than quietly configuring an eight-hour timeout.

Three things worth a reviewer's eye:

- **Relaxation is server-scoped state read at sweep time, not stamped per message.** Both timeout sweeps rely on head-of-line ordering and stop at the first message that has not timed out; per-message timeouts would invalidate that short-circuit and turn every heartbeat into a full scan of everything outstanding.
- **`CheckBacklogForTimeouts` was measuring message age against `_singleWriter.TimeoutMilliseconds`** - the write-*lock* acquisition timeout, which is about contention between writers rather than server latency. It now has its own expression, so relaxation cannot leak into lock acquisition. Pre-existing conflation that only became visible because relaxation forced the question.
- **The sync path grows a re-wait loop**, because `Monitor.Wait` commits to a duration when it parks: without it a sync caller already waiting when a notification lands would time out at the strict timeout while its async neighbour was relaxed. The loop also handles the way back - if a window closes mid-wait, the revised timeout drops and the wait ends.

Also seqID dedup, per notification type, which lands here because a replayed opening notification extending a window is the first place a replay does damage. The sequence numbers are not defined by any specification, so it is deliberately conservative.

**What is not relaxed, as a rule:** keep-alive, the heartbeat, and connection-failure detection - otherwise a server that died mid-maintenance would linger for the whole window, turning a latency mitigation into an availability regression. There is a test that kills a connection inside an absurdly generous window and requires the failure to still be noticed. The one refinement is the dead-socket heuristic in `PhysicalBridge`, which is *derived from* the command timeout and now tracks the effective one: at a 60s relaxed timeout, firing at 4x the strict 5s would tear down precisely the connection relaxation was protecting.

## Fault surface (`2116f7f3`)

`MaintenanceType` on `RedisTimeoutException`, `RedisConnectionException` and `FaultContext`, defaulting to `None`. "Timeout" and "timeout during an announced failover" call for very different reactions from whoever reads the log.

On `FaultContext` it is deliberately **reported and not acted on**: a fault during announced maintenance is expected and transient, and counting it towards a circuit-breaker trip that then withdraws a whole server is the opposite of what the notification was for - but "ignore faults during maintenance" is a judgement about a deployment, not about the protocol, so it belongs in policy. Happy to change `DefaultIsFailure` instead if that is the preference; it would change existing behaviour for AA users, so I left it.

## Cluster delta, read only (`70c07835`)

Cross-checking against the shipped clients (go-redis, redis-py) says `SMIGRATED` is nested - `["SMIGRATED", seq, [[source, target, slots], ...]]` - which two independent implementations agree on, and which means **we were dropping it**: the parser rejected any non-scalar element after the type. Now read and exposed as `ClusterSlotMigration` on the event. Still nothing applies the delta.

Two incidental fixes the cross-check produced, both worth knowing independently:

- We required a readable sequence id and dropped the frame without one; go-redis length-checks these at two elements and reads no sequence number at all for the shard notifications, so that was stricter than a client that demonstrably works. A missing id now costs only dedup.
- **`SlotRange.TryParseInt16` was `checked`**, so an out-of-range slot number threw `OverflowException` from a `Try*` method - pre-existing, reachable today from the public `SlotRange.TryParse` and from `CLUSTER NODES` parsing. It rejects now.

## Verification

Full `Build.csproj` clean across all TFMs (`TimeSpan * int` is netstandard2.1+, so the arithmetic is on `.Ticks`). Full net10.0 suite at 6249 tests with the switch at `Auto`; the only failure is `FailoverTests.SubscriptionsSurvivePrimarySwitchAsync`, which fails identically with the feature switched off and passes in isolation - an order/state artefact of the local failover pair, not from this work.