### PR TITLE
Fill in the neglected bitmap commands: BITFIELD, and an open-ended BITPOS

### DIFF
--- a/src/StackExchange.Redis/BitFieldEncoding.cs
+++ b/src/StackExchange.Redis/BitFieldEncoding.cs
@@ -1,0 +1,130 @@
+﻿using System;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// The width and signedness of a single bitfield, as used by the <c>BITFIELD</c> operations
+/// on <see cref="IDatabase"/>; for example <c>u8</c> or <c>i53</c>.
+/// </summary>
+/// <remarks>
+/// Signed encodings may be 1-64 bits wide; unsigned encodings are limited to 63 bits, because the
+/// server reports every value as a signed 64-bit integer. Every legal encoding therefore fits
+/// losslessly in <see cref="long"/>.
+/// </remarks>
+public readonly struct BitFieldEncoding : IEquatable<BitFieldEncoding>
+{
+    // negative: signed; positive: unsigned; zero: default (not a legal encoding)
+    private readonly sbyte _value;
+
+    private BitFieldEncoding(sbyte value) => _value = value;
+
+    /// <summary>A signed bitfield <paramref name="width"/> bits wide; 1-64.</summary>
+    /// <param name="width">The width of the field, in bits.</param>
+    public static BitFieldEncoding Signed(int width)
+    {
+        if (width is < 1 or > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), "Signed bitfield encodings must be 1-64 bits wide.");
+        }
+
+        return new((sbyte)-width);
+    }
+
+    /// <summary>An unsigned bitfield <paramref name="width"/> bits wide; 1-63.</summary>
+    /// <param name="width">The width of the field, in bits.</param>
+    public static BitFieldEncoding Unsigned(int width)
+    {
+        if (width is < 1 or > 63)
+        {
+            // the ceiling is 63 rather than 64 because every value comes back as a signed 64-bit
+            // integer, so u64 has nowhere to go; the server rejects it for the same reason
+            var message = width >= 64
+                ? "Unsigned bitfield encodings are limited to 63 bits, because the reply is a signed 64-bit integer; use UInt63 or Int64."
+                : "Unsigned bitfield encodings must be 1-63 bits wide.";
+            throw new ArgumentOutOfRangeException(nameof(width), message);
+        }
+
+        return new((sbyte)width);
+    }
+
+    /// <summary>A signed 8-bit field, <c>i8</c>.</summary>
+    public static BitFieldEncoding Int8 => new(-8);
+
+    /// <summary>A signed 16-bit field, <c>i16</c>.</summary>
+    public static BitFieldEncoding Int16 => new(-16);
+
+    /// <summary>A signed 32-bit field, <c>i32</c>.</summary>
+    public static BitFieldEncoding Int32 => new(-32);
+
+    /// <summary>A signed 64-bit field, <c>i64</c>; the widest field the server supports.</summary>
+    public static BitFieldEncoding Int64 => new(-64);
+
+    /// <summary>An unsigned 8-bit field, <c>u8</c>.</summary>
+    public static BitFieldEncoding UInt8 => new(8);
+
+    /// <summary>An unsigned 16-bit field, <c>u16</c>.</summary>
+    public static BitFieldEncoding UInt16 => new(16);
+
+    /// <summary>An unsigned 32-bit field, <c>u32</c>.</summary>
+    public static BitFieldEncoding UInt32 => new(32);
+
+    /// <summary>
+    /// An unsigned 63-bit field, <c>u63</c>; the widest unsigned field the server supports. There is
+    /// deliberately no <c>UInt64</c>: the reply is a signed 64-bit integer, so <c>u64</c> could not be
+    /// represented, and the server rejects it.
+    /// </summary>
+    public static BitFieldEncoding UInt63 => new(63);
+
+    /// <summary>The width of the field, in bits.</summary>
+    public int Width => _value < 0 ? -_value : _value;
+
+    /// <summary>Whether the field is signed.</summary>
+    public bool IsSigned => _value < 0;
+
+    internal bool IsDefault => _value == 0;
+
+    internal RedisValue ToLiteral()
+    {
+        if (_value == 0) ThrowDefault();
+        return Literals[_value + 64];
+
+        static void ThrowDefault() => throw new ArgumentException(
+            $"A {nameof(BitFieldEncoding)} must be created via {nameof(Signed)}, {nameof(Unsigned)}, or one of the named encodings.",
+            nameof(BitFieldEncoding));
+    }
+
+    // i64..i1 (indexes 0..63), unused (64), u1..u63 (65..127)
+    private static readonly RedisValue[] Literals = CreateLiterals();
+
+    private static RedisValue[] CreateLiterals()
+    {
+        var arr = new RedisValue[128];
+        for (int width = 1; width <= 64; width++)
+        {
+            arr[64 - width] = "i" + width.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (width <= 63)
+            {
+                arr[64 + width] = "u" + width.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+        }
+        return arr;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => _value == 0 ? "(default)" : (string)ToLiteral()!;
+
+    /// <inheritdoc/>
+    public bool Equals(BitFieldEncoding other) => _value == other._value;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is BitFieldEncoding other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => _value;
+
+    /// <summary>Compares two values for equality.</summary>
+    public static bool operator ==(BitFieldEncoding x, BitFieldEncoding y) => x._value == y._value;
+
+    /// <summary>Compares two values for non-equality.</summary>
+    public static bool operator !=(BitFieldEncoding x, BitFieldEncoding y) => x._value != y._value;
+}

--- a/src/StackExchange.Redis/BitFieldEncoding.cs
+++ b/src/StackExchange.Redis/BitFieldEncoding.cs
@@ -83,35 +83,46 @@ public readonly struct BitFieldEncoding : IEquatable<BitFieldEncoding>
 
     internal bool IsDefault => _value == 0;
 
-    internal RedisValue ToLiteral()
+    /// <summary>
+    /// Writes this encoding as a complete bulk string - <c>$2\r\ni8\r\n</c> or <c>$3\r\ni64\r\n</c> - since
+    /// the width is 1-64 and so the length prefix is always a single digit.
+    /// </summary>
+    internal void Write(in MessageWriter writer, Span<byte> scratch)
     {
         if (_value == 0) ThrowDefault();
-        return Literals[_value + 64];
+
+        int width = Width, len;
+        scratch[0] = (byte)'$';
+        scratch[2] = (byte)'\r';
+        scratch[3] = (byte)'\n';
+        scratch[4] = _value < 0 ? (byte)'i' : (byte)'u';
+        if (width >= 10)
+        {
+            scratch[1] = (byte)'3';
+            scratch[5] = (byte)('0' + (width / 10));
+            scratch[6] = (byte)('0' + (width % 10));
+            len = 7;
+        }
+        else
+        {
+            scratch[1] = (byte)'2';
+            scratch[5] = (byte)('0' + width);
+            len = 6;
+        }
+
+        scratch[len++] = (byte)'\r';
+        scratch[len++] = (byte)'\n';
+        writer.WriteRaw(scratch.Slice(0, len));
 
         static void ThrowDefault() => throw new ArgumentException(
             $"A {nameof(BitFieldEncoding)} must be created via {nameof(Signed)}, {nameof(Unsigned)}, or one of the named encodings.",
             nameof(BitFieldEncoding));
     }
 
-    // i64..i1 (indexes 0..63), unused (64), u1..u63 (65..127)
-    private static readonly RedisValue[] Literals = CreateLiterals();
-
-    private static RedisValue[] CreateLiterals()
-    {
-        var arr = new RedisValue[128];
-        for (int width = 1; width <= 64; width++)
-        {
-            arr[64 - width] = "i" + width.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            if (width <= 63)
-            {
-                arr[64 + width] = "u" + width.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            }
-        }
-        return arr;
-    }
-
     /// <inheritdoc/>
-    public override string ToString() => _value == 0 ? "(default)" : (string)ToLiteral()!;
+    public override string ToString() => _value == 0
+        ? "(default)"
+        : (IsSigned ? "i" : "u") + Width.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
     public bool Equals(BitFieldEncoding other) => _value == other._value;

--- a/src/StackExchange.Redis/BitFieldOffset.cs
+++ b/src/StackExchange.Redis/BitFieldOffset.cs
@@ -45,9 +45,18 @@ public readonly struct BitFieldOffset : IEquatable<BitFieldOffset>
     /// <param name="bit">The bit position.</param>
     public static implicit operator BitFieldOffset(long bit) => Bit(bit);
 
-    internal RedisValue ToLiteral() => _isElement
-        ? (RedisValue)("#" + _value.ToString(CultureInfo.InvariantCulture))
-        : (RedisValue)_value;
+    internal void Write(in MessageWriter writer, Span<byte> scratch)
+    {
+        if (!_isElement)
+        {
+            writer.WriteBulkString(_value);
+            return;
+        }
+
+        scratch[0] = (byte)'#';
+        var len = Format.FormatInt64(_value, scratch.Slice(1)) + 1;
+        writer.WriteBulkString(scratch.Slice(0, len));
+    }
 
     /// <inheritdoc/>
     public override string ToString() => _isElement

--- a/src/StackExchange.Redis/BitFieldOffset.cs
+++ b/src/StackExchange.Redis/BitFieldOffset.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Globalization;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// Where a bitfield sits inside a string: either an absolute bit offset, or - via
+/// <see cref="Index(long)"/> - a zero-based index into an array of consecutive fields of the same
+/// width, which the server multiplies out for us (the <c>#</c> form).
+/// </summary>
+/// <remarks><seealso href="https://redis.io/commands/bitfield"/></remarks>
+public readonly struct BitFieldOffset : IEquatable<BitFieldOffset>
+{
+    private readonly long _value;
+    private readonly bool _isIndex;
+
+    private BitFieldOffset(long value, bool isIndex)
+    {
+        _value = value;
+        _isIndex = isIndex;
+    }
+
+    /// <summary>
+    /// An absolute offset, in bits, from the start of the string.
+    /// </summary>
+    /// <param name="offset">The offset, in bits.</param>
+    public static BitFieldOffset Bits(long offset) => offset < 0
+        ? throw new ArgumentOutOfRangeException(nameof(offset), "A bitfield offset cannot be negative.")
+        : new(offset, false);
+
+    /// <summary>
+    /// A zero-based index into an array of consecutive fields of the encoding's own width; the
+    /// server multiplies the index by the width, so <c>Index(2)</c> of a <c>u8</c> is bit 16.
+    /// </summary>
+    /// <param name="index">The index of the field.</param>
+    public static BitFieldOffset Index(long index) => index < 0
+        ? throw new ArgumentOutOfRangeException(nameof(index), "A bitfield index cannot be negative.")
+        : new(index, true);
+
+    /// <summary>
+    /// Creates an absolute bit offset; equivalent to <see cref="Bits(long)"/>.
+    /// </summary>
+    /// <param name="offset">The offset, in bits.</param>
+    public static implicit operator BitFieldOffset(long offset) => Bits(offset);
+
+    internal RedisValue ToLiteral() => _isIndex
+        ? (RedisValue)("#" + _value.ToString(CultureInfo.InvariantCulture))
+        : (RedisValue)_value;
+
+    /// <inheritdoc/>
+    public override string ToString() => _isIndex
+        ? "#" + _value.ToString(CultureInfo.InvariantCulture)
+        : _value.ToString(CultureInfo.InvariantCulture);
+
+    /// <inheritdoc/>
+    public bool Equals(BitFieldOffset other) => _value == other._value && _isIndex == other._isIndex;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is BitFieldOffset other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => _isIndex ? ~_value.GetHashCode() : _value.GetHashCode();
+
+    /// <summary>Compares two values for equality.</summary>
+    public static bool operator ==(BitFieldOffset x, BitFieldOffset y) => x.Equals(y);
+
+    /// <summary>Compares two values for non-equality.</summary>
+    public static bool operator !=(BitFieldOffset x, BitFieldOffset y) => !x.Equals(y);
+}

--- a/src/StackExchange.Redis/BitFieldOffset.cs
+++ b/src/StackExchange.Redis/BitFieldOffset.cs
@@ -4,62 +4,64 @@ using System.Globalization;
 namespace StackExchange.Redis;
 
 /// <summary>
-/// Where a bitfield sits inside a string: either an absolute bit offset, or - via
-/// <see cref="Index(long)"/> - a zero-based index into an array of consecutive fields of the same
-/// width, which the server multiplies out for us (the <c>#</c> form).
+/// Where a bitfield sits inside a string: either a bit position, or - via
+/// <see cref="Element(long)"/> - the position of one element in an array of consecutive fields of
+/// the same width, which the server multiplies out for us (the <c>#</c> form).
 /// </summary>
 /// <remarks><seealso href="https://redis.io/commands/bitfield"/></remarks>
 public readonly struct BitFieldOffset : IEquatable<BitFieldOffset>
 {
     private readonly long _value;
-    private readonly bool _isIndex;
+    private readonly bool _isElement;
 
     private BitFieldOffset(long value, bool isIndex)
     {
         _value = value;
-        _isIndex = isIndex;
+        _isElement = isIndex;
     }
 
     /// <summary>
-    /// An absolute offset, in bits, from the start of the string.
+    /// The zero-based bit position, counted from the start of the string; <c>Bit(16)</c> is the
+    /// seventeenth bit.
     /// </summary>
-    /// <param name="offset">The offset, in bits.</param>
-    public static BitFieldOffset Bits(long offset) => offset < 0
-        ? throw new ArgumentOutOfRangeException(nameof(offset), "A bitfield offset cannot be negative.")
-        : new(offset, false);
+    /// <param name="bit">The bit position.</param>
+    public static BitFieldOffset Bit(long bit) => bit < 0
+        ? throw new ArgumentOutOfRangeException(nameof(bit), "A bitfield bit position cannot be negative.")
+        : new(bit, false);
 
     /// <summary>
-    /// A zero-based index into an array of consecutive fields of the encoding's own width; the
-    /// server multiplies the index by the width, so <c>Index(2)</c> of a <c>u8</c> is bit 16.
+    /// The zero-based position of one element in an array of consecutive fields of the encoding's
+    /// own width; the server multiplies it by the width, so <c>Element(2)</c> of a <c>u8</c> is
+    /// bit 16.
     /// </summary>
-    /// <param name="index">The index of the field.</param>
-    public static BitFieldOffset Index(long index) => index < 0
-        ? throw new ArgumentOutOfRangeException(nameof(index), "A bitfield index cannot be negative.")
-        : new(index, true);
+    /// <param name="element">The element position.</param>
+    public static BitFieldOffset Element(long element) => element < 0
+        ? throw new ArgumentOutOfRangeException(nameof(element), "A bitfield element position cannot be negative.")
+        : new(element, true);
 
     /// <summary>
-    /// Creates an absolute bit offset; equivalent to <see cref="Bits(long)"/>.
+    /// Creates a bit position; equivalent to <see cref="Bit(long)"/>.
     /// </summary>
-    /// <param name="offset">The offset, in bits.</param>
-    public static implicit operator BitFieldOffset(long offset) => Bits(offset);
+    /// <param name="bit">The bit position.</param>
+    public static implicit operator BitFieldOffset(long bit) => Bit(bit);
 
-    internal RedisValue ToLiteral() => _isIndex
+    internal RedisValue ToLiteral() => _isElement
         ? (RedisValue)("#" + _value.ToString(CultureInfo.InvariantCulture))
         : (RedisValue)_value;
 
     /// <inheritdoc/>
-    public override string ToString() => _isIndex
+    public override string ToString() => _isElement
         ? "#" + _value.ToString(CultureInfo.InvariantCulture)
         : _value.ToString(CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
-    public bool Equals(BitFieldOffset other) => _value == other._value && _isIndex == other._isIndex;
+    public bool Equals(BitFieldOffset other) => _value == other._value && _isElement == other._isElement;
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is BitFieldOffset other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => _isIndex ? ~_value.GetHashCode() : _value.GetHashCode();
+    public override int GetHashCode() => _isElement ? ~_value.GetHashCode() : _value.GetHashCode();
 
     /// <summary>Compares two values for equality.</summary>
     public static bool operator ==(BitFieldOffset x, BitFieldOffset y) => x.Equals(y);

--- a/src/StackExchange.Redis/BitFieldOperation.Message.cs
+++ b/src/StackExchange.Redis/BitFieldOperation.Message.cs
@@ -1,0 +1,149 @@
+﻿using System;
+
+namespace StackExchange.Redis;
+
+internal partial class RedisDatabase
+{
+    /// <summary>
+    /// <c>BITFIELD</c>/<c>BITFIELD_RO</c>: the key, then one clause per operation.
+    /// </summary>
+    /// <remarks>
+    /// The <c>OVERFLOW</c> token is sticky server-side, and is neither reset nor consumed by a
+    /// <c>GET</c>, so it is written only when the required mode changes - and never for a leading run
+    /// of <see cref="BitFieldOverflow.Wrap"/>, which is the server's own default.
+    /// </remarks>
+    internal abstract class BitFieldMessageBase : Message.CommandKeyBase
+    {
+        protected BitFieldMessageBase(int db, CommandFlags flags, RedisCommand command, in RedisKey key)
+            : base(db, flags, command, key)
+        {
+        }
+
+        /// <summary>
+        /// Counts the arguments needed by a set of operations, including the key, and rejects anything
+        /// that cannot be written - while we can still throw at the caller rather than mid-write.
+        /// </summary>
+        protected static int CountArgs(ReadOnlySpan<BitFieldOperation> operations, string paramName)
+        {
+            int count = 1; // the key
+            var overflow = BitFieldOverflow.Wrap;
+            foreach (ref readonly var op in operations)
+            {
+                switch (op.Kind)
+                {
+                    case BitFieldOperation.OperationKind.Get:
+                        count += 3; // GET, encoding, offset
+                        break;
+                    case BitFieldOperation.OperationKind.Set:
+                    case BitFieldOperation.OperationKind.IncrementBy:
+                        if (op.Overflow != overflow)
+                        {
+                            overflow = op.Overflow;
+                            count += 2; // OVERFLOW, mode
+                        }
+
+                        count += 4; // SET/INCRBY, encoding, offset, value
+                        break;
+                    default:
+                        throw new ArgumentException($"A default {nameof(BitFieldOperation)} is not a valid operation.", paramName);
+                }
+            }
+
+            return count;
+        }
+
+        protected static void WriteOperations(in MessageWriter writer, ReadOnlySpan<BitFieldOperation> operations)
+        {
+            // enough for the widest thing either part writes: a framed encoding ("$3\r\ni64\r\n", 9) or
+            // an element offset payload ('#' plus an int64, 21)
+            Span<byte> scratch = stackalloc byte[Format.MaxInt64TextLen + 1];
+            var overflow = BitFieldOverflow.Wrap;
+            foreach (ref readonly var op in operations)
+            {
+                if (op.Kind != BitFieldOperation.OperationKind.Get && op.Overflow != overflow)
+                {
+                    overflow = op.Overflow;
+                    writer.WriteRaw("$8\r\nOVERFLOW\r\n"u8);
+                    switch (overflow)
+                    {
+                        case BitFieldOverflow.Saturate:
+                            writer.WriteRaw("$3\r\nSAT\r\n"u8);
+                            break;
+                        case BitFieldOverflow.Fail:
+                            writer.WriteRaw("$4\r\nFAIL\r\n"u8);
+                            break;
+                        default:
+                            writer.WriteRaw("$4\r\nWRAP\r\n"u8);
+                            break;
+                    }
+                }
+
+                switch (op.Kind)
+                {
+                    case BitFieldOperation.OperationKind.Get:
+                        writer.WriteRaw("$3\r\nGET\r\n"u8);
+                        break;
+                    case BitFieldOperation.OperationKind.Set:
+                        writer.WriteRaw("$3\r\nSET\r\n"u8);
+                        break;
+                    default:
+                        writer.WriteRaw("$6\r\nINCRBY\r\n"u8);
+                        break;
+                }
+
+                op.Encoding.Write(in writer, scratch);
+                op.Offset.Write(in writer, scratch);
+                if (op.Kind != BitFieldOperation.OperationKind.Get)
+                {
+                    writer.WriteBulkString(op.Value);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="BitFieldMessageBase"/>
+    internal sealed class BitFieldMessage : BitFieldMessageBase
+    {
+        private readonly ReadOnlyMemory<BitFieldOperation> _operations;
+        private readonly int _argCount;
+
+        public BitFieldMessage(int db, CommandFlags flags, RedisCommand command, in RedisKey key, ReadOnlyMemory<BitFieldOperation> operations)
+            : base(db, flags, command, key)
+        {
+            _operations = operations;
+            _argCount = CountArgs(operations.Span, nameof(operations));
+        }
+
+        protected override void WriteImpl(in MessageWriter writer)
+        {
+            writer.WriteHeader(Command, _argCount);
+            writer.Write(Key);
+            WriteOperations(in writer, _operations.Span);
+        }
+
+        public override int ArgCount => _argCount;
+    }
+
+    /// <inheritdoc cref="BitFieldMessageBase"/>
+    internal sealed class BitFieldSingleMessage : BitFieldMessageBase
+    {
+        private readonly BitFieldOperation _operation;
+        private readonly int _argCount;
+
+        public BitFieldSingleMessage(int db, CommandFlags flags, RedisCommand command, in RedisKey key, in BitFieldOperation operation)
+            : base(db, flags, command, key)
+        {
+            _operation = operation;
+            _argCount = CountArgs([operation], nameof(operation));
+        }
+
+        protected override void WriteImpl(in MessageWriter writer)
+        {
+            writer.WriteHeader(Command, _argCount);
+            writer.Write(Key);
+            WriteOperations(in writer, [_operation]);
+        }
+
+        public override int ArgCount => _argCount;
+    }
+}

--- a/src/StackExchange.Redis/BitFieldOperation.Message.cs
+++ b/src/StackExchange.Redis/BitFieldOperation.Message.cs
@@ -20,12 +20,12 @@ internal partial class RedisDatabase
         }
 
         /// <summary>
-        /// Counts the arguments needed by a set of operations, including the key, and rejects anything
-        /// that cannot be written - while we can still throw at the caller rather than mid-write.
+        /// Counts the arguments needed by a set of operations, including the key; <see langword="false"/>
+        /// if any of them cannot be written.
         /// </summary>
-        protected static int CountArgs(ReadOnlySpan<BitFieldOperation> operations, string paramName)
+        protected static bool TryCountArgs(ReadOnlySpan<BitFieldOperation> operations, out int count)
         {
-            int count = 1; // the key
+            count = 1; // the key
             var overflow = BitFieldOverflow.Wrap;
             foreach (ref readonly var op in operations)
             {
@@ -45,12 +45,21 @@ internal partial class RedisDatabase
                         count += 4; // SET/INCRBY, encoding, offset, value
                         break;
                     default:
-                        throw new ArgumentException($"A default {nameof(BitFieldOperation)} is not a valid operation.", paramName);
+                        return false;
                 }
             }
 
-            return count;
+            return true;
         }
+
+        /// <summary>
+        /// Counts the arguments, throwing at the caller - rather than mid-write - if the operations
+        /// cannot be written.
+        /// </summary>
+        protected static int CountArgs(ReadOnlySpan<BitFieldOperation> operations, string paramName) =>
+            TryCountArgs(operations, out var count)
+                ? count
+                : throw new ArgumentException($"A default {nameof(BitFieldOperation)} is not a valid operation.", paramName);
 
         protected static void WriteOperations(in MessageWriter writer, ReadOnlySpan<BitFieldOperation> operations)
         {
@@ -73,6 +82,8 @@ internal partial class RedisDatabase
                             writer.WriteRaw("$4\r\nFAIL\r\n"u8);
                             break;
                         default:
+                            // shape-neutral (the count comes from the transition, not the mode), so
+                            // the server's own default is the safe answer here
                             writer.WriteRaw("$4\r\nWRAP\r\n"u8);
                             break;
                     }
@@ -86,9 +97,14 @@ internal partial class RedisDatabase
                     case BitFieldOperation.OperationKind.Set:
                         writer.WriteRaw("$3\r\nSET\r\n"u8);
                         break;
-                    default:
+                    case BitFieldOperation.OperationKind.IncrementBy:
                         writer.WriteRaw("$6\r\nINCRBY\r\n"u8);
                         break;
+                    default:
+                        // unreachable: the callers check the operations before writing the header.
+                        // Guessing here would be worse than failing - a wrong sub-command corrupts
+                        // data, and one of the wrong arity corrupts the connection
+                        throw new InvalidOperationException($"A default {nameof(BitFieldOperation)} is not a valid operation.");
                 }
 
                 op.Encoding.Write(in writer, scratch);
@@ -116,9 +132,19 @@ internal partial class RedisDatabase
 
         protected override void WriteImpl(in MessageWriter writer)
         {
+            // we alias the caller's memory rather than copying it, and here - unlike the messages that
+            // hold a RedisValue[] - the *shape* depends on the contents, so a mutation between issue
+            // and write would desync the frame. Re-check before the header goes out, so that a
+            // violated contract fails with nothing written rather than corrupting the connection
+            var operations = _operations.Span;
+            if (!TryCountArgs(operations, out var count) || count != _argCount)
+            {
+                throw new InvalidOperationException($"The {nameof(BitFieldOperation)} values were modified after the command was issued.");
+            }
+
             writer.WriteHeader(Command, _argCount);
             writer.Write(Key);
-            WriteOperations(in writer, _operations.Span);
+            WriteOperations(in writer, operations);
         }
 
         public override int ArgCount => _argCount;

--- a/src/StackExchange.Redis/BitFieldOperation.Message.cs
+++ b/src/StackExchange.Redis/BitFieldOperation.Message.cs
@@ -20,8 +20,34 @@ internal partial class RedisDatabase
         }
 
         /// <summary>
-        /// Counts the arguments needed by a set of operations, including the key; <see langword="false"/>
-        /// if any of them cannot be written.
+        /// Accumulates the arguments needed by one operation, tracking the sticky overflow mode;
+        /// <see langword="false"/> if it cannot be written.
+        /// </summary>
+        protected static bool TryCountArgs(in BitFieldOperation operation, ref BitFieldOverflow overflow, ref int count)
+        {
+            switch (operation.Kind)
+            {
+                case BitFieldOperation.OperationKind.Get:
+                    count += 3; // GET, encoding, offset
+                    return true;
+                case BitFieldOperation.OperationKind.Set:
+                case BitFieldOperation.OperationKind.IncrementBy:
+                    if (operation.Overflow != overflow)
+                    {
+                        overflow = operation.Overflow;
+                        count += 2; // OVERFLOW, mode
+                    }
+
+                    count += 4; // SET/INCRBY, encoding, offset, value
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Counts the arguments needed by a set of operations, including the key;
+        /// <see langword="false"/> if any of them cannot be written.
         /// </summary>
         protected static bool TryCountArgs(ReadOnlySpan<BitFieldOperation> operations, out int count)
         {
@@ -29,24 +55,7 @@ internal partial class RedisDatabase
             var overflow = BitFieldOverflow.Wrap;
             foreach (ref readonly var op in operations)
             {
-                switch (op.Kind)
-                {
-                    case BitFieldOperation.OperationKind.Get:
-                        count += 3; // GET, encoding, offset
-                        break;
-                    case BitFieldOperation.OperationKind.Set:
-                    case BitFieldOperation.OperationKind.IncrementBy:
-                        if (op.Overflow != overflow)
-                        {
-                            overflow = op.Overflow;
-                            count += 2; // OVERFLOW, mode
-                        }
-
-                        count += 4; // SET/INCRBY, encoding, offset, value
-                        break;
-                    default:
-                        return false;
-                }
+                if (!TryCountArgs(in op, ref overflow, ref count)) return false;
             }
 
             return true;
@@ -57,9 +66,10 @@ internal partial class RedisDatabase
         /// cannot be written.
         /// </summary>
         protected static int CountArgs(ReadOnlySpan<BitFieldOperation> operations, string paramName) =>
-            TryCountArgs(operations, out var count)
-                ? count
-                : throw new ArgumentException($"A default {nameof(BitFieldOperation)} is not a valid operation.", paramName);
+            TryCountArgs(operations, out var count) ? count : throw InvalidOperation(paramName);
+
+        protected static ArgumentException InvalidOperation(string paramName) =>
+            new($"A default {nameof(BitFieldOperation)} is not a valid operation.", paramName);
 
         protected static void WriteOperations(in MessageWriter writer, ReadOnlySpan<BitFieldOperation> operations)
         {
@@ -69,50 +79,58 @@ internal partial class RedisDatabase
             var overflow = BitFieldOverflow.Wrap;
             foreach (ref readonly var op in operations)
             {
-                if (op.Kind != BitFieldOperation.OperationKind.Get && op.Overflow != overflow)
-                {
-                    overflow = op.Overflow;
-                    writer.WriteRaw("$8\r\nOVERFLOW\r\n"u8);
-                    switch (overflow)
-                    {
-                        case BitFieldOverflow.Saturate:
-                            writer.WriteRaw("$3\r\nSAT\r\n"u8);
-                            break;
-                        case BitFieldOverflow.Fail:
-                            writer.WriteRaw("$4\r\nFAIL\r\n"u8);
-                            break;
-                        default:
-                            // shape-neutral (the count comes from the transition, not the mode), so
-                            // the server's own default is the safe answer here
-                            writer.WriteRaw("$4\r\nWRAP\r\n"u8);
-                            break;
-                    }
-                }
+                WriteOperation(in writer, in op, ref overflow, scratch);
+            }
+        }
 
-                switch (op.Kind)
+        /// <summary>
+        /// Writes one operation, emitting the <c>OVERFLOW</c> token only when the sticky mode changes.
+        /// </summary>
+        protected static void WriteOperation(in MessageWriter writer, in BitFieldOperation operation, ref BitFieldOverflow overflow, Span<byte> scratch)
+        {
+            if (operation.Kind != BitFieldOperation.OperationKind.Get && operation.Overflow != overflow)
+            {
+                overflow = operation.Overflow;
+                writer.WriteRaw("$8\r\nOVERFLOW\r\n"u8);
+                switch (overflow)
                 {
-                    case BitFieldOperation.OperationKind.Get:
-                        writer.WriteRaw("$3\r\nGET\r\n"u8);
+                    case BitFieldOverflow.Saturate:
+                        writer.WriteRaw("$3\r\nSAT\r\n"u8);
                         break;
-                    case BitFieldOperation.OperationKind.Set:
-                        writer.WriteRaw("$3\r\nSET\r\n"u8);
-                        break;
-                    case BitFieldOperation.OperationKind.IncrementBy:
-                        writer.WriteRaw("$6\r\nINCRBY\r\n"u8);
+                    case BitFieldOverflow.Fail:
+                        writer.WriteRaw("$4\r\nFAIL\r\n"u8);
                         break;
                     default:
-                        // unreachable: the callers check the operations before writing the header.
-                        // Guessing here would be worse than failing - a wrong sub-command corrupts
-                        // data, and one of the wrong arity corrupts the connection
-                        throw new InvalidOperationException($"A default {nameof(BitFieldOperation)} is not a valid operation.");
+                        // shape-neutral (the count comes from the transition, not the mode), so
+                        // the server's own default is the safe answer here
+                        writer.WriteRaw("$4\r\nWRAP\r\n"u8);
+                        break;
                 }
+            }
 
-                op.Encoding.Write(in writer, scratch);
-                op.Offset.Write(in writer, scratch);
-                if (op.Kind != BitFieldOperation.OperationKind.Get)
-                {
-                    writer.WriteBulkString(op.Value);
-                }
+            switch (operation.Kind)
+            {
+                case BitFieldOperation.OperationKind.Get:
+                    writer.WriteRaw("$3\r\nGET\r\n"u8);
+                    break;
+                case BitFieldOperation.OperationKind.Set:
+                    writer.WriteRaw("$3\r\nSET\r\n"u8);
+                    break;
+                case BitFieldOperation.OperationKind.IncrementBy:
+                    writer.WriteRaw("$6\r\nINCRBY\r\n"u8);
+                    break;
+                default:
+                    // unreachable: the callers check the operations before writing the header.
+                    // Guessing here would be worse than failing - a wrong sub-command corrupts
+                    // data, and one of the wrong arity corrupts the connection
+                    throw new InvalidOperationException($"A default {nameof(BitFieldOperation)} is not a valid operation.");
+            }
+
+            operation.Encoding.Write(in writer, scratch);
+            operation.Offset.Write(in writer, scratch);
+            if (operation.Kind != BitFieldOperation.OperationKind.Get)
+            {
+                writer.WriteBulkString(operation.Value);
             }
         }
     }
@@ -135,7 +153,9 @@ internal partial class RedisDatabase
             // we alias the caller's memory rather than copying it, and here - unlike the messages that
             // hold a RedisValue[] - the *shape* depends on the contents, so a mutation between issue
             // and write would desync the frame. Re-check before the header goes out, so that a
-            // violated contract fails with nothing written rather than corrupting the connection
+            // violated contract fails with nothing written rather than corrupting the connection.
+            // Note this becomes redundant once the write path serializes on the calling thread: with
+            // no deferral there is no interval in which reasonable code could mutate the operations
             var operations = _operations.Span;
             if (!TryCountArgs(operations, out var count) || count != _argCount)
             {
@@ -160,14 +180,23 @@ internal partial class RedisDatabase
             : base(db, flags, command, key)
         {
             _operation = operation;
-            _argCount = CountArgs([operation], nameof(operation));
+
+            // deliberately not `[operation]`: a collection expression of one element compiles to a
+            // heap array on the target frameworks without the by-ref span constructor, which would
+            // undo the point of holding the operation inline
+            _argCount = 1; // the key
+            var overflow = BitFieldOverflow.Wrap;
+            if (!TryCountArgs(in operation, ref overflow, ref _argCount)) throw InvalidOperation(nameof(operation));
         }
 
         protected override void WriteImpl(in MessageWriter writer)
         {
             writer.WriteHeader(Command, _argCount);
             writer.Write(Key);
-            WriteOperations(in writer, [_operation]);
+
+            Span<byte> scratch = stackalloc byte[Format.MaxInt64TextLen + 1];
+            var overflow = BitFieldOverflow.Wrap;
+            WriteOperation(in writer, in _operation, ref overflow, scratch);
         }
 
         public override int ArgCount => _argCount;

--- a/src/StackExchange.Redis/BitFieldOperation.cs
+++ b/src/StackExchange.Redis/BitFieldOperation.cs
@@ -1,0 +1,122 @@
+﻿using System;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// A single <c>BITFIELD</c> sub-operation; see <see cref="Get"/>, <see cref="Set"/> and
+/// <see cref="IncrementBy"/>.
+/// </summary>
+/// <remarks><seealso href="https://redis.io/commands/bitfield"/></remarks>
+public readonly struct BitFieldOperation : IEquatable<BitFieldOperation>
+{
+    internal enum OperationKind : byte
+    {
+        None = 0,
+        Get,
+        Set,
+        IncrementBy,
+    }
+
+    private readonly BitFieldOffset _offset;
+    private readonly BitFieldEncoding _encoding;
+    private readonly long _value;
+    private readonly BitFieldOverflow _overflow;
+    private readonly OperationKind _kind;
+
+    private BitFieldOperation(OperationKind kind, BitFieldEncoding encoding, BitFieldOffset offset, long value, BitFieldOverflow overflow)
+    {
+        if (encoding.IsDefault)
+        {
+            throw new ArgumentException(
+                $"A {nameof(BitFieldEncoding)} must be created via {nameof(BitFieldEncoding)}.{nameof(BitFieldEncoding.Signed)}, {nameof(BitFieldEncoding.Unsigned)}, or one of the named encodings.",
+                nameof(encoding));
+        }
+        if (overflow is < BitFieldOverflow.Wrap or > BitFieldOverflow.Fail)
+        {
+            throw new ArgumentOutOfRangeException(nameof(overflow));
+        }
+
+        _kind = kind;
+        _encoding = encoding;
+        _offset = offset;
+        _value = value;
+        _overflow = overflow;
+    }
+
+    /// <summary>
+    /// Reads the field at <paramref name="offset"/>. A field that lies beyond the end of the string
+    /// reads as zero, and no <see cref="BitFieldOverflow"/> applies.
+    /// </summary>
+    /// <param name="encoding">The width and signedness of the field.</param>
+    /// <param name="offset">The location of the field.</param>
+    public static BitFieldOperation Get(BitFieldEncoding encoding, BitFieldOffset offset) =>
+        new(OperationKind.Get, encoding, offset, 0, BitFieldOverflow.Wrap);
+
+    /// <summary>
+    /// Writes <paramref name="value"/> to the field at <paramref name="offset"/>, returning the
+    /// previous value; the string is zero-extended as needed.
+    /// </summary>
+    /// <param name="encoding">The width and signedness of the field.</param>
+    /// <param name="offset">The location of the field.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="overflow">How to handle a value that does not fit the encoding.</param>
+    public static BitFieldOperation Set(BitFieldEncoding encoding, BitFieldOffset offset, long value, BitFieldOverflow overflow = BitFieldOverflow.Wrap) =>
+        new(OperationKind.Set, encoding, offset, value, overflow);
+
+    /// <summary>
+    /// Increments the field at <paramref name="offset"/> by <paramref name="value"/> (which may be
+    /// negative), returning the new value; the string is zero-extended as needed.
+    /// </summary>
+    /// <param name="encoding">The width and signedness of the field.</param>
+    /// <param name="offset">The location of the field.</param>
+    /// <param name="value">The amount to increment by.</param>
+    /// <param name="overflow">How to handle an increment that does not fit the encoding.</param>
+    public static BitFieldOperation IncrementBy(BitFieldEncoding encoding, BitFieldOffset offset, long value, BitFieldOverflow overflow = BitFieldOverflow.Wrap) =>
+        new(OperationKind.IncrementBy, encoding, offset, value, overflow);
+
+    internal OperationKind Kind => _kind;
+
+    internal BitFieldEncoding Encoding => _encoding;
+
+    internal BitFieldOffset Offset => _offset;
+
+    internal long Value => _value;
+
+    /// <summary>
+    /// The overflow behavior of this operation; <see cref="BitFieldOverflow.Wrap"/> for a
+    /// <see cref="Get"/>, which cannot overflow.
+    /// </summary>
+    internal BitFieldOverflow Overflow => _overflow;
+
+    /// <inheritdoc/>
+    public override string ToString() => _kind switch
+    {
+        OperationKind.Get => $"GET {_encoding} {_offset}",
+        OperationKind.Set => $"SET {_encoding} {_offset} {_value} ({_overflow})",
+        OperationKind.IncrementBy => $"INCRBY {_encoding} {_offset} {_value} ({_overflow})",
+        _ => "(default)",
+    };
+
+    /// <inheritdoc/>
+    public bool Equals(BitFieldOperation other) =>
+        _kind == other._kind && _encoding == other._encoding && _offset == other._offset
+        && _value == other._value && _overflow == other._overflow;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is BitFieldOperation other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = ((int)_kind * 397) ^ ((int)_overflow * 31);
+        hash = (hash * 397) ^ _encoding.GetHashCode();
+        hash = (hash * 397) ^ _offset.GetHashCode();
+        return (hash * 397) ^ _value.GetHashCode();
+    }
+
+    /// <summary>Compares two values for equality.</summary>
+    public static bool operator ==(BitFieldOperation x, BitFieldOperation y) => x.Equals(y);
+
+    /// <summary>Compares two values for non-equality.</summary>
+    public static bool operator !=(BitFieldOperation x, BitFieldOperation y) => !x.Equals(y);
+}

--- a/src/StackExchange.Redis/Enums/BitFieldOverflow.cs
+++ b/src/StackExchange.Redis/Enums/BitFieldOverflow.cs
@@ -1,0 +1,24 @@
+﻿namespace StackExchange.Redis;
+
+/// <summary>
+/// How <c>BITFIELD</c> should behave when a <c>SET</c> or <c>INCRBY</c> operation would exceed the
+/// range of the target <see cref="BitFieldEncoding"/>.
+/// </summary>
+/// <remarks><seealso href="https://redis.io/commands/bitfield"/></remarks>
+public enum BitFieldOverflow
+{
+    /// <summary>
+    /// Wrap around, using the usual two's-complement arithmetic; this is the server default.
+    /// </summary>
+    Wrap,
+
+    /// <summary>
+    /// Saturate at the minimum or maximum value of the encoding.
+    /// </summary>
+    Saturate,
+
+    /// <summary>
+    /// Perform no operation at all, reporting no value for the failed operation.
+    /// </summary>
+    Fail,
+}

--- a/src/StackExchange.Redis/Enums/CommandFlags.Category.cs
+++ b/src/StackExchange.Redis/Enums/CommandFlags.Category.cs
@@ -1,4 +1,4 @@
-namespace StackExchange.Redis;
+﻿namespace StackExchange.Redis;
 
 internal static class CommandFlagsExtensions
 {
@@ -159,6 +159,7 @@ internal static class CommandFlagsExtensions
                 case RedisCommand.ZUNION:
                 case RedisCommand.ZINTERCARD:
                 case RedisCommand.BITCOUNT:
+                case RedisCommand.BITFIELD_RO:
                 case RedisCommand.BITPOS:
                 case RedisCommand.GETBIT:
                 case RedisCommand.PFCOUNT:
@@ -287,6 +288,7 @@ internal static class CommandFlagsExtensions
                 case RedisCommand.ZMPOP:
                 case RedisCommand.XADD: // explicit ids and IDMP/IDMPAUTO are demoted where we can see the args
                 case RedisCommand.PFMERGE: // destination accumulates union each call
+                case RedisCommand.BITFIELD: // INCRBY sub-ops compound; demoted to last-wins when the payload has none
                     return CommandFlags.CommandRetryWriteAccumulating;
 
                 // ==========================================================================

--- a/src/StackExchange.Redis/Enums/RedisCommand.cs
+++ b/src/StackExchange.Redis/Enums/RedisCommand.cs
@@ -35,6 +35,10 @@ internal enum RedisCommand
     BGREWRITEAOF,
     BGSAVE,
     BITCOUNT,
+    [AsciiHash("BITFIELD")]
+    BITFIELD,
+    [AsciiHash("BITFIELD_RO")]
+    BITFIELD_RO,
     BITOP,
     BITPOS,
     BLPOP,
@@ -346,6 +350,7 @@ internal static class RedisCommandExtensions
             case RedisCommand.ARRING:
             case RedisCommand.ARSEEK:
             case RedisCommand.ARSET:
+            case RedisCommand.BITFIELD:
             case RedisCommand.BITOP:
             case RedisCommand.BLPOP:
             case RedisCommand.BRPOP:
@@ -462,6 +467,7 @@ internal static class RedisCommandExtensions
             case RedisCommand.BGREWRITEAOF:
             case RedisCommand.BGSAVE:
             case RedisCommand.BITCOUNT:
+            case RedisCommand.BITFIELD_RO:
             case RedisCommand.BITPOS:
             case RedisCommand.CLIENT:
             case RedisCommand.CLUSTER:

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -3352,6 +3352,46 @@ namespace StackExchange.Redis
         long StringBitCount(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Performs a single arbitrary-width integer operation on the string at <paramref name="key"/>,
+        /// treating it as an array of bitfields.
+        /// </summary>
+        /// <param name="key">The key of the string.</param>
+        /// <param name="operation">The operation to perform.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>
+        /// The value read (for <see cref="BitFieldOperation.Get"/>), the previous value (for
+        /// <see cref="BitFieldOperation.Set"/>) or the new value (for
+        /// <see cref="BitFieldOperation.IncrementBy"/>); <see langword="null"/> if the operation was
+        /// skipped because of <see cref="BitFieldOverflow.Fail"/>.
+        /// </returns>
+        /// <remarks><seealso href="https://redis.io/commands/bitfield"/></remarks>
+#pragma warning disable RS0026 // competing overloads - disambiguated via parameter types
+        long? StringBitField(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
+        /// Performs a batch of arbitrary-width integer operations on the string at <paramref name="key"/>,
+        /// treating it as an array of bitfields. The operations are applied in order, and the result has
+        /// one element per operation.
+        /// </summary>
+        /// <param name="key">The key of the string.</param>
+        /// <param name="operations">The operations to perform; an empty batch is a no-op.</param>
+        /// <param name="flags">The flags to use for this operation.</param>
+        /// <returns>
+        /// One element per operation, in order; an element is <see langword="null"/> if that operation was
+        /// skipped because of <see cref="BitFieldOverflow.Fail"/>. The caller owns the returned lease.
+        /// </returns>
+        /// <remarks>
+        /// <para><seealso href="https://redis.io/commands/bitfield"/></para>
+        /// <para>
+        /// If every operation is a <see cref="BitFieldOperation.Get"/> this is issued as <c>BITFIELD_RO</c>
+        /// where the server supports it (6.0 and above), so it can be served by a replica; otherwise it is
+        /// issued as <c>BITFIELD</c>, which the server treats as a write and will only accept on a primary.
+        /// </para>
+        /// </remarks>
+        Lease<long?>? StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
+#pragma warning restore RS0026
+
+        /// <summary>
         /// Perform a bitwise operation between multiple keys (containing string values) and store the result in the destination key.
         /// The BITOP command supports four bitwise operations; note that NOT is a unary operator: the second key should be omitted in this case
         /// and only the first key will be considered.
@@ -3392,14 +3432,24 @@ namespace StackExchange.Redis
         /// <param name="key">The key of the string.</param>
         /// <param name="bit">True to check for the first 1 bit, false to check for the first 0 bit.</param>
         /// <param name="start">The position to start looking (defaults to 0).</param>
-        /// <param name="end">The position to stop looking (defaults to -1, unlimited).</param>
+        /// <param name="end">The position to stop looking (defaults to -1, the last byte); <see cref="StringIndex.Unbounded"/> leaves the range open-ended, which is not the same thing when <paramref name="bit"/> is <c>false</c> - see the remarks.</param>
         /// <param name="indexType">In Redis 7+, we can choose if <paramref name="start"/> and <paramref name="end"/> specify a bit index or byte index (defaults to <see cref="StringIndexType.Byte"/>).</param>
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>
         /// The command returns the position of the first bit set to 1 or 0 according to the request.
         /// If we look for set bits(the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned.
         /// </returns>
-        /// <remarks><seealso href="https://redis.io/commands/bitpos"/></remarks>
+        /// <remarks>
+        /// <para><seealso href="https://redis.io/commands/bitpos"/></para>
+        /// <para>
+        /// When looking for a clear bit (<paramref name="bit"/> is <c>false</c>), the server treats an explicit
+        /// range differently from an open-ended one: with an explicit <paramref name="end"/> the search is confined
+        /// to the string, so a string of all-set bits gives -1, whereas with no end at all the result is the first
+        /// bit past the end of the string. Pass <see cref="StringIndex.Unbounded"/> as <paramref name="end"/> for
+        /// the latter; that requires <see cref="StringIndexType.Byte"/>, since the server accepts a bit/byte index
+        /// type only after an explicit end.
+        /// </para>
+        /// </remarks>
         long StringBitPosition(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None);
 
         /// <summary>

--- a/src/StackExchange.Redis/Interfaces/IDatabase.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabase.cs
@@ -3378,7 +3378,8 @@ namespace StackExchange.Redis
         /// <param name="flags">The flags to use for this operation.</param>
         /// <returns>
         /// One element per operation, in order; an element is <see langword="null"/> if that operation was
-        /// skipped because of <see cref="BitFieldOverflow.Fail"/>. The caller owns the returned lease.
+        /// skipped because of <see cref="BitFieldOverflow.Fail"/>. Empty for an empty batch, or when the
+        /// result is not observable (<see cref="CommandFlags.FireAndForget"/>). The caller owns the lease.
         /// </returns>
         /// <remarks>
         /// <para><seealso href="https://redis.io/commands/bitfield"/></para>
@@ -3388,7 +3389,7 @@ namespace StackExchange.Redis
         /// issued as <c>BITFIELD</c>, which the server treats as a write and will only accept on a primary.
         /// </para>
         /// </remarks>
-        Lease<long?>? StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
+        Lease<long?> StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
 #pragma warning restore RS0026
 
         /// <summary>

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -823,6 +823,14 @@ namespace StackExchange.Redis
         /// <inheritdoc cref="IDatabase.StringBitCount(RedisKey, long, long, StringIndexType, CommandFlags)"/>
         Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None);
 
+        /// <inheritdoc cref="IDatabase.StringBitField(RedisKey, BitFieldOperation, CommandFlags)"/>
+#pragma warning disable RS0026 // competing overloads - disambiguated via parameter types
+        Task<long?> StringBitFieldAsync(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None);
+
+        /// <inheritdoc cref="IDatabase.StringBitField(RedisKey, System.ReadOnlyMemory{BitFieldOperation}, CommandFlags)"/>
+        Task<Lease<long?>?> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
+#pragma warning restore RS0026
+
         /// <inheritdoc cref="IDatabase.StringBitOperation(Bitwise, RedisKey, RedisKey, RedisKey, CommandFlags)"/>
         Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second = default, CommandFlags flags = CommandFlags.None);
 

--- a/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
+++ b/src/StackExchange.Redis/Interfaces/IDatabaseAsync.cs
@@ -828,7 +828,7 @@ namespace StackExchange.Redis
         Task<long?> StringBitFieldAsync(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None);
 
         /// <inheritdoc cref="IDatabase.StringBitField(RedisKey, System.ReadOnlyMemory{BitFieldOperation}, CommandFlags)"/>
-        Task<Lease<long?>?> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
+        Task<Lease<long?>> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
 #pragma warning restore RS0026
 
         /// <inheritdoc cref="IDatabase.StringBitOperation(Bitwise, RedisKey, RedisKey, RedisKey, CommandFlags)"/>

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -787,7 +787,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<long?> StringBitFieldAsync(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitFieldAsync(ToInner(key), operation, flags);
 
-        public Task<Lease<long?>?> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None) =>
+        public Task<Lease<long?>> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitFieldAsync(ToInner(key), operations, flags);
 
         public Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None) =>

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -784,6 +784,12 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitCountAsync(ToInner(key), start, end, indexType, flags);
 
+        public Task<long?> StringBitFieldAsync(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None) =>
+            Inner.StringBitFieldAsync(ToInner(key), operation, flags);
+
+        public Task<Lease<long?>?> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None) =>
+            Inner.StringBitFieldAsync(ToInner(key), operations, flags);
+
         public Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitOperationAsync(operation, ToInner(destination), ToInner(keys), flags);
 

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -751,6 +751,12 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public long StringBitCount(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitCount(ToInner(key), start, end, indexType, flags);
 
+        public long? StringBitField(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None) =>
+            Inner.StringBitField(ToInner(key), operation, flags);
+
+        public Lease<long?>? StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None) =>
+            Inner.StringBitField(ToInner(key), operations, flags);
+
         public long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitOperation(operation, ToInner(destination), ToInner(keys), flags);
 

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -754,7 +754,7 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public long? StringBitField(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitField(ToInner(key), operation, flags);
 
-        public Lease<long?>? StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None) =>
+        public Lease<long?> StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None) =>
             Inner.StringBitField(ToInner(key), operations, flags);
 
         public long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None) =>

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -85,9 +85,9 @@ StackExchange.Redis.BitFieldOverflow.Fail = 2 -> StackExchange.Redis.BitFieldOve
 StackExchange.Redis.BitFieldOverflow.Saturate = 1 -> StackExchange.Redis.BitFieldOverflow
 StackExchange.Redis.BitFieldOverflow.Wrap = 0 -> StackExchange.Redis.BitFieldOverflow
 StackExchange.Redis.IDatabaseAsync.StringBitFieldAsync(StackExchange.Redis.RedisKey key, StackExchange.Redis.BitFieldOperation operation, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long?>!
-StackExchange.Redis.IDatabaseAsync.StringBitFieldAsync(StackExchange.Redis.RedisKey key, System.ReadOnlyMemory<StackExchange.Redis.BitFieldOperation> operations, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<StackExchange.Redis.Lease<long?>?>!
+StackExchange.Redis.IDatabaseAsync.StringBitFieldAsync(StackExchange.Redis.RedisKey key, System.ReadOnlyMemory<StackExchange.Redis.BitFieldOperation> operations, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<StackExchange.Redis.Lease<long?>!>!
 StackExchange.Redis.IDatabase.StringBitField(StackExchange.Redis.RedisKey key, StackExchange.Redis.BitFieldOperation operation, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long?
-StackExchange.Redis.IDatabase.StringBitField(StackExchange.Redis.RedisKey key, System.ReadOnlyMemory<StackExchange.Redis.BitFieldOperation> operations, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> StackExchange.Redis.Lease<long?>?
+StackExchange.Redis.IDatabase.StringBitField(StackExchange.Redis.RedisKey key, System.ReadOnlyMemory<StackExchange.Redis.BitFieldOperation> operations, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> StackExchange.Redis.Lease<long?>!
 StackExchange.Redis.RedisFeatures.BitFieldReadOnly.get -> bool
 static StackExchange.Redis.BitFieldEncoding.Int16.get -> StackExchange.Redis.BitFieldEncoding
 static StackExchange.Redis.BitFieldEncoding.Int32.get -> StackExchange.Redis.BitFieldEncoding

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -101,9 +101,9 @@ static StackExchange.Redis.BitFieldEncoding.UInt32.get -> StackExchange.Redis.Bi
 static StackExchange.Redis.BitFieldEncoding.UInt63.get -> StackExchange.Redis.BitFieldEncoding
 static StackExchange.Redis.BitFieldEncoding.UInt8.get -> StackExchange.Redis.BitFieldEncoding
 static StackExchange.Redis.BitFieldEncoding.Unsigned(int width) -> StackExchange.Redis.BitFieldEncoding
-static StackExchange.Redis.BitFieldOffset.Bits(long offset) -> StackExchange.Redis.BitFieldOffset
-static StackExchange.Redis.BitFieldOffset.implicit operator StackExchange.Redis.BitFieldOffset(long offset) -> StackExchange.Redis.BitFieldOffset
-static StackExchange.Redis.BitFieldOffset.Index(long index) -> StackExchange.Redis.BitFieldOffset
+static StackExchange.Redis.BitFieldOffset.Bit(long bit) -> StackExchange.Redis.BitFieldOffset
+static StackExchange.Redis.BitFieldOffset.implicit operator StackExchange.Redis.BitFieldOffset(long bit) -> StackExchange.Redis.BitFieldOffset
+static StackExchange.Redis.BitFieldOffset.Element(long element) -> StackExchange.Redis.BitFieldOffset
 static StackExchange.Redis.BitFieldOffset.operator ==(StackExchange.Redis.BitFieldOffset x, StackExchange.Redis.BitFieldOffset y) -> bool
 static StackExchange.Redis.BitFieldOffset.operator !=(StackExchange.Redis.BitFieldOffset x, StackExchange.Redis.BitFieldOffset y) -> bool
 static StackExchange.Redis.BitFieldOperation.Get(StackExchange.Redis.BitFieldEncoding encoding, StackExchange.Redis.BitFieldOffset offset) -> StackExchange.Redis.BitFieldOperation

--- a/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/StackExchange.Redis/PublicAPI/PublicAPI.Unshipped.txt
@@ -58,3 +58,56 @@ StackExchange.Redis.StreamAddOptions.MinId.init -> void
 StackExchange.Redis.StreamAddOptions.StreamAddOptions() -> void
 StackExchange.Redis.StreamAddOptions.TrimMode.get -> StackExchange.Redis.StreamTrimMode
 StackExchange.Redis.StreamAddOptions.TrimMode.init -> void
+StackExchange.Redis.StringIndex
+const StackExchange.Redis.StringIndex.Unbounded = -9223372036854775808 -> long
+override StackExchange.Redis.BitFieldEncoding.Equals(object? obj) -> bool
+override StackExchange.Redis.BitFieldEncoding.GetHashCode() -> int
+override StackExchange.Redis.BitFieldEncoding.ToString() -> string!
+override StackExchange.Redis.BitFieldOffset.Equals(object? obj) -> bool
+override StackExchange.Redis.BitFieldOffset.GetHashCode() -> int
+override StackExchange.Redis.BitFieldOffset.ToString() -> string!
+override StackExchange.Redis.BitFieldOperation.Equals(object? obj) -> bool
+override StackExchange.Redis.BitFieldOperation.GetHashCode() -> int
+override StackExchange.Redis.BitFieldOperation.ToString() -> string!
+StackExchange.Redis.BitFieldEncoding
+StackExchange.Redis.BitFieldEncoding.BitFieldEncoding() -> void
+StackExchange.Redis.BitFieldEncoding.Equals(StackExchange.Redis.BitFieldEncoding other) -> bool
+StackExchange.Redis.BitFieldEncoding.IsSigned.get -> bool
+StackExchange.Redis.BitFieldEncoding.Width.get -> int
+StackExchange.Redis.BitFieldOffset
+StackExchange.Redis.BitFieldOffset.BitFieldOffset() -> void
+StackExchange.Redis.BitFieldOffset.Equals(StackExchange.Redis.BitFieldOffset other) -> bool
+StackExchange.Redis.BitFieldOperation
+StackExchange.Redis.BitFieldOperation.BitFieldOperation() -> void
+StackExchange.Redis.BitFieldOperation.Equals(StackExchange.Redis.BitFieldOperation other) -> bool
+StackExchange.Redis.BitFieldOverflow
+StackExchange.Redis.BitFieldOverflow.Fail = 2 -> StackExchange.Redis.BitFieldOverflow
+StackExchange.Redis.BitFieldOverflow.Saturate = 1 -> StackExchange.Redis.BitFieldOverflow
+StackExchange.Redis.BitFieldOverflow.Wrap = 0 -> StackExchange.Redis.BitFieldOverflow
+StackExchange.Redis.IDatabaseAsync.StringBitFieldAsync(StackExchange.Redis.RedisKey key, StackExchange.Redis.BitFieldOperation operation, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<long?>!
+StackExchange.Redis.IDatabaseAsync.StringBitFieldAsync(StackExchange.Redis.RedisKey key, System.ReadOnlyMemory<StackExchange.Redis.BitFieldOperation> operations, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> System.Threading.Tasks.Task<StackExchange.Redis.Lease<long?>?>!
+StackExchange.Redis.IDatabase.StringBitField(StackExchange.Redis.RedisKey key, StackExchange.Redis.BitFieldOperation operation, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> long?
+StackExchange.Redis.IDatabase.StringBitField(StackExchange.Redis.RedisKey key, System.ReadOnlyMemory<StackExchange.Redis.BitFieldOperation> operations, StackExchange.Redis.CommandFlags flags = StackExchange.Redis.CommandFlags.None) -> StackExchange.Redis.Lease<long?>?
+StackExchange.Redis.RedisFeatures.BitFieldReadOnly.get -> bool
+static StackExchange.Redis.BitFieldEncoding.Int16.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.Int32.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.Int64.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.Int8.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.operator ==(StackExchange.Redis.BitFieldEncoding x, StackExchange.Redis.BitFieldEncoding y) -> bool
+static StackExchange.Redis.BitFieldEncoding.operator !=(StackExchange.Redis.BitFieldEncoding x, StackExchange.Redis.BitFieldEncoding y) -> bool
+static StackExchange.Redis.BitFieldEncoding.Signed(int width) -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.UInt16.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.UInt32.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.UInt63.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.UInt8.get -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldEncoding.Unsigned(int width) -> StackExchange.Redis.BitFieldEncoding
+static StackExchange.Redis.BitFieldOffset.Bits(long offset) -> StackExchange.Redis.BitFieldOffset
+static StackExchange.Redis.BitFieldOffset.implicit operator StackExchange.Redis.BitFieldOffset(long offset) -> StackExchange.Redis.BitFieldOffset
+static StackExchange.Redis.BitFieldOffset.Index(long index) -> StackExchange.Redis.BitFieldOffset
+static StackExchange.Redis.BitFieldOffset.operator ==(StackExchange.Redis.BitFieldOffset x, StackExchange.Redis.BitFieldOffset y) -> bool
+static StackExchange.Redis.BitFieldOffset.operator !=(StackExchange.Redis.BitFieldOffset x, StackExchange.Redis.BitFieldOffset y) -> bool
+static StackExchange.Redis.BitFieldOperation.Get(StackExchange.Redis.BitFieldEncoding encoding, StackExchange.Redis.BitFieldOffset offset) -> StackExchange.Redis.BitFieldOperation
+static StackExchange.Redis.BitFieldOperation.IncrementBy(StackExchange.Redis.BitFieldEncoding encoding, StackExchange.Redis.BitFieldOffset offset, long value, StackExchange.Redis.BitFieldOverflow overflow = StackExchange.Redis.BitFieldOverflow.Wrap) -> StackExchange.Redis.BitFieldOperation
+static StackExchange.Redis.BitFieldOperation.operator ==(StackExchange.Redis.BitFieldOperation x, StackExchange.Redis.BitFieldOperation y) -> bool
+static StackExchange.Redis.BitFieldOperation.operator !=(StackExchange.Redis.BitFieldOperation x, StackExchange.Redis.BitFieldOperation y) -> bool
+static StackExchange.Redis.BitFieldOperation.Set(StackExchange.Redis.BitFieldEncoding encoding, StackExchange.Redis.BitFieldOffset offset, long value, StackExchange.Redis.BitFieldOverflow overflow = StackExchange.Redis.BitFieldOverflow.Wrap) -> StackExchange.Redis.BitFieldOperation

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -5439,13 +5439,13 @@ namespace StackExchange.Redis
                 }
             }
 
-            var command = SelectBitFieldCommand(key, allGet, anyIncrement, ref flags, out server);
+            var command = GetBitFieldCommand(key, allGet, anyIncrement, ref flags, out server);
             return new BitFieldMessage(Database, flags, command, key, operations);
         }
 
         private Message GetBitFieldMessage(in RedisKey key, in BitFieldOperation operation, CommandFlags flags, out ServerEndPoint? server)
         {
-            var command = SelectBitFieldCommand(
+            var command = GetBitFieldCommand(
                 key,
                 allGet: operation.Kind == BitFieldOperation.OperationKind.Get,
                 anyIncrement: operation.Kind == BitFieldOperation.OperationKind.IncrementBy,
@@ -5454,22 +5454,41 @@ namespace StackExchange.Redis
             return new BitFieldSingleMessage(Database, flags, command, key, operation);
         }
 
-        private RedisCommand SelectBitFieldCommand(in RedisKey key, bool allGet, bool anyIncrement, ref CommandFlags flags, out ServerEndPoint? server)
+        private RedisCommand GetBitFieldCommand(in RedisKey key, bool allGet, bool anyIncrement, ref CommandFlags flags, out ServerEndPoint? server)
         {
+            var readOnlyAvailable = false;
             server = null;
             if (allGet)
             {
                 // every operation is a read, so BITFIELD_RO will do - and unlike BITFIELD, a replica
                 // will accept it
                 var features = GetFeatures(key, flags, RedisCommand.BITFIELD_RO, out server);
-                if (server is not null && features.BitFieldReadOnly && multiplexer.CommandMap.IsAvailable(RedisCommand.BITFIELD_RO))
+                readOnlyAvailable = server is not null && features.BitFieldReadOnly
+                    && multiplexer.CommandMap.IsAvailable(RedisCommand.BITFIELD_RO);
+                if (!readOnlyAvailable)
                 {
-                    return RedisCommand.BITFIELD_RO;
+                    server = null; // BITFIELD is primary-only; forget the read-eligible server we picked
                 }
-
-                server = null; // BITFIELD is primary-only; forget the read-eligible server we picked
             }
-            else if (!anyIncrement)
+
+            return SelectBitFieldCommand(allGet, anyIncrement, readOnlyAvailable, ref flags);
+        }
+
+        /// <summary>
+        /// Chooses the command, and the retry category the payload deserves - which is a separate axis
+        /// from routing: the server treats BITFIELD as a write however read-only its sub-operations are,
+        /// but that governs which servers will accept it, not whether replaying it is safe.
+        /// </summary>
+        internal static RedisCommand SelectBitFieldCommand(bool allGet, bool anyIncrement, bool readOnlyAvailable, ref CommandFlags flags)
+        {
+            if (allGet)
+            {
+                // nothing to replay, whichever of the two commands we end up issuing
+                flags = flags.WithCategory(CommandFlags.CommandRetryReadOnly);
+                return readOnlyAvailable ? RedisCommand.BITFIELD_RO : RedisCommand.BITFIELD;
+            }
+
+            if (!anyIncrement)
             {
                 // SET is positional, so a replay lands on the same value; only INCRBY compounds
                 flags = flags.WithCategory(CommandFlags.CommandRetryWriteLastWins);

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3775,18 +3775,18 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.NullableInt64, server);
         }
 
-        public Lease<long?>? StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
+        public Lease<long?> StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
         {
             if (operations.IsEmpty) return Lease<long?>.Empty; // no operations, no reply elements
             var msg = GetBitFieldMessage(key, operations.Span, flags, out var server);
-            return ExecuteSync(msg, ResultProcessor.LeaseNullableInt64, server);
+            return ExecuteSync(msg, ResultProcessor.LeaseNullableInt64, server, defaultValue: Lease<long?>.Empty);
         }
 
-        public Task<Lease<long?>?> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
+        public Task<Lease<long?>> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
         {
-            if (operations.IsEmpty) return CompletedTask<Lease<long?>?>.FromDefault(Lease<long?>.Empty, asyncState);
+            if (operations.IsEmpty) return CompletedTask<Lease<long?>>.FromDefault(Lease<long?>.Empty, asyncState);
             var msg = GetBitFieldMessage(key, operations.Span, flags, out var server);
-            return ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, server);
+            return ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, Lease<long?>.Empty, server);
         }
 
         public long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3763,29 +3763,27 @@ namespace StackExchange.Redis
 
         public long? StringBitField(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None)
         {
-            ReadOnlySpan<BitFieldOperation> operations = [operation];
-            var msg = GetBitFieldMessage(key, operations, flags, out var server);
+            var msg = GetBitFieldMessage(key, operation, flags, out var server);
             return ExecuteSync(msg, ResultProcessor.NullableInt64, server);
         }
 
         public Task<long?> StringBitFieldAsync(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None)
         {
-            ReadOnlySpan<BitFieldOperation> operations = [operation];
-            var msg = GetBitFieldMessage(key, operations, flags, out var server);
+            var msg = GetBitFieldMessage(key, operation, flags, out var server);
             return ExecuteAsync(msg, ResultProcessor.NullableInt64, server);
         }
 
         public Lease<long?> StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
         {
             if (operations.IsEmpty) return Lease<long?>.Empty; // no operations, no reply elements
-            var msg = GetBitFieldMessage(key, operations.Span, flags, out var server);
+            var msg = GetBitFieldMessage(key, operations, flags, out var server);
             return ExecuteSync(msg, ResultProcessor.LeaseNullableInt64, server, defaultValue: Lease<long?>.Empty);
         }
 
         public Task<Lease<long?>> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
         {
             if (operations.IsEmpty) return CompletedTask<Lease<long?>>.FromDefault(Lease<long?>.Empty, asyncState);
-            var msg = GetBitFieldMessage(key, operations.Span, flags, out var server);
+            var msg = GetBitFieldMessage(key, operations, flags, out var server);
             return ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, Lease<long?>.Empty, server);
         }
 
@@ -5422,11 +5420,42 @@ namespace StackExchange.Redis
             return Message.CreateInSlot(Database, slot, flags, RedisCommand.BITOP, new[] { op, destination.AsRedisValue(), first.AsRedisValue(), second.AsRedisValue() });
         }
 
-        private Message GetBitFieldMessage(in RedisKey key, ReadOnlySpan<BitFieldOperation> operations, CommandFlags flags, out ServerEndPoint? server)
+        private Message GetBitFieldMessage(in RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags, out ServerEndPoint? server)
         {
-            var values = BuildBitFieldPayload(operations, out var allGet, out var anyIncrement);
+            bool allGet = true, anyIncrement = false;
+            foreach (ref readonly var op in operations.Span)
+            {
+                switch (op.Kind)
+                {
+                    case BitFieldOperation.OperationKind.Get:
+                        break;
+                    case BitFieldOperation.OperationKind.IncrementBy:
+                        anyIncrement = true;
+                        allGet = false;
+                        break;
+                    default:
+                        allGet = false;
+                        break;
+                }
+            }
 
-            var command = RedisCommand.BITFIELD;
+            var command = SelectBitFieldCommand(key, allGet, anyIncrement, ref flags, out server);
+            return new BitFieldMessage(Database, flags, command, key, operations);
+        }
+
+        private Message GetBitFieldMessage(in RedisKey key, in BitFieldOperation operation, CommandFlags flags, out ServerEndPoint? server)
+        {
+            var command = SelectBitFieldCommand(
+                key,
+                allGet: operation.Kind == BitFieldOperation.OperationKind.Get,
+                anyIncrement: operation.Kind == BitFieldOperation.OperationKind.IncrementBy,
+                ref flags,
+                out server);
+            return new BitFieldSingleMessage(Database, flags, command, key, operation);
+        }
+
+        private RedisCommand SelectBitFieldCommand(in RedisKey key, bool allGet, bool anyIncrement, ref CommandFlags flags, out ServerEndPoint? server)
+        {
             server = null;
             if (allGet)
             {
@@ -5435,12 +5464,10 @@ namespace StackExchange.Redis
                 var features = GetFeatures(key, flags, RedisCommand.BITFIELD_RO, out server);
                 if (server is not null && features.BitFieldReadOnly && multiplexer.CommandMap.IsAvailable(RedisCommand.BITFIELD_RO))
                 {
-                    command = RedisCommand.BITFIELD_RO;
+                    return RedisCommand.BITFIELD_RO;
                 }
-                else
-                {
-                    server = null; // BITFIELD is primary-only; forget the read-eligible server we picked
-                }
+
+                server = null; // BITFIELD is primary-only; forget the read-eligible server we picked
             }
             else if (!anyIncrement)
             {
@@ -5448,73 +5475,7 @@ namespace StackExchange.Redis
                 flags = flags.WithCategory(CommandFlags.CommandRetryWriteLastWins);
             }
 
-            return Message.Create(Database, flags, command, key, values);
-        }
-
-        /// <summary>
-        /// Renders the sub-operations of a BITFIELD call. The OVERFLOW token is sticky on the server
-        /// (and untouched by GET), so it is emitted only when the required mode changes - and never for
-        /// a leading run of <see cref="BitFieldOverflow.Wrap"/>, which is the server's own default.
-        /// </summary>
-        internal static RedisValue[] BuildBitFieldPayload(ReadOnlySpan<BitFieldOperation> operations, out bool allGet, out bool anyIncrement)
-        {
-            // first pass: size the payload, and note what kind of operations we have
-            allGet = true;
-            anyIncrement = false;
-            int count = 0;
-            var overflow = BitFieldOverflow.Wrap;
-            foreach (ref readonly var op in operations)
-            {
-                switch (op.Kind)
-                {
-                    case BitFieldOperation.OperationKind.Get:
-                        count += 3; // GET, encoding, offset
-                        break;
-                    case BitFieldOperation.OperationKind.Set:
-                    case BitFieldOperation.OperationKind.IncrementBy:
-                        allGet = false;
-                        anyIncrement |= op.Kind == BitFieldOperation.OperationKind.IncrementBy;
-                        if (op.Overflow != overflow)
-                        {
-                            overflow = op.Overflow;
-                            count += 2; // OVERFLOW, mode
-                        }
-                        count += 4; // SET/INCRBY, encoding, offset, value
-                        break;
-                    default:
-                        throw new ArgumentException($"A default {nameof(BitFieldOperation)} is not a valid operation.", nameof(operations));
-                }
-            }
-
-            // second pass: write it
-            var values = new RedisValue[count];
-            int index = 0;
-            overflow = BitFieldOverflow.Wrap;
-            foreach (ref readonly var op in operations)
-            {
-                if (op.Kind != BitFieldOperation.OperationKind.Get && op.Overflow != overflow)
-                {
-                    overflow = op.Overflow;
-                    values[index++] = RedisLiterals.OVERFLOW;
-                    values[index++] = RedisLiterals.Get(overflow);
-                }
-
-                values[index++] = op.Kind switch
-                {
-                    BitFieldOperation.OperationKind.Get => RedisLiterals.GET,
-                    BitFieldOperation.OperationKind.Set => RedisLiterals.SET,
-                    _ => RedisLiterals.INCRBY,
-                };
-                values[index++] = op.Encoding.ToLiteral();
-                values[index++] = op.Offset.ToLiteral();
-                if (op.Kind != BitFieldOperation.OperationKind.Get)
-                {
-                    values[index++] = op.Value;
-                }
-            }
-
-            Debug.Assert(index == count, "bitfield payload size mismatch");
-            return values;
+            return RedisCommand.BITFIELD;
         }
 
         internal Message GetStringBitPositionMessage(in RedisKey key, bool bit, long start, long end, StringIndexType indexType, CommandFlags flags)

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -3761,6 +3761,34 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
+        public long? StringBitField(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None)
+        {
+            ReadOnlySpan<BitFieldOperation> operations = [operation];
+            var msg = GetBitFieldMessage(key, operations, flags, out var server);
+            return ExecuteSync(msg, ResultProcessor.NullableInt64, server);
+        }
+
+        public Task<long?> StringBitFieldAsync(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None)
+        {
+            ReadOnlySpan<BitFieldOperation> operations = [operation];
+            var msg = GetBitFieldMessage(key, operations, flags, out var server);
+            return ExecuteAsync(msg, ResultProcessor.NullableInt64, server);
+        }
+
+        public Lease<long?>? StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
+        {
+            if (operations.IsEmpty) return Lease<long?>.Empty; // no operations, no reply elements
+            var msg = GetBitFieldMessage(key, operations.Span, flags, out var server);
+            return ExecuteSync(msg, ResultProcessor.LeaseNullableInt64, server);
+        }
+
+        public Task<Lease<long?>?> StringBitFieldAsync(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None)
+        {
+            if (operations.IsEmpty) return CompletedTask<Lease<long?>?>.FromDefault(Lease<long?>.Empty, asyncState);
+            var msg = GetBitFieldMessage(key, operations.Span, flags, out var server);
+            return ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, server);
+        }
+
         public long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
         {
             var msg = GetStringBitOperationMessage(operation, destination, first, second, flags);
@@ -3790,11 +3818,7 @@ namespace StackExchange.Redis
 
         public long StringBitPosition(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
         {
-            var msg = indexType switch
-            {
-                StringIndexType.Byte => Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start, end),
-                _ => Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start, end, indexType.ToLiteral()),
-            };
+            var msg = GetStringBitPositionMessage(key, bit, start, end, indexType, flags);
             return ExecuteSync(msg, ResultProcessor.Int64);
         }
 
@@ -3803,11 +3827,7 @@ namespace StackExchange.Redis
 
         public Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
         {
-            var msg = indexType switch
-            {
-                StringIndexType.Byte => Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start, end),
-                _ => Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start, end, indexType.ToLiteral()),
-            };
+            var msg = GetStringBitPositionMessage(key, bit, start, end, indexType, flags);
             return ExecuteAsync(msg, ResultProcessor.Int64);
         }
 
@@ -5400,6 +5420,122 @@ namespace StackExchange.Redis
             // binary
             slot = serverSelectionStrategy.CombineSlot(slot, second);
             return Message.CreateInSlot(Database, slot, flags, RedisCommand.BITOP, new[] { op, destination.AsRedisValue(), first.AsRedisValue(), second.AsRedisValue() });
+        }
+
+        private Message GetBitFieldMessage(in RedisKey key, ReadOnlySpan<BitFieldOperation> operations, CommandFlags flags, out ServerEndPoint? server)
+        {
+            var values = BuildBitFieldPayload(operations, out var allGet, out var anyIncrement);
+
+            var command = RedisCommand.BITFIELD;
+            server = null;
+            if (allGet)
+            {
+                // every operation is a read, so BITFIELD_RO will do - and unlike BITFIELD, a replica
+                // will accept it
+                var features = GetFeatures(key, flags, RedisCommand.BITFIELD_RO, out server);
+                if (server is not null && features.BitFieldReadOnly && multiplexer.CommandMap.IsAvailable(RedisCommand.BITFIELD_RO))
+                {
+                    command = RedisCommand.BITFIELD_RO;
+                }
+                else
+                {
+                    server = null; // BITFIELD is primary-only; forget the read-eligible server we picked
+                }
+            }
+            else if (!anyIncrement)
+            {
+                // SET is positional, so a replay lands on the same value; only INCRBY compounds
+                flags = flags.WithCategory(CommandFlags.CommandRetryWriteLastWins);
+            }
+
+            return Message.Create(Database, flags, command, key, values);
+        }
+
+        /// <summary>
+        /// Renders the sub-operations of a BITFIELD call. The OVERFLOW token is sticky on the server
+        /// (and untouched by GET), so it is emitted only when the required mode changes - and never for
+        /// a leading run of <see cref="BitFieldOverflow.Wrap"/>, which is the server's own default.
+        /// </summary>
+        internal static RedisValue[] BuildBitFieldPayload(ReadOnlySpan<BitFieldOperation> operations, out bool allGet, out bool anyIncrement)
+        {
+            // first pass: size the payload, and note what kind of operations we have
+            allGet = true;
+            anyIncrement = false;
+            int count = 0;
+            var overflow = BitFieldOverflow.Wrap;
+            foreach (ref readonly var op in operations)
+            {
+                switch (op.Kind)
+                {
+                    case BitFieldOperation.OperationKind.Get:
+                        count += 3; // GET, encoding, offset
+                        break;
+                    case BitFieldOperation.OperationKind.Set:
+                    case BitFieldOperation.OperationKind.IncrementBy:
+                        allGet = false;
+                        anyIncrement |= op.Kind == BitFieldOperation.OperationKind.IncrementBy;
+                        if (op.Overflow != overflow)
+                        {
+                            overflow = op.Overflow;
+                            count += 2; // OVERFLOW, mode
+                        }
+                        count += 4; // SET/INCRBY, encoding, offset, value
+                        break;
+                    default:
+                        throw new ArgumentException($"A default {nameof(BitFieldOperation)} is not a valid operation.", nameof(operations));
+                }
+            }
+
+            // second pass: write it
+            var values = new RedisValue[count];
+            int index = 0;
+            overflow = BitFieldOverflow.Wrap;
+            foreach (ref readonly var op in operations)
+            {
+                if (op.Kind != BitFieldOperation.OperationKind.Get && op.Overflow != overflow)
+                {
+                    overflow = op.Overflow;
+                    values[index++] = RedisLiterals.OVERFLOW;
+                    values[index++] = RedisLiterals.Get(overflow);
+                }
+
+                values[index++] = op.Kind switch
+                {
+                    BitFieldOperation.OperationKind.Get => RedisLiterals.GET,
+                    BitFieldOperation.OperationKind.Set => RedisLiterals.SET,
+                    _ => RedisLiterals.INCRBY,
+                };
+                values[index++] = op.Encoding.ToLiteral();
+                values[index++] = op.Offset.ToLiteral();
+                if (op.Kind != BitFieldOperation.OperationKind.Get)
+                {
+                    values[index++] = op.Value;
+                }
+            }
+
+            Debug.Assert(index == count, "bitfield payload size mismatch");
+            return values;
+        }
+
+        internal Message GetStringBitPositionMessage(in RedisKey key, bool bit, long start, long end, StringIndexType indexType, CommandFlags flags)
+        {
+            if (end == StringIndex.Unbounded)
+            {
+                // BITPOS takes the BYTE/BIT token only *after* an explicit end, so an open-ended range and a
+                // bit index cannot be expressed together; dropping the token silently would reinterpret start
+                if (indexType != StringIndexType.Byte)
+                {
+                    throw new ArgumentException($"{nameof(StringIndex)}.{nameof(StringIndex.Unbounded)} requires {nameof(StringIndexType)}.{nameof(StringIndexType.Byte)}; the server accepts a bit/byte index type only after an explicit end.", nameof(indexType));
+                }
+
+                return Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start);
+            }
+
+            return indexType switch
+            {
+                StringIndexType.Byte => Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start, end),
+                _ => Message.Create(Database, flags, RedisCommand.BITPOS, key, bit, start, end, indexType.ToLiteral()),
+            };
         }
 
         internal Message GetStringGetExMessage(in RedisKey key, Expiration expiry, CommandFlags flags = CommandFlags.None)

--- a/src/StackExchange.Redis/RedisFeatures.cs
+++ b/src/StackExchange.Redis/RedisFeatures.cs
@@ -75,6 +75,11 @@ namespace StackExchange.Redis
         public bool BitwiseOperations => Version.IsAtLeast(v2_6_0);
 
         /// <summary>
+        /// Is <see href="https://redis.io/commands/bitfield_ro/">BITFIELD_RO</see> available?
+        /// </summary>
+        public bool BitFieldReadOnly => Version.IsAtLeast(v6_0_0);
+
+        /// <summary>
         /// Is <see href="https://redis.io/commands/client-setname/">CLIENT SETNAME</see> available?
         /// </summary>
         public bool ClientName => Version.IsAtLeast(v2_6_9);

--- a/src/StackExchange.Redis/RedisLiterals.cs
+++ b/src/StackExchange.Redis/RedisLiterals.cs
@@ -40,6 +40,7 @@ namespace StackExchange.Redis
             EXACTLY = RedisValue.FromRaw("EXACTLY"u8),
             EXAT = RedisValue.FromRaw("EXAT"u8),
             EXISTS = RedisValue.FromRaw("EXISTS"u8),
+            FAIL = RedisValue.FromRaw("FAIL"u8),
             FIELDS = RedisValue.FromRaw("FIELDS"u8),
             FILTERBY = RedisValue.FromRaw("FILTERBY"u8),
             FLUSH = RedisValue.FromRaw("FLUSH"u8),
@@ -61,6 +62,7 @@ namespace StackExchange.Redis
             IDMPAUTO = RedisValue.FromRaw("IDMPAUTO"u8),
             IDMP_DURATION = RedisValue.FromRaw("IDMP-DURATION"u8),
             IDMP_MAXSIZE = RedisValue.FromRaw("IDMP-MAXSIZE"u8),
+            INCRBY = RedisValue.FromRaw("INCRBY"u8),
             KEEPTTL = RedisValue.FromRaw("KEEPTTL"u8),
             KILL = RedisValue.FromRaw("KILL"u8),
             LADDR = RedisValue.FromRaw("LADDR"u8),
@@ -94,6 +96,7 @@ namespace StackExchange.Redis
             OBO = RedisValue.FromRaw("OBO"u8),
             ONE = RedisValue.FromRaw("ONE"u8),
             OR = RedisValue.FromRaw("OR"u8),
+            OVERFLOW = RedisValue.FromRaw("OVERFLOW"u8),
             PATTERN = RedisValue.FromRaw("PATTERN"u8),
             PAUSE = RedisValue.FromRaw("PAUSE"u8),
             PERSIST = RedisValue.FromRaw("PERSIST"u8),
@@ -110,6 +113,7 @@ namespace StackExchange.Redis
             REV = RedisValue.FromRaw("REV"u8),
             REWRITE = RedisValue.FromRaw("REWRITE"u8),
             RIGHT = RedisValue.FromRaw("RIGHT"u8),
+            SAT = RedisValue.FromRaw("SAT"u8),
             SAVE = RedisValue.FromRaw("SAVE"u8),
             SEGFAULT = RedisValue.FromRaw("SEGFAULT"u8),
             SET = RedisValue.FromRaw("SET"u8),
@@ -127,6 +131,7 @@ namespace StackExchange.Redis
             WITHMATCHLEN = RedisValue.FromRaw("WITHMATCHLEN"u8),
             WITHSCORES = RedisValue.FromRaw("WITHSCORES"u8),
             WITHVALUES = RedisValue.FromRaw("WITHVALUES"u8),
+            WRAP = RedisValue.FromRaw("WRAP"u8),
             XOR = RedisValue.FromRaw("XOR"u8),
             XX = RedisValue.FromRaw("XX"u8),
 
@@ -187,6 +192,14 @@ namespace StackExchange.Redis
             slave_read_only = RedisValue.FromRaw("slave-read-only"u8),
             timeout = RedisValue.FromRaw("timeout"u8),
             yes = RedisValue.FromRaw("yes"u8);
+
+        internal static RedisValue Get(BitFieldOverflow overflow) => overflow switch
+        {
+            BitFieldOverflow.Wrap => WRAP,
+            BitFieldOverflow.Saturate => SAT,
+            BitFieldOverflow.Fail => FAIL,
+            _ => throw new ArgumentOutOfRangeException(nameof(overflow)),
+        };
 
         internal static RedisValue Get(Bitwise operation) => operation switch
         {

--- a/src/StackExchange.Redis/RedisLiterals.cs
+++ b/src/StackExchange.Redis/RedisLiterals.cs
@@ -40,7 +40,6 @@ namespace StackExchange.Redis
             EXACTLY = RedisValue.FromRaw("EXACTLY"u8),
             EXAT = RedisValue.FromRaw("EXAT"u8),
             EXISTS = RedisValue.FromRaw("EXISTS"u8),
-            FAIL = RedisValue.FromRaw("FAIL"u8),
             FIELDS = RedisValue.FromRaw("FIELDS"u8),
             FILTERBY = RedisValue.FromRaw("FILTERBY"u8),
             FLUSH = RedisValue.FromRaw("FLUSH"u8),
@@ -62,7 +61,6 @@ namespace StackExchange.Redis
             IDMPAUTO = RedisValue.FromRaw("IDMPAUTO"u8),
             IDMP_DURATION = RedisValue.FromRaw("IDMP-DURATION"u8),
             IDMP_MAXSIZE = RedisValue.FromRaw("IDMP-MAXSIZE"u8),
-            INCRBY = RedisValue.FromRaw("INCRBY"u8),
             KEEPTTL = RedisValue.FromRaw("KEEPTTL"u8),
             KILL = RedisValue.FromRaw("KILL"u8),
             LADDR = RedisValue.FromRaw("LADDR"u8),
@@ -96,7 +94,6 @@ namespace StackExchange.Redis
             OBO = RedisValue.FromRaw("OBO"u8),
             ONE = RedisValue.FromRaw("ONE"u8),
             OR = RedisValue.FromRaw("OR"u8),
-            OVERFLOW = RedisValue.FromRaw("OVERFLOW"u8),
             PATTERN = RedisValue.FromRaw("PATTERN"u8),
             PAUSE = RedisValue.FromRaw("PAUSE"u8),
             PERSIST = RedisValue.FromRaw("PERSIST"u8),
@@ -113,7 +110,6 @@ namespace StackExchange.Redis
             REV = RedisValue.FromRaw("REV"u8),
             REWRITE = RedisValue.FromRaw("REWRITE"u8),
             RIGHT = RedisValue.FromRaw("RIGHT"u8),
-            SAT = RedisValue.FromRaw("SAT"u8),
             SAVE = RedisValue.FromRaw("SAVE"u8),
             SEGFAULT = RedisValue.FromRaw("SEGFAULT"u8),
             SET = RedisValue.FromRaw("SET"u8),
@@ -131,7 +127,6 @@ namespace StackExchange.Redis
             WITHMATCHLEN = RedisValue.FromRaw("WITHMATCHLEN"u8),
             WITHSCORES = RedisValue.FromRaw("WITHSCORES"u8),
             WITHVALUES = RedisValue.FromRaw("WITHVALUES"u8),
-            WRAP = RedisValue.FromRaw("WRAP"u8),
             XOR = RedisValue.FromRaw("XOR"u8),
             XX = RedisValue.FromRaw("XX"u8),
 
@@ -192,14 +187,6 @@ namespace StackExchange.Redis
             slave_read_only = RedisValue.FromRaw("slave-read-only"u8),
             timeout = RedisValue.FromRaw("timeout"u8),
             yes = RedisValue.FromRaw("yes"u8);
-
-        internal static RedisValue Get(BitFieldOverflow overflow) => overflow switch
-        {
-            BitFieldOverflow.Wrap => WRAP,
-            BitFieldOverflow.Saturate => SAT,
-            BitFieldOverflow.Fail => FAIL,
-            _ => throw new ArgumentOutOfRangeException(nameof(overflow)),
-        };
 
         internal static RedisValue Get(Bitwise operation) => operation switch
         {

--- a/src/StackExchange.Redis/ResultProcessor.Lease.cs
+++ b/src/StackExchange.Redis/ResultProcessor.Lease.cs
@@ -8,6 +8,8 @@ internal abstract partial class ResultProcessor
     // Lease result processors
     public static readonly ResultProcessor<Lease<float>?> LeaseFloat32 = new LeaseFloat32Processor();
 
+    public static readonly ResultProcessor<Lease<long?>?> LeaseNullableInt64 = new LeaseNullableInt64Processor();
+
     public static readonly ResultProcessor<Lease<byte>>
         Lease = new LeaseProcessor();
 
@@ -139,6 +141,12 @@ internal abstract partial class ResultProcessor
                 throw;
             }
         }
+    }
+
+    private sealed class LeaseNullableInt64Processor : LeaseProcessor<long?>
+    {
+        // BITFIELD reports a nil element for any operation skipped by OVERFLOW FAIL
+        protected override long? TryParse(ref RespReader reader) => reader.IsNull ? null : reader.ReadInt64();
     }
 
     private sealed class LeaseFloat32Processor : LeaseProcessor<float>

--- a/src/StackExchange.Redis/ResultProcessor.Lease.cs
+++ b/src/StackExchange.Redis/ResultProcessor.Lease.cs
@@ -8,7 +8,10 @@ internal abstract partial class ResultProcessor
     // Lease result processors
     public static readonly ResultProcessor<Lease<float>?> LeaseFloat32 = new LeaseFloat32Processor();
 
-    public static readonly ResultProcessor<Lease<long?>?> LeaseNullableInt64 = new LeaseNullableInt64Processor();
+    // outer type is deliberately non-null: BITFIELD always replies with an array (empty for no
+    // operations), so the only null would come from a non-observable result such as fire-and-forget,
+    // which the callers handle with an explicit empty default
+    public static readonly ResultProcessor<Lease<long?>> LeaseNullableInt64 = new LeaseNullableInt64Processor()!;
 
     public static readonly ResultProcessor<Lease<byte>>
         Lease = new LeaseProcessor();

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -40,6 +40,7 @@
     <!-- imported into consuming projects; makes <RedisMinServerVersion> visible to the shipped analyzer -->
     <None Include="build\StackExchange.Redis.props" Pack="true" PackagePath="build\" />
 
+    <Compile Update="BitFieldOperation.*.cs" DependentUpon="BitFieldOperation.cs" />
     <Compile Update="HotKeys.*.cs" DependentUpon="HotKeys.cs" />
   </ItemGroup>
 

--- a/src/StackExchange.Redis/StringIndex.cs
+++ b/src/StackExchange.Redis/StringIndex.cs
@@ -1,0 +1,24 @@
+﻿namespace StackExchange.Redis;
+
+/// <summary>
+/// Well-known index values for the bitmap operations that take a start/end range.
+/// </summary>
+public static class StringIndex
+{
+    /// <summary>
+    /// Indicates that no end index should be sent to the server, leaving the range open-ended.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Valid only as the <c>end</c> of <see cref="IDatabase.StringBitPosition(RedisKey, bool, long, long, StringIndexType, CommandFlags)"/>
+    /// (and the async equivalent), and only in combination with <see cref="StringIndexType.Byte"/>: <c>BITPOS</c>
+    /// accepts a bit/byte index type only after an explicit end.
+    /// </para>
+    /// <para>
+    /// This is not interchangeable with <c>-1</c>. When searching for a clear bit, an explicit end restricts the
+    /// search to the string itself, so an all-set string yields -1; an open-ended range instead reports the first
+    /// bit beyond the end of the string.
+    /// </para>
+    /// </remarks>
+    public const long Unbounded = long.MinValue;
+}

--- a/tests/StackExchange.Redis.Tests/BitFieldTypeTests.cs
+++ b/tests/StackExchange.Redis.Tests/BitFieldTypeTests.cs
@@ -73,17 +73,17 @@ public class BitFieldTypeTests
     [Fact]
     public void OffsetForms()
     {
-        Assert.Equal("100", BitFieldOffset.Bits(100).ToString());
-        Assert.Equal("#100", BitFieldOffset.Index(100).ToString());
-        Assert.Equal(BitFieldOffset.Bits(3), (BitFieldOffset)3L); // implicit long is a bit offset
-        Assert.NotEqual(BitFieldOffset.Bits(3), BitFieldOffset.Index(3));
+        Assert.Equal("100", BitFieldOffset.Bit(100).ToString());
+        Assert.Equal("#100", BitFieldOffset.Element(100).ToString());
+        Assert.Equal(BitFieldOffset.Bit(3), (BitFieldOffset)3L); // implicit long is a bit offset
+        Assert.NotEqual(BitFieldOffset.Bit(3), BitFieldOffset.Element(3));
     }
 
     [Fact]
     public void OffsetsCannotBeNegative()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOffset.Bits(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOffset.Index(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOffset.Bit(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOffset.Element(-1));
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class BitFieldTypeTests
     [Fact]
     public void OperationToString()
     {
-        Assert.Equal("GET u8 #1", BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Index(1)).ToString());
+        Assert.Equal("GET u8 #1", BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Element(1)).ToString());
         Assert.Equal("SET i16 32 -5 (Saturate)", BitFieldOperation.Set(BitFieldEncoding.Int16, 32, -5, BitFieldOverflow.Saturate).ToString());
         Assert.Equal("INCRBY i8 0 1 (Wrap)", BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1).ToString());
     }

--- a/tests/StackExchange.Redis.Tests/BitFieldTypeTests.cs
+++ b/tests/StackExchange.Redis.Tests/BitFieldTypeTests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Unit tests for the BITFIELD value types; no server required.
+/// </summary>
+public class BitFieldTypeTests
+{
+    [Theory]
+    [InlineData(1, "i1")]
+    [InlineData(8, "i8")]
+    [InlineData(53, "i53")]
+    [InlineData(64, "i64")]
+    public void SignedWidths(int width, string expected)
+    {
+        var encoding = BitFieldEncoding.Signed(width);
+        Assert.Equal(expected, encoding.ToString());
+        Assert.Equal(width, encoding.Width);
+        Assert.True(encoding.IsSigned);
+    }
+
+    [Theory]
+    [InlineData(1, "u1")]
+    [InlineData(8, "u8")]
+    [InlineData(63, "u63")]
+    public void UnsignedWidths(int width, string expected)
+    {
+        var encoding = BitFieldEncoding.Unsigned(width);
+        Assert.Equal(expected, encoding.ToString());
+        Assert.Equal(width, encoding.Width);
+        Assert.False(encoding.IsSigned);
+    }
+
+    [Fact]
+    public void NamedEncodingsMatchTheirFactories()
+    {
+        Assert.Equal(BitFieldEncoding.Signed(8), BitFieldEncoding.Int8);
+        Assert.Equal(BitFieldEncoding.Signed(16), BitFieldEncoding.Int16);
+        Assert.Equal(BitFieldEncoding.Signed(32), BitFieldEncoding.Int32);
+        Assert.Equal(BitFieldEncoding.Signed(64), BitFieldEncoding.Int64);
+        Assert.Equal(BitFieldEncoding.Unsigned(8), BitFieldEncoding.UInt8);
+        Assert.Equal(BitFieldEncoding.Unsigned(16), BitFieldEncoding.UInt16);
+        Assert.Equal(BitFieldEncoding.Unsigned(32), BitFieldEncoding.UInt32);
+        Assert.Equal(BitFieldEncoding.Unsigned(63), BitFieldEncoding.UInt63);
+        Assert.NotEqual(BitFieldEncoding.Int8, BitFieldEncoding.UInt8);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65)]
+    public void SignedRejectsIllegalWidths(int width) =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldEncoding.Signed(width));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(64)]
+    public void UnsignedRejectsIllegalWidths(int width) =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldEncoding.Unsigned(width));
+
+    [Fact]
+    public void UnsignedSixtyFourExplainsItself()
+    {
+        // the obvious thing to reach for; the message should say why it cannot work, and what to use
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldEncoding.Unsigned(64));
+        Assert.Contains("UInt63", ex.Message);
+        Assert.Contains("Int64", ex.Message);
+    }
+
+    [Fact]
+    public void OffsetForms()
+    {
+        Assert.Equal("100", BitFieldOffset.Bits(100).ToString());
+        Assert.Equal("#100", BitFieldOffset.Index(100).ToString());
+        Assert.Equal(BitFieldOffset.Bits(3), (BitFieldOffset)3L); // implicit long is a bit offset
+        Assert.NotEqual(BitFieldOffset.Bits(3), BitFieldOffset.Index(3));
+    }
+
+    [Fact]
+    public void OffsetsCannotBeNegative()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOffset.Bits(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOffset.Index(-1));
+    }
+
+    [Fact]
+    public void DefaultEncodingIsRejectedAtConstruction()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => BitFieldOperation.Get(default, 0));
+        Assert.Equal("encoding", ex.ParamName);
+    }
+
+    [Fact]
+    public void UnknownOverflowIsRejected() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1, (BitFieldOverflow)42));
+
+    [Fact]
+    public void OperationToString()
+    {
+        Assert.Equal("GET u8 #1", BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Index(1)).ToString());
+        Assert.Equal("SET i16 32 -5 (Saturate)", BitFieldOperation.Set(BitFieldEncoding.Int16, 32, -5, BitFieldOverflow.Saturate).ToString());
+        Assert.Equal("INCRBY i8 0 1 (Wrap)", BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1).ToString());
+    }
+}

--- a/tests/StackExchange.Redis.Tests/BitTests.cs
+++ b/tests/StackExchange.Redis.Tests/BitTests.cs
@@ -59,8 +59,8 @@ public class BitTests(ITestOutputHelper output, SharedConnectionFixture fixture)
         db.KeyDelete(key, CommandFlags.FireAndForget);
 
         // SET reports the previous value, GET the current one; the #N form indexes by width
-        Assert.Equal(0, db.StringBitField(key, BitFieldOperation.Set(BitFieldEncoding.UInt8, BitFieldOffset.Index(1), 255)));
-        Assert.Equal(255, await db.StringBitFieldAsync(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Index(1))));
+        Assert.Equal(0, db.StringBitField(key, BitFieldOperation.Set(BitFieldEncoding.UInt8, BitFieldOffset.Element(1), 255)));
+        Assert.Equal(255, await db.StringBitFieldAsync(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Element(1))));
         Assert.Equal(255, db.StringBitField(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, 8))); // ... same field, by bit
         Assert.Equal(0, db.StringBitField(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, 0)));
 

--- a/tests/StackExchange.Redis.Tests/BitTests.cs
+++ b/tests/StackExchange.Redis.Tests/BitTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis.Profiling;
 using Xunit;
 
 namespace StackExchange.Redis.Tests;
@@ -17,5 +20,135 @@ public class BitTests(ITestOutputHelper output, SharedConnectionFixture fixture)
         db.StringSetBit(key, 10, true);
         Assert.True(db.StringGetBit(key, 10));
         Assert.False(db.StringGetBit(key, 11));
+    }
+
+    [Fact]
+    public async Task BitPositionUnboundedEndLooksPastEndOfString()
+    {
+        await using var conn = Create();
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+        for (int i = 0; i < 8; i++)
+        {
+            db.StringSetBit(key, i, true, CommandFlags.FireAndForget);
+        }
+        Assert.Equal(1, db.StringLength(key));
+
+        // an explicit end confines the search to the string, which has no clear bit
+        Assert.Equal(-1, db.StringBitPosition(key, false));
+        Assert.Equal(-1, await db.StringBitPositionAsync(key, false, 0, -1));
+
+        // an open-ended range reports the first clear bit past the end of the string
+        Assert.Equal(8, db.StringBitPosition(key, false, 0, StringIndex.Unbounded));
+        Assert.Equal(8, await db.StringBitPositionAsync(key, false, 0, StringIndex.Unbounded));
+
+        // set bits are unaffected either way
+        Assert.Equal(0, db.StringBitPosition(key, true));
+        Assert.Equal(0, db.StringBitPosition(key, true, 0, StringIndex.Unbounded));
+    }
+
+    [Fact]
+    public async Task BitFieldBasicOps()
+    {
+        await using var conn = Create(require: RedisFeatures.v3_2_0);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        // SET reports the previous value, GET the current one; the #N form indexes by width
+        Assert.Equal(0, db.StringBitField(key, BitFieldOperation.Set(BitFieldEncoding.UInt8, BitFieldOffset.Index(1), 255)));
+        Assert.Equal(255, await db.StringBitFieldAsync(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Index(1))));
+        Assert.Equal(255, db.StringBitField(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, 8))); // ... same field, by bit
+        Assert.Equal(0, db.StringBitField(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, 0)));
+
+        // INCRBY reports the new value
+        Assert.Equal(-1, db.StringBitField(key, BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, -1)));
+    }
+
+    [Fact]
+    public async Task BitFieldBatchAppliesInOrder()
+    {
+        await using var conn = Create(require: RedisFeatures.v3_2_0);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        db.KeyDelete(key, CommandFlags.FireAndForget);
+
+        using var lease = await db.StringBitFieldAsync(
+            key,
+            new[]
+            {
+                BitFieldOperation.Set(BitFieldEncoding.Int8, 0, 100),
+                BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Saturate),
+                BitFieldOperation.Get(BitFieldEncoding.Int8, 0),
+                BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Fail),
+                BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Wrap),
+            });
+
+        Assert.NotNull(lease);
+
+        // the FAIL element is null; note the sticky OVERFLOW state survives the intervening GET
+        Assert.Equal(new long?[] { 0, 127, 127, null, -29 }, lease.Span.ToArray());
+    }
+
+    [Fact]
+    public async Task BitFieldEmptyBatchIsANoOp()
+    {
+        await using var conn = Create(require: RedisFeatures.v3_2_0);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+
+        using var lease = db.StringBitField(key, ReadOnlyMemory<BitFieldOperation>.Empty);
+        Assert.NotNull(lease);
+        Assert.True(lease.IsEmpty);
+
+        using var leaseAsync = await db.StringBitFieldAsync(key, ReadOnlyMemory<BitFieldOperation>.Empty);
+        Assert.NotNull(leaseAsync);
+        Assert.True(leaseAsync.IsEmpty);
+    }
+
+    [Fact]
+    public async Task BitFieldAllGetGoesOutAsReadOnlyAndReachesAReplica()
+    {
+        await using var conn = Create(
+            require: RedisFeatures.v6_0_0,
+            configuration: TestConfig.Current.PrimaryServerAndPort + "," + TestConfig.Current.ReplicaServerAndPort);
+        Assert.SkipUnless(
+            conn.GetEndPoints().Any(ep => conn.GetServer(ep).IsReplica),
+            "No replica in this configuration");
+
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        var session = new ProfilingSession();
+        conn.RegisterProfiler(() => session);
+
+        // an all-GET batch is issued as BITFIELD_RO, so a replica will serve it; the value itself is
+        // not asserted here - reading from a replica makes that a race with replication
+        using var lease = db.StringBitField(
+            key,
+            new[] { BitFieldOperation.Get(BitFieldEncoding.UInt8, 0) },
+            CommandFlags.DemandReplica);
+        Assert.NotNull(lease);
+        Assert.Equal(1, lease.Length);
+        Assert.NotNull(db.StringBitField(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, 0), CommandFlags.DemandReplica));
+
+        // ... whereas anything that writes stays as BITFIELD
+        db.StringBitField(key, BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1));
+
+        var commands = session.FinishProfiling().ToList();
+        foreach (var command in commands)
+        {
+            Log($"{command.Command} -> {command.EndPoint}");
+        }
+
+        var readOnly = commands.Where(c => c.Command == "BITFIELD_RO").ToList();
+        Assert.Equal(2, readOnly.Count);
+        Assert.All(readOnly, c => Assert.True(conn.GetServer(c.EndPoint).IsReplica));
+
+        var write = Assert.Single(commands, c => c.Command == "BITFIELD");
+        Assert.False(conn.GetServer(write.EndPoint).IsReplica);
     }
 }

--- a/tests/StackExchange.Redis.Tests/BitTests.cs
+++ b/tests/StackExchange.Redis.Tests/BitTests.cs
@@ -88,8 +88,6 @@ public class BitTests(ITestOutputHelper output, SharedConnectionFixture fixture)
                 BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Wrap),
             });
 
-        Assert.NotNull(lease);
-
         // the FAIL element is null; note the sticky OVERFLOW state survives the intervening GET
         Assert.Equal(new long?[] { 0, 127, 127, null, -29 }, lease.Span.ToArray());
     }
@@ -102,11 +100,9 @@ public class BitTests(ITestOutputHelper output, SharedConnectionFixture fixture)
         RedisKey key = Me();
 
         using var lease = db.StringBitField(key, ReadOnlyMemory<BitFieldOperation>.Empty);
-        Assert.NotNull(lease);
         Assert.True(lease.IsEmpty);
 
         using var leaseAsync = await db.StringBitFieldAsync(key, ReadOnlyMemory<BitFieldOperation>.Empty);
-        Assert.NotNull(leaseAsync);
         Assert.True(leaseAsync.IsEmpty);
     }
 
@@ -131,7 +127,6 @@ public class BitTests(ITestOutputHelper output, SharedConnectionFixture fixture)
             key,
             new[] { BitFieldOperation.Get(BitFieldEncoding.UInt8, 0) },
             CommandFlags.DemandReplica);
-        Assert.NotNull(lease);
         Assert.Equal(1, lease.Length);
         Assert.NotNull(db.StringBitField(key, BitFieldOperation.Get(BitFieldEncoding.UInt8, 0), CommandFlags.DemandReplica));
 

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
@@ -28,7 +28,7 @@ public class BitFieldRoundTrip(ITestOutputHelper log)
         var msg = Message(
             RedisCommand.BITFIELD_RO,
             BitFieldOperation.Get(BitFieldEncoding.UInt8, 0),
-            BitFieldOperation.Get(BitFieldEncoding.UInt63, BitFieldOffset.Index(2)));
+            BitFieldOperation.Get(BitFieldEncoding.UInt63, BitFieldOffset.Element(2)));
         const string RequestResp = "*8\r\n$11\r\nBITFIELD_RO\r\n$1\r\nk\r\n$3\r\nGET\r\n$2\r\nu8\r\n$1\r\n0\r\n$3\r\nGET\r\n$3\r\nu63\r\n$2\r\n#2\r\n";
 
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*2\r\n:255\r\n:0\r\n", log: log);
@@ -52,7 +52,7 @@ public class BitFieldRoundTrip(ITestOutputHelper log)
         var msg = Message(
             RedisCommand.BITFIELD,
             BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1, BitFieldOverflow.Saturate),
-            BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, BitFieldOffset.Index(1), 2, BitFieldOverflow.Saturate),
+            BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, BitFieldOffset.Element(1), 2, BitFieldOverflow.Saturate),
             BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 3, BitFieldOverflow.Wrap));
         const string RequestResp = "*18\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n"
             + "$8\r\nOVERFLOW\r\n$3\r\nSAT\r\n$3\r\nSET\r\n$2\r\nu8\r\n$1\r\n0\r\n$1\r\n1\r\n"

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
@@ -168,6 +168,31 @@ public class BitFieldRoundTrip(ITestOutputHelper log)
         Assert.Empty(conn.GetOutboundData().ToArray());
     }
 
+    [Theory]
+    // all-GET: no side effects to replay, whichever command we end up issuing
+    [InlineData(true, false, true, "BITFIELD_RO", CommandFlags.CommandRetryReadOnly)]
+    [InlineData(true, false, false, "BITFIELD", CommandFlags.CommandRetryReadOnly)]
+    // SET only: a replay lands on the same value, because the offset is positional
+    [InlineData(false, false, false, "BITFIELD", CommandFlags.CommandRetryWriteLastWins)]
+    // anything with an INCRBY compounds, so it keeps BITFIELD's accumulating default
+    [InlineData(false, true, false, "BITFIELD", CommandFlags.None)]
+    public void CommandAndRetryCategoryFollowThePayload(bool allGet, bool anyIncrement, bool readOnlyAvailable, string expectedCommand, CommandFlags expectedCategory)
+    {
+        var flags = CommandFlags.None;
+        Assert.Equal(expectedCommand, RedisDatabase.SelectBitFieldCommand(allGet, anyIncrement, readOnlyAvailable, ref flags).ToString());
+
+        // CommandFlags.None here means "no opinion", leaving BITFIELD's own accumulating default in place
+        Assert.Equal(expectedCategory, flags & Message.MaskRetryCategory);
+    }
+
+    [Fact]
+    public void AnExplicitRetryCategoryIsNotOverridden()
+    {
+        var flags = CommandFlags.CommandRetryNever;
+        Assert.Equal(RedisCommand.BITFIELD_RO, RedisDatabase.SelectBitFieldCommand(allGet: true, anyIncrement: false, readOnlyAvailable: true, ref flags));
+        Assert.Equal(CommandFlags.CommandRetryNever, flags & Message.MaskRetryCategory);
+    }
+
     [Fact]
     public void ReadOnlyVariantIsNotPrimaryOnly()
     {

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
@@ -151,6 +151,24 @@ public class BitFieldRoundTrip(ITestOutputHelper log)
     }
 
     [Fact]
+    public void MutatingTheOperationsAfterIssue_FailsBeforeAnythingIsWritten()
+    {
+        // the batch form aliases the caller's memory rather than copying it, and the shape depends on
+        // the contents, so a mutation has to be caught before the header goes out
+        var operations = new[] { BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1) };
+        var msg = new RedisDatabase.BitFieldMessage(0, CommandFlags.None, RedisCommand.BITFIELD, (RedisKey)"k", operations);
+
+        operations[0] = default;
+
+        using var conn = new TestConnection(startReading: false);
+        var box = TaskResultBox<long?>.Create(out _, null);
+        msg.SetSource(box, ResultProcessor.NullableInt64);
+
+        Assert.Throws<InvalidOperationException>(() => conn.WriteOutbound(msg));
+        Assert.Empty(conn.GetOutboundData().ToArray());
+    }
+
+    [Fact]
     public void ReadOnlyVariantIsNotPrimaryOnly()
     {
         // BITFIELD is a write server-side even when every sub-operation is a GET; BITFIELD_RO is not

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
@@ -6,50 +6,90 @@ namespace StackExchange.Redis.Tests.RoundTripUnitTests;
 
 public class BitFieldRoundTrip(ITestOutputHelper log)
 {
-    private static Message Message(RedisCommand command, params BitFieldOperation[] operations)
-    {
-        var payload = RedisDatabase.BuildBitFieldPayload(operations, out _, out _);
-        return StackExchange.Redis.Message.Create(0, CommandFlags.None, command, (RedisKey)"k", payload);
-    }
+    private static Message Batch(RedisCommand command, params BitFieldOperation[] operations) =>
+        new RedisDatabase.BitFieldMessage(0, CommandFlags.None, command, (RedisKey)"k", operations);
+
+    private static Message Single(RedisCommand command, BitFieldOperation operation) =>
+        new RedisDatabase.BitFieldSingleMessage(0, CommandFlags.None, command, (RedisKey)"k", operation);
 
     [Fact(Timeout = 1000)]
     public async Task Increment_RoundTrips()
     {
-        var msg = Message(RedisCommand.BITFIELD, BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1));
+        var msg = Batch(RedisCommand.BITFIELD, BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1));
         const string RequestResp = "*6\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n$6\r\nINCRBY\r\n$2\r\ni8\r\n$1\r\n0\r\n$1\r\n1\r\n";
 
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*1\r\n:1\r\n", log: log);
-        Assert.Equal(new long?[] { 1 }, result!.Span.ToArray());
+        Assert.Equal(new long?[] { 1 }, result.Span.ToArray());
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task SingleOperation_WritesTheSameAsAUnitBatch()
+    {
+        // the single-operation overload avoids the array, but must produce identical bytes
+        var msg = Single(RedisCommand.BITFIELD, BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1));
+        const string RequestResp = "*6\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n$6\r\nINCRBY\r\n$2\r\ni8\r\n$1\r\n0\r\n$1\r\n1\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.NullableInt64, RequestResp, "*1\r\n:1\r\n", log: log);
+        Assert.Equal(1, result);
     }
 
     [Fact(Timeout = 1000)]
     public async Task AllGet_UsesReadOnlyCommand()
     {
-        var msg = Message(
+        var msg = Batch(
             RedisCommand.BITFIELD_RO,
             BitFieldOperation.Get(BitFieldEncoding.UInt8, 0),
             BitFieldOperation.Get(BitFieldEncoding.UInt63, BitFieldOffset.Element(2)));
         const string RequestResp = "*8\r\n$11\r\nBITFIELD_RO\r\n$1\r\nk\r\n$3\r\nGET\r\n$2\r\nu8\r\n$1\r\n0\r\n$3\r\nGET\r\n$3\r\nu63\r\n$2\r\n#2\r\n";
 
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*2\r\n:255\r\n:0\r\n", log: log);
-        Assert.Equal(new long?[] { 255, 0 }, result!.Span.ToArray());
+        Assert.Equal(new long?[] { 255, 0 }, result.Span.ToArray());
+    }
+
+    [Theory(Timeout = 1000)]
+    [InlineData(1, "$2\r\ni1\r\n")]
+    [InlineData(9, "$2\r\ni9\r\n")]
+    [InlineData(10, "$3\r\ni10\r\n")]
+    [InlineData(64, "$3\r\ni64\r\n")]
+    public async Task EncodingWidths_AreFramedCorrectly(int width, string encodingResp)
+    {
+        // the width is 1-64, so the length prefix is always one digit and the whole bulk string is
+        // written in one go
+        var msg = Batch(RedisCommand.BITFIELD_RO, BitFieldOperation.Get(BitFieldEncoding.Signed(width), 0));
+        var requestResp = "*5\r\n$11\r\nBITFIELD_RO\r\n$1\r\nk\r\n$3\r\nGET\r\n" + encodingResp + "$1\r\n0\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, requestResp, "*1\r\n:0\r\n", log: log);
+        Assert.Equal(new long?[] { 0 }, result.Span.ToArray());
+    }
+
+    [Theory(Timeout = 1000)]
+    [InlineData(0, "$2\r\n#0\r\n")]
+    [InlineData(9, "$2\r\n#9\r\n")]
+    [InlineData(1234567890123, "$14\r\n#1234567890123\r\n")]
+    public async Task ElementOffsets_AreFramedCorrectly(long element, string offsetResp)
+    {
+        var msg = Batch(RedisCommand.BITFIELD_RO, BitFieldOperation.Get(BitFieldEncoding.UInt8, BitFieldOffset.Element(element)));
+        var requestResp = "*5\r\n$11\r\nBITFIELD_RO\r\n$1\r\nk\r\n$3\r\nGET\r\n$2\r\nu8\r\n" + offsetResp;
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, requestResp, "*1\r\n:0\r\n", log: log);
+        Assert.Equal(new long?[] { 0 }, result.Span.ToArray());
     }
 
     [Fact(Timeout = 1000)]
     public async Task LeadingWrap_IsNotEmitted()
     {
         // WRAP is the server default, so there is nothing to say
-        var msg = Message(RedisCommand.BITFIELD, BitFieldOperation.Set(BitFieldEncoding.Int64, 0, 5, BitFieldOverflow.Wrap));
+        var msg = Batch(RedisCommand.BITFIELD, BitFieldOperation.Set(BitFieldEncoding.Int64, 0, 5, BitFieldOverflow.Wrap));
         const string RequestResp = "*6\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n$3\r\nSET\r\n$3\r\ni64\r\n$1\r\n0\r\n$1\r\n5\r\n";
 
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*1\r\n:0\r\n", log: log);
-        Assert.Equal(new long?[] { 0 }, result!.Span.ToArray());
+        Assert.Equal(new long?[] { 0 }, result.Span.ToArray());
     }
 
     [Fact(Timeout = 1000)]
     public async Task Overflow_IsEmittedOnlyWhenItChanges()
     {
-        var msg = Message(
+        var msg = Batch(
             RedisCommand.BITFIELD,
             BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1, BitFieldOverflow.Saturate),
             BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, BitFieldOffset.Element(1), 2, BitFieldOverflow.Saturate),
@@ -60,14 +100,14 @@ public class BitFieldRoundTrip(ITestOutputHelper log)
             + "$8\r\nOVERFLOW\r\n$4\r\nWRAP\r\n$3\r\nSET\r\n$2\r\nu8\r\n$1\r\n0\r\n$1\r\n3\r\n";
 
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*3\r\n:0\r\n:2\r\n:1\r\n", log: log);
-        Assert.Equal(new long?[] { 0, 2, 1 }, result!.Span.ToArray());
+        Assert.Equal(new long?[] { 0, 2, 1 }, result.Span.ToArray());
     }
 
     [Fact(Timeout = 1000)]
     public async Task Overflow_SurvivesAnInterveningGet_AndFailReportsNull()
     {
         // the sticky OVERFLOW state is not reset or consumed by a GET, so the second INCRBY needs no token
-        var msg = Message(
+        var msg = Batch(
             RedisCommand.BITFIELD,
             BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Fail),
             BitFieldOperation.Get(BitFieldEncoding.Int8, 0),
@@ -78,36 +118,36 @@ public class BitFieldRoundTrip(ITestOutputHelper log)
             + "$6\r\nINCRBY\r\n$2\r\ni8\r\n$1\r\n0\r\n$3\r\n100\r\n";
 
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*3\r\n:100\r\n:100\r\n$-1\r\n", log: log);
-        Assert.Equal(new long?[] { 100, 100, null }, result!.Span.ToArray());
+        Assert.Equal(new long?[] { 100, 100, null }, result.Span.ToArray());
     }
 
     [Fact]
-    public void Classification_ReflectsTheOperations()
+    public void ArgCountMatchesTheOperations()
     {
-        RedisDatabase.BuildBitFieldPayload([BitFieldOperation.Get(BitFieldEncoding.UInt8, 0)], out var allGet, out var anyIncrement);
-        Assert.True(allGet);
-        Assert.False(anyIncrement);
+        // key + (SET, enc, off, value)
+        Assert.Equal(5, Batch(RedisCommand.BITFIELD, BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1)).ArgCount);
+        Assert.Equal(5, Single(RedisCommand.BITFIELD, BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1)).ArgCount);
 
-        RedisDatabase.BuildBitFieldPayload(
-            [BitFieldOperation.Get(BitFieldEncoding.UInt8, 0), BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1)],
-            out allGet,
-            out anyIncrement);
-        Assert.False(allGet);
-        Assert.False(anyIncrement); // SET only: eligible for last-wins retry
+        // key + (GET, enc, off)
+        Assert.Equal(4, Batch(RedisCommand.BITFIELD_RO, BitFieldOperation.Get(BitFieldEncoding.UInt8, 0)).ArgCount);
 
-        RedisDatabase.BuildBitFieldPayload(
-            [BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1), BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, 0, 1)],
-            out allGet,
-            out anyIncrement);
-        Assert.False(allGet);
-        Assert.True(anyIncrement);
+        // key + (OVERFLOW, mode) + 2x(INCRBY, enc, off, value)
+        Assert.Equal(
+            11,
+            Batch(
+                RedisCommand.BITFIELD,
+                BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, 0, 1, BitFieldOverflow.Fail),
+                BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, 0, 1, BitFieldOverflow.Fail)).ArgCount);
     }
 
     [Fact]
-    public void DefaultOperation_IsRejected()
+    public void DefaultOperation_IsRejectedBeforeTheMessageIsQueued()
     {
-        var ex = Assert.Throws<ArgumentException>(() => RedisDatabase.BuildBitFieldPayload(new BitFieldOperation[1], out _, out _));
-        Assert.Equal("operations", ex.ParamName);
+        var batch = Assert.Throws<ArgumentException>(() => Batch(RedisCommand.BITFIELD, default(BitFieldOperation)));
+        Assert.Equal("operations", batch.ParamName);
+
+        var single = Assert.Throws<ArgumentException>(() => Single(RedisCommand.BITFIELD, default(BitFieldOperation)));
+        Assert.Equal("operation", single.ParamName);
     }
 
     [Fact]

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitFieldRoundTrip.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests.RoundTripUnitTests;
+
+public class BitFieldRoundTrip(ITestOutputHelper log)
+{
+    private static Message Message(RedisCommand command, params BitFieldOperation[] operations)
+    {
+        var payload = RedisDatabase.BuildBitFieldPayload(operations, out _, out _);
+        return StackExchange.Redis.Message.Create(0, CommandFlags.None, command, (RedisKey)"k", payload);
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task Increment_RoundTrips()
+    {
+        var msg = Message(RedisCommand.BITFIELD, BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1));
+        const string RequestResp = "*6\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n$6\r\nINCRBY\r\n$2\r\ni8\r\n$1\r\n0\r\n$1\r\n1\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*1\r\n:1\r\n", log: log);
+        Assert.Equal(new long?[] { 1 }, result!.Span.ToArray());
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task AllGet_UsesReadOnlyCommand()
+    {
+        var msg = Message(
+            RedisCommand.BITFIELD_RO,
+            BitFieldOperation.Get(BitFieldEncoding.UInt8, 0),
+            BitFieldOperation.Get(BitFieldEncoding.UInt63, BitFieldOffset.Index(2)));
+        const string RequestResp = "*8\r\n$11\r\nBITFIELD_RO\r\n$1\r\nk\r\n$3\r\nGET\r\n$2\r\nu8\r\n$1\r\n0\r\n$3\r\nGET\r\n$3\r\nu63\r\n$2\r\n#2\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*2\r\n:255\r\n:0\r\n", log: log);
+        Assert.Equal(new long?[] { 255, 0 }, result!.Span.ToArray());
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task LeadingWrap_IsNotEmitted()
+    {
+        // WRAP is the server default, so there is nothing to say
+        var msg = Message(RedisCommand.BITFIELD, BitFieldOperation.Set(BitFieldEncoding.Int64, 0, 5, BitFieldOverflow.Wrap));
+        const string RequestResp = "*6\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n$3\r\nSET\r\n$3\r\ni64\r\n$1\r\n0\r\n$1\r\n5\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*1\r\n:0\r\n", log: log);
+        Assert.Equal(new long?[] { 0 }, result!.Span.ToArray());
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task Overflow_IsEmittedOnlyWhenItChanges()
+    {
+        var msg = Message(
+            RedisCommand.BITFIELD,
+            BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1, BitFieldOverflow.Saturate),
+            BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, BitFieldOffset.Index(1), 2, BitFieldOverflow.Saturate),
+            BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 3, BitFieldOverflow.Wrap));
+        const string RequestResp = "*18\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n"
+            + "$8\r\nOVERFLOW\r\n$3\r\nSAT\r\n$3\r\nSET\r\n$2\r\nu8\r\n$1\r\n0\r\n$1\r\n1\r\n"
+            + "$6\r\nINCRBY\r\n$2\r\nu8\r\n$2\r\n#1\r\n$1\r\n2\r\n"
+            + "$8\r\nOVERFLOW\r\n$4\r\nWRAP\r\n$3\r\nSET\r\n$2\r\nu8\r\n$1\r\n0\r\n$1\r\n3\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*3\r\n:0\r\n:2\r\n:1\r\n", log: log);
+        Assert.Equal(new long?[] { 0, 2, 1 }, result!.Span.ToArray());
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task Overflow_SurvivesAnInterveningGet_AndFailReportsNull()
+    {
+        // the sticky OVERFLOW state is not reset or consumed by a GET, so the second INCRBY needs no token
+        var msg = Message(
+            RedisCommand.BITFIELD,
+            BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Fail),
+            BitFieldOperation.Get(BitFieldEncoding.Int8, 0),
+            BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 100, BitFieldOverflow.Fail));
+        const string RequestResp = "*15\r\n$8\r\nBITFIELD\r\n$1\r\nk\r\n"
+            + "$8\r\nOVERFLOW\r\n$4\r\nFAIL\r\n$6\r\nINCRBY\r\n$2\r\ni8\r\n$1\r\n0\r\n$3\r\n100\r\n"
+            + "$3\r\nGET\r\n$2\r\ni8\r\n$1\r\n0\r\n"
+            + "$6\r\nINCRBY\r\n$2\r\ni8\r\n$1\r\n0\r\n$3\r\n100\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.LeaseNullableInt64, RequestResp, "*3\r\n:100\r\n:100\r\n$-1\r\n", log: log);
+        Assert.Equal(new long?[] { 100, 100, null }, result!.Span.ToArray());
+    }
+
+    [Fact]
+    public void Classification_ReflectsTheOperations()
+    {
+        RedisDatabase.BuildBitFieldPayload([BitFieldOperation.Get(BitFieldEncoding.UInt8, 0)], out var allGet, out var anyIncrement);
+        Assert.True(allGet);
+        Assert.False(anyIncrement);
+
+        RedisDatabase.BuildBitFieldPayload(
+            [BitFieldOperation.Get(BitFieldEncoding.UInt8, 0), BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1)],
+            out allGet,
+            out anyIncrement);
+        Assert.False(allGet);
+        Assert.False(anyIncrement); // SET only: eligible for last-wins retry
+
+        RedisDatabase.BuildBitFieldPayload(
+            [BitFieldOperation.Set(BitFieldEncoding.UInt8, 0, 1), BitFieldOperation.IncrementBy(BitFieldEncoding.UInt8, 0, 1)],
+            out allGet,
+            out anyIncrement);
+        Assert.False(allGet);
+        Assert.True(anyIncrement);
+    }
+
+    [Fact]
+    public void DefaultOperation_IsRejected()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => RedisDatabase.BuildBitFieldPayload(new BitFieldOperation[1], out _, out _));
+        Assert.Equal("operations", ex.ParamName);
+    }
+
+    [Fact]
+    public void ReadOnlyVariantIsNotPrimaryOnly()
+    {
+        // BITFIELD is a write server-side even when every sub-operation is a GET; BITFIELD_RO is not
+        Assert.True(RedisCommand.BITFIELD.IsPrimaryOnly());
+        Assert.False(RedisCommand.BITFIELD_RO.IsPrimaryOnly());
+    }
+}

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitPositionRoundTrip.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/BitPositionRoundTrip.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests.RoundTripUnitTests;
+
+public class BitPositionRoundTrip(ITestOutputHelper log)
+{
+    [Fact(Timeout = 1000)]
+    public async Task ExplicitEnd_IsSent()
+    {
+        var db = new RedisDatabase(null!, 0, null);
+        var msg = db.GetStringBitPositionMessage("k", false, 0, -1, StringIndexType.Byte, CommandFlags.None);
+        const string RequestResp = "*5\r\n$6\r\nBITPOS\r\n$1\r\nk\r\n$1\r\n0\r\n$1\r\n0\r\n$2\r\n-1\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.Int64, RequestResp, ":-1\r\n", log: log);
+        Assert.Equal(-1, result);
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task ExplicitEnd_WithBitIndexType_SendsToken()
+    {
+        var db = new RedisDatabase(null!, 0, null);
+        var msg = db.GetStringBitPositionMessage("k", false, 0, 7, StringIndexType.Bit, CommandFlags.None);
+        const string RequestResp = "*6\r\n$6\r\nBITPOS\r\n$1\r\nk\r\n$1\r\n0\r\n$1\r\n0\r\n$1\r\n7\r\n$3\r\nBIT\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.Int64, RequestResp, ":-1\r\n", log: log);
+        Assert.Equal(-1, result);
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task UnboundedEnd_OmitsEnd()
+    {
+        var db = new RedisDatabase(null!, 0, null);
+        var msg = db.GetStringBitPositionMessage("k", false, 0, StringIndex.Unbounded, StringIndexType.Byte, CommandFlags.None);
+        const string RequestResp = "*4\r\n$6\r\nBITPOS\r\n$1\r\nk\r\n$1\r\n0\r\n$1\r\n0\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.Int64, RequestResp, ":8\r\n", log: log);
+        Assert.Equal(8, result);
+    }
+
+    [Fact(Timeout = 1000)]
+    public async Task UnboundedEnd_KeepsStart()
+    {
+        var db = new RedisDatabase(null!, 0, null);
+        var msg = db.GetStringBitPositionMessage("k", true, 2, StringIndex.Unbounded, StringIndexType.Byte, CommandFlags.None);
+        const string RequestResp = "*4\r\n$6\r\nBITPOS\r\n$1\r\nk\r\n$1\r\n1\r\n$1\r\n2\r\n";
+
+        var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.Int64, RequestResp, ":16\r\n", log: log);
+        Assert.Equal(16, result);
+    }
+
+    [Fact]
+    public void UnboundedEnd_RejectsBitIndexType()
+    {
+        var db = new RedisDatabase(null!, 0, null);
+        var ex = Assert.Throws<ArgumentException>(() => db.GetStringBitPositionMessage("k", false, 0, StringIndex.Unbounded, StringIndexType.Bit, CommandFlags.None));
+        Assert.Equal("indexType", ex.ParamName);
+    }
+}


### PR DESCRIPTION
Two gaps in the [bitmap family](https://redis.io/docs/latest/commands/?group=bitmap). Of the seven commands in that group, five were already covered (`SETBIT`, `GETBIT`, `BITCOUNT`, `BITPOS`, `BITOP` - the latter already current with the 8.2 `DIFF`/`DIFF1`/`ANDOR`/`ONE` additions from #2900). This adds the missing two, and fixes one thing `BITPOS` could not say.

## BITFIELD / BITFIELD_RO

Previously unimplemented; the only trace in the repo was a commented-out line in the envoy exclusion list.

```csharp
long?         StringBitField(RedisKey key, BitFieldOperation operation, CommandFlags flags = CommandFlags.None);
Lease<long?>  StringBitField(RedisKey key, ReadOnlyMemory<BitFieldOperation> operations, CommandFlags flags = CommandFlags.None);
// ... plus StringBitFieldAsync equivalents
```

with four new value types:

```csharp
BitFieldEncoding.Signed(int) / Unsigned(int)
BitFieldEncoding.Int8/Int16/Int32/Int64, UInt8/UInt16/UInt32/UInt63   // + Width, IsSigned
BitFieldOffset.Bits(long) / Index(long)                              // Index is the server's #N form
BitFieldOverflow.Wrap | Saturate | Fail
BitFieldOperation.Get(enc, off) / Set(enc, off, value, overflow = Wrap) / IncrementBy(...)
```

Usage:

```csharp
db.StringBitField(key, BitFieldOperation.IncrementBy(BitFieldEncoding.Int8, 0, 1));

using var results = db.StringBitField(key, new[]
{
    BitFieldOperation.Set(BitFieldEncoding.UInt8, BitFieldOffset.Index(3), 255),
    BitFieldOperation.IncrementBy(BitFieldEncoding.Int16, 64, -1, BitFieldOverflow.Saturate),
    BitFieldOperation.Get(BitFieldEncoding.UInt63, 0),
});
```

### Design notes

- **Signedness belongs with the width, not in a flags enum.** `u8` is one wire token and one semantic unit; overflow is a separate, sticky, kind-scoped concept that `GET` ignores entirely. A single flags bag would permit `Signed | Fail` on a `Get`, where half is meaningless. A named encoding type also stops `(width, offset)` transposition, both being bare integers otherwise.
- **`#N` belongs on the offset**, for the same reason: a flag that reinterprets a *different* argument is the hazard, not the ceremony.
- **Results are plain `long`.** Every legal encoding is `i1`-`i64` or `u1`-`u63`, and `u63`'s maximum is exactly `long.MaxValue` - which is *why* `u64` does not exist (the reply is a signed 64-bit integer). So there is nothing to disambiguate and no need for a struct with signed/unsigned accessors. Elements are nullable only because `OVERFLOW FAIL` reports a nil for the operation it skipped; the batch itself is non-null - the reply is always an array with one element per operation, so an empty lease covers both an empty batch and a non-observable result such as fire-and-forget.
- **There is a named `UInt63`** where `UInt64` would sit. The double-take is the point: it documents the ceiling exactly where someone reaches for the obvious thing, and `Unsigned(64)` throws with a message naming `UInt63` and `Int64` as the alternatives.
- **OVERFLOW is emitted only when it changes**, and never for a leading run of `WRAP` (the server default). The sticky state is neither reset nor consumed by an intervening `GET`, so the tracker carries across them.
- **All-`GET` batches go out as `BITFIELD_RO`** when the selected server is 6.0+ and the command is not disabled/renamed, so a replica can serve them; anything that writes stays as `BITFIELD`, which is primary-only (the server treats `BITFIELD` as a write even when every sub-operation is a `GET` - hence `BITFIELD_RO` existing at all). Write ops are detected client-side, so `BITFIELD_RO` is never issued with something it would reject.
- **Retry category follows the payload**, on a separate axis from routing: `ReadOnly` when every sub-operation is a `GET` (whichever of the two commands is issued - the server treating `BITFIELD` as a write governs which servers accept it, not whether replaying is safe), `WriteLastWins` when there is no `INCRBY` (`SET` is positional, so a replay lands on the same value), and `WriteAccumulating` otherwise. Follows the existing "demoted where we can see the args" pattern from `XADD`.
- **An empty batch short-circuits locally** to an empty lease - no round-trip.
- A `default(BitFieldEncoding)` is rejected at operation construction *and* in the writer, so a `default(BitFieldOperation)` sitting in an unfilled array cannot reach the wire as `i0`.

Not included, deliberately - both non-breaking to add later if wanted: scalar `StringBitFieldGet`/`Set`/`Increment` helpers (the single-op overload subsumes them; the only loss is `long?` rather than `long` for a pure `Get`), and public accessors on `BitFieldOperation` (`Kind`/`Encoding`/`Offset`/`Value`/`Overflow` are internal).

The command is rendered by a `Message` subclass in `WriteImpl` (the `HotKeysStartMessage` shape) rather than via an intermediate `RedisValue[]`, so the batch form aliases the caller's memory and the single-operation form holds the operation inline; sub-command and overflow tokens are framed `u8` spans written raw, and the encoding is one framed write into a scratch buffer. Verified against the IL on all six TFMs that neither path allocates - notably, a `[operation]` collection expression *does* allocate a one-element array on every framework without the by-ref span constructor (net461, netstandard2.0, net472, net6.0), so that path takes `in BitFieldOperation` instead.

The two `StringBitField` overloads need `#pragma warning disable RS0026`, with the same "disambiguated via parameter types" justification already used in `RedisChannel`.

## StringBitPosition: an open-ended end

`StringBitPosition` always sent an explicit `end`, and for a clear-bit search the server distinguishes the two cases:

```
BITPOS key 0        -> 8     # first clear bit past the end of the string
BITPOS key 0 0      -> 8     # start alone: still open-ended
BITPOS key 0 0 -1   -> -1    # explicit range: no clear bit in the string
```

(single all-ones byte). The `end` parameter documented `-1` as "unlimited", which was the wrong mental model - `-1` is the *last byte*, and the open-ended result was unreachable.

Passing `StringIndex.Unbounded` as `end` now omits it. That requires `StringIndexType.Byte`, since `BYTE`/`BIT` is only legal *after* an explicit end; silently dropping the token would reinterpret `start` from bits to bytes, so it throws instead.

A sentinel rather than an overload because a no-end overload would be equally applicable to the existing one at every call site, with both needing defaults substituted - i.e. CS0121 for callers. The sentinel also costs no new interface members and flows through the legacy overload, `IBatch`/`ITransaction` and the keyspace-isolation wrappers for free.

`BITCOUNT` is untouched: its `start`/`end` are an inseparable pair on the wire (`BITCOUNT key 0` is a syntax error), so a sentinel there could only silently discard `start`, and `0 -1` is anyway equivalent to no range.

## Testing

- Exact-bytes round-trip tests (no server): OVERFLOW dedup and stickiness across a `GET`, the `#N` and `i64`/`u63` tokens, nil parsing, payload classification, `BITFIELD_RO` vs `BITFIELD` primary-only-ness, and the `BITPOS` omitted-end layout.
- Type unit tests: width limits and their messages, offset forms, default/unknown-value rejection.
- Live integration: `SET`/`GET`/`INCRBY` semantics, `OVERFLOW FAIL` nils, index offsets, the empty batch, and a profiler assertion that all-`GET` calls left as `BITFIELD_RO` to the replica while the write left as `BITFIELD` to the primary.

`dotnet build Build.csproj -c Release /p:CI=true` is clean across all TFMs. Full suite on net10.0: 6022 passed, 149 skipped, with one failure that differs run-to-run (`RetryTests.WithRetry_FailsOverBetweenGroupsOnLoading` once, `InProcPubSubTests.TestBasicPubSub` once; each passes in isolation) - neither touches bitmaps, and both look like pre-existing flakiness under parallel load rather than anything here, though I have not bisected them.


