### PR TITLE
Tests: don't assume endpoint discovery is synchronous with connect

### DIFF
--- a/tests/StackExchange.Redis.Tests/EndpointPruningUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/EndpointPruningUnitTests.cs
@@ -46,7 +46,11 @@ public class EndpointPruningUnitTests(ITestOutputHelper log)
         // defaultOnly, so the doomed node is *discovered* rather than configured - a configured endpoint is
         // exempt by design, and connecting to every toy node would make this test vacuous
         await using var conn = await server.ConnectAsync(defaultOnly: true);
-        Assert.Contains(doomed, conn.GetEndPoints());
+
+        // discovery is prompt but not synchronous with ConnectAsync returning: the node is learned from the
+        // CLUSTER SLOTS reply during handshake, and registering it does not have to have finished on the
+        // connecting thread. Asserting instantly passes on a fast machine and fails on a two-core runner
+        Assert.True(await Poll.UntilAsync(() => conn.GetEndPoints().Contains(doomed)), $"{doomed} was never discovered");
 
         // hand its slot back, so the topology stops listing it - and it owns nothing, so it is prunable
         server.Migrate((RedisKey)"prune-key", server.DefaultEndPoint);
@@ -187,8 +191,11 @@ public class EndpointPruningUnitTests(ITestOutputHelper log)
             log.WriteLine($"endpoint: {ep}");
         }
 
-        // reached by name, since that is what this cluster advertises
-        Assert.Contains(conn.GetEndPoints(), ep => ep is DnsEndPoint { Host: "host-2.redis.example.com" });
+        // reached by name, since that is what this cluster advertises (polled for the same reason as above:
+        // the newcomer is discovered, not configured)
+        Assert.True(
+            await Poll.UntilAsync(() => conn.GetEndPoints().Any(ep => ep is DnsEndPoint { Host: "host-2.redis.example.com" })),
+            "the newcomer was never discovered by name");
         Assert.DoesNotContain(conn.GetEndPoints(), ep => ep is IPEndPoint { Port: var p } && p == port + 1);
     }
 

--- a/tests/StackExchange.Redis.Tests/Helpers/Poll.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Poll.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace StackExchange.Redis.Tests;
 
@@ -17,13 +18,20 @@ internal static class Poll
     /// <summary>
     /// Polls until the predicate holds, or the timeout expires; returns whether it held.
     /// </summary>
+    /// <remarks>
+    /// The ambient test cancellation token is passed to each delay, so the framework's own timeout wins and
+    /// wins *promptly* - a cancelled test stops inside the current poll interval rather than after it, and a
+    /// hung predicate surfaces as the framework's cancellation rather than as this method quietly reporting
+    /// false. The local timeout is only a backstop for tests with no ambient limit.
+    /// </remarks>
     public static async Task<bool> UntilAsync(Func<bool> predicate, int timeoutMilliseconds = 5000, int pollMilliseconds = 25)
     {
         if (predicate()) return true; // usually already true, so don't pay a delay for the common case
 
+        var cancellationToken = TestContext.Current.CancellationToken;
         for (int i = 0; i < timeoutMilliseconds / pollMilliseconds; i++)
         {
-            await Task.Delay(pollMilliseconds).ConfigureAwait(false);
+            await Task.Delay(pollMilliseconds, cancellationToken).ConfigureAwait(false);
             if (predicate()) return true;
         }
 

--- a/tests/StackExchange.Redis.Tests/Helpers/Poll.cs
+++ b/tests/StackExchange.Redis.Tests/Helpers/Poll.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// Waiting for something that is *promptly* true rather than synchronously true.
+/// </summary>
+/// <remarks>
+/// The case this exists for: endpoint discovery. A node learned from <c>CLUSTER SLOTS</c> during handshake is
+/// registered on the connection's own path, so a test that asserts on <c>GetEndPoints()</c> the instant
+/// <c>ConnectAsync</c> returns is asserting an ordering the library never promised - the endpoint collection is
+/// a snapshot. It passes on a fast machine and fails on a two-core CI runner, which is the worst kind of test.
+/// </remarks>
+internal static class Poll
+{
+    /// <summary>
+    /// Polls until the predicate holds, or the timeout expires; returns whether it held.
+    /// </summary>
+    public static async Task<bool> UntilAsync(Func<bool> predicate, int timeoutMilliseconds = 5000, int pollMilliseconds = 25)
+    {
+        if (predicate()) return true; // usually already true, so don't pay a delay for the common case
+
+        for (int i = 0; i < timeoutMilliseconds / pollMilliseconds; i++)
+        {
+            await Task.Delay(pollMilliseconds).ConfigureAwait(false);
+            if (predicate()) return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
`EndpointPruningUnitTests.NodeAbsentFromTopologyIsPrunedAfterThreeGenerations` fails on CI roughly **one run in four**, and it fails at the `Assert.Contains` *before* any pruning happens - so the test was never reaching the behaviour it exists to check. Seen on #3193; confirmed to reproduce on `main`, so it is pre-existing rather than from that stack.

## Cause

A node learned from the `CLUSTER SLOTS` reply during handshake is registered on the connection's own path, and that does not have to have completed by the time `ConnectAsync` returns - `GetEndPoints()` is a snapshot. The test asserted the discovered node was present the instant connect returned, which is an ordering the library never promised. The invariant it actually cares about is that a discovered node appears *promptly*, so it now polls.

## Reproducing it, which is the useful part

It needs **CPU constraint, not load**:

```
taskset -c 0,1 dotnet test tests/StackExchange.Redis.Tests/StackExchange.Redis.Tests.csproj \
  --no-build -c Release -f net10.0 /p:CI=true
```

Two cores is what a GitHub runner has. On `main`, that fails about 1 run in 4; with this change, 0 in 6. Six whole-suite runs under heavy parallel load on 14 cores never reproduced it once, which is why it looked like a mystery - and is worth remembering for the next runner-only failure.

## Scope

Swept the sibling suites (`EndpointPruningUnitTests`, `EndpointResolutionUnitTests`, `ServerRetirementUnitTests`) for the same assumption. Most assertions on `GetEndPoints()` are about *configured* endpoints - present from the start, so not racy - or follow awaited topology work. Only two assert on discovery: the one above, and `NewNodeIsDialledByTheAdvertisedForm`. Both now poll.

`Poll.UntilAsync` is new (`Helpers/Poll.cs`); `TestBase.UntilConditionAsync` already exists but is `protected`, and these suites don't derive from `TestBase`.

Test-only change; no library code touched.

Note in passing: the same two-core setup also turned up a *different* pre-existing flake, `ScriptingTests.SimpleRawScriptEvaluate (RESP3)` (1 run in 6, fails in 3ms). Not touched here.