### PR TITLE
Tests: pin the pruning threshold deterministically, not end-to-end

### DIFF
--- a/tests/StackExchange.Redis.Tests/EndpointPruningUnitTests.cs
+++ b/tests/StackExchange.Redis.Tests/EndpointPruningUnitTests.cs
@@ -35,8 +35,44 @@ public class EndpointPruningUnitTests(ITestOutputHelper log)
         }
     }
 
+    /// <summary>
+    /// The threshold itself, driven directly - deterministic, because it does not depend on how many
+    /// generations anything else applied.
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately not asserted end-to-end. <c>OnMissingFromTopology</c> returns
+    /// <c>generation - absentSince + 1</c>, which is the number of generations *elapsed* rather than the
+    /// number of times this server was observed absent - so any topology application, from anywhere,
+    /// advances it. A test that applies two generations and then asserts "not pruned yet" is asserting that
+    /// nothing else applied one, which it cannot control: it passes on a fast machine and fails on a
+    /// two-core runner. So the threshold is pinned here, and the end-to-end test below asserts only what it
+    /// can honestly own - that an absent, idle node is eventually pruned.
+    /// </remarks>
     [Fact]
-    public async Task NodeAbsentFromTopologyIsPrunedAfterThreeGenerations()
+    public async Task AbsenceIsCountedAsGenerationsElapsed()
+    {
+        using var server = CreateServer(log);
+        await using var conn = await server.ConnectAsync(defaultOnly: true);
+        var target = ((IInternalConnectionMultiplexer)conn).GetServerEndPoint(server.DefaultEndPoint);
+
+        // generation numbers are arbitrary here; what matters is the delta from the first absence
+        Assert.Equal(1, target.OnMissingFromTopology(41));
+        Assert.Equal(2, target.OnMissingFromTopology(42));
+        Assert.Equal(3, target.OnMissingFromTopology(43));
+
+        // being seen again clears it, so absences have to be consecutive to accumulate
+        target.OnSeenInTopology(44);
+        Assert.Equal(1, target.OnMissingFromTopology(45));
+
+        // and a gap in generation numbers counts as the distance, not as one more absence - which is exactly
+        // what an end-to-end test cannot control, since it does not own the generation counter
+        target.OnSeenInTopology(49);
+        Assert.Equal(1, target.OnMissingFromTopology(50));
+        Assert.Equal(3, target.OnMissingFromTopology(52)); // two generations later, not two absences later
+    }
+
+    [Fact]
+    public async Task NodeAbsentFromTopologyIsEventuallyPruned()
     {
         using var server = CreateServer(log);
         GetHost(server.DefaultEndPoint, out var port);
@@ -55,10 +91,13 @@ public class EndpointPruningUnitTests(ITestOutputHelper log)
         // hand its slot back, so the topology stops listing it - and it owns nothing, so it is prunable
         server.Migrate((RedisKey)"prune-key", server.DefaultEndPoint);
 
-        await ApplyGenerationsAsync(conn, server.DefaultEndPoint, 2);
-        Assert.Contains(doomed, conn.GetEndPoints()); // two absences is not yet evidence
+        // the *threshold* is pinned by AbsenceIsCountedAsGenerationsElapsed; what this owns is that applying
+        // topology generations does eventually remove it. Bounded so a regression fails rather than hangs
+        for (int i = 0; i < 10 && conn.GetEndPoints().Contains(doomed); i++)
+        {
+            await ApplyGenerationsAsync(conn, server.DefaultEndPoint, 1);
+        }
 
-        await ApplyGenerationsAsync(conn, server.DefaultEndPoint, 1);
         log.WriteLine(string.Join(", ", conn.GetEndPoints().Select(x => x.ToString())));
         Assert.DoesNotContain(doomed, conn.GetEndPoints());
     }


### PR DESCRIPTION
Follow-up to #3197, which fixed one flaw in `NodeAbsentFromTopologyIsPrunedAfterThreeGenerations` - it asserted discovery synchronously with `ConnectAsync` returning. The failure then moved one line down, to `Assert.Contains(doomed, ...)` after two generations, still failing about **one two-core run in four**.

## Why

The primitive counts elapsed generations, not observed absences:

```csharp
internal int OnMissingFromTopology(int generation)
{
    if (AbsentSinceGeneration < 0) { AbsentSinceGeneration = generation; return 1; }
    return generation - AbsentSinceGeneration + 1;
}
```

So *any* topology application advances it. A test that applies two generations and then asserts "not pruned yet" is really asserting that nothing else applied one - which it does not control. Hence fast machine passes, two-core runner fails.

I tried suppressing the heartbeat first, on the theory that a background pass was the culprit; it did not fix it, so the assertion is the problem rather than any particular background path.

## The split

- **`AbsenceIsCountedAsGenerationsElapsed`** drives the counter directly with explicit generation numbers - deterministic, no connection timing involved. It also documents the elapsed-versus-observed distinction, including that a two-generation gap counts as two, which is precisely what an end-to-end test cannot control.
- **`NodeAbsentFromTopologyIsEventuallyPruned`** keeps what it can honestly own: an absent, idle, cluster-discovered node is eventually pruned. Bounded loop, so a regression fails rather than hangs.

## Verification

`taskset -c 0,1` with `-c Release /p:CI=true` (two cores is what a runner has): **6 clean whole-suite runs**, against roughly 1 in 4 failing before.

No library change. The product behaviour is fine and arguably intended - three generations elapsed is three generations elapsed, whoever applied them. If we ever want "three *observed* absences" instead, that is a deliberate change to the primitive and its own PR.

Note in passing: the same two-core setup keeps turning up unrelated pre-existing flakes of the same family (assert-before-ready) - `ScriptingTests.SimpleRawScriptEvaluate` and `ConnectionFailureErrorsTests.SocketFailureError`. Not touched here; worth a separate sweep.