### PR TITLE
Prevent response queue writes during connection teardown

### DIFF
--- a/src/StackExchange.Redis/PhysicalConnection.Read.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Read.cs
@@ -702,6 +702,15 @@ internal sealed partial class PhysicalConnection
 
             if (!_writtenAwaitingResponse.TryDequeue(out msg))
             {
+                // A failure can race bytes that were already in the socket or read buffer. Once shutdown has
+                // started, no new command can enter this queue, so these are replies to commands the failure
+                // path has already completed. Drop them with the dead connection instead of reporting a fresh
+                // protocol failure.
+                if (_isShutdown)
+                {
+                    return;
+                }
+
                 Throw(frame, connectionType, _protocol);
 
                 [DoesNotReturn]

--- a/src/StackExchange.Redis/PhysicalConnection.Write.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Write.cs
@@ -13,8 +13,9 @@ internal partial class PhysicalConnection
     private BufferedStreamWriter? _output;
 
     /// <summary>
-    /// Set by <see cref="Shutdown"/> before it discards <see cref="_output"/>, so a writer that finds the
-    /// output gone can tell the two cases apart; see <see cref="ThrowOutputUnavailable"/>.
+    /// Set when connection shutdown starts, before responses are failed or <see cref="_output"/> is discarded,
+    /// so writers cannot add new response expectations to a connection being torn down; see
+    /// <see cref="ThrowOutputUnavailable"/>.
     /// </summary>
     private volatile bool _isShutdown;
 

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -413,6 +413,15 @@ namespace StackExchange.Redis
             bool isInitialConnect = false,
             Stream? connectingStream = null)
         {
+            // Close the response queue to new writers before detaching the bridge or failing messages.
+            // A writer may already hold a reference to this physical connection; without this gate it can
+            // enqueue against the old socket after the failure path has drained the queue. A reply already in
+            // flight can then be matched to that newer command, permanently shifting response ownership.
+            lock (_writtenAwaitingResponse)
+            {
+                _isShutdown = true;
+            }
+
             Exception? outerException = innerException;
             IdentifyFailureType(innerException, ref failureType);
             var bridge = BridgeCouldBeNull;
@@ -676,6 +685,14 @@ namespace StackExchange.Redis
             bool wasEmpty;
             lock (_writtenAwaitingResponse)
             {
+                if (_isShutdown)
+                {
+                    throw new RedisConnectionException(
+                        ConnectionFailureType.SocketClosed,
+                        next.Flags,
+                        "The connection was closed before the command could be written");
+                }
+
                 wasEmpty = _writtenAwaitingResponse.Count == 0;
                 _writtenAwaitingResponse.Enqueue(next);
             }

--- a/tests/StackExchange.Redis.Tests/Issues/Issue3167Tests.cs
+++ b/tests/StackExchange.Redis.Tests/Issues/Issue3167Tests.cs
@@ -116,6 +116,7 @@ public class Issue3167Tests(ITestOutputHelper output) : TestBase(output)
 
             var outputPipeFaults = new ConcurrentQueue<Exception>();
             var internalFailures = new ConcurrentQueue<Exception>();
+            var responseIntegrityFailures = new ConcurrentQueue<Exception>();
             var internalErrors = new ConcurrentQueue<Exception>();
             long totalOps = 0, totalFaults = 0;
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -130,11 +131,21 @@ public class Issue3167Tests(ITestOutputHelper output) : TestBase(output)
                     outputPipeFaults.Enqueue(ex);
                 }
 
+                if (ex.ToString().Contains("response with no message waiting", StringComparison.OrdinalIgnoreCase)
+                    || ex.ToString().Contains("Unexpected response to", StringComparison.OrdinalIgnoreCase))
+                {
+                    responseIntegrityFailures.Enqueue(ex);
+                }
+
                 for (Exception? walk = ex; walk is not null; walk = walk.InnerException)
                 {
                     if (walk is RedisConnectionException { FailureType: ConnectionFailureType.InternalFailure })
                     {
                         internalFailures.Enqueue(ex);
+                    }
+                    else if (walk is RedisConnectionException { FailureType: ConnectionFailureType.ResponseIntegrityFailure })
+                    {
+                        responseIntegrityFailures.Enqueue(ex);
                     }
                 }
             }
@@ -187,7 +198,7 @@ public class Issue3167Tests(ITestOutputHelper output) : TestBase(output)
 
             var ops = Volatile.Read(ref totalOps);
             Log($"ops: {ops}, faults: {Volatile.Read(ref totalFaults)}, kills: {kills}");
-            Log($"internal failures: {internalFailures.Count}, output-pipe faults: {outputPipeFaults.Count}, internal errors: {internalErrors.Count}");
+            Log($"internal failures: {internalFailures.Count}, response-integrity failures: {responseIntegrityFailures.Count}, output-pipe faults: {outputPipeFaults.Count}, internal errors: {internalErrors.Count}");
 
             void Dump(string label, ConcurrentQueue<Exception> queue)
             {
@@ -200,6 +211,7 @@ public class Issue3167Tests(ITestOutputHelper output) : TestBase(output)
 
             Dump("output-pipe fault", outputPipeFaults);
             Dump("internal failure", internalFailures);
+            Dump("response-integrity failure", responseIntegrityFailures);
 
             // this only means anything if we actually raced teardown; if these trip, the writers or the kill
             // loop stopped doing their job, rather than the bug being fixed
@@ -209,6 +221,7 @@ public class Issue3167Tests(ITestOutputHelper output) : TestBase(output)
 
             Assert.Empty(outputPipeFaults);
             Assert.Empty(internalFailures);
+            Assert.Empty(responseIntegrityFailures);
         }
         finally
         {

--- a/tests/StackExchange.Redis.Tests/WriteFailureTeardownTests.cs
+++ b/tests/StackExchange.Redis.Tests/WriteFailureTeardownTests.cs
@@ -46,6 +46,20 @@ public class WriteFailureTeardownTests(ITestOutputHelper output) : TestBase(outp
     }
 
     [Fact]
+    public void ConnectionFailureRejectsCommandsThatCapturedTheOldPhysicalConnection()
+    {
+        using var stream = new MemoryStream();
+        using var connection = PhysicalConnection.Dummy(stream);
+        connection.RecordConnectionFailed(ConnectionFailureType.SocketClosed);
+
+        var message = Message.Create(0, CommandFlags.None, RedisCommand.GET, (RedisKey)"late-write");
+
+        var exception = Assert.Throws<RedisConnectionException>(() => connection.EnqueueInsideWriteLock(message, enforceMuxer: false));
+        Assert.Equal(ConnectionFailureType.SocketClosed, exception.FailureType);
+        Assert.Contains("closed before the command could be written", exception.Message);
+    }
+
+    [Fact]
     public async Task WriteFailure_TearsDownPhysicalConnection()
     {
         // We deliberately raise InternalError + ConnectionFailed events here, so don't fail


### PR DESCRIPTION
## Summary

Close a failed physical connection's response queue to new writers before detaching the bridge and draining outstanding messages.

A writer can already hold a reference to the old `PhysicalConnection` when `RecordConnectionFailed` starts. Today teardown detaches the bridge, drains `_writtenAwaitingResponse`, and only then calls `Shutdown()`. In that interval the writer can enqueue a new response expectation against the old socket. A reply already in the socket/read buffer can then be matched to that later command, shifting response ownership.

This complements #3189 / #3167. That change correctly treats a writer losing its output pipe as a normal closure, but it does not close the response queue while teardown is draining it.

The change:

- marks shutdown under the response-queue lock at the start of `RecordConnectionFailed`
- rejects commands that captured the old physical connection with `SocketClosed`
- drops trailing replies after the dead connection's response queue has been drained
- extends the existing teardown stress test to fail on response-integrity symptoms

## Reproduction

I reproduced this against Valkey 9.1.0 by running concurrent `SET`/`GET`, hash, list, and optional pub/sub traffic while repeatedly issuing `CLIENT KILL` for the active client sockets.

The failure occurs on:

- StackExchange.Redis 3.1.31 and current `main` (`322688fa`)
- RESP2 and RESP3
- direct Redis traffic with no FusionCache or pub/sub operations

Observed errors include:

```text
Received Interactive/Resp3 response with no message waiting: BulkString
Unexpected response to PUBLISH: BulkString
Unexpected response to HMSET: Integer
Invalid format parsing BulkString as Boolean
```

That makes this protocol-independent and rules out RESP3 push framing and FusionCache as requirements. The server is closing sockets on request; the corruption is the client-side race between response-queue draining and a writer that captured the old physical connection.

Patched stress runs:

- RESP3, direct-only: 18,274 expected disconnect errors, 0 protocol faults
- RESP2, direct-only: 15,505 expected disconnect errors, 0 protocol faults
- RESP3, shared direct + FusionCache/pub-sub: 43,343 expected disconnect errors, 0 protocol faults

No wrong non-null values were observed in the patched runs.

## Validation

- focused `WriteFailureTeardownTests`: pass
- deterministic #3167 test: pass
- explicit `WritesRacingTeardownAreNeverInternalFailures`: pass with response-integrity assertions
- multi-target Release build: pass
- complete net10 suite: 6,037 passed, 150 skipped, 1 unrelated failure

The single suite failure is `ConnectionFailureErrorsTests.SocketFailureError`, where DNS resolution produced an outer exception without the expected inner exception. It reproduces unchanged from a clean `322688fa` checkout in this environment.

Related: #3091, #3167, #3189
