### PR TITLE
D8: document the notifications, and make the diagnostic it recommends work

### DIFF
--- a/docs/ServerMaintenanceEvent.md
+++ b/docs/ServerMaintenanceEvent.md
@@ -1,6 +1,13 @@
-# Introducing ServerMaintenanceEvents
+﻿# Introducing ServerMaintenanceEvents
 
 StackExchange.Redis now automatically subscribes to notifications about upcoming maintenance from supported Redis providers. The ServerMaintenanceEvent on the ConnectionMultiplexer raises events in response to notifications about server maintenance, and application code can subscribe to the event to handle connection drops more gracefully during these maintenance operations.
+
+There are two sources of these events, and they arrive by completely different routes:
+
+* **Azure Cache for Redis** publishes them on a pub/sub channel (`AzureRedisEvents`), and they surface as `AzureMaintenanceEvent`. This is the original support, and is described below.
+* **Redis Enterprise and Redis Cloud** send them as RESP3 *push frames* on the connection that carries your commands, and they surface as `PushMaintenanceEvent`. This is newer, does more than report, and is covered in [its own section](#server-native-maintenance-notifications-redis-enterprise-and-redis-cloud).
+
+Both raise the same `ServerMaintenanceEvent` event, so a handler can watch for either.
 
 If you are a Redis vendor and want to integrate support for ServerMaintenanceEvents into StackExchange.Redis, we recommend opening an issue so we can discuss the details.
 
@@ -65,3 +72,144 @@ It's important to understand that this does *not* mean downtime if you are using
 #### NodeMaintenanceEnded event
 
 `NodeMaintenanceEnded` events are raised to indicate that the maintenance operation has completed and that the replica is once again available. You do *NOT* need to wait for this event to use the load balancer endpoint, as it is available throughout. However, we included this for logging purposes and for customers who use the replica endpoint in clusters for read workloads.
+
+# Server-native maintenance notifications (Redis Enterprise and Redis Cloud)
+
+> These APIs are experimental, behind diagnostic id `SER010`; see [SER010](exp/SER010.md).
+
+Redis Enterprise and Redis Cloud can tell a client *directly* that a disruption is coming: a shard is migrating, a node is failing over, or the endpoint you are connected to is being replaced. Unlike the Azure events above, these arrive as RESP3 push frames on the connection itself, and the client does not merely report them: it relaxes timeouts for the duration, re-reads the cluster topology when slots have moved, recovers sharded subscriptions that were stranded, and moves off an endpoint that is going away rather than waiting to be disconnected.
+
+## Do I need to configure anything?
+
+Usually not. If you connect using the hostname your provider gave you, the matching options provider recognizes it and turns the feature on for you.
+
+| You connect to | Recognized as | Notifications |
+|---|---|---|
+| `something.cloud.redislabs.com`, `.cloud.redis.io`, `.redislabs.com` | Redis Cloud | on (`Auto`) |
+| `something.redis.azure.net`, `.redisenterprise.cache.azure.net` | Azure Managed Redis | on (`Auto`) |
+| your own hostname, a CNAME, private DNS, or through a proxy | nothing | **off** |
+| a self-managed Redis Enterprise cluster | nothing (there is no DNS pattern to recognize) | **off** |
+
+The last two rows are the ones to know about, because nothing fails: the connection works normally and you simply never receive a notification. If your endpoint does not look like your provider's, say so explicitly. Either:
+
+```csharp
+// the whole deployment posture: prefer RESP3, skip the OSS config-broadcast channel, and ask for notifications
+var options = ConfigurationOptions.Parse("my-redis.internal.example.com:6379,defaults=enterprise");
+```
+
+or, to change nothing except this feature:
+
+```csharp
+var options = ConfigurationOptions.Parse("my-redis.internal.example.com:6379,maintNotifications=Auto");
+```
+
+`defaults=` accepts `rediscloud`, `enterprise`, `amr` and `azure`; see [Configuration](Configuration.md) for what each provider sets. It is also the right answer for a *hosted* deployment reached somewhere its own provider cannot see it, such as behind a CNAME or a private endpoint.
+
+### RESP3 is required, and is already the default
+
+These notifications are RESP3 push frames, so RESP3 is a hard requirement. You do not normally need to ask for it: with no protocol configured the client assumes a 6.0 server and negotiates RESP3, which is enough. But three settings take RESP3 away again, and each one silently disables this feature:
+
+* `protocol=resp2` (or `Protocol = RedisProtocol.Resp2`)
+* `defaultVersion` below 6.0, which is how the client decides RESP3 is available at all
+* disabling or renaming `HELLO` in the [command map](Configuration.md), since RESP3 is negotiated by `HELLO`
+
+If you use `maintNotifications=Enabled` (see below) you will find out about this immediately, because the connection will be refused rather than quietly running without the feature.
+
+## Choosing a mode
+
+```csharp
+options.MaintenanceNotifications = MaintenanceNotificationMode.Auto;
+```
+
+| Mode | Meaning |
+|---|---|
+| `Disabled` | never ask. The default when nothing recognizes your endpoint |
+| `Auto` | ask, and carry on if the server says no. What the providers select |
+| `Enabled` | **require** them: if the server will not deliver them, or the connection ends up on RESP2, the connection is **rejected** |
+
+`Auto` is the right choice almost always: asking costs one command during the handshake, and a server that accepts and then never sends anything costs nothing at all. `Enabled` exists for the case where running without advance warning is worse than not running: it turns a silent absence into a startup failure, which also makes it a useful way to prove the feature is live in a staging environment.
+
+## What the client does without your involvement
+
+| Notification | What the client does |
+|---|---|
+| `MIGRATING`, `FAILING_OVER`, `SMIGRATING` | relaxes command timeouts for that server while the disruption lasts |
+| `MIGRATED`, `FAILED_OVER` | ends the window, but keeps timeouts relaxed for a short tail while things settle |
+| `SMIGRATED` | as above, and re-reads the cluster topology, and re-subscribes any sharded channels whose slots moved |
+| `MOVING` | works out the replacement address, lets in-flight work finish, then replaces the connections |
+
+So an application that does nothing at all still benefits: commands that would have timed out during a migration are given more room, a moved slot is learned without waiting to be redirected, and a `MOVING` is acted on before the server closes the socket.
+
+Note that a deliberate handoff appears as a `ConnectionFailed` event with `FailureType == ConnectionFailureType.MaintenanceHandoff`. That is expected during planned maintenance and does not indicate a fault; if you alert on `ConnectionFailed`, filter it out.
+
+## Watching the events
+
+```csharp
+multiplexer.ServerMaintenanceEvent += (sender, e) =>
+{
+    if (e is PushMaintenanceEvent maintenance)
+    {
+        logger.LogInformation(
+            "{Type} from {EndPoint} (seq {Sequence}, {Time})",
+            maintenance.NotificationType, maintenance.EndPoint, maintenance.SequenceId, maintenance.Time);
+
+        foreach (var migration in maintenance.SlotMigrations)
+        {
+            logger.LogInformation("slots {Slots}: {Source} -> {Target}", migration.RawSlots, migration.Source, migration.Target);
+        }
+    }
+};
+```
+
+Two things are worth knowing before you build on the detail:
+
+* **`EndPoint` is whichever node told us first.** Every node broadcasts a given event, so the client collapses the copies and raises one event; it is not necessarily the node being maintained, and for the cluster notifications it is usually a bystander reporting somebody else's movements.
+* **`SequenceId` is observed behaviour, not a contract.** No specification defines it. In practice it is monotonic per database and shared across notification types, which makes it useful for spotting a replay, but do not depend on it across deployments or versions.
+
+`Time` is what the server announced, and may legitimately be zero or negative for a connection that arrived mid-window, meaning "this is happening now".
+
+## Timeouts during maintenance
+
+Three settings control the relaxed window, all in seconds:
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `maintRelaxedTimeout` | 10s | the timeout to use while a disruption is in progress, and the floor for how long a window lasts |
+| `maintRelaxedWindowMax` | 3x the relaxed timeout | the longest a single window may last, in case a closing notification never arrives |
+| `maintPostEventRelaxed` | 2x the relaxed timeout | how long timeouts stay relaxed *after* the disruption ends |
+
+The announced duration is clamped rather than honoured literally. Windows as short as two seconds have been observed in practice, which is not long enough to cover a client reconnecting, and a client that trusted the announced value would stop being patient exactly when it mattered. The tail exists for the same reason in reverse: after a handoff, servers and other clients are still settling.
+
+If a command does time out during a window, the exception carries the reason: `RedisTimeoutException.MaintenanceType` (and the same property on `RedisConnectionException`) names the notification that was in effect, which distinguishes "the deployment was moving" from "this query is slow".
+
+## Checking that it is working
+
+Wire up an `ILoggerFactory` and the client reports the outcome of the opt-in, per server:
+
+```csharp
+options.LoggerFactory = loggerFactory;
+await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(options);
+```
+
+```
+10.0.0.1:6379: Requesting maintenance notifications (Auto)
+10.0.0.1:6379: Maintenance notifications accepted
+```
+
+or, when the server declines, the reason it gave:
+
+```
+10.0.0.1:6379: Maintenance notifications refused (ERR maintenance notifications are disabled on this server)
+```
+
+A handoff is reported the same way, which is worth knowing because it replaces connections:
+
+```
+10.0.0.1:6379: Maintenance handoff: Recycle -> 10.0.0.2:6379: db.example.com now resolves to 10.0.0.2:6379
+```
+
+Alternatively set `MaintenanceNotifications = Enabled` in a test or staging environment: if anything prevents the feature working, including ending up on RESP2, the connection fails instead of running silently without it.
+
+## Which deployments send these
+
+Redis Enterprise and Redis Cloud send them, subject to the feature being enabled on the cluster. Azure Managed Redis is configured to ask for them ahead of its own rollout, so the setting is harmless until their servers begin emitting. Redis Open Source, Valkey and other servers do not send them at all, and the setting is simply inert there: the opt-in is refused and the client carries on.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Documentation
 - [Pub/Sub Key Notifications](KeyspaceNotifications) - how to use keyspace and keyevent notifications
 - [Hot Keys](HotKeys) - how to use `HOTKEYS` profiling
 - [Using RESP3](Resp3) - information on using RESP3
-- [ServerMaintenanceEvent](ServerMaintenanceEvent) - how to listen and prepare for hosted server maintenance (e.g. Azure Cache for Redis)
+- [ServerMaintenanceEvent](ServerMaintenanceEvent) - how to listen and prepare for hosted server maintenance, including the server-native notifications sent by Redis Enterprise and Redis Cloud
 - [Streams](Streams) - how to use the Stream data type
 - [Arrays](Arrays) - how to use Redis Arrays as sparse arrays of values
 - [Vector Sets](VectorSets) - how to use Vector Sets for similarity search with embeddings

--- a/src/StackExchange.Redis/LoggerExtensions.cs
+++ b/src/StackExchange.Redis/LoggerExtensions.cs
@@ -771,4 +771,22 @@ internal static partial class LoggerExtensions
         EventId = 116,
         Message = "{Server}: Requesting maintenance notifications ({Mode})")]
     internal static partial void LogInformationRequestingMaintenanceNotifications(this ILogger logger, ServerEndPointLogValue server, MaintenanceNotificationMode mode);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 117,
+        Message = "{Server}: Maintenance notifications accepted")]
+    internal static partial void LogInformationMaintenanceNotificationsAccepted(this ILogger logger, ServerEndPointLogValue server);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 118,
+        Message = "{Server}: Maintenance notifications refused ({Reason})")]
+    internal static partial void LogInformationMaintenanceNotificationsRefused(this ILogger logger, ServerEndPointLogValue server, string reason);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        EventId = 119,
+        Message = "{Server}: Maintenance handoff: {Outcome}")]
+    internal static partial void LogInformationMaintenanceHandoff(this ILogger logger, ServerEndPointLogValue server, string outcome);
 }

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -3214,7 +3214,7 @@ The coordinates as an array of two items x,y (longitude,latitude).
 
                 if (reader.IsScalar && Literals.OK.Hash.IsCS(reader.TryGetSpan(out var span) ? span : reader.Buffer(stackalloc byte[16])))
                 {
-                    server?.OnMaintenanceNotificationsAccepted();
+                    server?.OnMaintenanceNotificationsAccepted(connection);
                     SetResult(message, true);
                     return true;
                 }

--- a/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
+++ b/src/StackExchange.Redis/ServerEndPoint.Maintenance.cs
@@ -46,7 +46,19 @@ internal sealed partial class ServerEndPoint
         && MaintenanceMode != MaintenanceNotificationMode.Disabled
         && Multiplexer.CommandMap.IsAvailable(RedisCommand.CLIENT);
 
-    internal void OnMaintenanceNotificationsAccepted() => _maintenanceNotificationsActive = true;
+    /// <summary>
+    /// The server agreed to send them.
+    /// </summary>
+    /// <remarks>
+    /// Logged as well as recorded, so that the connect log answers "is this actually on?" outright. Previously
+    /// only the *refusal* was logged, which meant a working feature left no trace and could only be inferred
+    /// from the absence of a complaint - and that is indistinguishable from never having asked.
+    /// </remarks>
+    internal void OnMaintenanceNotificationsAccepted(PhysicalConnection connection)
+    {
+        _maintenanceNotificationsActive = true;
+        Multiplexer.Logger?.LogInformationMaintenanceNotificationsAccepted(new(this));
+    }
 
     /// <summary>
     /// The server declined our request. Recorded rather than acted on: whether that matters is a question for
@@ -56,7 +68,11 @@ internal sealed partial class ServerEndPoint
     {
         _maintenanceNotificationsActive = false;
         _maintenanceNotificationsRefusal = reason;
-        connection.OnDetailLog($"maintenance notifications refused: {reason}");
+
+        // via the configured logger, not OnDetailLog: that is [Conditional("PARSE_DETAIL")] and compiles away
+        // in any normal build, so for as long as it was the only report of a refusal, the reason a server
+        // declined was invisible to everybody who was not debugging the parser.
+        Multiplexer.Logger?.LogInformationMaintenanceNotificationsRefused(new(this), reason);
     }
 
     /// <summary>
@@ -281,6 +297,11 @@ internal sealed partial class ServerEndPoint
 
             Multiplexer.Trace($"MOVING: {decision}", ToString());
             _lastHandoffOutcome = decision.ToString();
+
+            // Trace is [Conditional("VERBOSE")], so without this a handoff leaves no record in a normal build -
+            // and a handoff replaces connections, which is exactly the kind of thing somebody needs to be able
+            // to find afterwards.
+            Multiplexer.Logger?.LogInformationMaintenanceHandoff(new(this), _lastHandoffOutcome);
             switch (decision.Action)
             {
                 case HandoffAction.Recycle:

--- a/tests/StackExchange.Redis.Tests/MaintenanceOptInClientTests.cs
+++ b/tests/StackExchange.Redis.Tests/MaintenanceOptInClientTests.cs
@@ -1,6 +1,8 @@
-﻿﻿using System.Collections.Generic;
+﻿﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using static StackExchange.Redis.Server.RedisServer;
 
@@ -206,6 +208,58 @@ public class MaintenanceOptInClientTests(ITestOutputHelper log)
         Assert.Empty(OptedIn(server));
         Assert.False(IsActive(conn, server));
         Assert.Equal("value", await Set(conn));
+    }
+
+    /// <summary>
+    /// Captures log messages so a test can assert on what an operator would actually see.
+    /// </summary>
+    private sealed class CapturingLoggerFactory : ILoggerFactory, ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => this;
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            lock (Messages) Messages.Add(formatter(state, exception));
+        }
+
+        public string All
+        {
+            get { lock (Messages) return string.Join("\n", Messages); }
+        }
+
+        public void Dispose() { }
+    }
+
+    [Theory]
+    [InlineData(MaintenanceNotificationSupport.Supported, "Maintenance notifications accepted")]
+    [InlineData(MaintenanceNotificationSupport.Disabled, "Maintenance notifications refused")]
+    public async Task TheLogSaysWhetherTheFeatureIsLive(MaintenanceNotificationSupport support, string expected)
+    {
+        // This is the diagnostic docs/ServerMaintenanceEvent.md tells people to use, so it is worth a test.
+        // It also guards a mistake that was live for a while: the refusal was reported via
+        // PhysicalConnection.OnDetailLog, which is [Conditional("PARSE_DETAIL")] and compiles away in any normal
+        // build - so the reason a server declined was invisible to everybody who was not debugging the parser.
+        Assert.SkipUnless(TestContext.Current.IsResp3(), "the opt-in is only sent under RESP3");
+
+        using var server = CreateServer(log);
+        server.MaintenanceNotifications = support;
+
+        var captured = new CapturingLoggerFactory();
+        var config = Config(server, MaintenanceNotificationMode.Auto);
+        config.LoggerFactory = captured;
+
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(config);
+
+        log.WriteLine(captured.All);
+        Assert.Contains(expected, captured.All);
     }
 
     [Fact]


### PR DESCRIPTION
docs/ServerMaintenanceEvent.md already existed for the Azure pub/sub family, so this extends it rather than adding a page: the intro now distinguishes the two routes, and a new section covers the server-native RESP3 family.

The section leads on the thing most likely to bite a user: for a recognised hostname the feature is automatic, because the matching options provider turns it on - but a custom domain, a CNAME, private DNS, a proxy, or a self-managed cluster matches nothing, so it falls back to Disabled and *nothing fails*. You simply never get notifications. Both fixes are spelled out, with their differing blast radius: defaults=<provider> for the whole posture, or maintNotifications= Auto for this feature alone.

Related: RESP3 needs no configuration (with no protocol set the client assumes 6.0 and negotiates it), but three settings silently take it away - protocol= resp2, defaultVersion below 6.0, and disabling or renaming HELLO - and without RESP3 there are no push frames to receive.

Writing the "how do I check it is on?" section turned up that the diagnostic did not exist. The opt-in *refusal* was reported through PhysicalConnection.OnDetailLog, which is [Conditional("PARSE_DETAIL")] and compiles away in any normal build, so the reason a server declined was visible only to somebody debugging the parser; acceptance was not reported at all. All three - accepted, refused, and the handoff outcome - now go through the configured ILoggerFactory as LoggerMessage extensions (event ids 117-119), which is the channel that survives and the one an application actually reads. The handoff line closes a gap noted earlier: Multiplexer.Trace is [Conditional("VERBOSE")], so a handoff that replaced connections left no record.

Two tests assert the accepted and refused messages, since they are documented behaviour now rather than incidental logging.

<!-- Describe what this PR changes and why. Link any related issues. -->

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
