### PR TITLE
Never match responses on a connection whose write failed mid-flight

### DIFF
--- a/src/StackExchange.Redis/ConnectionMultiplexer.Debug.cs
+++ b/src/StackExchange.Redis/ConnectionMultiplexer.Debug.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
 namespace StackExchange.Redis;
 
@@ -15,6 +16,15 @@ public partial class ConnectionMultiplexer
         finalized = Volatile.Read(ref _collectedWithoutDispose);
         return created - (disposed + finalized);
     }
+
+    /// <summary>
+    /// Test seam: invoked immediately before a failed write attempts to tear the connection down.
+    /// Lets tests simulate the case that motivated <see cref="PhysicalConnection.PoisonWrite"/> - an
+    /// OutOfMemoryException landing in the failure path itself, so teardown never completes (#2919).
+    /// </summary>
+    internal volatile Action? BeforeWriteTeardown;
+
+    internal void OnBeforeWriteTeardown() => BeforeWriteTeardown?.Invoke();
 
     /// <summary>
     /// Invoked by the garbage collector.

--- a/src/StackExchange.Redis/PhysicalBridge.cs
+++ b/src/StackExchange.Redis/PhysicalBridge.cs
@@ -1445,6 +1445,10 @@ namespace StackExchange.Redis
 
         private WriteResult HandleWriteException(PhysicalConnection? physical, Message message, Exception ex)
         {
+            // FIRST, before anything that can allocate - see the note in WriteMessageToServerInsideWriteLock.
+            physical?.PoisonWrite();
+            MarkNeedsReconnect();
+
             var failureType = PhysicalConnection.ClassifyWriteFailure(ex, physical);
             var inner = new RedisConnectionException(failureType, message.Flags, "Failed to write", ex);
             message.SetExceptionAndComplete(inner, physical);
@@ -1452,6 +1456,7 @@ namespace StackExchange.Redis
             // wire, and continuing to use the same socket would let the next reply match the wrong message
             // in the response queue. Forcing a reconnect drains the in-flight queue with failures and
             // restores wire-level synchronization.
+            Multiplexer.OnBeforeWriteTeardown();
             physical?.RecordConnectionFailed(failureType, inner);
             return WriteResult.WriteFailure;
         }
@@ -1589,6 +1594,12 @@ namespace StackExchange.Redis
                 return WriteResult.Success; // for some definition of success
             }
 
+            if (connection.IsWriteFaulted)
+            {
+                // never add to the response queue of a connection whose queue we no longer trust
+                return WriteResult.WriteFailure;
+            }
+
             bool isQueued = false;
             try
             {
@@ -1721,6 +1732,13 @@ namespace StackExchange.Redis
             }
             catch (Exception ex)
             {
+                // FIRST, before anything that can allocate: mark the connection untrustworthy. Everything
+                // below here allocates, and it only runs because something already failed; under memory
+                // exhaustion it can fail again, and then we would never reach RecordConnectionFailed and
+                // would leave a queued-but-unwritten message desyncing every later reply (#2919).
+                connection?.PoisonWrite();
+                MarkNeedsReconnect();
+
                 Trace("Write failed: " + ex.Message);
 
                 // Most likely an IOException, or the connection being torn down underneath us
@@ -1729,6 +1747,7 @@ namespace StackExchange.Redis
                 message.Complete(connection);
 
                 // We don't know how far the write got; kill the connection
+                Multiplexer.OnBeforeWriteTeardown();
                 connection?.RecordConnectionFailed(failureType, ex);
                 return WriteResult.WriteFailure;
             }

--- a/src/StackExchange.Redis/PhysicalConnection.Read.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.Read.cs
@@ -680,6 +680,16 @@ internal sealed partial class PhysicalConnection
     {
         Trace("Matching result...");
 
+        if (IsWriteFaulted)
+        {
+            // a write failed part-way and we could not complete teardown, so the queue may be out of
+            // step with the wire; matching *anything* now risks handing a reply to the wrong caller.
+            // bail out instead - the read loop records the failure, which fails everything queued.
+            // the sentinel is pre-allocated: we may be here precisely because we are out of memory.
+            _readStatus = ReadStatus.Faulted;
+            throw WriteFaultedSentinel;
+        }
+
         Message? msg = null;
         // check whether we're waiting for a high-integrity mode post-response checksum (using cheap null-check first)
         if (_awaitingToken is not null && (msg = Interlocked.Exchange(ref _awaitingToken, null)) is not null)

--- a/src/StackExchange.Redis/PhysicalConnection.cs
+++ b/src/StackExchange.Redis/PhysicalConnection.cs
@@ -46,6 +46,36 @@ namespace StackExchange.Redis
         // things sent to this physical, but not yet received
         private readonly Queue<Message> _writtenAwaitingResponse = new Queue<Message>();
 
+        private volatile bool _writeFaulted;
+
+        /// <summary>
+        /// Indicates that a write against this connection failed part-way through, so the messages in
+        /// <see cref="_writtenAwaitingResponse"/> may no longer line up with the replies on the wire.
+        /// </summary>
+        internal bool IsWriteFaulted => _writeFaulted;
+
+        /// <summary>
+        /// Marks this connection as untrustworthy for response matching.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately allocation-free and infallible. The richer teardown in
+        /// <see cref="RecordConnectionFailed"/> is reached via callers that allocate first (building
+        /// failure messages and exceptions), and those callers only run *because* something already
+        /// failed - under memory exhaustion they can fail again, skipping teardown and leaving a
+        /// queued-but-unwritten message at the head of the queue. From that point every reply matches
+        /// the wrong message, silently and permanently. See #2919.
+        /// </remarks>
+        internal void PoisonWrite() => _writeFaulted = true;
+
+        /// <summary>
+        /// Pre-allocated so that it can be thrown from the read loop when we are poisoned - which may
+        /// well be because we are out of memory. See <see cref="PoisonWrite"/>.
+        /// </summary>
+        private static readonly Exception WriteFaultedSentinel = new RedisConnectionException(
+            ConnectionFailureType.ProtocolFailure,
+            CommandFlags.None,
+            "A write failed part-way and the connection could not be torn down cleanly; the request and response queues may be out of step, so this connection has been abandoned.");
+
         private Message? _awaitingToken;
 
         private readonly string _physicalName;

--- a/tests/StackExchange.Redis.Tests/WriteFailureTeardownTests.cs
+++ b/tests/StackExchange.Redis.Tests/WriteFailureTeardownTests.cs
@@ -17,6 +17,73 @@ public class WriteFailureTeardownTests(ITestOutputHelper output) : TestBase(outp
         protected override void WriteImpl(in MessageWriter writer) => throw toThrow;
     }
 
+    /// <summary>
+    /// A write that fails after the message has been queued for a response, where the teardown that
+    /// is supposed to clean up *also* fails - which is what an OutOfMemoryException does in practice,
+    /// because the failure path allocates and it only runs because an allocation already failed.
+    /// Without the poison flag this desyncs the response queue permanently and every caller on the
+    /// connection silently receives somebody else's reply. See #2919.
+    /// </summary>
+    [Fact]
+    public async Task WriteFailure_WhenTeardownAlsoFails_DoesNotMisrouteResponses()
+    {
+        // we deliberately provoke write failures and connection teardown here
+        SetExpectedAmbientFailureCount(-1);
+
+        await using var conn = Create(shared: false, allowAdmin: true, syncTimeout: 3000);
+        var db = conn.GetDatabase();
+        var prefix = Me();
+
+        const int Keys = 8;
+        for (int i = 0; i < Keys; i++)
+        {
+            await db.StringSetAsync(prefix + i, "v" + i);
+        }
+
+        var muxer = conn.UnderlyingMultiplexer;
+        var server = muxer.GetServerSnapshot()[0];
+
+        // simulate the OOM landing in the failure path itself, so *neither* teardown attempt completes
+        muxer.BeforeWriteTeardown = static () => throw new OutOfMemoryException("simulated: teardown cannot allocate");
+        try
+        {
+            var boom = new ThrowingMessage(new InvalidOperationException("simulated WriteImpl failure"));
+            muxer.CheckMessage(boom);
+            await Assert.ThrowsAnyAsync<Exception>(
+                async () => await muxer.ExecuteAsyncImpl(boom, ResultProcessor.ResponseTimer, state: null, server));
+        }
+        finally
+        {
+            muxer.BeforeWriteTeardown = null;
+        }
+
+        // now hammer the connection with concurrent, individually-identifiable reads. Failing is fine -
+        // the connection may well be being recycled - but answering the *wrong question* is not.
+        for (int round = 0; round < 10; round++)
+        {
+            var pending = new Task<RedisValue>[Keys];
+            for (int i = 0; i < Keys; i++)
+            {
+                pending[i] = db.StringGetAsync(prefix + i);
+            }
+
+            for (int i = 0; i < Keys; i++)
+            {
+                RedisValue actual;
+                try
+                {
+                    actual = await pending[i];
+                }
+                catch (RedisException)
+                {
+                    continue; // an error is an acceptable outcome; bad data is not
+                }
+
+                Assert.Equal("v" + i, (string?)actual);
+            }
+        }
+    }
+
     [Fact]
     public void WriteTo_PropagatesWriteImplException()
     {


### PR DESCRIPTION
Fix #2919

A write that dies after its message has been queued in _writtenAwaitingResponse must either complete, or take the connection out of service. Otherwise the queue is permanently one message out of step with the replies on the wire, and every caller on that connection silently receives somebody else's answer.

Both recovery paths allocate before they reach RecordConnectionFailed: message.Fail goes via ResultProcessor.ConnectionFail (StringBuilder plus message.ToString()), and HandleWriteException builds a RedisConnectionException. That code only ever runs *because* something already failed, so under memory exhaustion it fails again and teardown is skipped. v3 adding the second teardown attempt in HandleWriteException narrowed this from two faults to three; it did not close it.

So make the decision to stop trusting the connection allocation-free, infallible, and first:

- PhysicalConnection.PoisonWrite sets a volatile bool, nothing more
- both write-failure catches call it before anything that can allocate
- MatchNextResult refuses to match once poisoned, throwing a pre-allocated sentinel so the read loop runs the normal teardown and fails everything queued
- the write path refuses to queue onto a poisoned connection

Worst case this degrades to timeouts, which is the right trade against handing back silently wrong data.

Adds a regression test, plus the internal seam it needs to simulate a teardown that cannot allocate. On the previous code that test fails with GET k0 returning v1 - the exact symptom reported in #2919.

## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
