### PR TITLE
Drop net6.0 from TargetFrameworks

### DIFF
--- a/src/RESPite/RESPite.csproj
+++ b/src/RESPite/RESPite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-    <TargetFrameworks>net461;netstandard2.0;net472;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net472;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/StackExchange.Redis/StackExchange.Redis.csproj
+++ b/src/StackExchange.Redis/StackExchange.Redis.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <!-- extend the default lib targets for the main lib; mostly because of "vectors" -->
-    <TargetFrameworks>net461;netstandard2.0;net472;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net472;net8.0;net10.0</TargetFrameworks>
     <Description>High performance Redis client, incorporating both synchronous and asynchronous usage.</Description>
     <AssemblyName>StackExchange.Redis</AssemblyName>
     <AssemblyTitle>StackExchange.Redis</AssemblyTitle>


### PR DESCRIPTION
crossref https://github.com/StackExchange/StackExchange.Redis/issues/3184

Experiment to reduce package size for the MyGet size limit. Consumers on net6.0 fall back to the netstandard2.0 asset via NuGet compatibility

For release notes: on net6, this loses the UNIX_SOCKET code path and other net8.0+ optimizations without a build-time signal.

Reduces the StackExchange.Redis package from ~6.29MB to ~5.26MB (-16.5%).


## Checklist

- [x] I fully and freely contribute this code in accordance with the [project license](../LICENSE) (and am legally able to do so)  
- [x] I take responsibility for this contribution's quality and correctness, including any portions produced with AI assistance (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
