### PR TITLE
CI: hash the NuGet cache key before starting redis, not after

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,21 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch the full history
+      # Restore is ~80s of the build step on a cold runner, and the package set changes rarely.
+      #
+      # Keep this immediately after checkout, and *before* the WSL/redis steps. The key globs the whole
+      # workspace for **/*.csproj, and once the servers are up there are sixteen redis processes writing
+      # into that same tree through DrvFs - rdb files into RedisConfigs/Temp, nodes-*.conf into
+      # RedisConfigs/Cluster, and BGSAVE's temp-<pid>.rdb appearing and being renamed under the walk.
+      # Enumerating a tree that is changing underneath you is how you get an intermittent
+      # "hashFiles(...) failed. Fail to hash files under directory ...", which is exactly what this job
+      # started doing. Nothing here needs redis, so hash a still checkout instead.
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('Directory.Packages.props', 'global.json', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
       - uses: Vampire/setup-wsl@v7 # v7 is the first version running on Node 24
         with:
           distribution: Ubuntu-22.04
@@ -165,13 +180,6 @@ jobs:
             exit 1
           fi
 
-      # Restore is ~80s of the build step on a cold runner, and the package set changes rarely.
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('Directory.Packages.props', 'global.json', '**/*.csproj') }}
-          restore-keys: ${{ runner.os }}-nuget-
       - name: .NET Build
         run: dotnet build Build.csproj -c Release /p:CI=true
       # The analyzer and the props that configures it reach consumers only through the package, and a


### PR DESCRIPTION
The Windows job intermittently fails the cache step with:

```
Error: The template is not valid. .github/workflows/CI.yml (Line: 173, Col: 16):
hashFiles('Directory.Packages.props, global.json, **/*.csproj') failed.
Fail to hash files under directory 'D:\a\StackExchange.Redis\StackExchange.Redis'
```

Two things it is *not*: the expression is the correct three-argument form (the error renders the arguments comma-joined, which makes it look like a single malformed pattern), and the files are certainly present — checkout is the first step, and the build a few steps later succeeds.

What is wrong is where the step sits. The key globs the whole workspace for `**/*.csproj`, and by that point the job has started **sixteen redis servers from inside WSL**, all writing into that same tree through DrvFs: rdb files into `RedisConfigs/Temp`, `nodes-*.conf` into `RedisConfigs/Cluster`, and `BGSAVE` creating then renaming `temp-<pid>.rdb` while the walk is in progress. Enumerating a tree that is changing underneath you is a plausible way to get precisely this error, and fits it being intermittent rather than constant.

To be clear about confidence: the ordering hazard is verifiable from the workflow; that it is *the* cause of any given failure is inference — I have not reproduced it on a runner. But the step gains nothing from running late.

So: move it to immediately after checkout, where it hashes a still tree. The key is unchanged, so existing caches stay valid. A comment records why it must not drift back down.

Narrowing the globs instead would not be enough on its own — `tests/**/*.csproj` still has to enumerate `tests/RedisConfigs`.