### PR TITLE
Bump SourceLink past CVE-2026-62900, and System.IO.Hashing with it

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.Pipelines" Version="10.0.5" />
     <!-- note that this bumps System.Buffers, so is pinned in down-level in SE csproj -->
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.5" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.12" />
     <!-- for RESPite -->
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="2.1.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
NuGet audit started failing every build yesterday:

```
error NU1902: Warning As Error: Package 'Microsoft.Build.Tasks.Git' 10.0.201 has a known
moderate severity vulnerability, https://github.com/advisories/GHSA-23fw-v26w-5fgq
```

[GHSA-23fw-v26w-5fgq](https://github.com/advisories/GHSA-23fw-v26w-5fgq) (CVE-2026-62900) was published **2026-09-08**, so this is new and unrelated to any code change. We pull `Microsoft.Build.Tasks.Git` transitively via `Microsoft.SourceLink.GitHub`, pinned at `10.0.201`.

The awkward part is that the advisory lists the whole `10.0.200`–`10.0.204` band as affected with **no patched version in that band**, so there is nothing to move to inside it:

| affected | first patched |
|---|---|
| `= 8.0.0` | *none* |
| `>= 10.0.102, <= 10.0.110` | `10.0.111` |
| `>= 10.0.200, <= 10.0.204` | **none** |
| `>= 10.0.300, <= 10.0.301` | `10.0.303` |

`10.0.401` is past every affected range. It wants `System.IO.Hashing 10.0.12` where we pinned `10.0.5`, so bumping SourceLink alone just trades `NU1902` for `NU1605` (package downgrade) — hence both move together.

### Consumer-visible

`System.IO.Hashing` is a real dependency of the library, so the floor it declares moves from `10.0.5` to `10.0.12` on all six target frameworks. Confirmed by unpacking the built nupkg. SourceLink is build-time only and stays out of the package's dependency groups, so that half is invisible to consumers.

### Alternative, if the floor bump is unwelcome

`Microsoft.SourceLink.GitHub 10.0.112` clears the advisory (it is past `10.0.111`) and has **no** `System.IO.Hashing` dependency at all, so it fixes CI with a one-line change and no consumer impact. The cost is moving back a servicing band, `10.0.2xx` → `10.0.1xx`. I verified that route too: restore, build and pack are all clean on it. Say the word and I will swap.

### Verified

- `dotnet restore Build.csproj` — clean, no `NU1902`, no `NU1605`
- `dotnet build Build.csproj -c Release /p:CI=true` — 0 warnings, 0 errors
- `dotnet pack` — succeeds; nuspec inspected for the dependency groups above