### PR TITLE
For ROM-based APIs (mostly ScriptEvaluate/Execute): render request keys and values into one pooled buffer up front

### DIFF
--- a/docs/Execute.md
+++ b/docs/Execute.md
@@ -50,33 +50,62 @@ For a single scalar (blob) reply, reading it via `ExecuteResp`/`ScriptEvaluateRe
 Leasing the argument buffer
 ---
 
-The examples above allocate a fresh `RedisKeyOrValue[]` per call, which rather defeats the point of an API whose main selling point is low allocation. On a hot path, rent the array from `ArrayPool<RedisKeyOrValue>.Shared` instead - but the buffer can only be recycled once you know the server has fully received the write. For a synchronous call, that's once `ExecuteResp` has returned successfully *or* thrown `RedisServerException` (the server still definitely got the command - it just responded with an error). Any other exception (a timeout, a dropped connection) can mean a retry is still using the same buffer, so don't recycle it in that case:
+The examples above allocate a fresh `RedisKeyOrValue[]` per call, which rather defeats the point of an API whose main selling point is low allocation. On a hot path, rent the array from `ArrayPool<RedisKeyOrValue>.Shared` instead - and you can return it as soon as the call returns:
 
 ```csharp
 var args = ArrayPool<RedisKeyOrValue>.Shared.Rent(1); // usually larger!
-args[0] = (RedisKey)"mykey";
-var canReturn = true;
 try
 {
+    args[0] = (RedisKey)"mykey";
     using RespResult result = db.ExecuteResp("GET", args.AsMemory(0, 1));
     // use result...
 }
-catch (RedisServerException)
-{
-    throw; // the server responded - still safe to recycle below
-}
-catch
-{
-    canReturn = false; // e.g. a timeout/connection failure - a retry may still need this buffer
-    throw;
-}
 finally
 {
-    if (canReturn) ArrayPool<RedisKeyOrValue>.Shared.Return(args, clearArray: true);
+    ArrayPool<RedisKeyOrValue>.Shared.Return(args, clearArray: true);
 }
 ```
 
-The same rule applies to `ExecuteRespAsync` - just `await` the call before deciding whether it's safe to return the lease.
+No conditions, and nothing to work out from the exception that came back: the arguments are rendered into the request before the call returns, so the library is not looking at your array afterwards. That holds for a call that succeeds, one that throws for any reason at all, and a fire-and-forget call that never waits for a reply.
+
+The async form is the same, and does *not* need the `await` to happen first - `ExecuteRespAsync` renders the arguments before it hands back the task, so the buffer is yours again the moment the method returns:
+
+```csharp
+var args = ArrayPool<RedisKeyOrValue>.Shared.Rent(1);
+Task<RespResult> pending;
+try
+{
+    args[0] = (RedisKey)"mykey";
+    pending = db.ExecuteRespAsync("GET", args.AsMemory(0, 1));
+}
+finally
+{
+    ArrayPool<RedisKeyOrValue>.Shared.Return(args, clearArray: true); // before awaiting, deliberately
+}
+
+using RespResult result = await pending;
+```
+
+That also means one buffer can be refilled and reused across a whole run of queued calls - a batch, say - without waiting for any of them:
+
+```csharp
+var batch = db.CreateBatch();
+var args = ArrayPool<RedisKeyOrValue>.Shared.Rent(3);
+var pending = new List<Task<RespResult>>();
+for (int i = 0; i < count; i++)
+{
+    args[0] = key;
+    args[1] = (RedisValue)("field" + i);
+    args[2] = (RedisValue)("value" + i);
+    pending.Add(batch.ExecuteRespAsync("HSET", args.AsMemory(0, 3))); // rendered here, not at Execute()
+}
+
+ArrayPool<RedisKeyOrValue>.Shared.Return(args, clearArray: true);
+batch.Execute();
+await Task.WhenAll(pending);
+```
+
+One caveat, for values built over memory you own: a `RedisValue` can wrap a `ReadOnlyMemory<byte>`, and rendering copies the *value*, not the bytes behind it. Returning the `RedisKeyOrValue[]` is safe; overwriting the byte buffer a `RedisValue` points at, before the request has been written, is not. Values built from `string`, `byte[]` you don't then mutate, or numbers are unaffected.
 
 The original `Execute`/`ExecuteAsync` overload
 ---

--- a/docs/Execute.md
+++ b/docs/Execute.md
@@ -107,6 +107,8 @@ await Task.WhenAll(pending);
 
 One caveat, for values built over memory you own: a `RedisValue` can wrap a `ReadOnlyMemory<byte>`, and rendering copies the *value*, not the bytes behind it. Returning the `RedisKeyOrValue[]` is safe; overwriting the byte buffer a `RedisValue` points at, before the request has been written, is not. Values built from `string`, `byte[]` you don't then mutate, or numbers are unaffected.
 
+This last gap is known, and is expected to close in a future update: the same work that moves serialization onto the calling thread consumes the payload bytes before the call returns too, at which point the rule becomes simply "everything you passed is yours again when the call returns", with no exception for memory-backed values.
+
 The original `Execute`/`ExecuteAsync` overload
 ---
 

--- a/docs/Scripting.md
+++ b/docs/Scripting.md
@@ -110,6 +110,31 @@ RedisValue[]? values = parent.ReadPastArray(static (ref r) => r.ReadRedisValue()
 
 This is equivalent to the manual loop above, just without needing to write it out yourself, and capturing the results as an array.
 
+Leasing the keys and values
+---
+
+`ScriptEvaluateResp` takes its keys and values as `ReadOnlyMemory<>`, so on a hot path you can rent those arrays rather than allocating a pair per call - and return them as soon as the call returns, with no conditions attached:
+
+```csharp
+var keys = ArrayPool<RedisKey>.Shared.Rent(1);
+var values = ArrayPool<RedisValue>.Shared.Rent(2);
+try
+{
+    keys[0] = "mykey";
+    values[0] = 123;
+    values[1] = 456;
+    using RespResult result = db.ScriptEvaluateResp(script, keys.AsMemory(0, 1), values.AsMemory(0, 2));
+    // use result...
+}
+finally
+{
+    ArrayPool<RedisKey>.Shared.Return(keys, clearArray: true);
+    ArrayPool<RedisValue>.Shared.Return(values, clearArray: true);
+}
+```
+
+The arguments are rendered into the request before the call returns - before the task is handed back, for the async form - so the library is not reading your arrays afterwards, whether the call succeeded, threw, or was fire-and-forget. See [Leasing the argument buffer](Execute#leasing-the-argument-buffer) for the async and batched shapes, and for the one caveat: a `RedisValue` wrapping a `ReadOnlyMemory<byte>` is rendered by value, so the array is yours again but the bytes behind such a value are not.
+
 Ad-hoc commands
 ---
 

--- a/docs/Scripting.md
+++ b/docs/Scripting.md
@@ -133,7 +133,7 @@ finally
 }
 ```
 
-The arguments are rendered into the request before the call returns - before the task is handed back, for the async form - so the library is not reading your arrays afterwards, whether the call succeeded, threw, or was fire-and-forget. See [Leasing the argument buffer](Execute#leasing-the-argument-buffer) for the async and batched shapes, and for the one caveat: a `RedisValue` wrapping a `ReadOnlyMemory<byte>` is rendered by value, so the array is yours again but the bytes behind such a value are not.
+The arguments are rendered into the request before the call returns - before the task is handed back, for the async form - so the library is not reading your arrays afterwards, whether the call succeeded, threw, or was fire-and-forget. See [Leasing the argument buffer](Execute#leasing-the-argument-buffer) for the async and batched shapes, and for the one caveat: a `RedisValue` wrapping a `ReadOnlyMemory<byte>` is rendered by value, so the array is yours again but the bytes behind such a value are not - a known gap, expected to close in a future update.
 
 Ad-hoc commands
 ---

--- a/eng/StackExchange.Redis.Build/AutoDatabaseGenerator.cs
+++ b/eng/StackExchange.Redis.Build/AutoDatabaseGenerator.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ParamInfo = (string Name, string Type, Microsoft.CodeAnalysis.RefKind RefKind, bool IsParams, bool IsOptional, bool HasDefault, string? Default);
 using MethodInfo = (string Name, string ReturnType, StackExchange.Redis.Build.BasicArray<(string Name, string Type, Microsoft.CodeAnalysis.RefKind RefKind, bool IsParams, bool IsOptional, bool HasDefault, string? Default)> Parameters, StackExchange.Redis.Build.BasicArray<string> TypeArgs);
 using InterfaceInfo = (string Name, string Namespace, StackExchange.Redis.Build.AutoDatabaseGenerator.KnownInterfaces KnownType, StackExchange.Redis.Build.BasicArray<(string Name, string ReturnType, StackExchange.Redis.Build.BasicArray<(string Name, string Type, Microsoft.CodeAnalysis.RefKind RefKind, bool IsParams, bool IsOptional, bool HasDefault, string? Default)> Parameters, StackExchange.Redis.Build.BasicArray<string> TypeArgs)> Methods);
-using ClassInfo = (string Name, string Namespace, StackExchange.Redis.Build.AutoDatabaseGenerator.KnownInterfaces Interfaces, bool IsMutator);
+using ClassInfo = (string Name, string Namespace, StackExchange.Redis.Build.AutoDatabaseGenerator.KnownInterfaces Interfaces, bool IsMutator, bool Replays);
 
 namespace StackExchange.Redis.Build;
 
@@ -219,8 +219,20 @@ public class AutoDatabaseGenerator : IIncrementalGenerator
             }
         }
 
+        // [AutoDatabase(Replays = true)] - the owning database can invoke a captured operation more than
+        // once, so captured Memory<T> arguments have to be copies rather than the caller's own buffer
+        bool replays = false;
+        foreach (var attrib in cls.GetAttributes())
+        {
+            if (attrib.AttributeClass?.Name is not ("AutoDatabaseAttribute" or "AutoDatabase")) continue;
+            foreach (var named in attrib.NamedArguments)
+            {
+                if (named.Key == "Replays" && named.Value.Value is bool b) replays = b;
+            }
+        }
+
         var ns = cls.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-        return (cls.Name, ns, known, isMutator);
+        return (cls.Name, ns, known, isMutator, replays);
     }
 
     [Flags]
@@ -243,6 +255,17 @@ public class AutoDatabaseGenerator : IIncrementalGenerator
     //    not a replayable server command; wrappers want their own behaviour here (e.g. a connection-group
     //    resolving against the currently-active member and returning null when there is none)
     //  - streaming returns (IEnumerable<T> / IAsyncEnumerable<T>) whose execution is deferred
+    // Memory<T>/ReadOnlyMemory<T> arguments still belong to the caller once the call returns; a database
+    // that replays has to capture a copy. Matched on the open generic prefix so a nullable or an array *of*
+    // them - neither of which is the caller's own buffer in the same way - does not match.
+    private static bool IsMemoryArg(string type)
+        => type.StartsWith("System.ReadOnlyMemory<", StringComparison.Ordinal)
+        || type.StartsWith("System.Memory<", StringComparison.Ordinal);
+
+    // the element type, for the ArrayPool we rent the copy from
+    private static string MemoryElement(string type)
+        => type.Substring(type.IndexOf('<') + 1, type.Length - type.IndexOf('<') - 2);
+
     private static bool SkipMethod(MethodInfo method)
         => !method.TypeArgs.IsEmpty
         || method.Name.Contains("Wait")
@@ -501,12 +524,22 @@ public class AutoDatabaseGenerator : IIncrementalGenerator
                     if (flagsArg >= 0)
                     {
                         writer.Append(firstBase ? " : " : ", ").Append("global::StackExchange.Redis.IFlaggedRedisArgs");
+                        firstBase = false;
+                    }
+
+                    // a replaying funnel constrains its TState to IDisposable so it can give cloned
+                    // arguments back; every one of its captures implements it, most as a no-op
+                    if (cls.Replays)
+                    {
+                        writer.Append(firstBase ? " : " : ", ").Append("global::System.IDisposable");
                     }
                     writer.NewLine().Append("{").Indent();
                     for (int p = 0; p < parameters.Length; p++)
                     {
+                        var clone = cls.Replays && IsMemoryArg(parameters[p].Type);
                         writer.NewLine().Append("public ").Append(cls.IsMutator && NeedsMap(parameters[p].Type) ? "" : "readonly ").Append(parameters[p].Type)
-                            .Append(" Arg").Append(p).Append(" = arg").Append(p).Append(";");
+                            .Append(" Arg").Append(p).Append(" = ")
+                            .Append(clone ? "global::StackExchange.Redis.CapturedArgs.Clone(arg" : "arg").Append(p).Append(clone ? ");" : ";");
                     }
 
                     if (flagsArg >= 0)
@@ -516,6 +549,19 @@ public class AutoDatabaseGenerator : IIncrementalGenerator
                         writer.NewLine().Append(cls.IsMutator ? "readonly " : "")
                             .Append("global::StackExchange.Redis.CommandFlags global::StackExchange.Redis.IFlaggedRedisArgs.Flags => Arg")
                             .Append(flagsArg).Append(";");
+                    }
+
+                    if (cls.Replays)
+                    {
+                        // emitted even when there is nothing to give back: the funnel's TState constraint
+                        // needs every capture to satisfy it, and an empty one inlines away
+                        writer.NewLine().Append(cls.IsMutator ? "readonly " : "").Append("public void Dispose()").NewLine().Append("{").Indent();
+                        for (int p = 0; p < parameters.Length; p++)
+                        {
+                            if (!IsMemoryArg(parameters[p].Type)) continue;
+                            writer.NewLine().Append("global::StackExchange.Redis.CapturedArgs.Release(in Arg").Append(p).Append(");");
+                        }
+                        writer.Outdent().NewLine().Append("}");
                     }
 
                     if (!cls.IsMutator)

--- a/src/StackExchange.Redis/APITypes/HashImport.cs
+++ b/src/StackExchange.Redis/APITypes/HashImport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -196,31 +197,36 @@ public sealed class HashImport : IDisposable, IAsyncDisposable
 
 // HIMPORT SET <key> <field-set> <value...>: the user-facing per-row import. Carries a reference to its field-set so
 // the write path can inject a PREPARE the first time this field-set is seen on a connection (see PhysicalBridge).
-internal sealed class HashImportSetMessage : Message.CommandKeyBase
+internal sealed class HashImportSetMessage : Message.CommandKeyBase, IRenderedArgsOwner
 {
     private readonly HashImport _fieldSet;
-    private readonly ReadOnlyMemory<RedisValue> _values;
 
-    public HashImportSetMessage(int db, CommandFlags flags, HashImport fieldSet, in RedisKey key, ReadOnlyMemory<RedisValue> values)
+    // rendered at construction rather than aliased: this is the per-row bulk-import API, so reusing one
+    // values buffer per row is the intended usage - and a batch defers every write to Execute(), by which
+    // point that buffer holds only the last row. Not readonly; see RenderedArgs.
+    private RenderedArgs _values;
+
+    public HashImportSetMessage(int db, CommandFlags flags, HashImport fieldSet, in RedisKey key, ReadOnlyMemory<RedisValue> values, MemoryPool<byte>? pool)
         : base(db, flags, RedisCommand.HIMPORT, key)
     {
         _fieldSet = fieldSet;
-        _values = values;
+        _values = RenderedArgs.Create(default, values.Span, pool);
     }
+
+    void IRenderedArgsOwner.ReleaseRenderedArgs() => RenderedArgs.Recycle(ref _values);
 
     internal HashImport FieldSet => _fieldSet;
 
     protected override void WriteImpl(in MessageWriter writer)
     {
-        var values = _values.Span;
-        writer.WriteHeader(RedisCommand.HIMPORT, 3 + values.Length);
+        writer.WriteHeader(RedisCommand.HIMPORT, ArgCount);
         writer.WriteBulkString(RedisLiterals.SET);
         writer.Write(Key);
         _fieldSet.WriteName(writer);
-        for (int i = 0; i < values.Length; i++) writer.WriteBulkString(values[i]);
+        _values.WriteTo(writer);
     }
 
-    public override int ArgCount => 3 + _values.Length;
+    public override int ArgCount => 3 + _values.Count;
 }
 
 // HIMPORT PREPARE <field-set> <field...>: injected fire-and-forget ahead of the first SET for a field-set on a

--- a/src/StackExchange.Redis/AutoDatabase.cs
+++ b/src/StackExchange.Redis/AutoDatabase.cs
@@ -11,6 +11,18 @@ namespace StackExchange.Redis;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
 internal sealed class AutoDatabaseAttribute : Attribute
 {
+    /// <summary>
+    /// Whether the owning database can invoke a captured operation more than once, i.e. it replays.
+    /// </summary>
+    /// <remarks>
+    /// A replaying database outlives the call it captured: it re-invokes with the same captured arguments
+    /// after the caller has long since regained control. Arguments passed as <c>Memory</c>/<c>ReadOnlyMemory</c>
+    /// still belong to the caller, who is entitled to reuse that buffer once the call returns - so a replay
+    /// would read whatever is in it by then. When this is set, the generated capture takes a pooled shallow
+    /// copy of those arguments and the funnel disposes it; when it is not, the arguments are captured as-is,
+    /// because a single forward cannot outlive the call.
+    /// </remarks>
+    public bool Replays { get; set; }
 }
 
 // Implemented by a generated captured-arguments struct only when the owning auto-database implements

--- a/src/StackExchange.Redis/Availability/RetryDatabase.cs
+++ b/src/StackExchange.Redis/Availability/RetryDatabase.cs
@@ -5,7 +5,7 @@ using StackExchange.Redis.Interfaces;
 
 namespace StackExchange.Redis.Availability;
 
-[AutoDatabase]
+[AutoDatabase(Replays = true)]
 internal partial class RetryDatabase : IDatabaseAsync, IInternalDatabaseAsync
     // IRedisArgsMutator <==== if we ever want to support key-mapping
 {
@@ -82,57 +82,78 @@ internal partial class RetryDatabase : IDatabaseAsync, IInternalDatabaseAsync
     // note: the state cannot be taken by `in` here (async methods forbid by-ref parameters);
     // only the projection takes it by readonly-ref, avoiding a copy per attempt
     private async Task<TResult> ExecuteAsync<TState, TResult>(TState state, AutoDatabaseAsyncOperation<TState, TResult> operation)
-        where TState : struct
+        where TState : struct, IDisposable
     {
         /* key mapping, not used currently
          * state.MapInPlace(this); */
 
-        int attempt = 0;
-        TResult result;
-        // note we need to capture this *before* the attempt - otherwise the failover could happen
-        // between the failed attempt and fetching this, and we'd miss it
-        CancellationToken failover = GetNextFailover();
-        while (true)
+        // the capture owns a pooled copy of any Memory<T> arguments it holds: the caller's own buffer is
+        // theirs again once the call returns, and we may still be replaying long after that. Disposed here
+        // rather than by the capture's creator, because this is the only point that knows the last attempt
+        // is done. The IDisposable constraint makes that call constrained rather than boxed.
+        try
         {
-            try
+            int attempt = 0;
+            TResult result;
+            // note we need to capture this *before* the attempt - otherwise the failover could happen
+            // between the failed attempt and fetching this, and we'd miss it
+            CancellationToken failover = GetNextFailover();
+            while (true)
             {
-                result = await operation(in state, _inner).ConfigureAwait(false);
-                break;
+                try
+                {
+                    result = await operation(in state, _inner).ConfigureAwait(false);
+                    break;
+                }
+                catch (Exception ex) when (_controller.CanRetry(++attempt, ex, ref failover, out var delay))
+                {
+                    await _controller.FailoverOrDelayAsync(delay).ConfigureAwait(false);
+                }
             }
-            catch (Exception ex) when (_controller.CanRetry(++attempt, ex, ref failover, out var delay))
-            {
-                await _controller.FailoverOrDelayAsync(delay).ConfigureAwait(false);
-            }
+
+            /* key mapping, not used currently
+            // post-process results outside the loop
+            return this.UnMap(state, result);*/
+            return result;
         }
-        /* key mapping, not used currently
-        // post-process results outside the loop
-        return this.UnMap(state, result);*/
-        return result;
+        finally
+        {
+            state.Dispose();
+        }
     }
 
     private async Task ExecuteAsync<TState>(TState state, AutoDatabaseAsyncOperation<TState> operation)
-        where TState : struct
+        where TState : struct, IDisposable
     {
         /* key mapping, not used currently
          * state.MapInPlace(this); */
 
-        int attempt = 0;
-        // note we need to capture this *before* the attempt - otherwise the failover could happen
-        // between the failed attempt and fetching this, and we'd miss it
-        CancellationToken failover = GetNextFailover();
-        while (true)
+        // see the TResult overload
+        try
         {
-            try
+            int attempt = 0;
+            // note we need to capture this *before* the attempt - otherwise the failover could happen
+            // between the failed attempt and fetching this, and we'd miss it
+            CancellationToken failover = GetNextFailover();
+            while (true)
             {
-                await operation(in state, _inner).ConfigureAwait(false);
-                break;
+                try
+                {
+                    await operation(in state, _inner).ConfigureAwait(false);
+                    break;
+                }
+                catch (Exception ex) when (_controller.CanRetry(++attempt, ex, ref failover, out var delay))
+                {
+                    await _controller.FailoverOrDelayAsync(delay).ConfigureAwait(false);
+                }
             }
-            catch (Exception ex) when (_controller.CanRetry(++attempt, ex, ref failover, out var delay))
-            {
-                await _controller.FailoverOrDelayAsync(delay).ConfigureAwait(false);
-            }
+
+            // (nothing to post-process)
         }
-        // (nothing to post-process)
+        finally
+        {
+            state.Dispose();
+        }
     }
 
     // forwarding is not using: these decorators must implement the interface in full, and the

--- a/src/StackExchange.Redis/Availability/RetryTransaction.cs
+++ b/src/StackExchange.Redis/Availability/RetryTransaction.cs
@@ -20,6 +20,12 @@ namespace StackExchange.Redis.Availability;
 // interface can move to a retrying database without rewriting their transaction code; the synchronous
 // Execute is sync-over-async (see below). Note that ITransaction : IBatch : IDatabaseAsync, so the only
 // members this adds over ITransactionAsync are the two Execute overloads.
+// NOTE: deliberately not Replays = true yet. It does replay - the recorded ops are re-run as a unit - so it
+// wants the same captured-argument copies as RetryDatabase, arguably more since a queued op is held from
+// capture until Execute. But there is no single point here that means "this op will not run again": ops end
+// via ForwardSuccess, Fault or Observe, and the whole list is replayed together, so nothing can dispose a
+// capture without first working out that lifetime properly. Marking it without that would swap an aliasing
+// bug for a guaranteed leak.
 [AutoDatabase]
 internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
 {

--- a/src/StackExchange.Redis/Availability/RetryTransaction.cs
+++ b/src/StackExchange.Redis/Availability/RetryTransaction.cs
@@ -20,13 +20,12 @@ namespace StackExchange.Redis.Availability;
 // interface can move to a retrying database without rewriting their transaction code; the synchronous
 // Execute is sync-over-async (see below). Note that ITransaction : IBatch : IDatabaseAsync, so the only
 // members this adds over ITransactionAsync are the two Execute overloads.
-// NOTE: deliberately not Replays = true yet. It does replay - the recorded ops are re-run as a unit - so it
-// wants the same captured-argument copies as RetryDatabase, arguably more since a queued op is held from
-// capture until Execute. But there is no single point here that means "this op will not run again": ops end
-// via ForwardSuccess, Fault or Observe, and the whole list is replayed together, so nothing can dispose a
-// capture without first working out that lifetime properly. Marking it without that would swap an aliasing
-// bug for a guaranteed leak.
-[AutoDatabase]
+// Replays: the recorded operations are re-run as a unit on every attempt, and a capture is held from the
+// moment it is recorded until Execute - longer than RetryDatabase holds one - so the captured arguments must
+// be copies of the caller's memory rather than the caller's own buffer. They are released in ExecuteAsync,
+// which is the only point that knows an operation will not be replayed again; a transaction that is never
+// executed keeps its captures, and nothing here could know otherwise.
+[AutoDatabase(Replays = true)]
 internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
 {
     // Note: the *command* surface is async-only, exactly like RetryDatabase - retrying is inherently
@@ -34,7 +33,11 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
     private readonly IDatabaseAsync _source;
     private readonly RetryController _controller;
 
-    private readonly List<IRecordedOp> _ops = new();
+    // not readonly, and null until something is recorded: ExecuteAsync takes it and clears it, so the
+    // replay loop below runs over a list nothing else can still be adding to. A caller doing something
+    // strange - recording from another thread while executing - then gets an empty transaction rather than
+    // a collection mutated mid-enumeration, and the captures it recorded are its own to lose.
+    private List<IRecordedOp>? _ops;
     private List<RecordedCondition>? _conditions;
     private int _executed;
     private volatile bool _watchConflict;
@@ -61,20 +64,20 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
     // overloads, capturing the arguments in a generated state struct plus a cacheable static projection
     // (no per-call closure). Here we simply *record* them and return a durable proxy task.
     private Task<TResult> ExecuteAsync<TState, TResult>(in TState state, AutoDatabaseAsyncOperation<TState, TResult> operation)
-        where TState : struct
+        where TState : struct, IDisposable
     {
         CheckNotExecuted();
         var op = new RecordedOp<TState, TResult>(state, operation, IsFireAndForget(in state));
-        _ops.Add(op);
+        (_ops ??= new List<IRecordedOp>()).Add(op);
         return op.Proxy;
     }
 
     private Task ExecuteAsync<TState>(in TState state, AutoDatabaseAsyncOperation<TState> operation)
-        where TState : struct
+        where TState : struct, IDisposable
     {
         CheckNotExecuted();
         var op = new RecordedVoidOp<TState>(state, operation, IsFireAndForget(in state));
-        _ops.Add(op);
+        (_ops ??= new List<IRecordedOp>()).Add(op);
         return op.Proxy;
     }
 
@@ -127,12 +130,36 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
             throw new InvalidOperationException("This transaction has already been executed");
         }
 
+        // take the recordings off the instance before replaying any of them, so the loops below run over
+        // lists nothing else can still be adding to; a caller recording from another thread mid-execution
+        // then gets left out rather than mutating a collection under enumeration. The operations' captured
+        // arguments are released once we are done with them, however that turns out - though a transaction
+        // that is never executed keeps its captures, since nothing here could know.
+        var ops = _ops;
+        var conditions = _conditions;
+        _ops = null;
+        _conditions = null;
+        try
+        {
+            return await ExecuteAsync(flags, ops ?? EmptyOps, conditions).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (ops is not null)
+            {
+                foreach (var op in ops) op.Release();
+            }
+        }
+    }
+
+    private static readonly List<IRecordedOp> EmptyOps = new();
+
+    private async Task<bool> ExecuteAsync(CommandFlags flags, List<IRecordedOp> ops, List<RecordedCondition>? conditions)
+    {
         int attempt = 0;
         // capture the next-failover token *before* the first attempt - otherwise a failover between a
         // failed attempt and re-reading the token could be missed
         CancellationToken failover = _controller.TracksFailover ? _source.GetNextFailover() : CancellationToken.None;
-
-        var conditions = _conditions;
 
         // watch contention gets its own budget; only meaningful when there are conditions to WATCH
         int watchAttempt = 0;
@@ -148,7 +175,7 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
             {
                 foreach (var c in conditions) c.Replay(inner);
             }
-            foreach (var op in _ops) op.Replay(inner);
+            foreach (var op in ops) op.Replay(inner);
 
             // inject the aggregate retry category onto the EXEC flags so the resulting fault carries it, and
             // the shared RetryPolicy/FaultContext logic gates the whole transaction exactly like one command
@@ -170,7 +197,7 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
                     && _watchConflict
                     && ++watchAttempt < maxWatchAttempts)
                 {
-                    foreach (var op in _ops) op.Observe();
+                    foreach (var op in ops) op.Observe();
                     await _controller.WatchConflictDelayAsync().ConfigureAwait(false);
                     continue;
                 }
@@ -181,7 +208,7 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
                 {
                     foreach (var c in conditions) c.ForwardSuccess();
                 }
-                foreach (var op in _ops) op.ForwardSuccess();
+                foreach (var op in ops) op.ForwardSuccess();
                 return committed;
             }
             catch (Exception ex)
@@ -190,13 +217,13 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
                 {
                     // discard this attempt; observe its faulted per-attempt tasks so they don't surface as
                     // unobserved, then wait / failover and replay from the recorded snapshot
-                    foreach (var op in _ops) op.Observe();
+                    foreach (var op in ops) op.Observe();
                     await _controller.FailoverOrDelayAsync(delay).ConfigureAwait(false);
                     continue;
                 }
 
                 // out of road: fault the durable proxies and surface the failure to the caller
-                foreach (var op in _ops) op.Fault(ex);
+                foreach (var op in ops) op.Fault(ex);
                 throw;
             }
         }
@@ -250,12 +277,19 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
         void ForwardSuccess();
         void Fault(Exception ex);
         void Observe();
+
+        /// <summary>
+        /// Give back anything the captured arguments own. Called once, after the transaction has finished
+        /// with this operation for good - not per attempt, since every attempt replays the same capture.
+        /// </summary>
+        void Release();
     }
 
     private sealed class RecordedOp<TState, TResult> : IRecordedOp
-        where TState : struct
+        where TState : struct, IDisposable
     {
-        private readonly TState _state;
+        // not readonly: releasing clears the capture in place, which a defensive copy would not
+        private TState _state;
         private readonly AutoDatabaseAsyncOperation<TState, TResult> _operation;
         private readonly TaskCompletionSource<TResult>? _proxy;
         private Task<TResult>? _attempt;
@@ -329,12 +363,15 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
         }
 
         public void Observe() => _ = _attempt?.Exception;
+
+        public void Release() => _state.Dispose();
     }
 
     private sealed class RecordedVoidOp<TState> : IRecordedOp
-        where TState : struct
+        where TState : struct, IDisposable
     {
-        private readonly TState _state;
+        // not readonly: releasing clears the capture in place, which a defensive copy would not
+        private TState _state;
         private readonly AutoDatabaseAsyncOperation<TState> _operation;
         private readonly TaskCompletionSource<bool>? _proxy;
         private Task? _attempt;
@@ -392,6 +429,8 @@ internal sealed partial class RetryTransaction : IDatabaseAsync, ITransaction
         }
 
         public void Observe() => _ = _attempt?.Exception;
+
+        public void Release() => _state.Dispose();
     }
 
     private sealed class RecordedCondition

--- a/src/StackExchange.Redis/CapturedArgs.cs
+++ b/src/StackExchange.Redis/CapturedArgs.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace StackExchange.Redis;
+
+/// <summary>
+/// Helpers for the captured-argument structs emitted by <c>[AutoDatabase(Replays = true)]</c>.
+/// </summary>
+/// <remarks>
+/// A database that replays re-invokes with the same captured arguments after the caller has regained
+/// control, and a <see cref="Memory{T}"/> argument still belongs to that caller - who is entitled to reuse
+/// the buffer once the call returns. So a replaying capture takes a shallow copy and gives it back when the
+/// operation is finally done with.
+/// <para>
+/// Shallow: the elements are copied, not anything they refer to. A <see cref="RedisValue"/> wrapping a
+/// caller's <c>Memory&lt;byte&gt;</c> still points at the caller's bytes, so mutating *those* would still
+/// be seen by a replay. That gap closes when serialization moves to the calling thread; this covers the
+/// buffer the caller is most likely to reuse.
+/// </para>
+/// </remarks>
+internal static class CapturedArgs
+{
+    /// <summary>Take a pooled shallow copy of a captured argument.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="value">The caller's memory to copy.</param>
+    /// <returns>A copy owned by us, to be given back via <see cref="Release{T}(in ReadOnlyMemory{T})"/>.</returns>
+    public static ReadOnlyMemory<T> Clone<T>(ReadOnlyMemory<T> value)
+    {
+        if (value.IsEmpty) return default; // nothing rented, so nothing for Release to give back
+
+        var rented = ArrayPool<T>.Shared.Rent(value.Length);
+        value.Span.CopyTo(rented);
+        return new ReadOnlyMemory<T>(rented, 0, value.Length);
+    }
+
+    /// <inheritdoc cref="Clone{T}(ReadOnlyMemory{T})"/>
+    public static Memory<T> Clone<T>(Memory<T> value)
+    {
+        if (value.IsEmpty) return default;
+
+        var rented = ArrayPool<T>.Shared.Rent(value.Length);
+        value.Span.CopyTo(rented);
+        return new Memory<T>(rented, 0, value.Length);
+    }
+
+    /// <summary>Give a cloned argument back to the pool.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="field">The captured field, cleared as it is released.</param>
+    /// <remarks>
+    /// Clears the field first, so a second call has nothing to give back. Returning the same array twice is
+    /// not an error the pool reports - it simply pools it twice, and two later rents then hand out the same
+    /// array to different callers - so this is worth the cheek of writing through a readonly field.
+    /// <para>
+    /// Sequential only: the clear is not atomic with the read. That is sufficient here because a captured
+    /// state is a local within a single async flow, never shared. Note also that calling this on a
+    /// defensive copy - i.e. via a <c>readonly</c> holder - would clear the copy and leak; the generated
+    /// funnels hold their state in a plain local.
+    /// </para>
+    /// </remarks>
+    public static void Release<T>(in ReadOnlyMemory<T> field)
+    {
+        var captured = field;
+        Unsafe.AsRef(in field) = default;
+        Return(captured);
+    }
+
+    /// <inheritdoc cref="Release{T}(in ReadOnlyMemory{T})"/>
+    public static void Release<T>(in Memory<T> field)
+    {
+        var captured = field;
+        Unsafe.AsRef(in field) = default;
+        Return<T>(captured);
+    }
+
+    private static void Return<T>(ReadOnlyMemory<T> captured)
+    {
+        // note the Length check rather than a null check: an empty ReadOnlyMemory reports a non-null,
+        // zero-length array through TryGetArray, so testing for null here would never be true
+        if (MemoryMarshal.TryGetArray(captured, out var segment) && segment.Array is { Length: > 0 })
+        {
+            // cleared on return: these elements can hold references (RedisValue, RedisKeyOrValue), and a
+            // pooled array would otherwise keep the caller's keys and values alive indefinitely
+            ArrayPool<T>.Shared.Return(segment.Array, clearArray: true);
+        }
+    }
+}

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixed.cs
@@ -412,11 +412,18 @@ namespace StackExchange.Redis.KeyspaceIsolation
 
         public Task<RespResult> ExecuteRespAsync(string command, ReadOnlyMemory<RedisKeyOrValue> args, CommandFlags flags = CommandFlags.None)
         {
-            if ((flags & CommandFlags.FireAndForget) != 0)
-                return Inner.ExecuteRespAsync(command, ToInnerCopy(args), flags);
-
-            var result = Inner.ExecuteRespAsync(command, ToInnerLease(args, out var lease), flags);
-            return lease != null ? ReturnAfterResult(result, lease) : result;
+            // the callee renders the arguments before it hands back the task, so the lease comes
+            // home immediately rather than being held for the whole round trip - and there is no
+            // fire-and-forget special case left, since that path renders too
+            var inner = ToInnerLease(args, out var lease);
+            try
+            {
+                return Inner.ExecuteRespAsync(command, inner, flags);
+            }
+            finally
+            {
+                ReturnLease(lease);
+            }
         }
 
         public Task<RedisResult> ExecuteAsync(string command, params object[] args) =>
@@ -432,11 +439,18 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<RespResult> ScriptEvaluateRespAsync(string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
         {
             // TODO: The return value could contain prefixed keys. It might make sense to 'unprefix' those?
-            if ((flags & CommandFlags.FireAndForget) != 0)
-                return Inner.ScriptEvaluateRespAsync(script, ToInnerCopy(keys), values, flags);
-
-            var result = Inner.ScriptEvaluateRespAsync(script, ToInnerLease(keys, out var lease), values, flags);
-            return lease != null ? ReturnAfterResult(result, lease) : result;
+            // the callee renders the arguments before it hands back the task, so the lease comes
+            // home immediately rather than being held for the whole round trip - and there is no
+            // fire-and-forget special case left, since that path renders too
+            var inner = ToInnerLease(keys, out var lease);
+            try
+            {
+                return Inner.ScriptEvaluateRespAsync(script, inner, values, flags);
+            }
+            finally
+            {
+                ReturnLease(lease);
+            }
         }
 
         public Task<RedisResult> ScriptEvaluateAsync(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None) =>
@@ -458,11 +472,18 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public Task<RespResult> ScriptEvaluateReadOnlyRespAsync(string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
         {
             // TODO: The return value could contain prefixed keys. It might make sense to 'unprefix' those?
-            if ((flags & CommandFlags.FireAndForget) != 0)
-                return Inner.ScriptEvaluateReadOnlyRespAsync(script, ToInnerCopy(keys), values, flags);
-
-            var result = Inner.ScriptEvaluateReadOnlyRespAsync(script, ToInnerLease(keys, out var lease), values, flags);
-            return lease != null ? ReturnAfterResult(result, lease) : result;
+            // the callee renders the arguments before it hands back the task, so the lease comes
+            // home immediately rather than being held for the whole round trip - and there is no
+            // fire-and-forget special case left, since that path renders too
+            var inner = ToInnerLease(keys, out var lease);
+            try
+            {
+                return Inner.ScriptEvaluateReadOnlyRespAsync(script, inner, values, flags);
+            }
+            finally
+            {
+                ReturnLease(lease);
+            }
         }
 
         public Task<RedisResult> ScriptEvaluateReadOnlyAsync(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None) =>
@@ -1081,26 +1102,22 @@ namespace StackExchange.Redis.KeyspaceIsolation
         // takes state + a (typically static) delegate rather than a capturing lambda, so callers can
         // avoid allocating a closure and delegate per call; TState carries what the delegate needs
         // instead (plain struct, not ValueTuple - this type still targets net461/netstandard2.0).
-        protected static TResult InvokeAndReturnLease<TState, TResult, TElement>(TState state, Func<TState, TResult> invoke, TElement[] lease)
+
+        /// <summary>
+        /// Hand a rented argument buffer back. Safe to call with <c>null</c>, which is what
+        /// <c>ToInnerLease</c> reports when there was nothing worth renting for.
+        /// </summary>
+        /// <remarks>
+        /// Unconditional on purpose. The APIs this is used for render their arguments before returning, so
+        /// there is no longer any question of the callee reading the buffer later - which is what the old
+        /// shape had to guard against by abandoning the lease whenever an unexpected exception made the
+        /// answer unknowable.
+        /// </remarks>
+        /// <typeparam name="TElement">The element type of the rented buffer.</typeparam>
+        /// <param name="lease">The buffer to return, if any.</param>
+        protected static void ReturnLease<TElement>(TElement[]? lease)
         {
-            var returnLease = true;
-            try
-            {
-                return invoke(state);
-            }
-            catch (RedisServerException)
-            {
-                throw;
-            }
-            catch
-            {
-                returnLease = false;
-                throw;
-            }
-            finally
-            {
-                if (returnLease) ArrayPool<TElement>.Shared.Return(lease, clearArray: true);
-            }
+            if (lease is not null) ArrayPool<TElement>.Shared.Return(lease, clearArray: true);
         }
 
         protected ReadOnlyMemory<RedisKey> ToInnerCopy(ReadOnlyMemory<RedisKey> outer)

--- a/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
+++ b/src/StackExchange.Redis/KeyspaceIsolation/KeyPrefixedDatabase.cs
@@ -384,29 +384,19 @@ namespace StackExchange.Redis.KeyspaceIsolation
 
         public RespResult ExecuteResp(string command, ReadOnlyMemory<RedisKeyOrValue> args, CommandFlags flags = CommandFlags.None)
         {
-            if ((flags & CommandFlags.FireAndForget) != 0)
-                return Inner.ExecuteResp(command, ToInnerCopy(args), flags);
-
+            // the callee renders the arguments before it returns, so the lease is ours again the moment
+            // the call comes back - however it comes back. No fire-and-forget special case (that path
+            // renders too, it just does not wait for a reply) and no suppressing the return on unexpected
+            // exceptions, which is what the old shape had to do when it could not know.
             var inner = ToInnerLease(args, out var lease);
-            return lease != null
-                ? InvokeAndReturnLease(new ExecuteRespState(Inner, command, inner, flags), static s => s.Inner.ExecuteResp(s.Command, s.Args, s.Flags), lease)
-                : Inner.ExecuteResp(command, inner, flags);
-        }
-
-        private readonly struct ExecuteRespState
-        {
-            public ExecuteRespState(IDatabase inner, string command, ReadOnlyMemory<RedisKeyOrValue> args, CommandFlags flags)
+            try
             {
-                Inner = inner;
-                Command = command;
-                Args = args;
-                Flags = flags;
+                return Inner.ExecuteResp(command, inner, flags);
             }
-
-            public readonly IDatabase Inner;
-            public readonly string Command;
-            public readonly ReadOnlyMemory<RedisKeyOrValue> Args;
-            public readonly CommandFlags Flags;
+            finally
+            {
+                ReturnLease(lease);
+            }
         }
 
         public RedisResult Execute(string command, params object[] args)
@@ -422,13 +412,16 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public RespResult ScriptEvaluateResp(string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
         {
             // note the Resp API explicitly doesn't unprefix keys
-            if ((flags & CommandFlags.FireAndForget) != 0)
-                return Inner.ScriptEvaluateResp(script, ToInnerCopy(keys), values, flags);
-
+            // see ExecuteResp
             var inner = ToInnerLease(keys, out var lease);
-            return lease != null
-                ? InvokeAndReturnLease(new ScriptEvaluateRespState(Inner, script, inner, values, flags), static s => s.Inner.ScriptEvaluateResp(s.Script, s.Keys, s.Values, s.Flags), lease)
-                : Inner.ScriptEvaluateResp(script, inner, values, flags);
+            try
+            {
+                return Inner.ScriptEvaluateResp(script, inner, values, flags);
+            }
+            finally
+            {
+                ReturnLease(lease);
+            }
         }
 
         public RedisResult ScriptEvaluate(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None) =>
@@ -450,31 +443,16 @@ namespace StackExchange.Redis.KeyspaceIsolation
         public RespResult ScriptEvaluateReadOnlyResp(string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
         {
             // note the Resp API explicitly doesn't unprefix keys
-            if ((flags & CommandFlags.FireAndForget) != 0)
-                return Inner.ScriptEvaluateReadOnlyResp(script, ToInnerCopy(keys), values, flags);
-
+            // see ExecuteResp
             var inner = ToInnerLease(keys, out var lease);
-            return lease != null
-                ? InvokeAndReturnLease(new ScriptEvaluateRespState(Inner, script, inner, values, flags), static s => s.Inner.ScriptEvaluateReadOnlyResp(s.Script, s.Keys, s.Values, s.Flags), lease)
-                : Inner.ScriptEvaluateReadOnlyResp(script, inner, values, flags);
-        }
-
-        private readonly struct ScriptEvaluateRespState
-        {
-            public ScriptEvaluateRespState(IDatabase inner, string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags)
+            try
             {
-                Inner = inner;
-                Script = script;
-                Keys = keys;
-                Values = values;
-                Flags = flags;
+                return Inner.ScriptEvaluateReadOnlyResp(script, inner, values, flags);
             }
-
-            public readonly IDatabase Inner;
-            public readonly string Script;
-            public readonly ReadOnlyMemory<RedisKey> Keys;
-            public readonly ReadOnlyMemory<RedisValue> Values;
-            public readonly CommandFlags Flags;
+            finally
+            {
+                ReturnLease(lease);
+            }
         }
 
         public RedisResult ScriptEvaluateReadOnly(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None) =>

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -199,6 +199,20 @@ namespace StackExchange.Redis
             SetName,
         }
 
+        /// <summary>
+        /// Called once a reply for this message has arrived and is known to be the final one, i.e. the
+        /// message will not be re-issued. Anything held only for the benefit of writing the request can go.
+        /// </summary>
+        /// <remarks>
+        /// The arrival of a reply is what makes this safe: it proves the write completed, which completion
+        /// alone does not - a message becomes visible to the async-timeout heartbeat when it is queued,
+        /// before WriteImpl has run. Implementations must be idempotent; a redirect or a NOSCRIPT retry
+        /// re-issues this same instance, so those replies deliberately do not call it.
+        /// </remarks>
+        internal virtual void OnFinalReply()
+        {
+        }
+
         protected virtual bool TryGetSubCommand(out SubCommand subCommand)
         {
             subCommand = SubCommand.Unknown;
@@ -536,12 +550,7 @@ namespace StackExchange.Redis
             return true;
         }
 
-        // virtual so a subclass owning a rented request buffer (e.g. RenderedArgs) can recycle it here:
-        // every path that terminally finishes a message - normal completion, high-integrity validation,
-        // and the RecordConnectionFailed drain - runs through this (via SetExceptionAndComplete, for the
-        // last one), and PrepareToResend/caller-side timeouts never call it at all, which is exactly the
-        // "message is definitely never touched again" boundary the buffer needs.
-        public virtual void Complete(PhysicalConnection? connection)
+        public void Complete(PhysicalConnection? connection)
         {
             // Ensure we can never call Complete on the same resultBox from two threads by grabbing it now
             var currBox = Interlocked.Exchange(ref resultBox, null);

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -199,20 +199,6 @@ namespace StackExchange.Redis
             SetName,
         }
 
-        /// <summary>
-        /// Called once a reply for this message has arrived and is known to be the final one, i.e. the
-        /// message will not be re-issued. Anything held only for the benefit of writing the request can go.
-        /// </summary>
-        /// <remarks>
-        /// The arrival of a reply is what makes this safe: it proves the write completed, which completion
-        /// alone does not - a message becomes visible to the async-timeout heartbeat when it is queued,
-        /// before WriteImpl has run. Implementations must be idempotent; a redirect or a NOSCRIPT retry
-        /// re-issues this same instance, so those replies deliberately do not call it.
-        /// </remarks>
-        internal virtual void OnFinalReply()
-        {
-        }
-
         protected virtual bool TryGetSubCommand(out SubCommand subCommand)
         {
             subCommand = SubCommand.Unknown;

--- a/src/StackExchange.Redis/Message.cs
+++ b/src/StackExchange.Redis/Message.cs
@@ -536,7 +536,12 @@ namespace StackExchange.Redis
             return true;
         }
 
-        public void Complete(PhysicalConnection? connection)
+        // virtual so a subclass owning a rented request buffer (e.g. RenderedArgs) can recycle it here:
+        // every path that terminally finishes a message - normal completion, high-integrity validation,
+        // and the RecordConnectionFailed drain - runs through this (via SetExceptionAndComplete, for the
+        // last one), and PrepareToResend/caller-side timeouts never call it at all, which is exactly the
+        // "message is definitely never touched again" boundary the buffer needs.
+        public virtual void Complete(PhysicalConnection? connection)
         {
             // Ensure we can never call Complete on the same resultBox from two threads by grabbing it now
             var currBox = Interlocked.Exchange(ref resultBox, null);

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -6355,8 +6355,16 @@ namespace StackExchange.Redis
 
             public override void Complete(PhysicalConnection? connection)
             {
-                // see ExecMessage.Complete for why this is gated on Status rather than unconditional
-                if (Status == CommandStatus.Sent) RenderedArgs.Recycle(ref _args);
+                // see ExecMessage.Complete for why this is gated on Status rather than unconditional.
+                //
+                // IsScriptUnavailable is the other half: a NOSCRIPT reply completes this message and then
+                // the caller re-issues *this same instance* as EVAL (see ScriptEvaluateResp and friends),
+                // so completion is not the end of the road here at all - recycling now would leave the
+                // retry writing from a buffer that has already gone back to the pool. The flag is set by
+                // the result processor before the completion that carries the error, so it is visible by
+                // the time we get here. If the retry does not happen after all, the buffer leaks - the
+                // same trade as above.
+                if (Status == CommandStatus.Sent && !IsScriptUnavailable) RenderedArgs.Recycle(ref _args);
                 base.Complete(connection);
             }
         }

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -6134,6 +6134,18 @@ namespace StackExchange.Redis
                 subCommand = _hasSubCommand ? _subCommand : SubCommand.Unknown;
                 return _hasSubCommand;
             }
+
+            public override void Complete(PhysicalConnection? connection)
+            {
+                // Status flips to Sent strictly *after* WriteImpl returns (see WriteMessageToServerInsideWriteLock),
+                // but a message is enqueued into _writtenAwaitingResponse - making it eligible for the async-timeout
+                // heartbeat's SetExceptionAndComplete - *before* that write actually happens. Recycling on that
+                // premature completion would race an in-flight WriteImpl reading the same buffer. If the write did
+                // land, the real reply's own later Complete() call recycles once Status has caught up; if it never
+                // gets sent at all, the buffer leaks rather than risking corruption - the lesser evil.
+                if (Status == CommandStatus.Sent) RenderedArgs.Recycle(ref _args);
+                base.Complete(connection);
+            }
         }
 
         internal sealed class ExecuteMessage : Message
@@ -6340,6 +6352,13 @@ namespace StackExchange.Redis
             }
 
             public override int ArgCount => 2 + _args.Count;
+
+            public override void Complete(PhysicalConnection? connection)
+            {
+                // see ExecMessage.Complete for why this is gated on Status rather than unconditional
+                if (Status == CommandStatus.Sent) RenderedArgs.Recycle(ref _args);
+                base.Complete(connection);
+            }
         }
 
         private sealed class ScriptEvaluateMessage : Message, IMultiMessage

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -2007,7 +2007,7 @@ namespace StackExchange.Redis
 
         public RespResult ExecuteResp(string command, ReadOnlyMemory<RedisKeyOrValue> args, CommandFlags flags = CommandFlags.None)
         {
-            var msg = new ExecMessage(multiplexer?.CommandMap, Database, flags, command, args);
+            var msg = new ExecMessage(multiplexer?.CommandMap, Database, flags, command, args, multiplexer?.RawConfig?.RequestBufferPool);
             return ExecuteSync(msg, ResultProcessor.RespResult)!;
         }
 
@@ -2022,7 +2022,7 @@ namespace StackExchange.Redis
 
         public Task<RespResult> ExecuteRespAsync(string command, ReadOnlyMemory<RedisKeyOrValue> args, CommandFlags flags = CommandFlags.None)
         {
-            var msg = new ExecMessage(multiplexer?.CommandMap, Database, flags, command, args);
+            var msg = new ExecMessage(multiplexer?.CommandMap, Database, flags, command, args, multiplexer?.RawConfig?.RequestBufferPool);
             return ExecuteAsync(msg, ResultProcessor.RespResult, defaultValue: RespResult.NullReply);
         }
 
@@ -2038,7 +2038,7 @@ namespace StackExchange.Redis
         public RespResult ScriptEvaluateResp(string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
         {
             var command = ResultProcessor.ScriptLoadProcessor.IsSHA1(script) ? RedisCommand.EVALSHA : RedisCommand.EVAL;
-            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values);
+            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values, multiplexer?.RawConfig?.RequestBufferPool);
             try
             {
                 return ExecuteSync(msg, ResultProcessor.RespResult)!;
@@ -2084,7 +2084,7 @@ namespace StackExchange.Redis
         public async Task<RespResult> ScriptEvaluateRespAsync(string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
         {
             var command = ResultProcessor.ScriptLoadProcessor.IsSHA1(script) ? RedisCommand.EVALSHA : RedisCommand.EVAL;
-            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values);
+            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values, multiplexer?.RawConfig?.RequestBufferPool);
 
             try
             {
@@ -2158,7 +2158,7 @@ namespace StackExchange.Redis
                 multiplexer.CommandMap,
                 ResultProcessor.ScriptLoadProcessor.IsSHA1(script) ? RedisCommand.EVALSHA_RO : RedisCommand.EVAL_RO,
                 ref flags);
-            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values);
+            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values, multiplexer?.RawConfig?.RequestBufferPool);
             try
             {
                 return ExecuteSync(msg, ResultProcessor.RespResult)!;
@@ -2201,7 +2201,7 @@ namespace StackExchange.Redis
                 multiplexer.CommandMap,
                 ResultProcessor.ScriptLoadProcessor.IsSHA1(script) ? RedisCommand.EVALSHA_RO : RedisCommand.EVAL_RO,
                 ref flags);
-            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values);
+            var msg = new ScriptEvalMessage(Database, flags, command, script, keys, values, multiplexer?.RawConfig?.RequestBufferPool);
             try
             {
                 return await ExecuteAsync(msg, ResultProcessor.RespResult, defaultValue: RespResult.NullReply).ForAwait();
@@ -6045,7 +6045,11 @@ namespace StackExchange.Redis
 
         internal sealed class ExecMessage : Message
         {
-            private readonly ReadOnlyMemory<RedisKeyOrValue> _args;
+            // not readonly: RenderedArgs.Recycle swaps the buffer out, and cannot do that through a
+            // defensive copy - see RenderedArgs
+            private RenderedArgs _args;
+            private readonly bool _hasSubCommand;
+            private readonly SubCommand _subCommand;
             private string _unknownCommand;
 
             private static int RemoveDbIfNotRequired(int suggestedDb, string adhocCommand, out RedisCommand knownCommand)
@@ -6065,7 +6069,7 @@ namespace StackExchange.Redis
                 return suggestedDb;
             }
 
-            public ExecMessage(CommandMap? map, int db, CommandFlags flags, string command, ReadOnlyMemory<RedisKeyOrValue> args)
+            public ExecMessage(CommandMap? map, int db, CommandFlags flags, string command, ReadOnlyMemory<RedisKeyOrValue> args, MemoryPool<byte>? pool)
                 : base(RemoveDbIfNotRequired(db, command, out var knownCommand), flags, knownCommand)
             {
                 if (args.Length >= MessageWriter.REDIS_MAX_ARGS) // using >= here because we will be adding 1 for the command itself (which is an arg for the purposes of the multi-bulk protocol)
@@ -6088,71 +6092,47 @@ namespace StackExchange.Redis
                 {
                     throw ExceptionFactory.CommandDisabled(command);
                 }
-                _args = args;
+
+                // resolved now, while we still have the arguments as values; only the first one is a
+                // sub-command candidate, which is what the old write-time loop amounted to
+                if (args.Length != 0)
+                {
+                    ref readonly var first = ref args.Span[0];
+                    if (first.IsValue) _hasSubCommand = SubCommandMetadata.TryGetSubCommand(first.Value, out _subCommand);
+                }
+
+                _args = RenderedArgs.Create(args.Span, pool);
             }
 
             protected override void WriteImpl(in MessageWriter writer)
             {
                 if (Command is RedisCommand.UNKNOWN)
                 {
-                    writer.WriteHeader(_unknownCommand, _args.Length);
+                    writer.WriteHeader(_unknownCommand, _args.Count);
                 }
                 else
                 {
-                    writer.WriteHeader(Command, _args.Length);
+                    writer.WriteHeader(Command, _args.Count);
                 }
-                foreach (ref readonly var arg in _args.Span)
-                {
-                    if (arg.IsKey)
-                    {
-                        writer.Write(arg.Key);
-                    }
-                    else if (arg.IsValue)
-                    {
-                        writer.WriteBulkString(arg.Value);
-                    }
-                    else
-                    {
-                        Debug.Assert(arg.IsNull);
-                        throw new InvalidOperationException("A null is not valid in this context");
-                    }
-                }
+
+                // keys already carry their prefix, and a key and a value are the same thing on the wire
+                _args.WriteTo(writer);
             }
 
             public override string CommandString => Command is RedisCommand.UNKNOWN ? _unknownCommand : base.CommandString;
             public override string CommandAndKey => CommandString;
 
             public override int GetHashSlot(ServerSelectionStrategy serverSelectionStrategy)
-            {
-                int slot = ServerSelectionStrategy.NoSlot;
-                foreach (ref readonly var arg in _args.Span)
-                {
-                    var key = arg.Key;
-                    if (!key.IsNull)
-                    {
-                        slot = serverSelectionStrategy.CombineSlot(slot, key);
-                    }
-                }
-                return slot;
-            }
-            public override int ArgCount => _args.Length;
+                => _args.GetHashSlot(serverSelectionStrategy);
+
+            public override int ArgCount => _args.Count;
 
             protected override bool TryGetSubCommand(out SubCommand subCommand)
             {
-                // the sub-command (if any) is the first argument after the command itself,
-                // e.g. CLIENT [GETNAME]; ad-hoc Execute args are boxed objects, so normalize
-                // the first one to a RedisValue before probing it against the known sub-commands
-                foreach (ref readonly var arg in _args.Span)
-                {
-                    var value = arg.Value;
-                    if (!value.IsNull)
-                    {
-                        return SubCommandMetadata.TryGetSubCommand(value, out subCommand);
-                    }
-                    break; // only the first argument is a sub-command candidate
-                }
-                subCommand = SubCommand.Unknown;
-                return false;
+                // resolved in the constructor: by now the arguments are rendered bytes, and this needs
+                // them as values
+                subCommand = _hasSubCommand ? _subCommand : SubCommand.Unknown;
+                return _hasSubCommand;
             }
         }
 
@@ -6297,28 +6277,24 @@ namespace StackExchange.Redis
 
         private sealed class ScriptEvalMessage : Message, IMultiMessage
         {
-            private readonly ReadOnlyMemory<RedisKey> _keys;
-            private readonly ReadOnlyMemory<RedisValue> _values;
+            // not readonly: RenderedArgs.Recycle swaps the buffer out, and cannot do that through a
+            // defensive copy - see RenderedArgs. The script itself stays out of the buffer: it is needed
+            // intact for hash lookup and SCRIPT LOAD, and being a string it carries no lifetime hazard.
+            private RenderedArgs _args;
+            private readonly int _keyCount;
             private readonly string _script;
             private byte[]? asciiHash;
             private bool useReadOnly;
-            public ScriptEvalMessage(int db, CommandFlags flags, RedisCommand command, string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values)
+            public ScriptEvalMessage(int db, CommandFlags flags, RedisCommand command, string script, ReadOnlyMemory<RedisKey> keys, ReadOnlyMemory<RedisValue> values, MemoryPool<byte>? pool)
                 : base(db, flags, command)
             {
                 _script = script ?? throw new ArgumentNullException(nameof(script));
-                _keys = keys;
-                _values = values;
+                _keyCount = keys.Length;
+                _args = RenderedArgs.Create(keys.Span, values.Span, pool);
             }
 
             public override int GetHashSlot(ServerSelectionStrategy serverSelectionStrategy)
-            {
-                int slot = ServerSelectionStrategy.NoSlot;
-                foreach (ref readonly var key in _keys.Span)
-                {
-                    slot = serverSelectionStrategy.CombineSlot(slot, key);
-                }
-                return slot;
-            }
+                => _args.GetHashSlot(serverSelectionStrategy);
 
             public IEnumerable<Message> GetMessages(PhysicalConnection connection)
             {
@@ -6348,28 +6324,22 @@ namespace StackExchange.Redis
             {
                 if (asciiHash != null)
                 {
-                    writer.WriteHeader(useReadOnly ? RedisCommand.EVALSHA_RO : RedisCommand.EVALSHA, 2 + _keys.Length + _values.Length);
+                    writer.WriteHeader(useReadOnly ? RedisCommand.EVALSHA_RO : RedisCommand.EVALSHA, ArgCount);
                     writer.WriteBulkString(asciiHash);
                 }
                 else
                 {
-                    writer.WriteHeader(useReadOnly ? RedisCommand.EVAL_RO : RedisCommand.EVAL, 2 + _keys.Length + _values.Length);
+                    writer.WriteHeader(useReadOnly ? RedisCommand.EVAL_RO : RedisCommand.EVAL, ArgCount);
                     writer.WriteBulkString(_script);
                 }
 
-                writer.WriteBulkString(_keys.Length);
+                writer.WriteBulkString(_keyCount);
 
-                foreach (ref readonly var key in _keys.Span)
-                {
-                    writer.Write(key);
-                }
-
-                foreach (ref readonly var value in _values.Span)
-                {
-                    writer.WriteBulkString(value);
-                }
+                // rendered keys-then-values, in the order EVAL wants them; keys already carry their prefix
+                _args.WriteTo(writer);
             }
-            public override int ArgCount => 2 + _keys.Length + _values.Length;
+
+            public override int ArgCount => 2 + _args.Count;
         }
 
         private sealed class ScriptEvaluateMessage : Message, IMultiMessage

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -1026,10 +1026,10 @@ namespace StackExchange.Redis
         }
 
         public void HashImport(RedisKey key, HashImport fieldSet, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
-            => ExecuteSync(GetHashImportMessage(key, fieldSet, values, flags), ResultProcessor.DemandOK);
+            => ExecuteSync(GetHashImportMessage(key, fieldSet, values, flags), ResultProcessor.HashImportOK);
 
         public Task HashImportAsync(RedisKey key, HashImport fieldSet, ReadOnlyMemory<RedisValue> values, CommandFlags flags = CommandFlags.None)
-            => ExecuteAsync(GetHashImportMessage(key, fieldSet, values, flags), ResultProcessor.DemandOK);
+            => ExecuteAsync(GetHashImportMessage(key, fieldSet, values, flags), ResultProcessor.HashImportOK);
 
         private HashImportSetMessage GetHashImportMessage(in RedisKey key, HashImport fieldSet, ReadOnlyMemory<RedisValue> values, CommandFlags flags)
         {
@@ -1052,7 +1052,7 @@ namespace StackExchange.Redis
             {
                 throw new NotSupportedException("HashImport is not supported inside a transaction; the connection-local HIMPORT PREPARE cannot be injected into a MULTI/EXEC without desyncing the EXEC result array.");
             }
-            return new HashImportSetMessage(Database, flags, fieldSet, key, values);
+            return new HashImportSetMessage(Database, flags, fieldSet, key, values, multiplexer?.RawConfig?.RequestBufferPool);
         }
 
         public Task<bool> HashSetIfNotExistsAsync(RedisKey key, RedisValue hashField, RedisValue value, CommandFlags flags)

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -6135,17 +6135,10 @@ namespace StackExchange.Redis
                 return _hasSubCommand;
             }
 
-            public override void Complete(PhysicalConnection? connection)
-            {
-                // Status flips to Sent strictly *after* WriteImpl returns (see WriteMessageToServerInsideWriteLock),
-                // but a message is enqueued into _writtenAwaitingResponse - making it eligible for the async-timeout
-                // heartbeat's SetExceptionAndComplete - *before* that write actually happens. Recycling on that
-                // premature completion would race an in-flight WriteImpl reading the same buffer. If the write did
-                // land, the real reply's own later Complete() call recycles once Status has caught up; if it never
-                // gets sent at all, the buffer leaks rather than risking corruption - the lesser evil.
-                if (Status == CommandStatus.Sent) RenderedArgs.Recycle(ref _args);
-                base.Complete(connection);
-            }
+            // driven by the reply rather than by completion: the reply proves the write finished, so there
+            // is no in-flight WriteImpl left to race, and a message that is going to be re-issued simply
+            // never gets one
+            internal override void OnFinalReply() => RenderedArgs.Recycle(ref _args);
         }
 
         internal sealed class ExecuteMessage : Message
@@ -6353,20 +6346,9 @@ namespace StackExchange.Redis
 
             public override int ArgCount => 2 + _args.Count;
 
-            public override void Complete(PhysicalConnection? connection)
-            {
-                // see ExecMessage.Complete for why this is gated on Status rather than unconditional.
-                //
-                // IsScriptUnavailable is the other half: a NOSCRIPT reply completes this message and then
-                // the caller re-issues *this same instance* as EVAL (see ScriptEvaluateResp and friends),
-                // so completion is not the end of the road here at all - recycling now would leave the
-                // retry writing from a buffer that has already gone back to the pool. The flag is set by
-                // the result processor before the completion that carries the error, so it is visible by
-                // the time we get here. If the retry does not happen after all, the buffer leaks - the
-                // same trade as above.
-                if (Status == CommandStatus.Sent && !IsScriptUnavailable) RenderedArgs.Recycle(ref _args);
-                base.Complete(connection);
-            }
+            // see ExecMessage.OnFinalReply; for scripts this is also what keeps a NOSCRIPT retry working,
+            // since that reply is not a final one and so never reaches here
+            internal override void OnFinalReply() => RenderedArgs.Recycle(ref _args);
         }
 
         private sealed class ScriptEvaluateMessage : Message, IMultiMessage

--- a/src/StackExchange.Redis/RedisDatabase.cs
+++ b/src/StackExchange.Redis/RedisDatabase.cs
@@ -6043,7 +6043,7 @@ namespace StackExchange.Redis
             }
         }
 
-        internal sealed class ExecMessage : Message
+        internal sealed class ExecMessage : Message, IRenderedArgsOwner
         {
             // not readonly: RenderedArgs.Recycle swaps the buffer out, and cannot do that through a
             // defensive copy - see RenderedArgs
@@ -6138,7 +6138,7 @@ namespace StackExchange.Redis
             // driven by the reply rather than by completion: the reply proves the write finished, so there
             // is no in-flight WriteImpl left to race, and a message that is going to be re-issued simply
             // never gets one
-            internal override void OnFinalReply() => RenderedArgs.Recycle(ref _args);
+            void IRenderedArgsOwner.ReleaseRenderedArgs() => RenderedArgs.Recycle(ref _args);
         }
 
         internal sealed class ExecuteMessage : Message
@@ -6280,7 +6280,7 @@ namespace StackExchange.Redis
         private static bool IsReadOnlyScript(RedisCommand command)
             => command is RedisCommand.EVAL_RO or RedisCommand.EVALSHA_RO;
 
-        private sealed class ScriptEvalMessage : Message, IMultiMessage
+        private sealed class ScriptEvalMessage : Message, IMultiMessage, IRenderedArgsOwner
         {
             // not readonly: RenderedArgs.Recycle swaps the buffer out, and cannot do that through a
             // defensive copy - see RenderedArgs. The script itself stays out of the buffer: it is needed
@@ -6348,7 +6348,7 @@ namespace StackExchange.Redis
 
             // see ExecMessage.OnFinalReply; for scripts this is also what keeps a NOSCRIPT retry working,
             // since that reply is not a final one and so never reaches here
-            internal override void OnFinalReply() => RenderedArgs.Recycle(ref _args);
+            void IRenderedArgsOwner.ReleaseRenderedArgs() => RenderedArgs.Recycle(ref _args);
         }
 
         private sealed class ScriptEvaluateMessage : Message, IMultiMessage

--- a/src/StackExchange.Redis/RenderedArgs.cs
+++ b/src/StackExchange.Redis/RenderedArgs.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace StackExchange.Redis
+{
+    /// <summary>
+    /// The keys and values of a request, rendered once into a single pooled buffer at the point of the
+    /// call, so that the request no longer refers to any memory the caller owns.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Callers can pass keys and values backed by their own arrays - and are encouraged to, for the sake
+    /// of allocation - but the request is not necessarily written before the call returns: it may be
+    /// queued in the backlog, or in a batch, and fire-and-forget callers get no completion signal at all.
+    /// Rendering here means the caller's buffers are theirs again the moment the call returns, and it also
+    /// moves the formatting off the writer thread, where it would otherwise be done while holding the
+    /// single-writer lock.
+    /// </para>
+    /// <para>
+    /// Entries are laid out back to back as a 4-byte little-endian length followed by that many payload
+    /// bytes. A negative length marks a key, with <c>~length</c> giving the real size; the complement
+    /// rather than negation so that a zero-length key is still distinguishable from a zero-length value.
+    /// </para>
+    /// <para>
+    /// <b>This type owns a pooled buffer, so it must live in exactly one place and must never be copied.</b>
+    /// Copying it duplicates the ownership and gets the buffer returned to the pool twice, which is a
+    /// silent corruption rather than a loud failure. Note also that the field holding it must not be
+    /// <c>readonly</c> - see <see cref="Recycle"/>.
+    /// </para>
+    /// </remarks>
+    internal struct RenderedArgs
+    {
+        // deliberately not readonly: Recycle swaps this out atomically. Either a byte[] from
+        // ArrayPool<byte>.Shared or an IMemoryOwner<byte> from the configured RequestBufferPool - the
+        // same shape RespResult and Lease<T> use, so that a caller who supplies a pool gets it honoured
+        // on the request side too.
+        private object _buffer;
+        private int _count, _length;
+
+        /// <summary>The number of entries rendered.</summary>
+        public readonly int Count => _count;
+
+        private const int PrefixLength = sizeof(int);
+
+        /// <summary>
+        /// Render the arguments of an ad-hoc command, which may be a mix of keys and values.
+        /// </summary>
+        public static RenderedArgs Create(ReadOnlySpan<RedisKeyOrValue> args, MemoryPool<byte>? pool)
+        {
+            int total = 0;
+            foreach (ref readonly var arg in args)
+            {
+                total += PrefixLength + (arg.IsKey ? arg.Key.TotalLength() : arg.Value.GetByteCount());
+            }
+
+            var result = Rent(args.Length, total, pool);
+            var target = result.Buffer;
+            foreach (ref readonly var arg in args)
+            {
+                target = arg.IsKey ? WriteKey(target, arg.Key) : WriteValue(target, arg.Value);
+            }
+
+            Debug.Assert(target.IsEmpty, "should have filled the buffer exactly");
+            return result;
+        }
+
+        /// <summary>
+        /// Render the keys and values of a script invocation; keys are emitted first, as EVAL expects.
+        /// </summary>
+        public static RenderedArgs Create(ReadOnlySpan<RedisKey> keys, ReadOnlySpan<RedisValue> values, MemoryPool<byte>? pool)
+        {
+            int total = 0;
+            foreach (ref readonly var key in keys) total += PrefixLength + key.TotalLength();
+            foreach (ref readonly var value in values) total += PrefixLength + value.GetByteCount();
+
+            var result = Rent(keys.Length + values.Length, total, pool);
+            var target = result.Buffer;
+            foreach (ref readonly var key in keys) target = WriteKey(target, key);
+            foreach (ref readonly var value in values) target = WriteValue(target, value);
+
+            Debug.Assert(target.IsEmpty, "should have filled the buffer exactly");
+            return result;
+        }
+
+        private static RenderedArgs Rent(int count, int length, MemoryPool<byte>? pool) => new RenderedArgs
+        {
+            _buffer = length == 0 ? Array.Empty<byte>()
+                : pool is null ? ArrayPool<byte>.Shared.Rent(length) : pool.Rent(length),
+            _count = count,
+            _length = length,
+        };
+
+        // the rented buffer is usually larger than we asked for; only the used span is ours
+        private readonly Span<byte> Buffer => _buffer switch
+        {
+            byte[] arr => new Span<byte>(arr, 0, _length),
+            IMemoryOwner<byte> owner => owner.Memory.Span.Slice(0, _length),
+            _ => default,
+        };
+
+        private static Span<byte> WriteKey(Span<byte> target, scoped in RedisKey key)
+        {
+            var length = key.TotalLength();
+            Unsafe.WriteUnaligned(ref target[0], ~length);
+            var written = key.CopyTo(target.Slice(PrefixLength));
+            Debug.Assert(written == length, "key length disagreed with itself");
+            return target.Slice(PrefixLength + length);
+        }
+
+        private static Span<byte> WriteValue(Span<byte> target, scoped in RedisValue value)
+        {
+            var length = value.GetByteCount();
+            Unsafe.WriteUnaligned(ref target[0], length);
+            var written = value.CopyTo(target.Slice(PrefixLength));
+            Debug.Assert(written == length, "value length disagreed with itself");
+            return target.Slice(PrefixLength + length);
+        }
+
+        /// <summary>
+        /// Walks the rendered entries in order.
+        /// </summary>
+        public readonly Enumerator GetEnumerator() => new Enumerator(Buffer);
+
+        /// <summary>
+        /// Return the buffer to the pool; safe to call repeatedly, and from multiple threads - only the
+        /// first caller sees the buffer.
+        /// </summary>
+        /// <remarks>
+        /// Taken by <c>ref</c> on purpose. As an instance method this would compile perfectly happily
+        /// against a <c>readonly</c> field and silently operate on a defensive copy, leaving the real
+        /// buffer stranded; as a <c>ref</c> parameter, that same mistake is CS0192 at build time.
+        /// </remarks>
+        public static void Recycle(ref RenderedArgs args)
+        {
+            var buffer = Interlocked.Exchange(ref args._buffer, Array.Empty<byte>());
+            args._length = args._count = 0;
+
+            // null when never rendered, empty when already recycled or nothing to render
+            if (buffer is byte[] { Length: > 0 } arr) ArrayPool<byte>.Shared.Return(arr);
+            else if (buffer is IMemoryOwner<byte> owner) owner.Dispose();
+        }
+
+        /// <summary>Walks rendered entries.</summary>
+        internal ref struct Enumerator(Span<byte> remaining)
+        {
+            private Span<byte> _remaining = remaining;
+
+            /// <summary>The payload of the current entry.</summary>
+            public ReadOnlySpan<byte> Current { get; private set; }
+
+            /// <summary>Whether the current entry was supplied as a key rather than a value.</summary>
+            public bool IsKey { get; private set; }
+
+            /// <summary>Move to the next entry.</summary>
+            public bool MoveNext()
+            {
+                if (_remaining.IsEmpty)
+                {
+                    Current = default;
+                    IsKey = false;
+                    return false;
+                }
+
+                var prefix = Unsafe.ReadUnaligned<int>(ref _remaining[0]);
+                IsKey = prefix < 0;
+                var length = IsKey ? ~prefix : prefix;
+                Current = _remaining.Slice(PrefixLength, length);
+                _remaining = _remaining.Slice(PrefixLength + length);
+                return true;
+            }
+        }
+    }
+}

--- a/src/StackExchange.Redis/RenderedArgs.cs
+++ b/src/StackExchange.Redis/RenderedArgs.cs
@@ -120,6 +120,45 @@ namespace StackExchange.Redis
         }
 
         /// <summary>
+        /// Write every entry as a RESP bulk string, in the order they were rendered.
+        /// </summary>
+        /// <remarks>
+        /// Keys and values are indistinguishable on the wire - the flag exists for slot routing, not for
+        /// framing - so this writes them identically.
+        /// </remarks>
+        public readonly void WriteTo(in MessageWriter writer)
+        {
+            var iter = GetEnumerator();
+            while (iter.MoveNext())
+            {
+                writer.WriteBulkString(iter.Current);
+            }
+        }
+
+        /// <summary>
+        /// The combined cluster slot of the keys, or <see cref="ServerSelectionStrategy.NoSlot"/> when
+        /// there are none, or <see cref="ServerSelectionStrategy.MultipleSlots"/> when they disagree.
+        /// </summary>
+        /// <remarks>
+        /// Values are skipped: only arguments the caller declared as keys take part in routing. Note this
+        /// hashes the rendered bytes directly, where <see cref="ServerSelectionStrategy.GetHashSlot"/> has
+        /// to copy the key out first - we already have exactly the bytes it would have produced.
+        /// </remarks>
+        public readonly int GetHashSlot(ServerSelectionStrategy strategy)
+        {
+            if (strategy.ServerType is ServerType.Standalone) return ServerSelectionStrategy.NoSlot;
+
+            var slot = ServerSelectionStrategy.NoSlot;
+            var iter = GetEnumerator();
+            while (iter.MoveNext())
+            {
+                if (!iter.IsKey) continue;
+                slot = ServerSelectionStrategy.CombineSlot(slot, ServerSelectionStrategy.GetClusterSlot(iter.Current));
+            }
+            return slot;
+        }
+
+        /// <summary>
         /// Walks the rendered entries in order.
         /// </summary>
         public readonly Enumerator GetEnumerator() => new Enumerator(Buffer);

--- a/src/StackExchange.Redis/RenderedArgs.cs
+++ b/src/StackExchange.Redis/RenderedArgs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace StackExchange.Redis
@@ -183,9 +184,10 @@ namespace StackExchange.Redis
         }
 
         /// <summary>Walks rendered entries.</summary>
-        internal ref struct Enumerator(Span<byte> remaining)
+        internal ref struct Enumerator(ReadOnlySpan<byte> remaining)
         {
-            private Span<byte> _remaining = remaining;
+            // read-only: walking never writes to the rendered buffer, it only slices through it
+            private ReadOnlySpan<byte> _remaining = remaining;
 
             /// <summary>The payload of the current entry.</summary>
             public ReadOnlySpan<byte> Current { get; private set; }
@@ -203,7 +205,7 @@ namespace StackExchange.Redis
                     return false;
                 }
 
-                var prefix = Unsafe.ReadUnaligned<int>(ref _remaining[0]);
+                var prefix = Unsafe.ReadUnaligned<int>(ref MemoryMarshal.GetReference(_remaining));
                 IsKey = prefix < 0;
                 var length = IsKey ? ~prefix : prefix;
                 Current = _remaining.Slice(PrefixLength, length);

--- a/src/StackExchange.Redis/RenderedArgs.cs
+++ b/src/StackExchange.Redis/RenderedArgs.cs
@@ -54,6 +54,9 @@ namespace StackExchange.Redis
             int total = 0;
             foreach (ref readonly var arg in args)
             {
+                // rejected here rather than at write time: the caller finds out on the call that made
+                // the mistake, instead of from a background writer some time later
+                if (arg.IsNull) throw new InvalidOperationException("A null is not valid in this context");
                 total += PrefixLength + (arg.IsKey ? arg.Key.TotalLength() : arg.Value.GetByteCount());
             }
 
@@ -74,8 +77,16 @@ namespace StackExchange.Redis
         public static RenderedArgs Create(ReadOnlySpan<RedisKey> keys, ReadOnlySpan<RedisValue> values, MemoryPool<byte>? pool)
         {
             int total = 0;
-            foreach (ref readonly var key in keys) total += PrefixLength + key.TotalLength();
-            foreach (ref readonly var value in values) total += PrefixLength + value.GetByteCount();
+            foreach (ref readonly var key in keys)
+            {
+                key.AssertNotNull();
+                total += PrefixLength + key.TotalLength();
+            }
+            foreach (ref readonly var value in values)
+            {
+                value.AssertNotNull();
+                total += PrefixLength + value.GetByteCount();
+            }
 
             var result = Rent(keys.Length + values.Length, total, pool);
             var target = result.Buffer;

--- a/src/StackExchange.Redis/RenderedArgs.cs
+++ b/src/StackExchange.Redis/RenderedArgs.cs
@@ -9,6 +9,30 @@ using System.Threading;
 namespace StackExchange.Redis
 {
     /// <summary>
+    /// Implemented by a message that holds a <see cref="RenderedArgs"/> for the lifetime of its request.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately an interface rather than a virtual on <c>Message</c>: only the handful of messages that
+    /// render their arguments up front care, and the one processor that calls this is used by nothing else,
+    /// so the type test always hits. No reason to put a slot on the base type of every command in the
+    /// library for it.
+    /// </remarks>
+    internal interface IRenderedArgsOwner
+    {
+        /// <summary>
+        /// Called once a reply has arrived that is known to be the final one for this message, so the
+        /// request buffer will not be needed again.
+        /// </summary>
+        /// <remarks>
+        /// The arrival of a reply is what makes this safe: it proves the write completed, which completion
+        /// alone does not - a message becomes visible to the async-timeout heartbeat when it is queued,
+        /// before WriteImpl has run. Must be idempotent; a redirect or a NOSCRIPT retry re-issues the same
+        /// instance, so those replies deliberately do not call it.
+        /// </remarks>
+        void ReleaseRenderedArgs();
+    }
+
+    /// <summary>
     /// The keys and values of a request, rendered once into a single pooled buffer at the point of the
     /// call, so that the request no longer refers to any memory the caller owns.
     /// </summary>

--- a/src/StackExchange.Redis/RenderedArgs.cs
+++ b/src/StackExchange.Redis/RenderedArgs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -140,12 +141,26 @@ namespace StackExchange.Redis
         /// </remarks>
         public readonly void WriteTo(in MessageWriter writer)
         {
+            var written = 0;
             var iter = GetEnumerator();
             while (iter.MoveNext())
             {
                 writer.WriteBulkString(iter.Current);
+                written++;
             }
+
+            // deliberately not a Debug.Assert: the header has already declared Count arguments, so writing
+            // a different number puts a malformed frame on the wire, and the server's complaint arrives
+            // later and somewhere else. If the buffer went away underneath us - recycled early, or torn by
+            // a race - fail here, loudly, attached to the request that caused it.
+            if (written != _count) ThrowArgCountMismatch(written, _count);
         }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowArgCountMismatch(int written, int expected) =>
+            throw new InvalidOperationException(
+                $"Rendered arguments were expected to write {expected} value(s), but wrote {written}; the request buffer is no longer valid.");
 
         /// <summary>
         /// The combined cluster slot of the keys, or <see cref="ServerSelectionStrategy.NoSlot"/> when
@@ -186,8 +201,17 @@ namespace StackExchange.Redis
         /// </remarks>
         public static void Recycle(ref RenderedArgs args)
         {
+            // length first, and before the exchange: a reader derives its span from _buffer and then
+            // _length, so anything that observes the swapped-out buffer is guaranteed to see a length of
+            // zero, and anything still holding the old buffer may see it too. Losing this race then writes
+            // nothing - which WriteTo turns into a loud count mismatch - instead of writing whatever the
+            // next renter has since put in that array. The exchange below is the barrier that orders it.
+            args._length = 0;
+
             var buffer = Interlocked.Exchange(ref args._buffer, Array.Empty<byte>());
-            args._length = args._count = 0;
+
+            // _count is deliberately left alone: it is what WriteTo checks itself against, and zeroing it
+            // would make a write after recycling look perfectly consistent while emitting nothing.
 
             // null when never rendered, empty when already recycled or nothing to render
             if (buffer is byte[] { Length: > 0 } arr) ArrayPool<byte>.Shared.Return(arr);

--- a/src/StackExchange.Redis/ResultProcessor.RespResult.cs
+++ b/src/StackExchange.Redis/ResultProcessor.RespResult.cs
@@ -26,11 +26,14 @@ internal abstract partial class ResultProcessor
                 // an EVALSHA can come back NOSCRIPT at any time - the server may have been flushed,
                 // restarted, or failed over - and the callers of this processor retry on that, but only
                 // if we tell them; see NoteIfScriptUnavailable
-                NoteIfScriptUnavailable(connection, message, in probe);
+                var isNoScript = NoteIfScriptUnavailable(connection, message, in probe);
 
                 // every other error is the end of the road for this message; a NOSCRIPT is not, because
-                // the caller re-issues this same instance, and it still needs its request buffer
-                if (!message.IsScriptUnavailable && message is IRenderedArgsOwner errorOwner) errorOwner.ReleaseRenderedArgs();
+                // the caller re-issues this same instance, and it still needs its request buffer.
+                // Note this asks about *this* reply rather than reading message.IsScriptUnavailable: that
+                // flag is sticky, so a retry that fails with some other error would still look like a
+                // NOSCRIPT and the buffer would never come back.
+                if (!isNoScript && message is IRenderedArgsOwner errorOwner) errorOwner.ReleaseRenderedArgs();
 
                 return base.SetResult(connection, message, ref reader);
             }

--- a/src/StackExchange.Redis/ResultProcessor.RespResult.cs
+++ b/src/StackExchange.Redis/ResultProcessor.RespResult.cs
@@ -27,11 +27,17 @@ internal abstract partial class ResultProcessor
                 // restarted, or failed over - and the callers of this processor retry on that, but only
                 // if we tell them; see NoteIfScriptUnavailable
                 NoteIfScriptUnavailable(connection, message, in probe);
+
+                // every other error is the end of the road for this message; a NOSCRIPT is not, because
+                // the caller re-issues this same instance, and it still needs its request buffer
+                if (!message.IsScriptUnavailable) message.OnFinalReply();
+
                 return base.SetResult(connection, message, ref reader);
             }
 
             var pool = connection.BridgeCouldBeNull?.Multiplexer?.RawConfig?.ResponseBufferPool;
             SetResult(message, StackExchange.Redis.RespResult.Capture(probe.Prefix, probe.IsNull, ref reader, totalBytes, pool));
+            message.OnFinalReply();
             return true;
         }
 

--- a/src/StackExchange.Redis/ResultProcessor.RespResult.cs
+++ b/src/StackExchange.Redis/ResultProcessor.RespResult.cs
@@ -30,14 +30,14 @@ internal abstract partial class ResultProcessor
 
                 // every other error is the end of the road for this message; a NOSCRIPT is not, because
                 // the caller re-issues this same instance, and it still needs its request buffer
-                if (!message.IsScriptUnavailable) message.OnFinalReply();
+                if (!message.IsScriptUnavailable && message is IRenderedArgsOwner errorOwner) errorOwner.ReleaseRenderedArgs();
 
                 return base.SetResult(connection, message, ref reader);
             }
 
             var pool = connection.BridgeCouldBeNull?.Multiplexer?.RawConfig?.ResponseBufferPool;
             SetResult(message, StackExchange.Redis.RespResult.Capture(probe.Prefix, probe.IsNull, ref reader, totalBytes, pool));
-            message.OnFinalReply();
+            if (message is IRenderedArgsOwner owner) owner.ReleaseRenderedArgs();
             return true;
         }
 

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -21,18 +21,30 @@ namespace StackExchange.Redis
         /// drop our cached hashes for the server.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Every processor that can be the target of an EVALSHA needs this, not just the one returning
         /// <see cref="RedisResult"/>: without it the retry filters on <c>IsScriptUnavailable</c> can never
         /// match, and the NOSCRIPT surfaces to the caller.
+        /// </para>
+        /// <para>
+        /// Returns whether <em>this</em> reply was a NOSCRIPT, which is not the same question as
+        /// <c>message.IsScriptUnavailable</c>: that flag is set once and never cleared, so on a retry that
+        /// comes back with some other error it still reads true. Callers deciding something about the reply
+        /// in hand - rather than about the message's history - want this.
+        /// </para>
         /// </remarks>
-        private protected static void NoteIfScriptUnavailable(PhysicalConnection connection, Message message, in RespReader errorReader)
+        /// <returns><c>true</c> if this reply was a NOSCRIPT error.</returns>
+        private protected static bool NoteIfScriptUnavailable(PhysicalConnection connection, Message message, in RespReader errorReader)
         {
             if (errorReader.IsError && RedisErrorKindMetadata.Classify(errorReader) == RedisErrorKind.NoScript)
             {
                 // scripts are not flushed individually, so assume the entire script cache is toast ("SCRIPT FLUSH")
                 connection.BridgeCouldBeNull?.ServerEndPoint?.FlushScriptCache();
                 message.SetScriptUnavailable();
+                return true;
             }
+
+            return false;
         }
 
         public static readonly ResultProcessor<bool>

--- a/src/StackExchange.Redis/ResultProcessor.cs
+++ b/src/StackExchange.Redis/ResultProcessor.cs
@@ -50,6 +50,7 @@ namespace StackExchange.Redis
         public static readonly ResultProcessor<bool>
             Boolean = new BooleanProcessor(),
             DemandOK = new ExpectBasicStringProcessor(Literals.OK.Hash),
+            HashImportOK = HashImportProcessor.Instance,
             DemandPONG = new ExpectBasicStringProcessor(Literals.PONG.Hash),
             DemandZeroOrOne = new DemandZeroOrOneProcessor(),
             AutoConfigure = new AutoConfigureProcessor(),
@@ -1415,6 +1416,31 @@ namespace StackExchange.Redis
                 }
                 return false;
             }
+        }
+
+        /// <summary>
+        /// As <see cref="DemandOK"/>, but also releases the message's rendered request buffer.
+        /// </summary>
+        /// <remarks>
+        /// A dedicated processor rather than a change to the shared one: HIMPORT is the only command whose
+        /// message renders its arguments up front *and* has no notion of being re-issued, so any reply at
+        /// all - success or error - is the end of the road for its buffer. Releasing from the reply rather
+        /// than from completion for the same reason as everything else here: a reply proves the write
+        /// finished, which completion on its own does not.
+        /// </remarks>
+        private sealed class HashImportProcessor : ResultProcessor<bool>
+        {
+            public override bool SetResult(PhysicalConnection connection, Message message, ref RespReader reader)
+            {
+                if (message is IRenderedArgsOwner owner) owner.ReleaseRenderedArgs();
+                return DemandOK.SetResult(connection, message, ref reader);
+            }
+
+            protected override bool SetResultCore(PhysicalConnection connection, Message message, ref RespReader reader) =>
+                throw new NotSupportedException(); // SetResult is fully overridden above
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801", Justification = "n/a")]
+            internal static readonly HashImportProcessor Instance = new();
         }
 
         private sealed class ExpectBasicStringProcessor : ResultProcessor<bool>

--- a/tests/StackExchange.Redis.Tests/RenderedArgsAliasingTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsAliasingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
@@ -106,6 +107,52 @@ public class RenderedArgsAliasingTests(ITestOutputHelper output) : TestBase(outp
         {
             Assert.Equal("v" + i, (string?)await db.HashGetAsync((RedisKey)(Me() + ":" + i), "f"));
         }
+    }
+
+    /// <summary>
+    /// The shape the docs recommend: rent, issue the calls, return the buffer to the pool, and only then
+    /// await. Queued through a batch so the writes are genuinely still pending when the buffer goes back -
+    /// against the open database an uncontended write lock writes each call inline, so returning the array
+    /// afterwards would prove nothing (a read-late implementation passes that version).
+    /// </summary>
+    [Fact]
+    public async Task ArgumentsMayBeReturnedToThePoolBeforeAwaiting()
+    {
+        await using var conn = Create(shared: false);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        await db.KeyDeleteAsync(key);
+
+        var batch = db.CreateBatch();
+        var args = ArrayPool<RedisKeyOrValue>.Shared.Rent(3);
+        var pending = new List<Task<RespResult>>(Iterations);
+        try
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                args[0] = key;
+                args[1] = (RedisValue)("f" + i);
+                args[2] = (RedisValue)("v" + i);
+                pending.Add(batch.ExecuteRespAsync("HSET", args.AsMemory(0, 3)));
+            }
+        }
+        finally
+        {
+            ArrayPool<RedisKeyOrValue>.Shared.Return(args, clearArray: true);
+        }
+
+        // and behave like the next renter: take it back and fill it with something else entirely
+        var stomp = ArrayPool<RedisKeyOrValue>.Shared.Rent(3);
+        for (int i = 0; i < 3; i++) stomp[i] = (RedisValue)"stomped";
+
+        batch.Execute();
+        foreach (var task in pending)
+        {
+            using var result = await task;
+        }
+
+        ArrayPool<RedisKeyOrValue>.Shared.Return(stomp, clearArray: true);
+        await AssertHashIsIntact(db, key);
     }
 
     private async Task AssertHashIsIntact(IDatabase db, RedisKey key)

--- a/tests/StackExchange.Redis.Tests/RenderedArgsAliasingTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsAliasingTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// The reason the arguments are rendered at the point of the call: once the call returns, the caller's
+/// buffer is theirs again. These reuse a single argument array across overlapping, un-awaited calls,
+/// mutating it between each - which is precisely what a caller renting one array from a pool would do,
+/// and precisely what breaks if the request still refers to that memory when it is eventually written.
+/// </summary>
+[RunPerProtocol]
+public class RenderedArgsAliasingTests(ITestOutputHelper output) : TestBase(output)
+{
+    private const int Iterations = 200;
+
+    [Fact]
+    public async Task ExecuteResp_SurvivesTheCallerMutatingOneSharedArgArray()
+    {
+        await using var conn = Create(shared: false);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        await db.KeyDeleteAsync(key);
+
+        // a batch, so the writes are provably deferred: every message is queued here and none of them
+        // reaches the wire until Execute() below, by which point the array holds only the last iteration.
+        // Overlapping un-awaited calls on the open database are not enough on their own - an uncontended
+        // write lock means each one is written inline, before the next iteration can stomp the array.
+        var batch = db.CreateBatch();
+        var args = new RedisKeyOrValue[3];
+        var pending = new List<Task<RespResult>>(Iterations);
+        for (int i = 0; i < Iterations; i++)
+        {
+            args[0] = key;
+            args[1] = (RedisValue)("f" + i);
+            args[2] = (RedisValue)("v" + i);
+            pending.Add(batch.ExecuteRespAsync("HSET", args));
+        }
+
+        batch.Execute();
+
+        foreach (var task in pending)
+        {
+            using var result = await task;
+        }
+
+        await AssertHashIsIntact(db, key);
+    }
+
+    [Fact]
+    public async Task ScriptEvaluateResp_SurvivesTheCallerMutatingOneSharedArgArray()
+    {
+        await using var conn = Create(shared: false);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        await db.KeyDeleteAsync(key);
+
+        const string Script = "return redis.call('hset', KEYS[1], ARGV[1], ARGV[2])";
+        var batch = db.CreateBatch();
+        var keys = new RedisKey[1];
+        var values = new RedisValue[2];
+        var pending = new List<Task<RespResult>>(Iterations);
+        for (int i = 0; i < Iterations; i++)
+        {
+            keys[0] = key;
+            values[0] = "f" + i;
+            values[1] = "v" + i;
+            pending.Add(batch.ScriptEvaluateRespAsync(Script, keys, values));
+        }
+
+        batch.Execute();
+
+        foreach (var task in pending)
+        {
+            using var result = await task;
+        }
+
+        await AssertHashIsIntact(db, key);
+    }
+
+    private async Task AssertHashIsIntact(IDatabase db, RedisKey key)
+    {
+        // if any call had been written from the array *after* a later iteration overwrote it, that call
+        // would have set some other field - so the hash would be short, and some values would be paired
+        // with the wrong field
+        var all = await db.HashGetAllAsync(key);
+        var actual = new Dictionary<string, string>(all.Length);
+        foreach (var entry in all) actual[entry.Name!] = entry.Value!;
+
+        Assert.Equal(Iterations, actual.Count);
+        for (int i = 0; i < Iterations; i++)
+        {
+            Assert.True(actual.TryGetValue("f" + i, out var value), $"field f{i} never arrived");
+            Assert.Equal("v" + i, value);
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/RenderedArgsAliasingTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsAliasingTests.cs
@@ -80,6 +80,34 @@ public class RenderedArgsAliasingTests(ITestOutputHelper output) : TestBase(outp
         await AssertHashIsIntact(db, key);
     }
 
+    [Fact]
+    public async Task HashImport_SurvivesTheCallerMutatingOneSharedValuesArray()
+    {
+        await using var conn = Create(shared: false, require: RedisFeatures.v8_0_0_M04);
+        var db = conn.GetDatabase();
+        RedisKey key = Me();
+        await db.KeyDeleteAsync(key);
+
+        // the per-row bulk-import shape: one field-set, one values buffer, refilled for every row
+        using var fieldSet = HashImport.Create("f");
+        var batch = db.CreateBatch();
+        var values = new RedisValue[1];
+        var pending = new List<Task>(Iterations);
+        for (int i = 0; i < Iterations; i++)
+        {
+            values[0] = "v" + i;
+            pending.Add(batch.HashImportAsync((RedisKey)(Me() + ":" + i), fieldSet, values));
+        }
+
+        batch.Execute();
+        await Task.WhenAll(pending);
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            Assert.Equal("v" + i, (string?)await db.HashGetAsync((RedisKey)(Me() + ":" + i), "f"));
+        }
+    }
+
     private async Task AssertHashIsIntact(IDatabase db, RedisKey key)
     {
         // if any call had been written from the array *after* a later iteration overwrote it, that call

--- a/tests/StackExchange.Redis.Tests/RenderedArgsLeakTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsLeakTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Buffers;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+[RunPerProtocol]
+public class RenderedArgsLeakTests(ITestOutputHelper output) : TestBase(output)
+{
+    // end-to-end companion to the codec-level RenderedArgsTests: drives real ExecuteResp/ScriptEvaluateResp
+    // traffic against a live server and confirms the rented request buffers actually come back - normal
+    // completion, not just the isolated Recycle() calls the unit tests exercise directly.
+    [Fact]
+    public async Task ExecuteRespAndScriptEvaluateResp_DoNotLeakRentedBuffers()
+    {
+        const int Iterations = 500;
+        var pool = new CountingPool();
+        var options = new ConfigurationOptions
+        {
+            EndPoints = { TestConfig.Current.PrimaryServerAndPort },
+            RequestBufferPool = pool,
+            Protocol = TestContext.Current.GetProtocol(),
+        };
+
+        RedisKey key = Me();
+        await using (var conn = await ConnectionMultiplexer.ConnectAsync(options))
+        {
+            var db = conn.GetDatabase();
+            for (int i = 0; i < Iterations; i++)
+            {
+                using var setResult = await db.ExecuteRespAsync("SET", new RedisKeyOrValue[] { key, (RedisValue)i });
+                using var getResult = await db.ScriptEvaluateRespAsync("return redis.call('get', KEYS[1])", new RedisKey[] { key }, default);
+                Assert.Equal(i.ToString(), (string?)getResult.ReadScalar().ReadRedisValue());
+            }
+        }
+
+        // after full teardown, every rented buffer should have come back - modulo a small, stable
+        // residual for whatever the connection's own write/read buffering happened to be holding at the
+        // moment of measurement, not a per-call leak (see PR #3211 discussion: ballpark 500 calls -> ~550
+        // rents [500 for the request buffers, the rest for IO], with almost all of them returned).
+        var outstanding = pool.Rented - pool.Returned;
+        Output.WriteLine($"rented={pool.Rented}, returned={pool.Returned}, outstanding={outstanding}");
+        Assert.True(pool.Rented >= Iterations * 2, $"expected at least one rent per call, got {pool.Rented} for {Iterations} iterations");
+        Assert.True(outstanding <= 5, $"expected only a small residual, got {outstanding} outstanding (rented={pool.Rented}, returned={pool.Returned})");
+    }
+
+    // DIAGNOSTIC: same loop, but through the *old*, pre-RenderedArgs ScriptEvaluateAsync path, to determine
+    // whether the "keys > args" corruption seen under full-suite load is specific to the new codec or a
+    // pre-existing race in the write path that predates this PR entirely.
+    [Fact]
+    public async Task OldScriptEvaluateAsync_DoesNotCorruptUnderLoad()
+    {
+        const int Iterations = 500;
+        RedisKey key = Me();
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(new ConfigurationOptions
+        {
+            EndPoints = { TestConfig.Current.PrimaryServerAndPort },
+            Protocol = TestContext.Current.GetProtocol(),
+        });
+        var db = conn.GetDatabase();
+        for (int i = 0; i < Iterations; i++)
+        {
+            await db.StringSetAsync(key, i);
+            var result = await db.ScriptEvaluateAsync("return redis.call('get', KEYS[1])", new RedisKey[] { key }, default);
+            Assert.Equal(i.ToString(), (string?)result);
+        }
+    }
+
+    private sealed class CountingPool : MemoryPool<byte>
+    {
+        private int _rented, _returned;
+        public int Rented => _rented;
+        public int Returned => _returned;
+        public override int MaxBufferSize => Shared.MaxBufferSize;
+
+        public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
+        {
+            Interlocked.Increment(ref _rented);
+            return new Owner(this, Shared.Rent(minBufferSize));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+
+        private sealed class Owner(CountingPool pool, IMemoryOwner<byte> inner) : IMemoryOwner<byte>
+        {
+            public Memory<byte> Memory => inner.Memory;
+            public void Dispose()
+            {
+                Interlocked.Increment(ref pool._returned);
+                inner.Dispose();
+            }
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/RenderedArgsTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsTests.cs
@@ -147,6 +147,118 @@ public class RenderedArgsTests
         }
     }
 
+    private static byte[] Write(in RenderedArgs args)
+    {
+        var writer = new MessageWriter(null, CommandMap.Default, MessageWriter.BlockBuffer);
+        ReadOnlyMemory<byte> payload = default;
+        try
+        {
+            args.WriteTo(writer);
+            payload = MessageWriter.FlushBlockBuffer();
+            return payload.Span.ToArray();
+        }
+        catch
+        {
+            MessageWriter.RevertBlockBuffer();
+            throw;
+        }
+        finally
+        {
+            MessageWriter.ReleaseBlockBuffer(payload);
+        }
+    }
+
+    [Fact]
+    public void WritesEachEntryAsABulkString()
+    {
+        var args = RenderedArgs.Create([(RedisKey)"key", (RedisValue)"value", (RedisValue)42], pool: null);
+        try
+        {
+            // keys and values are indistinguishable on the wire; the flag is only for routing
+            Assert.Equal("$3\r\nkey\r\n$5\r\nvalue\r\n$2\r\n42\r\n", Encoding.UTF8.GetString(Write(in args)));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    [Fact]
+    public void WritesNothingForNoArguments()
+    {
+        var args = RenderedArgs.Create([], pool: null);
+        try
+        {
+            Assert.Empty(Write(in args));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    [Theory]
+    [InlineData("abc")]                 // single key
+    [InlineData("abc,abc")]             // same key twice - one slot
+    [InlineData("{tag}a,{tag}b")]       // hash tags - still one slot
+    [InlineData("one,two")]             // disagreeing keys - MultipleSlots
+    [InlineData("")]                    // no keys at all
+    public void HashSlotAgreesWithThePerKeyPath(string keyNames)
+    {
+        var strategy = new ServerSelectionStrategy(null) { ServerType = ServerType.Cluster };
+        var keys = keyNames.Length == 0
+            ? []
+            : keyNames.Split(',').Select(x => (RedisKey)x).ToArray();
+
+        // what the existing per-key routing would decide
+        var expected = ServerSelectionStrategy.NoSlot;
+        foreach (var key in keys) expected = strategy.CombineSlot(expected, key);
+
+        var args = RenderedArgs.Create(keys, [(RedisValue)"ignored", (RedisValue)"also ignored"], pool: null);
+        try
+        {
+            Assert.Equal(expected, args.GetHashSlot(strategy));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    [Fact]
+    public void HashSlotIgnoresValuesEvenWhenTheyLookLikeKeys()
+    {
+        var strategy = new ServerSelectionStrategy(null) { ServerType = ServerType.Cluster };
+
+        var keyed = RenderedArgs.Create([(RedisKey)"abc"], pool: null);
+        var valued = RenderedArgs.Create([(RedisValue)"abc"], pool: null);
+        try
+        {
+            Assert.Equal(strategy.HashSlot((RedisKey)"abc"), keyed.GetHashSlot(strategy));
+            Assert.Equal(ServerSelectionStrategy.NoSlot, valued.GetHashSlot(strategy));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref keyed);
+            RenderedArgs.Recycle(ref valued);
+        }
+    }
+
+    [Fact]
+    public void HashSlotIsNoSlotForStandalone()
+    {
+        var strategy = new ServerSelectionStrategy(null) { ServerType = ServerType.Standalone };
+        var args = RenderedArgs.Create([(RedisKey)"abc"], pool: null);
+        try
+        {
+            Assert.Equal(ServerSelectionStrategy.NoSlot, args.GetHashSlot(strategy));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
     private sealed class CountingPool : MemoryPool<byte>
     {
         public int Rented { get; private set; }

--- a/tests/StackExchange.Redis.Tests/RenderedArgsTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace StackExchange.Redis.Tests;
+
+/// <summary>
+/// The codec only: entries round-trip, keys and values stay distinguishable, and the buffer goes back to
+/// the pool exactly once however many times it is asked to.
+/// </summary>
+public class RenderedArgsTests
+{
+    private static List<(bool IsKey, string Payload)> Drain(in RenderedArgs args)
+    {
+        var result = new List<(bool, string)>();
+        var iter = args.GetEnumerator();
+        while (iter.MoveNext())
+        {
+            result.Add((iter.IsKey, Encoding.UTF8.GetString(iter.Current)));
+        }
+        return result;
+    }
+
+    [Fact]
+    public void MixedKeysAndValuesRoundTrip()
+    {
+        RedisKeyOrValue[] input = [(RedisKey)"k1", (RedisValue)"v1", (RedisKey)"k2", (RedisValue)123];
+        var args = RenderedArgs.Create(input, pool: null);
+        try
+        {
+            Assert.Equal(4, args.Count);
+            Assert.Equal(
+                [(true, "k1"), (false, "v1"), (true, "k2"), (false, "123")],
+                Drain(in args));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    [Fact]
+    public void ScriptFormPutsKeysFirst()
+    {
+        RedisKey[] keys = ["a", "bb"];
+        RedisValue[] values = ["x", "yy", "zzz"];
+        var args = RenderedArgs.Create(keys, values, pool: null);
+        try
+        {
+            Assert.Equal(5, args.Count);
+            Assert.Equal(
+                [(true, "a"), (true, "bb"), (false, "x"), (false, "yy"), (false, "zzz")],
+                Drain(in args));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    [Fact]
+    public void ZeroLengthKeyAndValueStayDistinguishable()
+    {
+        // this is why the prefix uses ~length rather than -length: negation cannot tell a zero-length
+        // key from a zero-length value, because -0 == 0
+        RedisKeyOrValue[] input = [(RedisKey)"", (RedisValue)""];
+        var args = RenderedArgs.Create(input, pool: null);
+        try
+        {
+            Assert.Equal([(true, ""), (false, "")], Drain(in args));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    [Fact]
+    public void EmptyInputRendersNothingAndRecyclesCleanly()
+    {
+        var args = RenderedArgs.Create([], pool: null);
+        Assert.Equal(0, args.Count);
+        Assert.Empty(Drain(in args));
+        RenderedArgs.Recycle(ref args);
+        RenderedArgs.Recycle(ref args);
+    }
+
+    [Fact]
+    public void DefaultInstanceIsSafeToRecycle()
+    {
+        // a message that fails before its arguments are ever rendered still has to be tidied up
+        RenderedArgs args = default;
+        Assert.Equal(0, args.Count);
+        RenderedArgs.Recycle(ref args);
+    }
+
+    [Fact]
+    public void RecycleIsOnceOnly()
+    {
+        var pool = new CountingPool();
+        var args = RenderedArgs.Create([(RedisValue)"payload"], pool);
+        Assert.Equal(1, pool.Rented);
+
+        RenderedArgs.Recycle(ref args);
+        RenderedArgs.Recycle(ref args);
+        RenderedArgs.Recycle(ref args);
+
+        Assert.Equal(1, pool.Returned); // and not three
+        Assert.Equal(0, args.Count);
+        Assert.Empty(Drain(in args)); // reading after recycling is empty rather than a fault
+    }
+
+    [Fact]
+    public void ConfiguredPoolIsUsedInsteadOfTheSharedArrayPool()
+    {
+        var pool = new CountingPool();
+        var args = RenderedArgs.Create([(RedisKey)"key", (RedisValue)"value"], pool);
+        try
+        {
+            Assert.Equal(1, pool.Rented);
+            Assert.Equal([(true, "key"), (false, "value")], Drain(in args));
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+        Assert.Equal(1, pool.Returned);
+    }
+
+    [Fact]
+    public void LargePayloadsSurviveTheLengthPrefix()
+    {
+        var big = new string('x', 100_000);
+        var args = RenderedArgs.Create([(RedisValue)big], pool: null);
+        try
+        {
+            var drained = Drain(in args);
+            Assert.Single(drained);
+            Assert.Equal(big, drained[0].Payload);
+        }
+        finally
+        {
+            RenderedArgs.Recycle(ref args);
+        }
+    }
+
+    private sealed class CountingPool : MemoryPool<byte>
+    {
+        public int Rented { get; private set; }
+        public int Returned { get; private set; }
+        public override int MaxBufferSize => Shared.MaxBufferSize;
+        public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
+        {
+            Rented++;
+            return new Owner(this, Shared.Rent(minBufferSize));
+        }
+        protected override void Dispose(bool disposing) { }
+
+        private sealed class Owner(CountingPool pool, IMemoryOwner<byte> inner) : IMemoryOwner<byte>
+        {
+            public Memory<byte> Memory => inner.Memory;
+            public void Dispose() { pool.Returned++; inner.Dispose(); }
+        }
+    }
+}

--- a/tests/StackExchange.Redis.Tests/RenderedArgsTests.cs
+++ b/tests/StackExchange.Redis.Tests/RenderedArgsTests.cs
@@ -109,8 +109,24 @@ public class RenderedArgsTests
         RenderedArgs.Recycle(ref args);
 
         Assert.Equal(1, pool.Returned); // and not three
-        Assert.Equal(0, args.Count);
-        Assert.Empty(Drain(in args)); // reading after recycling is empty rather than a fault
+
+        // Count is deliberately retained: it is what WriteTo checks itself against, so zeroing it here
+        // would make a write after recycling look consistent while emitting nothing
+        Assert.Equal(1, args.Count);
+        Assert.Empty(Drain(in args)); // walking after recycling is empty rather than a fault
+    }
+
+    [Fact]
+    public void WritingAfterRecyclingFailsLoudlyRatherThanSilently()
+    {
+        // the header has already declared Count arguments by the time WriteTo runs, so quietly writing
+        // fewer would put a malformed frame on the wire and the server would complain later, somewhere
+        // else - this is the shape of a use-after-recycle, and it should fail here instead
+        var args = RenderedArgs.Create([(RedisKey)"key", (RedisValue)"value"], pool: null);
+        RenderedArgs.Recycle(ref args);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Write(in args));
+        Assert.Contains("2 value(s), but wrote 0", ex.Message);
     }
 
     [Fact]

--- a/tests/StackExchange.Redis.Tests/RoundTripUnitTests/HashImport.cs
+++ b/tests/StackExchange.Redis.Tests/RoundTripUnitTests/HashImport.cs
@@ -39,7 +39,7 @@ public class HashImport(ITestOutputHelper log)
         var token = StackExchange.Redis.HashImport.Create("f1", "f2");
         byte[] name = BitConverter.GetBytes(token.Id);
         ReadOnlyMemory<RedisValue> values = new RedisValue[] { "v1", "v2" };
-        var msg = new HashImportSetMessage(0, CommandFlags.None, token, (RedisKey)"user:1", values);
+        var msg = new HashImportSetMessage(0, CommandFlags.None, token, (RedisKey)"user:1", values, null);
 
         // HIMPORT SET user:1 <field-set> v1 v2
         var request = "*6\r\n$7\r\nHIMPORT\r\n$3\r\nSET\r\n$6\r\nuser:1\r\n" + Bulk(name) + "$2\r\nv1\r\n$2\r\nv2\r\n";
@@ -53,7 +53,7 @@ public class HashImport(ITestOutputHelper log)
         var token = StackExchange.Redis.HashImport.Create("only");
         byte[] name = BitConverter.GetBytes(token.Id);
         ReadOnlyMemory<RedisValue> values = new RedisValue[] { "v" };
-        var msg = new HashImportSetMessage(0, CommandFlags.None, token, (RedisKey)"k", values);
+        var msg = new HashImportSetMessage(0, CommandFlags.None, token, (RedisKey)"k", values, null);
 
         var request = "*5\r\n$7\r\nHIMPORT\r\n$3\r\nSET\r\n$1\r\nk\r\n" + Bulk(name) + "$1\r\nv\r\n";
         var result = await TestConnection.ExecuteAsync(msg, ResultProcessor.DemandOK, request, "+OK\r\n", log: log);

--- a/tests/StackExchange.Redis.Tests/ScriptEvalRespNoScriptTests.cs
+++ b/tests/StackExchange.Redis.Tests/ScriptEvalRespNoScriptTests.cs
@@ -11,6 +11,7 @@ namespace StackExchange.Redis.Tests;
 /// </summary>
 public class ScriptEvalRespNoScriptTests(ITestOutputHelper output) : TestBase(output)
 {
+    private const string ArgScript = "return ARGV[1] .. '|' .. ARGV[2]";
     private const string Script = "return 'hello from ScriptEvalRespNoScriptTests'";
     private const string Expected = "hello from ScriptEvalRespNoScriptTests";
 
@@ -27,6 +28,7 @@ public class ScriptEvalRespNoScriptTests(ITestOutputHelper output) : TestBase(ou
     {
         var conn = Create(shared: false, allowAdmin: true);
         conn.GetServerSnapshot()[0].AddScript(Script, UnknownHash);
+        conn.GetServerSnapshot()[0].AddScript(ArgScript, UnknownHash);
         return conn;
     }
 
@@ -66,6 +68,28 @@ public class ScriptEvalRespNoScriptTests(ITestOutputHelper output) : TestBase(ou
     /// Control: the classic RedisResult-returning path already copes, so this shows the difference is the
     /// result processor rather than anything about the message or the test setup.
     /// </summary>
+    /// <summary>
+    /// The retry re-issues the *same message instance*, so anything the message released on completion has
+    /// to still be there for the second write. With no keys or values there is nothing to release and
+    /// nothing to notice - which is why the cases above missed this - so this one carries arguments.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RecoversFromNoScript_WithArguments(bool readOnly)
+    {
+        await using var conn = ConnectWithStaleHash();
+        var db = conn.GetDatabase();
+        RedisKey[] keys = [Me()];
+        RedisValue[] values = ["alpha", "beta"];
+
+        using var result = readOnly
+            ? await db.ScriptEvaluateReadOnlyRespAsync(ArgScript, keys, values)
+            : await db.ScriptEvaluateRespAsync(ArgScript, keys, values);
+
+        Assert.Equal("alpha|beta", (string?)result.ReadScalar().ReadRedisValue());
+    }
+
     [Fact]
     public async Task ScriptEvaluate_Classic_RecoversFromNoScript()
     {

--- a/tests/StackExchange.Redis.Tests/ScriptEvalRespNoScriptTests.cs
+++ b/tests/StackExchange.Redis.Tests/ScriptEvalRespNoScriptTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -88,6 +90,67 @@ public class ScriptEvalRespNoScriptTests(ITestOutputHelper output) : TestBase(ou
             : await db.ScriptEvaluateRespAsync(ArgScript, keys, values);
 
         Assert.Equal("alpha|beta", (string?)result.ReadScalar().ReadRedisValue());
+    }
+
+    /// <summary>
+    /// A NOSCRIPT means "not final, a retry is coming", but that is a fact about the reply, not about the
+    /// message: the flag it sets is never cleared, so if the retry then fails for some *other* reason, a
+    /// check against the message would still read as NOSCRIPT and the request buffer would never come back.
+    /// </summary>
+    [Fact]
+    public async Task RetryFailingForADifferentReasonStillReleasesItsBuffer()
+    {
+        const string Broken = "this is not lua";
+        var pool = new CountingPool();
+        await using var conn = await ConnectionMultiplexer.ConnectAsync(new ConfigurationOptions
+        {
+            EndPoints = { TestConfig.Current.PrimaryServerAndPort },
+            RequestBufferPool = pool,
+            Protocol = TestContext.Current.GetProtocol(),
+        });
+
+        const int Iterations = 20;
+        for (int i = 0; i < Iterations; i++)
+        {
+            // stale hash each time, so every attempt is a NOSCRIPT followed by a real EVAL - which then
+            // fails to compile, i.e. an error that is emphatically not a NOSCRIPT
+            conn.GetServerSnapshot()[0].AddScript(Broken, UnknownHash);
+            await Assert.ThrowsAsync<RedisServerException>(
+                async () => await conn.GetDatabase().ScriptEvaluateRespAsync(Broken, default, new RedisValue[] { "x" }));
+        }
+
+        await Task.Delay(100);
+
+        // the residual is whatever the still-open connection's own IO buffering is holding; what matters
+        // is that it does not grow with the number of calls, which is what a per-call leak looks like
+        var outstanding = pool.Rented - pool.Returned;
+        Output.WriteLine($"rented={pool.Rented} returned={pool.Returned} outstanding={outstanding}");
+        Assert.True(pool.Rented >= Iterations, $"expected a rent per call, got {pool.Rented} for {Iterations}");
+        Assert.True(outstanding <= 5, $"buffers are not coming back: {outstanding} outstanding after {Iterations} calls");
+    }
+
+    private sealed class CountingPool : System.Buffers.MemoryPool<byte>
+    {
+        private int _rented, _returned;
+        public int Rented => Volatile.Read(ref _rented);
+        public int Returned => Volatile.Read(ref _returned);
+        public override int MaxBufferSize => Shared.MaxBufferSize;
+        public override System.Buffers.IMemoryOwner<byte> Rent(int minBufferSize = -1)
+        {
+            Interlocked.Increment(ref _rented);
+            return new Owner(this, Shared.Rent(minBufferSize));
+        }
+        protected override void Dispose(bool disposing) { }
+        private sealed class Owner(CountingPool pool, System.Buffers.IMemoryOwner<byte> inner) : System.Buffers.IMemoryOwner<byte>
+        {
+            private int _disposed;
+            public Memory<byte> Memory => inner.Memory;
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0) Interlocked.Increment(ref pool._returned);
+                inner.Dispose();
+            }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
tl;dr: fix the problem with using `ReadOnlyMemory<...>` leases with `Execute` / `ScriptEvaluate`:

Consider:

``` c#
var lease = ...
lease[0] = "foo";
lease[1] = 42;
var result = conn.ExecuteAsync("some_cmd", lease);
```

Now: when can you return/reuse `lease`? It isn't simple.

1. commands can be queued, delayed, redirected (`-MOVED`, which also means they're written multiple times)
2. when fire-and-forget is used, you have *no idea* when it is "done"
3. if it timed out... is it done? could it ever be written again?
4. `WithRetry` complicates things even more

Long term, we know that the "write" half of the IO core rewrite is designed to solve all of this, but for now, we need it to just not suck, so:

1. when appropriate (`ScriptEvaluate`, `Execute`), pre-render the values to bytes, so we know the values are safe
2. when that doesn't cover everything (`WithRetry`), we use safe local copies, removing the problem from the caller
3. note that this also *simplifies* how `WithKeyPrefix` works, since it can remove some defenses

### Why

`ExecuteResp`/`ScriptEvaluate*` take `ReadOnlyMemory<RedisKeyOrValue>` / `ReadOnlyMemory<RedisKey>` / `ReadOnlyMemory<RedisValue>` and hold the caller's memory until write time. But the request is not necessarily written before the call returns: it can sit in the backlog, or in a batch, and a fire-and-forget caller gets no completion signal at all. So a caller who rents an args array and returns it afterwards — which is exactly what the docs teach for the hot path — is racing the writer and loses silently: whatever is in the recycled array when we get there is what goes on the wire.

Rendering at the point of the call means the request stops referring to caller memory. It also moves the formatting off the writer thread, where it currently happens while holding the single-writer lock, so it should help throughput as well as correctness — and it is the direction the IO core rewrite goes anyway, so it is a down payment rather than a detour.

### Shape

One buffer per request instead of one per argument. Entries are laid out back to back as a 4-byte length followed by that many payload bytes; a negative length marks a key, with `~length` giving the real size. The complement rather than the negation, because `-0 == 0` cannot distinguish a zero-length key from a zero-length value.

`RedisKey` and `RedisValue` can both already measure and copy themselves exactly, so there is no oversize estimate and no backfilling: measure, rent, fill.

Rents from `RequestBufferPool` when configured, falling back to `ArrayPool<byte>.Shared`, matching what the write path already does.

### On lifetime

This is the part that killed `IRequestDisposer`, so it is worth being explicit about what is different: the whole thing is `internal`, so no caller participates in a lifetime protocol and there is no public surface to get stuck with.

`Recycle` takes the state by `ref` on purpose. As an instance method it would compile perfectly happily against a `readonly` field and silently operate on a defensive copy, stranding the buffer; as a `ref` parameter that same mistake is `CS0192` at build time — verified, along with the fact that the instance form produces no warning at all.

The invariant `ref` cannot enforce is that the state must never be *copied*, since two owners means a double-return to the pool. That is documented on the type.

### Done

- ~~Wiring `ExecMessage` and `ScriptEvalMessage` to it~~ — done. `ScriptEvalMessage` keeps the script itself out of the buffer, since it is needed intact for hash management and `SCRIPT LOAD`.

### Considerations

- The recycle-on-definitely-final-completion rule. `PrepareToResend` and caller-side timeouts must *not* recycle; the `RecordConnectionFailed` drain, `-ERR` and normal completion must. Note `Message.Complete`'s once-only latch keys off `resultBox`, which is null for fire-and-forget — so the buffer needs its own latch rather than riding on that one.
- Batches and transactions hold queued messages until `Execute`, so this changes the pool-pressure profile: a large batch will hold a rented buffer per queued command where today it holds references to caller memory.

### Follow-on: the same guarantee has to hold through every wrapper, not just at the base database

The point of this type is that as soon as an `Execute*` call exits — sync, async, fire-and-forget, delayed in the backlog, redirected — the caller's own buffers are done and safe to recycle. That only actually holds if every layer between the caller and this rendering step preserves it. Two places don't yet:

- `KeyPrefixedDatabase`'s `ExecuteResp`/`ScriptEvaluateResp`/`ScriptEvaluateReadOnlyResp` currently hold their own leased, prefixed copy open until the inner call completes with success or `RedisServerException`, because that used to be the earliest point at which the write was known to be over. Once the inner database renders synchronously at message-construction time (this PR), that copy is fully consumed the moment the inner call is made — the lease can be returned immediately after making that call, without waiting on its result at all. Needs review once the recycle lifecycle below lands, to confirm the assumption and simplify accordingly.
  - finding: `KeyPrefixedDatabase` already uses lease/return; we can now simplify the return logic here
- `RetryDatabase` captures the caller's `ReadOnlyMemory<RedisKeyOrValue>`/`RedisKey`/`RedisValue` by reference across every retry attempt, with no copy of its own. The first attempt renders synchronously same as any direct call, but a *later* retry re-reads the same captured memory - and by then the caller may already have recycled it, believing the call was done. `RetryDatabase` needs its own local copy/lease taken once, up front, before the retry loop starts, so a retry always reads back its own snapshot rather than memory the caller has moved on from.
- audit for other likely methods - `HashImport` maybe?