### PR TITLE
Bump to 3.2

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,5 @@
 {
-  "version": "3.1",
-  "versionHeightOffset": -2,
-  "versionHeightOffsetAppliesTo": "3.1",
+  "version": "3.2",
   "assemblyVersion": "3.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
Three consumer-visible changes this cycle that a build bump would under-signal:

- **net6.0 dropped** from `TargetFrameworks` (#3208). Anyone still targeting it doesn't get a worse version, they get *no* version.
- **`System.IO.Hashing`'s declared floor moved `10.0.5` → `10.0.12`** (#3210), on every target framework.
- **`ScriptEvaluateReadOnly` now genuinely sends `EVAL_RO`** where the server (7.0+) and command map allow it — so a script that *writes* on that API starts being rejected where plain `EVAL` used to let it through.

Plus the new surface from #3201 — `RespResult`, `RedisKeyOrValue`, the `*Resp` family, and the un-gated `RespReader` API — additive, but substantial.

### `assemblyVersion` stays at 3.0

Deliberately. It's decoupled from the package version precisely so a minor bump isn't a binding break; moving it would be one for anyone with a compiled reference or a binding redirect. Confirmed against a local pack:

```
package version:  3.2.0-ge621b46b17     (the suffix is just the non-release ref; on main this is 3.2.0)
AssemblyVersion:  3.0.0.0
```

### `versionHeightOffset` removed

It was scoped to 3.1 via `versionHeightOffsetAppliesTo`, so it stopped applying the moment the version changed — dead config rather than a live adjustment. Verified the computed version is byte-identical with and without it, so this is a tidy-up, not a behaviour change.

The version height restarts at 0 for the new minor, which is why the first build is `3.2.0` rather than continuing the 3.1 height.