### PR TITLE
Fix tag-triggered releases: accept unprefixed tags, keep 3.2.0 reachable

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,12 +1,12 @@
 {
   "version": "3.2",
-  "versionHeightOffset": -2,
+  "versionHeightOffset": -3,
   "versionHeightOffsetAppliesTo": "3.2",
   "assemblyVersion": "3.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v[0-9]+$",
-    "^refs/tags/v\\d+\\.\\d+"
+    "^refs/tags/v?\\d+\\.\\d+"
   ],
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
The 3.2.0 release run failed its `Verify tag matches computed version` guard:

```
Tag '3.2.0' does not match the computed version '3.2.0-g8460293104'; retag the release commit so the two agree.
```

## Cause

`version.json` still carried the v2-era refspec `^refs/tags/v\d+\.\d+`. The entire v3 line tags *without* the `v` (`3.0.0` … `3.1.31`, `3.2.0`), so on a `release: published` event — where `GITHUB_REF` is `refs/tags/3.2.0` — nbgv did not treat the build as a public release and appended the `-g<commit>` suffix. The guard then correctly refused to publish a package whose version disagreed with its release.

Reproduced with nbgv against 84602931:

| `GITHUB_REF` | `NuGetPackageVersion` |
| --- | --- |
| `refs/tags/3.2.0` | `3.2.0-g8460293104` :x: |
| `refs/tags/v3.2.0` | `3.2.0` |
| `refs/heads/main` | `3.2.0` |

This never bit us before because `release.yml` is new (#3213); every earlier v3 package was pushed from a main build, where the refspec did match. The stray [`3.1.1-g7441909d06`](https://www.nuget.org/packages/StackExchange.Redis/3.1.1-g7441909d06) on nuget.org is the same failure mode escaping under the old MyGet pipeline.

## Change

- Relax the refspec to `^refs/tags/v?\d+\.\d+` so both spellings count as a public release. The workflow guard already strips a leading `v` before comparing, so either works end to end.
- Drop `versionHeightOffset` from `-2` to `-3`. This commit adds to the commit height, and without the compensation the release commit would compute as `3.2.1` and 3.2.0 would be skipped. `versionHeightOffsetAppliesTo` is already `"3.2"`, so the height itself is not reset.

Verified with nbgv on this commit — `refs/tags/3.2.0`, `refs/tags/v3.2.0` and `refs/heads/main` all compute `NuGetPackageVersion` `3.2.0`.

## Releasing after this merges

The `3.2.0` tag and its GitHub release have been deleted. Tag the **merge commit** `3.2.0` and publish from there.

Note that `-3` is load-bearing for exactly one commit: anything that lands on main after this becomes 3.2.1, so if further commits land before the release is cut, either drop the offset again or just ship 3.2.1.